### PR TITLE
feat: Add AllocationUrgency enum with entity and import integration

### DIFF
--- a/assets/icons/tabler/traffic-lights.svg
+++ b/assets/icons/tabler/traffic-lights.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M7 7a5 5 0 0 1 5-5h0a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5h0a5 5 0 0 1-5-5z"/><path d="M11 7a1 1 0 1 0 2 0a1 1 0 1 0-2 0m0 5a1 1 0 1 0 2 0a1 1 0 1 0-2 0m0 5a1 1 0 1 0 2 0a1 1 0 1 0-2 0"/></g></svg>

--- a/migrations/Version20250902183554.php
+++ b/migrations/Version20250902183554.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250902183554 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE allocation ADD urgency INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE allocation DROP urgency');
+    }
+}

--- a/src/Entity/Allocation.php
+++ b/src/Entity/Allocation.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Enum\AllocationGender;
 use App\Enum\AllocationTransportType;
+use App\Enum\AllocationUrgency;
 use App\Repository\AllocationRepository;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -66,6 +67,9 @@ class Allocation
 
     #[ORM\Column(nullable: true, enumType: AllocationTransportType::class)]
     private ?AllocationTransportType $transportType = null;
+
+    #[ORM\Column(enumType: AllocationUrgency::class)]
+    private ?AllocationUrgency $urgency = null;
 
     public function getId(): ?int
     {
@@ -268,6 +272,18 @@ class Allocation
     public function setTransportType(?AllocationTransportType $transportType): static
     {
         $this->transportType = $transportType;
+
+        return $this;
+    }
+
+    public function getUrgency(): ?AllocationUrgency
+    {
+        return $this->urgency;
+    }
+
+    public function setUrgency(AllocationUrgency $urgency): static
+    {
+        $this->urgency = $urgency;
 
         return $this;
     }

--- a/src/Enum/AllocationUrgency.php
+++ b/src/Enum/AllocationUrgency.php
@@ -18,7 +18,7 @@ enum AllocationUrgency: int
     }
 
     /**
-     * @return string[]
+     * @return int[]
      */
     public static function getValues(): array
     {

--- a/src/Enum/AllocationUrgency.php
+++ b/src/Enum/AllocationUrgency.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Enum;
+
+enum AllocationUrgency: int
+{
+    case IMMEDIATE = 1;
+    case URGENT = 2;
+    case DELAYED = 3;
+
+    public function getType(): int
+    {
+        return match ($this) {
+            self::IMMEDIATE => self::IMMEDIATE->value,
+            self::URGENT => self::URGENT->value,
+            self::DELAYED => self::DELAYED->value,
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getValues(): array
+    {
+        return [
+            self::IMMEDIATE->value,
+            self::URGENT->value,
+            self::DELAYED->value,
+        ];
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::IMMEDIATE => 'label.urgency.immediate',
+            self::URGENT => 'label.urgency.urgent',
+            self::DELAYED => 'label.urgency.delayed',
+        };
+    }
+}

--- a/src/Factory/AllocationFactory.php
+++ b/src/Factory/AllocationFactory.php
@@ -5,6 +5,7 @@ namespace App\Factory;
 use App\Entity\Allocation;
 use App\Enum\AllocationGender;
 use App\Enum\AllocationTransportType;
+use App\Enum\AllocationUrgency;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
 /**
@@ -44,6 +45,7 @@ final class AllocationFactory extends PersistentProxyObjectFactory
             'requiresCathlab' => self::faker()->boolean(),
             'requiresResus' => self::faker()->boolean(),
             'transportType' => self::faker()->randomElement(AllocationTransportType::cases()),
+            'urgency' => self::faker()->randomElement(AllocationUrgency::cases()),
         ];
     }
 }

--- a/src/Query/ListAllocationsQuery.php
+++ b/src/Query/ListAllocationsQuery.php
@@ -21,7 +21,7 @@ final class ListAllocationsQuery
     {
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('a.id, a.createdAt, a.arrivalAt, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
-                h.id as hospital_id, h.name as hospital, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock, a.isPregnant, a.isWithPhysician')
+                h.id as hospital_id, h.name as hospital, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock, a.isPregnant, a.isWithPhysician, a.urgency')
             ->from(Allocation::class, 'a')
             ->leftJoin(
                 State::class,
@@ -43,7 +43,7 @@ final class ListAllocationsQuery
             );
 
         if (null !== $queryParametersDTO->importId) {
-            $qb->andWhere('a.import = :importId')  // Allocation hat ManyToOne Import
+            $qb->andWhere('a.import = :importId')
             ->setParameter('importId', $queryParametersDTO->importId);
         }
 

--- a/src/Service/Import/Adapter/SplCsvRowReader.php
+++ b/src/Service/Import/Adapter/SplCsvRowReader.php
@@ -42,7 +42,7 @@ final class SplCsvRowReader implements RowReaderInterface
         private readonly \SplFileObject $file,
         private readonly string $inputEncoding = 'ISO-8859-1',
         string $delimiter = ';',
-        string $enclosure = "\0",
+        string $enclosure = '"',
         string $escape = '\\',
     ) {
         $this->file->setFlags(

--- a/src/Service/Import/DTO/AllocationRowDTO.php
+++ b/src/Service/Import/DTO/AllocationRowDTO.php
@@ -66,4 +66,9 @@ final class AllocationRowDTO
 
     #[Assert\Choice(choices: ['G', 'A'], message: 'Unknown transport')]
     public ?string $transportType = null;
+
+    #[Assert\NotNull]
+    #[Assert\Type('integer')]
+    #[Assert\Range(min: 1, max: 3)]
+    public ?int $urgency = null;
 }

--- a/src/Service/Import/Mapping/AllocationImportFactory.php
+++ b/src/Service/Import/Mapping/AllocationImportFactory.php
@@ -9,6 +9,7 @@ use App\Entity\Import;
 use App\Entity\State;
 use App\Enum\AllocationGender;
 use App\Enum\AllocationTransportType;
+use App\Enum\AllocationUrgency;
 use App\Repository\DispatchAreaRepository;
 use App\Repository\StateRepository;
 use App\Service\Import\DTO\AllocationRowDTO;
@@ -152,7 +153,7 @@ final class AllocationImportFactory
         $allocation->setIsShock($dto->isShock ?? false);
         $allocation->setIsPregnant($dto->isPregnant ?? false);
         $allocation->setIsWithPhysician($dto->isWithPhysician ?? false);
-        $allocation->setUrgency($dto->urgency);
+        $allocation->setUrgency(AllocationUrgency::from($dto->urgency));
 
         return $allocation;
     }

--- a/src/Service/Import/Mapping/AllocationImportFactory.php
+++ b/src/Service/Import/Mapping/AllocationImportFactory.php
@@ -140,6 +140,10 @@ final class AllocationImportFactory
             throw new \LogicException('Age must be integer after validation');
         }
 
+        if (!\is_int($dto->urgency)) {
+            throw new \LogicException('Urgency must be integer after validation');
+        }
+
         $allocation->setAge($dto->age);
         $allocation->setRequiresResus($dto->requiresResus ?? false);
         $allocation->setRequiresCathlab($dto->requiresCathlab ?? false);
@@ -148,6 +152,7 @@ final class AllocationImportFactory
         $allocation->setIsShock($dto->isShock ?? false);
         $allocation->setIsPregnant($dto->isPregnant ?? false);
         $allocation->setIsWithPhysician($dto->isWithPhysician ?? false);
+        $allocation->setUrgency($dto->urgency);
 
         return $allocation;
     }

--- a/src/Service/Import/Mapping/AllocationRowMapper.php
+++ b/src/Service/Import/Mapping/AllocationRowMapper.php
@@ -56,7 +56,7 @@ final class AllocationRowMapper implements RowToDtoMapperInterface
         $dto->isPregnant = self::normalizeBoolean(self::getStringOrNull($row, 'schwanger') ?? 'false');
         $dto->isWithPhysician = self::normalizeBoolean(self::getStringOrNull($row, 'arztbegleitet') ?? 'false');
         $dto->transportType = self::normalizeTransportType(self::getStringOrNull($row, 'transportmittel'));
-        $dto->urgency = self::normalizeUrgencyFromPZC(self::getIntegerOrNull($row, 'pzc'));
+        $dto->urgency = self::normalizeUrgencyFromPZC(self::getStringOrNull($row, 'pzc'));
 
         return $dto;
     }

--- a/src/Service/Import/Mapping/AllocationRowMapper.php
+++ b/src/Service/Import/Mapping/AllocationRowMapper.php
@@ -56,6 +56,7 @@ final class AllocationRowMapper implements RowToDtoMapperInterface
         $dto->isPregnant = self::normalizeBoolean(self::getStringOrNull($row, 'schwanger') ?? 'false');
         $dto->isWithPhysician = self::normalizeBoolean(self::getStringOrNull($row, 'arztbegleitet') ?? 'false');
         $dto->transportType = self::normalizeTransportType(self::getStringOrNull($row, 'transportmittel'));
+        $dto->urgency = self::normalizeUrgencyFromPZC(self::getIntegerOrNull($row, 'pzc'));
 
         return $dto;
     }

--- a/src/Service/Import/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Service/Import/Mapping/AllocationRowNormalizationTrait.php
@@ -17,26 +17,6 @@ trait AllocationRowNormalizationTrait
         return '' === $value ? null : $value;
     }
 
-    /**
-     * Extracts an integer value from the given row key, or returns null if not set or not numeric.
-     *
-     * @param array<string, scalar|null> $row
-     */
-    protected static function getIntegerOrNull(array $row, string $key): ?int
-    {
-        if (!array_key_exists($key, $row)) {
-            return null;
-        }
-
-        $value = trim((string) $row[$key]);
-
-        if ('' === $value || !ctype_digit($value)) {
-            return null;
-        }
-
-        return (int) $value;
-    }
-
     protected static function combineDateAndTime(?string $date, ?string $time): ?string
     {
         if (null === $date || null === $time) {

--- a/src/Service/Import/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Service/Import/Mapping/AllocationRowNormalizationTrait.php
@@ -17,6 +17,26 @@ trait AllocationRowNormalizationTrait
         return '' === $value ? null : $value;
     }
 
+    /**
+     * Extracts an integer value from the given row key, or returns null if not set or not numeric.
+     *
+     * @param array<string, scalar|null> $row
+     */
+    protected static function getIntegerOrNull(array $row, string $key): ?int
+    {
+        if (!array_key_exists($key, $row)) {
+            return null;
+        }
+
+        $value = trim((string) $row[$key]);
+
+        if ('' === $value || !ctype_digit($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
     protected static function combineDateAndTime(?string $date, ?string $time): ?string
     {
         if (null === $date || null === $time) {
@@ -130,5 +150,35 @@ trait AllocationRowNormalizationTrait
         }
 
         return null;
+    }
+
+    /**
+     * Extracts the last digit from a six-digit integer string representing the
+     * PZC and returns it as an int if it is 1, 2 or 3. Otherwise, returns null.
+     *
+     * Examples:
+     *  '123451' → 1
+     *  '000002' → 2
+     *  '999993' → 3
+     *  '123450' → null   (last digit not in 1..3)
+     *  '12345'  → null   (not six digits)
+     *  null     → null
+     */
+    protected static function normalizeUrgencyFromPZC(?string $value): ?int
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $clean = trim($value);
+
+        // PZC must be exactly six digits (allow leading zeros)
+        if (6 !== strlen($clean) || !ctype_digit($clean)) {
+            return null;
+        }
+
+        $last = (int) substr($clean, -1);
+
+        return \in_array($last, [1, 2, 3], true) ? $last : null;
     }
 }

--- a/templates/_macros/badges.html.twig
+++ b/templates/_macros/badges.html.twig
@@ -17,6 +17,11 @@
             Medium: {class: 'bg-green text-green-fg', label: 'Medium'},
             Large: {class: 'bg-teal text-teal-fg', label: 'Large'},
         },
+        allocation_urgency: {
+            1: {class: 'bg-red text-red-fg', label: 'Immediate'},
+            2: {class: 'bg-yellow text-yellow-fg', label: 'Urgent'},
+            3: {class: 'bg-green text-green-fg', label: 'Delayed'},
+        },
     } %}
 
     {% set badge = mappings[type][value] ?? {class: 'bg-secondary text-secondary-fg', label: value} %}

--- a/templates/data/allocations/list.html.twig
+++ b/templates/data/allocations/list.html.twig
@@ -77,7 +77,10 @@
                     <th class="col-2">
                         {{ 'label.locations'|trans }}
                     </th>
-                    <th class="col-3">
+                    <th class="col-1">
+                        {{ 'label.urgency'|trans }}
+                    </th>
+                    <th class="col-2">
                         {{ 'label.properties'|trans }}
                     </th>
                     <th class="col-1">
@@ -107,6 +110,11 @@
                         <td>
                             {{ allocation.dispatchArea }}<br/>
                             {{ allocation.state }}
+                        </td>
+                        <td>
+                            {% import '_macros/badges.html.twig' as badges %}
+
+                            {{ badges.render('allocation_urgency', allocation.urgency.value) }}
                         </td>
                         <td>
                             <span class="text-danger fw-bold">

--- a/templates/data/allocations/show.html.twig
+++ b/templates/data/allocations/show.html.twig
@@ -160,7 +160,7 @@
                             </div>
                         </div>
                         <div class="datagrid-item">
-                            <div class="datagrid-title">{{ 'allocations.field.isShock'|trans }}r</div>
+                            <div class="datagrid-title">{{ 'allocations.field.isShock'|trans }}</div>
                             <div class="datagrid-content">
                                 {% if allocation.isShock %}
                                     <span class="status status-green">{{ 'field.true'|trans }}</span>
@@ -189,6 +189,8 @@
                     <twig:Card
                         title="{{ 'label.basic_info'|trans }}"
                     >
+                        {% import '_macros/badges.html.twig' as badges %}
+
                         <div id="allocation-created-at" class="mb-2">
                             <twig:ux:icon name="tabler:clock-play" class="w-3 h-3" />
                             {{ 'label.created_at'|trans }} <strong>{{ allocation.createdAt|date('d.m.Y H:i') }}</strong>
@@ -201,7 +203,7 @@
                             <twig:ux:icon name="tabler:user" class="w-3 h-3" />
                             {{ 'field.age'|trans }} <strong>{{ allocation.age }}</strong>
                         </div>
-                        <div id="allocation-gender">
+                        <div id="allocation-gender" class="mb-2">
                             {% if allocation.gender.value == 'M' %}
                                 <twig:ux:icon name="tabler:gender-male" class="w-3 h-3" />
                             {% elseif allocation.gender.value == 'F' %}
@@ -210,6 +212,10 @@
                                 <twig:ux:icon name="tabler:gender-agender" class="w-3 h-3" />
                             {% endif %}
                             {{ 'field.gender'|trans }} <strong>{{ allocation.gender.label|trans }}</strong>
+                        </div>
+                        <div id="allocation-urgency">
+                            <twig:ux:icon name="tabler:traffic-lights" class="w-3 h-3" />
+                            {{ 'field.urgency'|trans }} {{ badges.render('allocation_urgency', allocation.urgency.value) }}
                         </div>
                     </twig:Card>
                 </div>

--- a/tests/Fixtures/allocation_import_sample.csv
+++ b/tests/Fixtures/allocation_import_sample.csv
@@ -1,6 +1,6 @@
-Versorgungsbereich;KHS-Versorgungsgebiet;Krankenhaus;Krankenhaus-Kurzname;Datum (Eintreffzeit);Uhrzeit (Eintreffzeit);Geschlecht;Alter;Schockraum;Herzkatheter;Reanimation;Beatmet;Schock;Schwanger;Arztbegleitet;Transportmittel;Datum (Erstellungsdatum);Uhrzeit (Erstellungsdatum)
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;07.01.2025;13:14;W;74;S+;H+;R+;B-;;Schwanger;N+;Boden;07.01.2025;10:19;
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;02.03.2025;16:43;D;34;S-;;;B-;;;N-;Boden;02.03.2025;15:09
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;16.02.2025;13:01:43;W;0;;;;B-;;;N-;Boden;16.02.2025;12:00:43
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;09.01.2025;01:12:55;M;79;;;;B-;;;N-;Luft;08.01.2025;01:10:55
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;11.02.2025;09:33;M;64;;;R+;B-;;;N-;Boden;11.02.2025;08:02
+Versorgungsbereich;KHS-Versorgungsgebiet;Krankenhaus;Krankenhaus-Kurzname;Datum (Eintreffzeit);Uhrzeit (Eintreffzeit);Geschlecht;Alter;Schockraum;Herzkatheter;Reanimation;Beatmet;Schock;Schwanger;Arztbegleitet;Transportmittel;Datum (Erstellungsdatum);Uhrzeit (Erstellungsdatum);PZC
+Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;07.01.2025;13:14;W;74;S+;H+;R+;B-;;Schwanger;N+;Boden;07.01.2025;10:19;123741
+Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;02.03.2025;16:43;D;34;S-;;;B-;;;N-;Boden;02.03.2025;15:09;123342
+Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;16.02.2025;13:01:43;W;0;;;;B-;;;N-;Boden;16.02.2025;12:00:43;123433
+Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;09.01.2025;01:12:55;M;79;;;;B-;;;N-;Luft;08.01.2025;01:10:55;123551
+Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;11.02.2025;09:33;M;64;;;R+;B-;;;N-;Boden;11.02.2025;08:02;123642

--- a/tests/Fixtures/allocation_import_sample.csv
+++ b/tests/Fixtures/allocation_import_sample.csv
@@ -1,6 +1,6 @@
-Versorgungsbereich;KHS-Versorgungsgebiet;Krankenhaus;Krankenhaus-Kurzname;Datum (Eintreffzeit);Uhrzeit (Eintreffzeit);Geschlecht;Alter;Schockraum;Herzkatheter;Reanimation;Beatmet;Schock;Schwanger;Arztbegleitet;Transportmittel;Datum (Erstellungsdatum);Uhrzeit (Erstellungsdatum);PZC
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;07.01.2025;13:14;W;74;S+;H+;R+;B-;;Schwanger;N+;Boden;07.01.2025;10:19;123741
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;02.03.2025;16:43;D;34;S-;;;B-;;;N-;Boden;02.03.2025;15:09;123342
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;16.02.2025;13:01:43;W;0;;;;B-;;;N-;Boden;16.02.2025;12:00:43;123433
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;09.01.2025;01:12:55;M;79;;;;B-;;;N-;Luft;08.01.2025;01:10:55;123551
-Test Area;1;Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt;KH Test;11.02.2025;09:33;M;64;;;R+;B-;;;N-;Boden;11.02.2025;08:02;123642
+"Versorgungsbereich";"KHS-Versorgungsgebiet";"Krankenhaus";"Krankenhaus-Kurzname";"Datum (Eintreffzeit)";"Uhrzeit (Eintreffzeit)";"Geschlecht";"Alter";"Schockraum";"Herzkatheter";"Reanimation";"Beatmet";"Schock";"Schwanger";"Arztbegleitet";"Transportmittel";"Datum (Erstellungsdatum)";"Uhrzeit (Erstellungsdatum)";"PZC"
+"Test Area";"1";"Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt";"KH Test";"07.01.2025";"13:14";"W";"74";"S+";"H+";"R+";"B-";"";"Schwanger";"N+";"Boden";"07.01.2025";"10:19";"123741"
+"Test Area";"1";"Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt";"KH Test";"02.03.2025";"16:43";"D";"34";"S-";"";"";"B-";"";"";"N-";"Boden";"02.03.2025";"15:09";"123342"
+"Test Area";"1";"Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt";"KH Test";"16.02.2025";"13:01:43";"W";"0";"";"";"";"B-";"";"";"N-";"Boden";"16.02.2025";"12:00:43";"123433"
+"Test Area";"1";"Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt";"KH Test";"09.01.2025";"01:12:55";"M";"79";"";"";"";"B-";"";"";"N-";"Luft";"08.01.2025";"01:10:55";"123551"
+"Test Area";"1";"Testkrankenhaus Musterstadt, Teststraße 1, 12345 Musterstadt";"KH Test";"11.02.2025";"09:33";"M";"64";"";"";"R+";"B-";"";"";"N-";"Boden";"11.02.2025";"08:02";"123642"

--- a/tests/Integration/Entity/AllocationOrmTest.php
+++ b/tests/Integration/Entity/AllocationOrmTest.php
@@ -11,6 +11,7 @@ use App\Entity\Import;
 use App\Entity\State;
 use App\Enum\AllocationGender;
 use App\Enum\AllocationTransportType;
+use App\Enum\AllocationUrgency;
 use App\Factory\DispatchAreaFactory;
 use App\Factory\HospitalFactory;
 use App\Factory\ImportFactory;
@@ -67,7 +68,8 @@ final class AllocationOrmTest extends KernelTestCase
             ->setIsShock(false)
             ->setIsPregnant(false)
             ->setIsWithPhysician(true)
-            ->setTransportType(AllocationTransportType::GROUND);
+            ->setTransportType(AllocationTransportType::GROUND)
+            ->setUrgency(AllocationUrgency::IMMEDIATE);
 
         $this->em->persist($allocation);
         $this->em->flush();
@@ -94,6 +96,7 @@ final class AllocationOrmTest extends KernelTestCase
         self::assertFalse($object->isShock());
         self::assertFalse($object->isPregnant());
         self::assertTrue($object->isWithPhysician());
+        self::assertSame($object->getUrgency(), AllocationUrgency::IMMEDIATE);
 
         // Relations
         self::assertSame('St. Test Hospital', $object->getHospital()?->getName());
@@ -132,7 +135,8 @@ final class AllocationOrmTest extends KernelTestCase
             ->setIsShock(false)
             ->setIsPregnant(false)
             ->setIsWithPhysician(false)
-            ->setTransportType(null);
+            ->setTransportType(null)
+            ->setUrgency(AllocationUrgency::IMMEDIATE);
 
         $this->em->persist($allocation);
         $this->em->flush();

--- a/tests/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
+++ b/tests/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
@@ -52,12 +52,13 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
             'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
             'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
             'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC',
         ];
 
         $rows = [
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19'],
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '02.03.2025', '15:09', '02.03.2025', '16:43', 'D', '34', 'S-', '', '', 'B-', '', 'N-', 'Boden', '02.03.2025', '15:09'],
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '16.02.2025', '12:00', '16.02.2025', '13:01', 'W', '0', '', '', '', 'B-', '', 'N-', 'Boden', '16.02.2025', '12:00'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '02.03.2025', '15:09', '02.03.2025', '16:43', 'D', '34', 'S-', '', '', 'B-', '', 'N-', 'Boden', '02.03.2025', '15:09', '123341'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '16.02.2025', '12:00', '16.02.2025', '13:01', 'W', '0', '', '', '', 'B-', '', 'N-', 'Boden', '16.02.2025', '12:00', '123001'],
         ];
 
         $userRef = $this->em->getReference(\App\Entity\User::class, $owner->getId());

--- a/tests/Integration/Service/Import/AllocationImportFeatureTest.php
+++ b/tests/Integration/Service/Import/AllocationImportFeatureTest.php
@@ -54,12 +54,13 @@ final class AllocationImportFeatureTest extends KernelTestCase
             'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
             'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
             'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC',
         ];
 
         $rows = [
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19'],
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '02.03.2025', '15:09', '02.03.2025', '16:43', 'D', '34', 'S-', '', '', 'B-', '', 'N-', 'Boden', '02.03.2025', '15:09'],
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '16.02.2025', '12:00', '16.02.2025', '13:01', 'W', '0', '', '', '', 'B-', '', 'N-', 'Boden', '16.02.2025', '12:00'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '02.03.2025', '15:09', '02.03.2025', '16:43', 'D', '34', 'S-', '', '', 'B-', '', 'N-', 'Boden', '02.03.2025', '15:09', '123341'],
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '16.02.2025', '12:00', '16.02.2025', '13:01', 'W', '0', '', '', '', 'B-', '', 'N-', 'Boden', '16.02.2025', '12:00', '123001'],
         ];
 
         $reader = new InMemoryRowReader($header, $rows);

--- a/tests/Integration/Service/Import/Mapping/AllocationImportFactoryTest.php
+++ b/tests/Integration/Service/Import/Mapping/AllocationImportFactoryTest.php
@@ -69,6 +69,7 @@ final class AllocationImportFactoryTest extends KernelTestCase
         $dto->isPregnant = false;
         $dto->isWithPhysician = true;
         $dto->transportType = 'G';
+        $dto->urgency = 1;
 
         foreach ($override as $k => $v) {
             $dto->$k = $v;

--- a/tests/Unit/Enum/AllocationUrgencyTest.php
+++ b/tests/Unit/Enum/AllocationUrgencyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enum;
+
+use App\Enum\AllocationUrgency;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationUrgencyTest extends TestCase
+{
+    #[DataProvider('caseProvider')]
+    public function testGetTypeReturnsValue(AllocationUrgency $case, int $value, string $label): void
+    {
+        self::assertSame($value, $case->getType());
+        self::assertSame($value, $case->value);
+        self::assertSame($label, $case->label());
+    }
+
+    public function testGetValuesReturnsAllValuesInOrder(): void
+    {
+        $expected = [1, 2, 3];
+        self::assertSame($expected, AllocationUrgency::getValues());
+    }
+
+    public function testFromAndTryFrom(): void
+    {
+        self::assertSame(AllocationUrgency::IMMEDIATE, AllocationUrgency::from(1));
+        self::assertSame(AllocationUrgency::URGENT, AllocationUrgency::from(2));
+        self::assertSame(AllocationUrgency::DELAYED, AllocationUrgency::from(3));
+
+        self::assertNull(AllocationUrgency::tryFrom(0));
+        self::assertNull(AllocationUrgency::tryFrom(4));
+    }
+
+    public function testLabelsAreUniqueAndWellFormed(): void
+    {
+        $labels = array_map(static fn (AllocationUrgency $c) => $c->label(), AllocationUrgency::cases());
+        self::assertSame($labels, array_values(array_unique($labels)));
+        foreach ($labels as $label) {
+            self::assertMatchesRegularExpression('/^label\.urgency\.(immediate|urgent|delayed)$/', $label);
+        }
+    }
+
+    /**
+     * @return array<string, array{case: AllocationUrgency, value: int, label: string}>
+     */
+    public static function caseProvider(): array
+    {
+        return [
+            'Immediate' => ['case' => AllocationUrgency::IMMEDIATE, 'value' => 1, 'label' => 'label.urgency.immediate'],
+            'Urgent' => ['case' => AllocationUrgency::URGENT, 'value' => 2, 'label' => 'label.urgency.urgent'],
+            'Delayed' => ['case' => AllocationUrgency::DELAYED, 'value' => 3, 'label' => 'label.urgency.delayed'],
+        ];
+    }
+}

--- a/tests/Unit/Service/Import/DTO/AllocationRowDTOTest.php
+++ b/tests/Unit/Service/Import/DTO/AllocationRowDTOTest.php
@@ -38,6 +38,7 @@ final class AllocationRowDTOTest extends TestCase
         $dto->isPregnant = false;
         $dto->isWithPhysician = true;
         $dto->transportType = 'G';
+        $dto->urgency = 1;
 
         return $dto;
     }

--- a/tests/Unit/Service/Import/Mapping/AllocationRowMapperTest.php
+++ b/tests/Unit/Service/Import/Mapping/AllocationRowMapperTest.php
@@ -119,4 +119,26 @@ final class AllocationRowMapperTest extends TestCase
         yield 'missing date' => [null, '12:34', null];
         yield 'both missing' => [null, null, null];
     }
+
+    #[DataProvider('pzcProvider')]
+    public function testNormalizeUrgencyFromPZC(?string $input, ?int $expected): void
+    {
+        self::assertSame($expected, TraitHelper::normalizeUrgencyFromPZC($input));
+    }
+
+    /**
+     * @return iterable<string, array{0:?string,1:?int}>
+     */
+    public static function pzcProvider(): iterable
+    {
+        yield 'valid: last digit 1' => ['123451', 1];
+        yield 'valid: last digit 2' => ['000002', 2];
+        yield 'valid: last digit 3' => ['999993', 3];
+        yield 'valid: last digit 0' => ['123450', null];
+        yield 'invalid: too short' => ['12345', null];
+        yield 'invalid: too long' => ['1234567', null];
+        yield 'invalid: non-digit' => ['12a456', null];
+        yield 'invalid: null' => [null, null];
+        yield 'invalid: whitespace trimmed' => [' 123451 ', 1];
+    }
 }

--- a/tests/Unit/Service/Import/Mapping/TraitHelper.php
+++ b/tests/Unit/Service/Import/Mapping/TraitHelper.php
@@ -13,6 +13,7 @@ final class TraitHelper
         normalizeTransportType as private traitNormalizeTransportType;
         normalizeBoolean as private traitNormalizeBoolean;
         normalizeAge as private traitNormalizeAge;
+        normalizeUrgencyFromPZC as private traitNormalizeUrgencyFromPZC;
         combineDateAndTime as private traitCombineDateAndTime;
         getStringOrNull as private traitGetStringOrNull;
     }
@@ -35,6 +36,11 @@ final class TraitHelper
     public static function normalizeAge(?string $value): ?int
     {
         return self::traitNormalizeAge($value);
+    }
+
+    public static function normalizeUrgencyFromPZC(?string $value): ?int
+    {
+        return self::traitNormalizeUrgencyFromPZC($value);
     }
 
     public static function combineDateAndTime(?string $date, ?string $time): ?string

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -85,6 +85,10 @@
         <source>field.true</source>
         <target>True</target>
       </trans-unit>
+      <trans-unit id="GvBH7QF" resname="field.urgency">
+        <source>field.urgency</source>
+        <target>Urgency</target>
+      </trans-unit>
       <trans-unit id="oB3P1Zq" resname="flash.import.created">
         <source>flash.import.created</source>
         <target>New Import has been created successfully!</target>
@@ -364,6 +368,22 @@
       <trans-unit id="YCDRQcj" resname="label.updated_by">
         <source>label.updated_by</source>
         <target>Updated by</target>
+      </trans-unit>
+      <trans-unit id="2WVqGGv" resname="label.urgency">
+        <source>label.urgency</source>
+        <target>Urgency</target>
+      </trans-unit>
+      <trans-unit id="krNU.kK" resname="label.urgency.delayed">
+        <source>label.urgency.delayed</source>
+        <target>Delayed</target>
+      </trans-unit>
+      <trans-unit id="3kkNmIA" resname="label.urgency.immediate">
+        <source>label.urgency.immediate</source>
+        <target>Immediate</target>
+      </trans-unit>
+      <trans-unit id="Ogn7GN1" resname="label.urgency.urgent">
+        <source>label.urgency.urgent</source>
+        <target>Urgent</target>
       </trans-unit>
       <trans-unit id="ZdrXMaQ" resname="link.allocations">
         <source>link.allocations</source>


### PR DESCRIPTION
### Summary

- Introduced `AllocationUrgency` enum
- Integrated urgency into `Allocation` entity
- Extended import pipeline to handle urgency values

### Motivation

- Capture and persist urgency level of an allocation
- Ensure imports include urgency for completeness


### Notes for Reviewers

- Review enum values for consistency and future extensibility
- Confirm pipeline correctly maps and persists urgency during import  