### PR TITLE
feat: Add bar and boxplot distribution visualizations per hospital

### DIFF
--- a/assets/controllers/distribution-panel_controller.js
+++ b/assets/controllers/distribution-panel_controller.js
@@ -42,7 +42,18 @@ export default class extends Controller {
             return;
         }
 
-        if (this.yAxisPercentValue) {
+        const series = options.series;
+        if (!series || !Array.isArray(series) || series.length === 0) {
+            if (this.chart) {
+                this.chart.destroy();
+                this.chart = null;
+            }
+            return;
+        }
+
+        const isPercentY =
+            this.yAxisPercentValue && options.chart && options.chart.type === 'bar';
+        if (isPercentY) {
             const y = options.yaxis || {};
             options.yaxis = {
                 ...y,
@@ -66,7 +77,6 @@ export default class extends Controller {
             this.chart = new ApexCharts(this.chartTarget, options);
             this.chart.render();
         } catch (error) {
-            // Keep visible signal in console for intermittent chart update issues.
             console.error('distribution-panel render failed', error);
         }
     }

--- a/src/Statistics/Application/Panel/Distribution/DistributionNumericMetric.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionNumericMetric.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Panel\Distribution;
+
+/**
+ * Whitelist: logical keys in panel config → allocation_stats_projection columns (box plot only).
+ */
+enum DistributionNumericMetric: string
+{
+    case Age = 'age';
+
+    case TransportTimeMinutes = 'transport_time_minutes';
+
+    public function sqlColumn(): string
+    {
+        return match ($this) {
+            self::Age => 'age',
+            self::TransportTimeMinutes => 'transport_time_minutes',
+        };
+    }
+}

--- a/src/Statistics/Application/Panel/Distribution/DistributionNumericMetricMerge.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionNumericMetricMerge.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Panel\Distribution;
+
+final class DistributionNumericMetricMerge
+{
+    /**
+     * Bar chart „Durchschnitt“: mean = allocations / distinct hospitals per cell; total row uses global ratio.
+     *
+     * @param array{
+     *     labels: list<string>,
+     *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
+     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>,
+     *     dimensionKeys: list<int>,
+     *     groupKeys: list<int>,
+     *     hospitalDistinctMatrix: array<int, array<int, int>>
+     * } $distribution
+     * @param array{allocations: int, distinct_hospitals: int}|null $overallParticipation
+     *
+     * @return array{
+     *     labels: list<string>,
+     *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
+     *     table: list<array<string, mixed>>,
+     *     dimensionKeys: list<int>,
+     *     groupKeys: list<int>,
+     *     statsByDimensionGroup: array<int, array<int, array<string, mixed>>>,
+     *     hospitalDistinctMatrix: array<int, array<int, int>>
+     * }
+     */
+    public function mergeCasesPerHospitalBarAverage(array $distribution, ?array $overallParticipation): array
+    {
+        $dimensionKeys = $distribution['dimensionKeys'];
+        $groupKeys = $distribution['groupKeys'];
+        $hospitalDistinct = $distribution['hospitalDistinctMatrix'] ?? [];
+        $table = $distribution['table'];
+        $statsByDg = [];
+
+        $newTable = [];
+        $i = 0;
+        foreach ($dimensionKeys as $dimensionKey) {
+            foreach ($groupKeys as $groupKey) {
+                $row = $table[$i];
+                $value = $row['value'];
+                $distinct = $hospitalDistinct[$groupKey][$dimensionKey] ?? 0;
+                $cellStats = $this->casesPerHospitalCellStats($value, $distinct);
+                $statsByDg[$dimensionKey][$groupKey] = $cellStats;
+                $newTable[] = [
+                    ...$row,
+                    'metricMean' => $this->roundMeanOrNull($cellStats['mean'], $value, $distinct),
+                    'metricN' => $value,
+                ];
+                ++$i;
+            }
+        }
+
+        $totalRow = $table[$i];
+        $totalMean = null;
+        $totalN = 0;
+        if (null !== $overallParticipation && $overallParticipation['distinct_hospitals'] > 0) {
+            $totalMean = round(
+                $overallParticipation['allocations'] / $overallParticipation['distinct_hospitals'],
+                1,
+            );
+            $totalN = $overallParticipation['allocations'];
+        }
+        $newTable[] = [
+            ...$totalRow,
+            'metricMean' => $totalMean,
+            'metricN' => $totalN,
+        ];
+
+        return [
+            'labels' => $distribution['labels'],
+            'series' => $distribution['series'],
+            'table' => $newTable,
+            'dimensionKeys' => $dimensionKeys,
+            'groupKeys' => $groupKeys,
+            'statsByDimensionGroup' => $statsByDg,
+            'hospitalDistinctMatrix' => $hospitalDistinct,
+        ];
+    }
+
+    /**
+     * @return array{n: int, mean: float, min: int, q1: float, median: float, q3: float, max: int}
+     */
+    private function casesPerHospitalCellStats(int $value, int $distinct): array
+    {
+        $mean = 0.0;
+        if ($value > 0 && $distinct > 0) {
+            $mean = (float) $value / (float) $distinct;
+        }
+
+        return [
+            'n' => $value,
+            'mean' => $mean,
+            'min' => 0,
+            'q1' => 0.0,
+            'median' => 0.0,
+            'q3' => 0.0,
+            'max' => 0,
+        ];
+    }
+
+    private function roundMeanOrNull(float $mean, int $value, int $distinct): ?float
+    {
+        if ($value <= 0 || $distinct <= 0) {
+            return null;
+        }
+
+        return round($mean, 1);
+    }
+
+    /**
+     * @param list<array{
+     *     dimension_key: int,
+     *     group_key: int|null,
+     *     n: int,
+     *     mean: float,
+     *     min: int,
+     *     q1: float,
+     *     median: float,
+     *     q3: float,
+     *     max: int
+     * }> $statRows
+     * @param array{
+     *     labels: list<string>,
+     *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
+     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}|array<string, mixed>>,
+     *     dimensionKeys: list<int>,
+     *     groupKeys: list<int>,
+     *     hospitalDistinctMatrix?: array<int, array<int, int>>,
+     *     statsByDimensionGroup?: array<int, array<int, array<string, mixed>>>,
+     * } $distribution
+     * @param array{n: int, mean: float, min: int, q1: float, median: float, q3: float, max: int}|null $overall
+     *
+     * @return array{
+     *     labels: list<string>,
+     *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
+     *     table: list<array<string, mixed>>,
+     *     dimensionKeys: list<int>,
+     *     groupKeys: list<int>,
+     *     statsByDimensionGroup: array<int, array<int, array<string, mixed>>>,
+     *     hospitalDistinctMatrix?: array<int, array<int, int>>,
+     * }
+     */
+    public function mergeBoxplotTable(array $distribution, array $statRows, ?array $overall): array
+    {
+        $statsByDg = $this->statsMap($statRows);
+
+        $dimensionKeys = $distribution['dimensionKeys'];
+        $groupKeys = $distribution['groupKeys'];
+        $table = $distribution['table'];
+        $newTable = [];
+        $i = 0;
+        foreach ($dimensionKeys as $dimensionKey) {
+            foreach ($groupKeys as $groupKey) {
+                $row = $table[$i];
+                $stats = $statsByDg[$dimensionKey][$groupKey] ?? null;
+                $newTable[] = [
+                    ...$row,
+                    ...$this->metricCells($stats),
+                ];
+                ++$i;
+            }
+        }
+
+        $totalRow = $table[$i];
+        $newTable[] = [
+            ...$totalRow,
+            ...$this->metricCells($overall),
+        ];
+
+        $out = [
+            'labels' => $distribution['labels'],
+            'series' => $distribution['series'],
+            'table' => $newTable,
+            'dimensionKeys' => $dimensionKeys,
+            'groupKeys' => $groupKeys,
+            'statsByDimensionGroup' => $statsByDg,
+        ];
+        if (isset($distribution['hospitalDistinctMatrix'])) {
+            $out['hospitalDistinctMatrix'] = $distribution['hospitalDistinctMatrix'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param list<array{dimension_key: int, group_key: int|null, n: int, mean: float, min: int, q1: float, median: float, q3: float, max: int}> $statRows
+     *
+     * @return array<int, array<int, array{n: int, mean: float, min: int, q1: float, median: float, q3: float, max: int}>>
+     */
+    private function statsMap(array $statRows): array
+    {
+        $map = [];
+        foreach ($statRows as $r) {
+            $d = $r['dimension_key'];
+            $g = $r['group_key'] ?? 0;
+            $map[$d][$g] = [
+                'n' => $r['n'],
+                'mean' => $r['mean'],
+                'min' => $r['min'],
+                'q1' => $r['q1'],
+                'median' => $r['median'],
+                'q3' => $r['q3'],
+                'max' => $r['max'],
+            ];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array{n: int, mean: float, min: int, q1: float, median: float, q3: float, max: int}|null $stats
+     *
+     * @return array<string, mixed>
+     */
+    private function metricCells(?array $stats): array
+    {
+        if (null === $stats || $stats['n'] <= 0) {
+            return [
+                'metricN' => 0,
+                'metricMin' => null,
+                'metricQ1' => null,
+                'metricMedian' => null,
+                'metricQ3' => null,
+                'metricMax' => null,
+                'metricMean' => null,
+            ];
+        }
+
+        return [
+            'metricN' => $stats['n'],
+            'metricMin' => $stats['min'],
+            'metricQ1' => round($stats['q1'], 1),
+            'metricMedian' => round($stats['median'], 1),
+            'metricQ3' => round($stats['q3'], 1),
+            'metricMax' => $stats['max'],
+            'metricMean' => round($stats['mean'], 1),
+        ];
+    }
+}

--- a/src/Statistics/Application/Panel/Distribution/DistributionPageConfigResolver.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionPageConfigResolver.php
@@ -47,6 +47,18 @@ final class DistributionPageConfigResolver
     {
         $p = $this->configurePanelResolver()->resolve($panelOptions);
 
+        $averageMetric = $p['average_metric'];
+        if (\is_string($averageMetric) && '' === trim($averageMetric)) {
+            $averageMetric = null;
+        }
+
+        $controls = $p['controls'];
+        if (null !== $averageMetric) {
+            $controls = array_replace([
+                'allow_chart_type_boxplot' => true,
+            ], $controls);
+        }
+
         return new PanelDefinition(
             key: $p['key'],
             type: $p['type'],
@@ -57,8 +69,9 @@ final class DistributionPageConfigResolver
             groupByLabel: $p['group_by_label'],
             filters: $p['filters'],
             options: $p['options'],
-            controls: $p['controls'],
+            controls: $controls,
             filterDefaults: $p['filter_defaults'],
+            averageMetric: $averageMetric,
         );
     }
 
@@ -108,6 +121,7 @@ final class DistributionPageConfigResolver
             'options',
             'controls',
             'filter_defaults',
+            'average_metric',
         ]);
         $resolver->setRequired([
             'key',
@@ -123,6 +137,7 @@ final class DistributionPageConfigResolver
             'group_by_field' => null,
             'group_by_label' => null,
             'filter_defaults' => [],
+            'average_metric' => null,
         ]);
 
         $resolver->setAllowedTypes('key', 'string');
@@ -136,10 +151,29 @@ final class DistributionPageConfigResolver
         $resolver->setAllowedTypes('options', 'array');
         $resolver->setAllowedTypes('controls', 'array');
         $resolver->setAllowedTypes('filter_defaults', 'array');
+        $resolver->setAllowedTypes('average_metric', ['string', 'null']);
 
         $resolver->setAllowedValues('dimension_kind', $dimensionValues);
 
         $resolver->setNormalizer('key', static fn (Options $options, string $value): string => '' !== trim($value) ? $value : throw new \InvalidArgumentException('panel key must be non-empty.'));
+
+        $resolver->setNormalizer('average_metric', static function (Options $options, mixed $value): ?string {
+            if (null === $value || '' === $value) {
+                return null;
+            }
+            if (!\is_string($value)) {
+                throw new \InvalidArgumentException('average_metric must be string or null.');
+            }
+            $trimmed = trim($value);
+            if ('' === $trimmed) {
+                return null;
+            }
+            if (null === DistributionNumericMetric::tryFrom($trimmed)) {
+                throw new \InvalidArgumentException(\sprintf('Unknown average_metric "%s".', $trimmed));
+            }
+
+            return $trimmed;
+        });
 
         return $resolver;
     }

--- a/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
@@ -55,7 +55,7 @@ final readonly class DistributionPanelNumericMetricPolicy
 
     public function needsNumericQuery(string $chartType): bool
     {
-        if (!$this->hasConfiguredMetric() || null === $this->metric()) {
+        if (!$this->hasConfiguredMetric() || !$this->metric() instanceof DistributionNumericMetric) {
             return false;
         }
 

--- a/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Panel\Distribution;
+
+use App\Statistics\Application\Panel\PanelDefinition;
+
+final readonly class DistributionPanelNumericMetricPolicy
+{
+    private function __construct(
+        private PanelDefinition $panel,
+    ) {
+    }
+
+    public static function for(PanelDefinition $panel): self
+    {
+        return new self($panel);
+    }
+
+    public function hasConfiguredMetric(): bool
+    {
+        $m = $this->panel->averageMetric;
+
+        return \is_string($m) && '' !== trim($m);
+    }
+
+    public function metric(): ?DistributionNumericMetric
+    {
+        if (!$this->hasConfiguredMetric()) {
+            return null;
+        }
+
+        return DistributionNumericMetric::tryFrom((string) $this->panel->averageMetric);
+    }
+
+    public function allowsAverageBars(): bool
+    {
+        return true === ($this->panel->controls['allow_bar_basis_average'] ?? false);
+    }
+
+    public function allowsBoxplotChart(): bool
+    {
+        return $this->hasConfiguredMetric()
+            && true === ($this->panel->controls['allow_chart_type_boxplot'] ?? false);
+    }
+
+    /**
+     * SQL fragment for WHERE / aggregates (validated column only).
+     */
+    public function projectionColumnSql(): string
+    {
+        return $this->metric()?->sqlColumn() ?? '';
+    }
+
+    public function needsNumericQuery(string $chartType): bool
+    {
+        if (!$this->hasConfiguredMetric() || !$this->metric() instanceof DistributionNumericMetric) {
+            return false;
+        }
+
+        return 'boxplot' === $chartType;
+    }
+
+    public function showChartTypeControl(): bool
+    {
+        return $this->allowsBoxplotChart();
+    }
+
+    public function showBarBasisControl(): bool
+    {
+        return $this->allowsAverageBars();
+    }
+
+    public function showMeanColumnInBarTable(string $chartType, string $barBasis): bool
+    {
+        return 'bar' === $chartType && 'average' === $barBasis;
+    }
+
+    public function isBoxplotTable(string $chartType): bool
+    {
+        return 'boxplot' === $chartType;
+    }
+}

--- a/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionPanelNumericMetricPolicy.php
@@ -55,7 +55,7 @@ final readonly class DistributionPanelNumericMetricPolicy
 
     public function needsNumericQuery(string $chartType): bool
     {
-        if (!$this->hasConfiguredMetric() || !$this->metric() instanceof DistributionNumericMetric) {
+        if (!$this->hasConfiguredMetric() || null === $this->metric()) {
             return false;
         }
 

--- a/src/Statistics/Application/Panel/Distribution/DistributionTransformer.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionTransformer.php
@@ -9,12 +9,15 @@ use App\Statistics\Application\Mapping\ValueMapper;
 final class DistributionTransformer
 {
     /**
-     * @param list<array{dimension_key: int, group_key: int|null, value: int}> $rows
+     * @param list<array{dimension_key: int, group_key: int|null, value: int, distinct_hospitals?: int}> $rows
      *
      * @return array{
      *     labels: list<string>,
      *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
-     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>
+     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>,
+     *     dimensionKeys: list<int>,
+     *     groupKeys: list<int>,
+     *     hospitalDistinctMatrix: array<int, array<int, int>>
      * }
      */
     public function transform(array $rows, ValueMapper $dimensionMapper, ?ValueMapper $groupMapper): array
@@ -22,6 +25,7 @@ final class DistributionTransformer
         $dimensionValues = [];
         $groupValues = [];
         $matrix = [];
+        $hospitalDistinct = [];
         foreach ($rows as $r) {
             $dimension = $r['dimension_key'];
             $group = $r['group_key'] ?? 0;
@@ -29,6 +33,10 @@ final class DistributionTransformer
             $groupValues[$group] = true;
             $matrix[$group] ??= [];
             $matrix[$group][$dimension] = (int) (($matrix[$group][$dimension] ?? 0) + $r['value']);
+            $distinct = $r['distinct_hospitals'] ?? 0;
+            $hospitalDistinct[$group] ??= [];
+            // One row per (dimension, group) from SQL; duplicates would break COUNT DISTINCT — last row wins.
+            $hospitalDistinct[$group][$dimension] = $distinct;
         }
 
         $dimensionKeys = array_keys($dimensionValues);
@@ -77,6 +85,9 @@ final class DistributionTransformer
             'labels' => $labels,
             'series' => $series,
             'table' => $this->buildTable($dimensionKeys, $groupKeys, $matrix, $dimensionTotals, $dimensionMapper, $groupMapper),
+            'dimensionKeys' => $dimensionKeys,
+            'groupKeys' => $groupKeys,
+            'hospitalDistinctMatrix' => $hospitalDistinct,
         ];
     }
 

--- a/src/Statistics/Application/Panel/Distribution/Renderer.php
+++ b/src/Statistics/Application/Panel/Distribution/Renderer.php
@@ -4,48 +4,214 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application\Panel\Distribution;
 
-final class Renderer
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class Renderer
 {
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
     /**
      * @param array{
      *     labels: list<string>,
      *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
-     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>
+     *     table: list<array<string, mixed>>,
+     *     dimensionKeys?: list<int>,
+     *     groupKeys?: list<int>,
+     *     statsByDimensionGroup?: array<int, array<int, array<string, mixed>>>,
+     *     hospitalDistinctMatrix?: array<int, array<int, int>>,
      * } $distribution
      *
      * @return array{
      *     chart: array<string, mixed>,
-     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>
+     *     table: list<array<string, mixed>>,
+     *     tableMode: string
      * }
      */
-    public function render(array $distribution, string $viewMode): array
-    {
-        $usePercent = \in_array($viewMode, ['percent', 'percent_of_total'], true);
-        $chartSeries = [];
-        foreach ($distribution['series'] as $item) {
-            $chartSeries[] = [
-                'name' => $item['name'],
-                'data' => $usePercent ? $item['percentages'] : $item['values'],
+    public function render(
+        array $distribution,
+        string $viewMode,
+        string $chartType,
+        string $barBasis,
+        ?DistributionNumericMetric $metric,
+    ): array {
+        $table = $distribution['table'];
+        $tableMode = 'boxplot' === $chartType ? 'boxplot' : ('average' === $barBasis ? 'bar_average' : 'bar_counts');
+
+        if ('boxplot' === $chartType) {
+            return [
+                'chart' => $this->buildBoxPlotChart($distribution, $metric),
+                'table' => $table,
+                'tableMode' => $tableMode,
             ];
         }
 
-        $stacked = \in_array($viewMode, ['stacked', 'percent'], true);
+        $usePercent = 'counts' === $barBasis && \in_array($viewMode, ['percent', 'percent_of_total'], true);
+        $chartSeries = [];
+
+        if ('average' === $barBasis) {
+            $statsMap = $distribution['statsByDimensionGroup'] ?? [];
+            $dimensionKeys = $distribution['dimensionKeys'] ?? [];
+            $groupKeys = $distribution['groupKeys'] ?? [];
+            foreach ($groupKeys as $gi => $groupKey) {
+                $name = $distribution['series'][$gi]['name'] ?? (string) $groupKey;
+                $data = [];
+                foreach ($dimensionKeys as $dimensionKey) {
+                    $stats = $statsMap[$dimensionKey][$groupKey] ?? null;
+                    $data[] = null !== $stats && $stats['n'] > 0 ? round((float) $stats['mean'], 2) : 0.0;
+                }
+                $chartSeries[] = ['name' => $name, 'data' => $data];
+            }
+        } else {
+            foreach ($distribution['series'] as $item) {
+                $chartSeries[] = [
+                    'name' => $item['name'],
+                    'data' => $usePercent ? $item['percentages'] : $item['values'],
+                ];
+            }
+        }
+
+        $stacked = 'counts' === $barBasis && \in_array($viewMode, ['stacked', 'percent'], true);
+
+        $yaxis = [];
+        if ($usePercent) {
+            $yaxis['max'] = 100;
+        }
+        if ('average' === $barBasis) {
+            $yaxis['title'] = ['text' => $this->translator->trans('statistics.distribution.bar_basis.average.yaxis_per_hospital')];
+            $yaxis['decimalsInFloat'] = 1;
+        }
 
         return [
             'chart' => [
                 'chart' => [
                     'type' => 'bar',
                     'stacked' => $stacked,
-                    'stackType' => 'percent' === $viewMode ? '100%' : null,
+                    'stackType' => 'counts' === $barBasis && 'percent' === $viewMode ? '100%' : null,
                     'height' => 320,
                     'toolbar' => ['show' => false],
                 ],
                 'xaxis' => ['categories' => $distribution['labels']],
                 'dataLabels' => ['enabled' => false],
-                'yaxis' => $usePercent ? ['max' => 100] : [],
+                'yaxis' => $yaxis,
                 'series' => $chartSeries,
             ],
-            'table' => $distribution['table'],
+            'table' => $table,
+            'tableMode' => $tableMode,
+        ];
+    }
+
+    private function metricYAxisLabel(DistributionNumericMetric $metric): string
+    {
+        $key = 'statistics.distribution.metric.'.$metric->value.'.yaxis';
+
+        return $this->translator->trans($key);
+    }
+
+    /**
+     * @param array{
+     *     labels: list<string>,
+     *     series: list<array{name: string, values: list<int>, percentages: list<float>}>,
+     *     table?: list<array<string, mixed>>,
+     *     dimensionKeys?: list<int>,
+     *     groupKeys?: list<int>,
+     *     statsByDimensionGroup?: array<int, array<int, array<string, mixed>>>,
+     *     hospitalDistinctMatrix?: array<int, array<int, int>>,
+     * } $distribution
+     *
+     * @return array<string, mixed>
+     */
+    private function buildBoxPlotChart(array $distribution, ?DistributionNumericMetric $metric): array
+    {
+        $statsMap = $distribution['statsByDimensionGroup'] ?? null;
+        $dimensionKeys = $distribution['dimensionKeys'] ?? null;
+        $groupKeys = $distribution['groupKeys'] ?? null;
+        $labels = $distribution['labels'];
+        $seriesMeta = $distribution['series'];
+
+        if (!\is_array($statsMap) || !\is_array($dimensionKeys) || !\is_array($groupKeys)) {
+            return $this->emptyBoxPlotFallback($metric);
+        }
+
+        $boxSeries = [];
+        foreach ($groupKeys as $gi => $groupKey) {
+            $name = $seriesMeta[$gi]['name'] ?? (string) $groupKey;
+            $data = [];
+            foreach ($dimensionKeys as $di => $dimensionKey) {
+                $stats = $statsMap[$dimensionKey][$groupKey] ?? null;
+                if (!\is_array($stats) || ($stats['n'] ?? 0) <= 0) {
+                    continue;
+                }
+
+                $data[] = [
+                    'x' => $labels[$di],
+                    'y' => [
+                        (float) $stats['min'],
+                        (float) $stats['q1'],
+                        (float) $stats['median'],
+                        (float) $stats['q3'],
+                        (float) $stats['max'],
+                    ],
+                ];
+            }
+
+            if ([] !== $data) {
+                $boxSeries[] = [
+                    'name' => $name,
+                    'type' => 'boxPlot',
+                    'data' => $data,
+                ];
+            }
+        }
+
+        if ([] === $boxSeries) {
+            return $this->emptyBoxPlotFallback($metric);
+        }
+
+        $yTitle = $metric instanceof DistributionNumericMetric
+            ? $this->metricYAxisLabel($metric)
+            : $this->translator->trans('statistics.distribution.boxplot.yaxis_generic');
+
+        return [
+            'chart' => [
+                'type' => 'boxPlot',
+                'height' => 320,
+                'toolbar' => ['show' => false],
+            ],
+            'xaxis' => [
+                'type' => 'category',
+                'title' => ['text' => $this->translator->trans('statistics.distribution.table.category')],
+            ],
+            'yaxis' => [
+                'title' => ['text' => $yTitle],
+                'decimalsInFloat' => 1,
+            ],
+            'series' => $boxSeries,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyBoxPlotFallback(?DistributionNumericMetric $metric): array
+    {
+        $yTitle = $metric instanceof DistributionNumericMetric
+            ? $this->metricYAxisLabel($metric)
+            : $this->translator->trans('statistics.distribution.boxplot.yaxis_generic');
+
+        return [
+            'chart' => [
+                'type' => 'boxPlot',
+                'height' => 320,
+                'toolbar' => ['show' => false],
+            ],
+            'xaxis' => ['type' => 'category'],
+            'yaxis' => [
+                'title' => ['text' => $yTitle],
+            ],
+            'series' => [],
         ];
     }
 }

--- a/src/Statistics/Application/Panel/PanelDefinition.php
+++ b/src/Statistics/Application/Panel/PanelDefinition.php
@@ -26,6 +26,7 @@ final readonly class PanelDefinition
         public array $options,
         public array $controls,
         public array $filterDefaults = [],
+        public ?string $averageMetric = null,
     ) {
     }
 

--- a/src/Statistics/Infrastructure/Query/DistributionPanelQuery.php
+++ b/src/Statistics/Infrastructure/Query/DistributionPanelQuery.php
@@ -7,6 +7,7 @@ namespace App\Statistics\Infrastructure\Query;
 use App\Statistics\Application\Filter\FilterState;
 use App\Statistics\Application\Panel\Distribution\AgeCohortBucketExpression;
 use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
 use App\Statistics\Application\Panel\PanelDefinition;
 use Doctrine\DBAL\Connection;
 
@@ -19,7 +20,7 @@ final readonly class DistributionPanelQuery
     }
 
     /**
-     * @return list<array{dimension_key: int, group_key: int|null, value: int}>
+     * @return list<array{dimension_key: int, group_key: int|null, value: int, distinct_hospitals: int}>
      */
     public function fetchDistribution(
         PanelDefinition $panel,
@@ -37,13 +38,14 @@ final readonly class DistributionPanelQuery
 
         $filter = $this->sqlFilterBuilder->buildWhere($filterState, $panel);
         $sql = 'SELECT '.$dimensionSelect.' AS dimension_key, '
-            .($groupByField ?? 'NULL').' AS group_key, COUNT(*) AS value '
+            .($groupByField ?? 'NULL').' AS group_key, COUNT(*) AS value, '
+            .'COUNT(DISTINCT hospital_id) AS distinct_hospitals '
             .'FROM allocation_stats_projection'
             .$filter['where']
             .' GROUP BY '.$dimensionSelect.(null === $groupByField ? '' : ', '.$groupByField)
             .' ORDER BY '.$dimensionSelect.(null === $groupByField ? '' : ', '.$groupByField);
 
-        /** @var list<array{dimension_key: mixed, group_key: mixed, value: mixed}> $rows */
+        /** @var list<array{dimension_key: mixed, group_key: mixed, value: mixed, distinct_hospitals: mixed}> $rows */
         $rows = $this->connection->fetchAllAssociative($sql, $filter['params'], $filter['types']);
 
         $out = [];
@@ -53,9 +55,193 @@ final readonly class DistributionPanelQuery
                 'dimension_key' => (int) $row['dimension_key'],
                 'group_key' => null === $groupRaw || '' === $groupRaw ? null : (int) $groupRaw,
                 'value' => (int) $row['value'],
+                'distinct_hospitals' => (int) $row['distinct_hospitals'],
             ];
         }
 
         return $out;
+    }
+
+    /**
+     * Overall case count and participating hospitals for the current filter (no dimension/group breakdown).
+     *
+     * @return array{allocations: int, distinct_hospitals: int}|null null when no rows
+     */
+    public function fetchOverallHospitalParticipation(
+        PanelDefinition $panel,
+        FilterState $filterState,
+    ): ?array {
+        $filter = $this->sqlFilterBuilder->buildWhere($filterState, $panel);
+        $sql = 'SELECT COUNT(*) AS allocations, COUNT(DISTINCT hospital_id) AS distinct_hospitals '
+            .'FROM allocation_stats_projection'
+            .$filter['where'];
+
+        $row = $this->connection->fetchAssociative($sql, $filter['params'], $filter['types']);
+
+        if (!\is_array($row)) {
+            return null;
+        }
+
+        $allocations = (int) $row['allocations'];
+        if ($allocations <= 0) {
+            return null;
+        }
+
+        return [
+            'allocations' => $allocations,
+            'distinct_hospitals' => max(0, (int) $row['distinct_hospitals']),
+        ];
+    }
+
+    /**
+     * Aggregates on a numeric projection column (non-null only), same GROUP BY as fetchDistribution.
+     *
+     * @return list<array{
+     *     dimension_key: int,
+     *     group_key: int|null,
+     *     n: int,
+     *     mean: float,
+     *     min: int,
+     *     q1: float,
+     *     median: float,
+     *     q3: float,
+     *     max: int
+     * }>
+     */
+    public function fetchNumericDistributionStats(
+        PanelDefinition $panel,
+        FilterState $filterState,
+        DistributionNumericMetric $metric,
+        ?string $groupByField = null,
+    ): array {
+        if (!\is_string($groupByField) || '' === $groupByField) {
+            $groupByField = null;
+        }
+
+        $column = $metric->sqlColumn();
+        $dimensionSelect = match ($panel->dimensionKind) {
+            DimensionKind::AgeCohort => '('.AgeCohortBucketExpression::sql('age').')',
+            DimensionKind::Column => $panel->dimensionField,
+        };
+
+        $filter = $this->sqlFilterBuilder->buildWhere($filterState, $panel);
+        $where = $this->appendColumnNotNull($filter['where'], $column);
+
+        $sql = 'SELECT '.$dimensionSelect.' AS dimension_key, '
+            .($groupByField ?? 'NULL').' AS group_key, '
+            .'COUNT(*) AS n, '
+            .'AVG('.$column.')::double precision AS mean_val, '
+            .'MIN('.$column.') AS min_val, '
+            .'percentile_cont(0.25) WITHIN GROUP (ORDER BY '.$column.') AS q1_val, '
+            .'percentile_cont(0.5) WITHIN GROUP (ORDER BY '.$column.') AS median_val, '
+            .'percentile_cont(0.75) WITHIN GROUP (ORDER BY '.$column.') AS q3_val, '
+            .'MAX('.$column.') AS max_val '
+            .'FROM allocation_stats_projection'
+            .$where
+            .' GROUP BY '.$dimensionSelect.(null === $groupByField ? '' : ', '.$groupByField)
+            .' ORDER BY '.$dimensionSelect.(null === $groupByField ? '' : ', '.$groupByField);
+
+        $rows = $this->connection->fetchAllAssociative($sql, $filter['params'], $filter['types']);
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = $this->mapNumericStatsRow($row);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{
+     *     n: int,
+     *     mean: float,
+     *     min: int,
+     *     q1: float,
+     *     median: float,
+     *     q3: float,
+     *     max: int
+     * }|null
+     */
+    public function fetchOverallNumericStats(
+        PanelDefinition $panel,
+        FilterState $filterState,
+        DistributionNumericMetric $metric,
+    ): ?array {
+        $column = $metric->sqlColumn();
+        $filter = $this->sqlFilterBuilder->buildWhere($filterState, $panel);
+        $where = $this->appendColumnNotNull($filter['where'], $column);
+
+        $sql = 'SELECT '
+            .'COUNT(*) AS n, '
+            .'AVG('.$column.')::double precision AS mean_val, '
+            .'MIN('.$column.') AS min_val, '
+            .'percentile_cont(0.25) WITHIN GROUP (ORDER BY '.$column.') AS q1_val, '
+            .'percentile_cont(0.5) WITHIN GROUP (ORDER BY '.$column.') AS median_val, '
+            .'percentile_cont(0.75) WITHIN GROUP (ORDER BY '.$column.') AS q3_val, '
+            .'MAX('.$column.') AS max_val '
+            .'FROM allocation_stats_projection'
+            .$where;
+
+        $row = $this->connection->fetchAssociative($sql, $filter['params'], $filter['types']);
+
+        if (!\is_array($row)) {
+            return null;
+        }
+
+        $n = (int) $row['n'];
+        if ($n <= 0) {
+            return null;
+        }
+
+        return [
+            'n' => $n,
+            'mean' => (float) $row['mean_val'],
+            'min' => (int) $row['min_val'],
+            'q1' => (float) $row['q1_val'],
+            'median' => (float) $row['median_val'],
+            'q3' => (float) $row['q3_val'],
+            'max' => (int) $row['max_val'],
+        ];
+    }
+
+    private function appendColumnNotNull(string $where, string $column): string
+    {
+        if ('' === $where) {
+            return ' WHERE '.$column.' IS NOT NULL';
+        }
+
+        return $where.' AND '.$column.' IS NOT NULL';
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return array{
+     *     dimension_key: int,
+     *     group_key: int|null,
+     *     n: int,
+     *     mean: float,
+     *     min: int,
+     *     q1: float,
+     *     median: float,
+     *     q3: float,
+     *     max: int
+     * }
+     */
+    private function mapNumericStatsRow(array $row): array
+    {
+        $groupRaw = $row['group_key'];
+
+        return [
+            'dimension_key' => (int) $row['dimension_key'],
+            'group_key' => null === $groupRaw || '' === $groupRaw ? null : (int) $groupRaw,
+            'n' => (int) $row['n'],
+            'mean' => (float) $row['mean_val'],
+            'min' => (int) $row['min_val'],
+            'q1' => (float) $row['q1_val'],
+            'median' => (float) $row['median_val'],
+            'q3' => (float) $row['q3_val'],
+            'max' => (int) $row['max_val'],
+        ];
     }
 }

--- a/src/Statistics/UI/Http/Controller/Distribution/AgeCohortDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/AgeCohortDistributionController.php
@@ -29,7 +29,11 @@ final class AgeCohortDistributionController extends AbstractController
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
      */
     private function pageOptions(): array
     {
@@ -47,7 +51,12 @@ final class AgeCohortDistributionController extends AbstractController
                     'group_by_label' => 'statistics.distribution.dim.hospital_tier',
                     'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
                     'options' => ['default_view' => 'absolute', 'show_percent' => false],
-                    'controls' => ['allow_view_mode_toggle' => true, 'allow_group_by' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'age',
                     'filter_defaults' => [
                         'date_range' => 'all_cases',
                         'hospital_tier' => [],

--- a/src/Statistics/UI/Http/Controller/Distribution/GenderDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/GenderDistributionController.php
@@ -29,7 +29,11 @@ final class GenderDistributionController extends AbstractController
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
      */
     private function pageOptions(): array
     {
@@ -47,7 +51,12 @@ final class GenderDistributionController extends AbstractController
                     'group_by_label' => 'statistics.distribution.dim.hospital_tier',
                     'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
                     'options' => ['default_view' => 'grouped', 'show_percent' => true],
-                    'controls' => ['allow_view_mode_toggle' => true, 'allow_group_by' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'age',
                     'filter_defaults' => [
                         'date_range' => 'all_cases',
                         'hospital_tier' => [],

--- a/src/Statistics/UI/Http/Controller/Distribution/UrgencyDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/UrgencyDistributionController.php
@@ -29,7 +29,11 @@ final class UrgencyDistributionController extends AbstractController
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
      */
     private function pageOptions(): array
     {
@@ -47,7 +51,12 @@ final class UrgencyDistributionController extends AbstractController
                     'group_by_label' => 'statistics.distribution.dim.hospital_tier',
                     'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
                     'options' => ['default_view' => 'grouped', 'show_percent' => true],
-                    'controls' => ['allow_view_mode_toggle' => true, 'allow_group_by' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'age',
                     'filter_defaults' => [
                         'date_range' => 'all_cases',
                         'hospital_tier' => [],

--- a/src/Statistics/UI/Live/DistributionPanelComponent.php
+++ b/src/Statistics/UI/Live/DistributionPanelComponent.php
@@ -15,8 +15,11 @@ use App\Statistics\Application\Mapping\HospitalTypeValueMapper;
 use App\Statistics\Application\Mapping\TriageValueMapper;
 use App\Statistics\Application\Mapping\ValueMapper;
 use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetricMerge;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfig;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use App\Statistics\Application\Panel\Distribution\DistributionPanelNumericMetricPolicy;
 use App\Statistics\Application\Panel\Distribution\DistributionSectionNavProvider;
 use App\Statistics\Application\Panel\Distribution\DistributionTransformer;
 use App\Statistics\Application\Panel\Distribution\Renderer;
@@ -33,7 +36,16 @@ final class DistributionPanelComponent
 {
     use DefaultActionTrait;
 
-    /** @var array<string, mixed> */
+    /**
+     * @var (
+     *     array{
+     *         route_name: string,
+     *         section_key: string,
+     *         panels: list<array<string, mixed>>,
+     *         default_panel_key?: string|null,
+     *     }|array{}
+     * )
+     */
     #[LiveProp(writable: true)]
     public array $distributionPageOptions = [];
 
@@ -50,12 +62,19 @@ final class DistributionPanelComponent
     #[LiveProp(writable: true)]
     public string $groupedBy = 'none';
 
+    #[LiveProp(writable: true)]
+    public string $chartType = 'bar';
+
+    #[LiveProp(writable: true)]
+    public string $barBasis = 'counts';
+
     public function __construct(
         private readonly DistributionSectionNavProvider $distributionSectionNavProvider,
         private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
         private readonly QueryStateResolver $queryStateResolver,
         private readonly DistributionPanelQuery $distributionPanelQuery,
         private readonly DistributionTransformer $transformer,
+        private readonly DistributionNumericMetricMerge $distributionNumericMetricMerge,
         private readonly Renderer $renderer,
         private readonly TriageValueMapper $triageMapper,
         private readonly GenderValueMapper $genderValueMapper,
@@ -68,7 +87,12 @@ final class DistributionPanelComponent
     }
 
     /**
-     * @param array<string, mixed> $distributionPageOptions
+     * @param array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     *     default_panel_key?: string|null,
+     * } $distributionPageOptions
      */
     public function mount(array $distributionPageOptions): void
     {
@@ -97,13 +121,18 @@ final class DistributionPanelComponent
 
         $showPercent = true === ($panel->options['show_percent'] ?? false);
         $this->viewMode = $this->queryStateResolver->resolveViewMode($request->query, $panel, $showPercent);
+
+        $this->chartType = $request->query->getString('chart_type', 'bar');
+        $this->barBasis = $request->query->getString('bar_basis', 'counts');
+        $this->normalizeChartState($panel);
         $this->viewMode = $this->normalizeViewMode($this->viewMode);
     }
 
     /**
      * @return array{
      *     chart: array<string, mixed>,
-     *     table: list<array{dimensionLabel: string, groupLabel: string|null, value: int, percent: float, isTotal: bool}>
+     *     table: list<array<string, mixed>>,
+     *     tableMode: string
      * }
      */
     public function getRenderedData(): array
@@ -111,6 +140,10 @@ final class DistributionPanelComponent
         $pageConfig = $this->pageConfig();
         $panel = $pageConfig->getPanel($this->panelKey) ?? $pageConfig->defaultPanel();
         $filterState = new FilterState($this->effectiveFilterValues($panel));
+        $policy = DistributionPanelNumericMetricPolicy::for($panel);
+        $metric = $policy->metric();
+
+        $this->normalizeChartState($panel);
 
         $groupByField = match ($this->groupedBy) {
             'tier' => 'hospital_tier_code',
@@ -125,9 +158,31 @@ final class DistributionPanelComponent
             $this->groupMapperForSelection(),
         );
 
+        if ('bar' === $this->chartType && 'average' === $this->barBasis && $policy->allowsAverageBars()) {
+            $overallH = $this->distributionPanelQuery->fetchOverallHospitalParticipation($panel, $filterState);
+            $distribution = $this->distributionNumericMetricMerge->mergeCasesPerHospitalBarAverage($distribution, $overallH);
+        }
+
+        if ($policy->needsNumericQuery($this->chartType) && $metric instanceof DistributionNumericMetric) {
+            $statRows = $this->distributionPanelQuery->fetchNumericDistributionStats(
+                $panel,
+                $filterState,
+                $metric,
+                $groupByField,
+            );
+            $overall = $this->distributionPanelQuery->fetchOverallNumericStats($panel, $filterState, $metric);
+            $distribution = $this->distributionNumericMetricMerge->mergeBoxplotTable($distribution, $statRows, $overall);
+        }
+
         $this->viewMode = $this->normalizeViewMode($this->viewMode);
 
-        return $this->renderer->render($distribution, $this->viewMode);
+        return $this->renderer->render(
+            $distribution,
+            $this->viewMode,
+            $this->chartType,
+            $this->barBasis,
+            $metric,
+        );
     }
 
     /**
@@ -141,6 +196,8 @@ final class DistributionPanelComponent
         $state['panel'] = $this->panelKey;
         $state['grouped_by'] = $this->groupedBy;
         $state['view'] = $this->normalizeViewMode($this->viewMode);
+        $state['chart_type'] = $this->chartType;
+        $state['bar_basis'] = $this->barBasis;
 
         return $state;
     }
@@ -153,6 +210,8 @@ final class DistributionPanelComponent
         return [
             'view' => $this->normalizeViewMode($this->viewMode),
             'grouped_by' => $this->groupedBy,
+            'chart_type' => $this->chartType,
+            'bar_basis' => $this->barBasis,
             'f' => $this->effectiveFilterValues($panel),
         ];
     }
@@ -164,11 +223,24 @@ final class DistributionPanelComponent
 
     public function pageConfig(): DistributionPageConfig
     {
+        $this->assertDistributionPageOptionsNotEmpty();
+
+        return $this->distributionPageConfigResolver->resolve($this->distributionPageOptions);
+    }
+
+    /**
+     * @psalm-assert array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     *     default_panel_key?: string|null,
+     * } $this->distributionPageOptions
+     */
+    private function assertDistributionPageOptionsNotEmpty(): void
+    {
         if ([] === $this->distributionPageOptions) {
             throw new \LogicException('distributionPageOptions must be set (e.g. from the distribution controller via Twig).');
         }
-
-        return $this->distributionPageConfigResolver->resolve($this->distributionPageOptions);
     }
 
     /**
@@ -192,6 +264,14 @@ final class DistributionPanelComponent
      */
     public function getAllowedViewModes(): array
     {
+        if ('boxplot' === $this->chartType) {
+            return ['absolute'];
+        }
+
+        if ('average' === $this->barBasis) {
+            return 'none' === $this->groupedBy ? ['absolute'] : ['grouped'];
+        }
+
         if ('none' === $this->groupedBy) {
             return ['absolute', 'percent_of_total'];
         }
@@ -250,8 +330,33 @@ final class DistributionPanelComponent
     public function showViewModeToggle(): bool
     {
         $panel = $this->pageConfig()->getPanel($this->panelKey) ?? $this->pageConfig()->defaultPanel();
+        $base = true === ($panel->controls['allow_view_mode_toggle'] ?? false);
 
-        return true === ($panel->controls['allow_view_mode_toggle'] ?? false);
+        return $base
+            && 'bar' === $this->chartType
+            && 'counts' === $this->barBasis;
+    }
+
+    public function showChartTypeControl(): bool
+    {
+        $panel = $this->pageConfig()->getPanel($this->panelKey) ?? $this->pageConfig()->defaultPanel();
+
+        return DistributionPanelNumericMetricPolicy::for($panel)->showChartTypeControl();
+    }
+
+    public function showBarBasisControl(): bool
+    {
+        $panel = $this->pageConfig()->getPanel($this->panelKey) ?? $this->pageConfig()->defaultPanel();
+
+        return 'bar' === $this->chartType
+            && DistributionPanelNumericMetricPolicy::for($panel)->showBarBasisControl();
+    }
+
+    public function useYAxisPercentFormatter(): bool
+    {
+        return 'bar' === $this->chartType
+            && 'counts' === $this->barBasis
+            && \in_array($this->viewMode, ['percent', 'percent_of_total'], true);
     }
 
     /**
@@ -305,6 +410,31 @@ final class DistributionPanelComponent
         }
 
         return $out;
+    }
+
+    private function normalizeChartState(PanelDefinition $panel): void
+    {
+        $policy = DistributionPanelNumericMetricPolicy::for($panel);
+
+        if (!\in_array($this->chartType, ['bar', 'boxplot'], true)) {
+            $this->chartType = 'bar';
+        }
+
+        if ('boxplot' === $this->chartType && !$policy->allowsBoxplotChart()) {
+            $this->chartType = 'bar';
+        }
+
+        if (!\in_array($this->barBasis, ['counts', 'average'], true)) {
+            $this->barBasis = 'counts';
+        }
+
+        if ('average' === $this->barBasis && !$policy->allowsAverageBars()) {
+            $this->barBasis = 'counts';
+        }
+
+        if ('boxplot' === $this->chartType) {
+            $this->barBasis = 'counts';
+        }
     }
 
     private function dimensionMapperFor(PanelDefinition $panel): ValueMapper

--- a/src/Statistics/UI/Twig/templates/components/AgeChart.html.twig
+++ b/src/Statistics/UI/Twig/templates/components/AgeChart.html.twig
@@ -55,6 +55,10 @@
     </div>
 
     <div class="card-body">
+        <p class="text-muted small mb-3">
+            <a href="{{ path('app_stats_distribution_age') }}">{{ 'statistics.distribution.dashboard_age_cohort_link'|trans }}</a>
+            <span class="d-none d-sm-inline"> — {{ 'statistics.distribution.dashboard_age_cohort_link_hint'|trans }}</span>
+        </p>
         {% if not this.hasData() %}
             <div class="empty">
                 <div class="empty-icon"><i class="ti ti-chart-bar"></i></div>

--- a/src/Statistics/UI/Twig/templates/components/DistributionPanel.html.twig
+++ b/src/Statistics/UI/Twig/templates/components/DistributionPanel.html.twig
@@ -98,6 +98,24 @@
                                 </select>
                             </div>
                         {% endif %}
+                        {% if this.showChartTypeControl %}
+                            <div class="col-auto">
+                                <label class="form-label">{{ 'statistics.distribution.chart_type'|trans }}</label>
+                                <select class="form-select" data-model="chartType" data-action="change->analytics-url-state#sync" name="chart_type">
+                                    <option value="bar" {{ this.chartType == 'bar' ? 'selected' : '' }}>{{ 'statistics.distribution.chart_type.bar'|trans }}</option>
+                                    <option value="boxplot" {{ this.chartType == 'boxplot' ? 'selected' : '' }}>{{ 'statistics.distribution.chart_type.boxplot'|trans }}</option>
+                                </select>
+                            </div>
+                        {% endif %}
+                        {% if this.showBarBasisControl %}
+                            <div class="col-auto">
+                                <label class="form-label">{{ 'statistics.distribution.bar_basis'|trans }}</label>
+                                <select class="form-select" data-model="barBasis" data-action="change->analytics-url-state#sync" name="bar_basis">
+                                    <option value="counts" {{ this.barBasis == 'counts' ? 'selected' : '' }}>{{ 'statistics.distribution.bar_basis.counts'|trans }}</option>
+                                    <option value="average" {{ this.barBasis == 'average' ? 'selected' : '' }}>{{ 'statistics.distribution.bar_basis.average'|trans }}</option>
+                                </select>
+                            </div>
+                        {% endif %}
                         {% if this.showViewModeToggle %}
                             <div class="col-auto">
                                 <label class="form-label">{{ 'statistics.distribution.chart_mode'|trans }}</label>
@@ -117,15 +135,19 @@
             {% set rendered = this.renderedData %}
             {% set chart = rendered.chart %}
             {% set tableRows = rendered.table %}
+            {% set tableMode = rendered.tableMode %}
 
             <div class="card mb-3">
                 <div class="card-body">
                     <div
                         data-controller="distribution-panel"
                         data-distribution-panel-options-value="{{ chart|json_encode|e('html_attr') }}"
-                        data-distribution-panel-y-axis-percent-value="{{ this.viewMode in ['percent', 'percent_of_total'] ? 'true' : 'false' }}"
+                        data-distribution-panel-y-axis-percent-value="{{ this.useYAxisPercentFormatter ? 'true' : 'false' }}"
                     >
                         <div class="position-relative mb-4" style="min-height: 320px" data-distribution-panel-target="chart" data-live-ignore></div>
+                        {% if tableMode == 'boxplot' and (chart.series is not defined or chart.series is empty) %}
+                            <p class="text-muted small mb-0">{{ 'statistics.distribution.boxplot.empty'|trans }}</p>
+                        {% endif %}
                     </div>
                     <div class="table-responsive">
                         <table class="table table-vcenter card-table table-striped text-nowrap">
@@ -135,8 +157,21 @@
                                 {% if this.groupedBy != 'none' %}
                                     <th>{{ 'statistics.distribution.table.group'|trans }}</th>
                                 {% endif %}
-                                <th class="text-end">{{ 'statistics.distribution.table.count'|trans }}</th>
-                                <th class="text-end">{{ 'statistics.distribution.table.percent'|trans }}</th>
+                                {% if tableMode != 'boxplot' %}
+                                    <th class="text-end">{{ 'statistics.distribution.table.count'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.percent'|trans }}</th>
+                                {% endif %}
+                                {% if tableMode == 'boxplot' %}
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_n'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_min'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_q1'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_median'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_q3'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_max'|trans }}</th>
+                                    <th class="text-end">{{ 'statistics.distribution.table.metric_mean'|trans }}</th>
+                                {% elseif tableMode == 'bar_average' %}
+                                    <th class="text-end">{{ 'statistics.distribution.bar_basis.average.table_mean_per_hospital'|trans }}</th>
+                                {% endif %}
                             </tr>
                             </thead>
                             <tbody>
@@ -146,8 +181,21 @@
                                     {% if this.groupedBy != 'none' %}
                                         <td>{{ row.groupLabel }}</td>
                                     {% endif %}
-                                    <td class="text-end">{{ row.value }}</td>
-                                    <td class="text-end">{{ row.percent }}%</td>
+                                    {% if tableMode != 'boxplot' %}
+                                        <td class="text-end">{{ row.value }}</td>
+                                        <td class="text-end">{{ row.percent }}%</td>
+                                    {% endif %}
+                                    {% if tableMode == 'boxplot' %}
+                                        <td class="text-end">{{ row.metricN|default(0) }}</td>
+                                        <td class="text-end">{% if row.metricMin is not null %}{{ row.metricMin|number_format(0, ',', '.') }}{% else %}–{% endif %}</td>
+                                        <td class="text-end">{% if row.metricQ1 is not null %}{{ row.metricQ1|number_format(1, ',', '.') }}{% else %}–{% endif %}</td>
+                                        <td class="text-end">{% if row.metricMedian is not null %}{{ row.metricMedian|number_format(1, ',', '.') }}{% else %}–{% endif %}</td>
+                                        <td class="text-end">{% if row.metricQ3 is not null %}{{ row.metricQ3|number_format(1, ',', '.') }}{% else %}–{% endif %}</td>
+                                        <td class="text-end">{% if row.metricMax is not null %}{{ row.metricMax|number_format(0, ',', '.') }}{% else %}–{% endif %}</td>
+                                        <td class="text-end">{% if row.metricMean is not null %}{{ row.metricMean|number_format(1, ',', '.') }}{% else %}–{% endif %}</td>
+                                    {% elseif tableMode == 'bar_average' %}
+                                        <td class="text-end">{% if row.metricMean is not null %}{{ row.metricMean|number_format(1, ',', '.') }}{% else %}–{% endif %}</td>
+                                    {% endif %}
                                 </tr>
                             {% endfor %}
                             </tbody>

--- a/tests/Statistics/Fixtures/DistributionPanelFixtures.php
+++ b/tests/Statistics/Fixtures/DistributionPanelFixtures.php
@@ -25,7 +25,12 @@ final class DistributionPanelFixtures
             'group_by_label' => 'statistics.distribution.dim.hospital_tier',
             'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
             'options' => ['default_view' => 'grouped', 'show_percent' => true],
-            'controls' => ['allow_view_mode_toggle' => true, 'allow_group_by' => true],
+            'controls' => [
+                'allow_view_mode_toggle' => true,
+                'allow_group_by' => true,
+                'allow_bar_basis_average' => true,
+            ],
+            'average_metric' => 'age',
             'filter_defaults' => [
                 'date_range' => 'all_cases',
                 'hospital_tier' => [],
@@ -49,7 +54,12 @@ final class DistributionPanelFixtures
             'group_by_label' => 'statistics.distribution.dim.hospital_tier',
             'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
             'options' => ['default_view' => 'absolute', 'show_percent' => false],
-            'controls' => ['allow_view_mode_toggle' => true, 'allow_group_by' => true],
+            'controls' => [
+                'allow_view_mode_toggle' => true,
+                'allow_group_by' => true,
+                'allow_bar_basis_average' => true,
+            ],
+            'average_metric' => 'age',
             'filter_defaults' => [
                 'date_range' => 'all_cases',
                 'hospital_tier' => [],

--- a/tests/Statistics/Functional/Controller/DistributionPagesControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DistributionPagesControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Functional\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DistributionPagesControllerTest extends WebTestCase
+{
+    public function testUrgencyDistributionPageIsReachable(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/statistics/distribution/urgency');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testGenderDistributionPageIsReachable(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/statistics/distribution/gender');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testAgeCohortDistributionPageIsReachable(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/statistics/distribution/age');
+
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionNumericMetricMergeTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionNumericMetricMergeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Panel\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetricMerge;
+use PHPUnit\Framework\TestCase;
+
+final class DistributionNumericMetricMergeTest extends TestCase
+{
+    public function testMergeCasesPerHospitalBarAverageUsesValueOverDistinctAndOverallRatio(): void
+    {
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [
+                [
+                    'name' => 'Gesamt',
+                    'values' => [1, 2],
+                    'percentages' => [50.0, 50.0],
+                ],
+            ],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [0],
+            'hospitalDistinctMatrix' => [
+                0 => [
+                    1 => 1,
+                    2 => 0,
+                ],
+            ],
+            'table' => [
+                [
+                    'dimensionLabel' => 'A',
+                    'groupLabel' => null,
+                    'value' => 1,
+                    'percent' => 50.0,
+                    'isTotal' => false,
+                ],
+                [
+                    'dimensionLabel' => 'B',
+                    'groupLabel' => null,
+                    'value' => 2,
+                    'percent' => 50.0,
+                    'isTotal' => false,
+                ],
+                [
+                    'dimensionLabel' => 'Total',
+                    'groupLabel' => null,
+                    'value' => 3,
+                    'percent' => 100.0,
+                    'isTotal' => true,
+                ],
+            ],
+        ];
+
+        $overall = ['allocations' => 10, 'distinct_hospitals' => 4];
+
+        $merged = new DistributionNumericMetricMerge()->mergeCasesPerHospitalBarAverage($distribution, $overall);
+
+        self::assertEqualsWithDelta(1.0, (float) $merged['table'][0]['metricMean'], 0.001);
+        self::assertSame(1, $merged['table'][0]['metricN']);
+        self::assertNull($merged['table'][1]['metricMean']);
+        self::assertSame(2, $merged['table'][1]['metricN']);
+        self::assertSame(2.5, $merged['table'][2]['metricMean']);
+        self::assertSame(10, $merged['table'][2]['metricN']);
+
+        self::assertEqualsWithDelta(1.0, (float) $merged['statsByDimensionGroup'][1][0]['mean'], 0.001);
+        self::assertEqualsWithDelta(0.0, (float) $merged['statsByDimensionGroup'][2][0]['mean'], 0.001);
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionNumericMetricMergeTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionNumericMetricMergeTest.php
@@ -67,4 +67,145 @@ final class DistributionNumericMetricMergeTest extends TestCase
         self::assertEqualsWithDelta(1.0, (float) $merged['statsByDimensionGroup'][1][0]['mean'], 0.001);
         self::assertEqualsWithDelta(0.0, (float) $merged['statsByDimensionGroup'][2][0]['mean'], 0.001);
     }
+
+    public function testMergeCasesPerHospitalBarAverageWithNullOverallLeavesTotalMetricEmpty(): void
+    {
+        $distribution = [
+            'labels' => ['A'],
+            'series' => [['name' => 'Gesamt', 'values' => [3], 'percentages' => [100.0]]],
+            'dimensionKeys' => [1],
+            'groupKeys' => [0],
+            'hospitalDistinctMatrix' => [0 => [1 => 2]],
+            'table' => [
+                ['dimensionLabel' => 'A', 'groupLabel' => null, 'value' => 3, 'percent' => 100.0, 'isTotal' => false],
+                ['dimensionLabel' => 'Total', 'groupLabel' => null, 'value' => 3, 'percent' => 100.0, 'isTotal' => true],
+            ],
+        ];
+
+        $merged = new DistributionNumericMetricMerge()->mergeCasesPerHospitalBarAverage($distribution, null);
+
+        self::assertSame(1.5, $merged['table'][0]['metricMean']);
+        self::assertNull($merged['table'][1]['metricMean']);
+        self::assertSame(0, $merged['table'][1]['metricN']);
+    }
+
+    public function testMergeCasesPerHospitalBarAverageMultipleGroups(): void
+    {
+        $distribution = [
+            'labels' => ['A'],
+            'series' => [
+                ['name' => 'G10', 'values' => [2], 'percentages' => [100.0]],
+                ['name' => 'G20', 'values' => [4], 'percentages' => [100.0]],
+            ],
+            'dimensionKeys' => [1],
+            'groupKeys' => [10, 20],
+            'hospitalDistinctMatrix' => [
+                10 => [1 => 2],
+                20 => [1 => 1],
+            ],
+            'table' => [
+                ['dimensionLabel' => 'A', 'groupLabel' => 'G10', 'value' => 2, 'percent' => 33.33, 'isTotal' => false],
+                ['dimensionLabel' => 'A', 'groupLabel' => 'G20', 'value' => 4, 'percent' => 66.67, 'isTotal' => false],
+                ['dimensionLabel' => 'Total', 'groupLabel' => null, 'value' => 6, 'percent' => 100.0, 'isTotal' => true],
+            ],
+        ];
+
+        $merged = new DistributionNumericMetricMerge()->mergeCasesPerHospitalBarAverage(
+            $distribution,
+            ['allocations' => 12, 'distinct_hospitals' => 3],
+        );
+
+        self::assertSame(1.0, $merged['table'][0]['metricMean']);
+        self::assertSame(4.0, $merged['table'][1]['metricMean']);
+        self::assertSame(4.0, $merged['table'][2]['metricMean']);
+    }
+
+    public function testMergeBoxplotTableFillsMetricCellsPerDimensionAndGroup(): void
+    {
+        $statRow = static fn (int $d, int $g, int $n): array => [
+            'dimension_key' => $d,
+            'group_key' => $g,
+            'n' => $n,
+            'mean' => 10.0,
+            'min' => 1,
+            'q1' => 2.0,
+            'median' => 5.0,
+            'q3' => 8.0,
+            'max' => 9,
+        ];
+
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [
+                ['name' => 'G10', 'values' => [1, 1], 'percentages' => [50.0, 50.0]],
+                ['name' => 'G20', 'values' => [1, 1], 'percentages' => [50.0, 50.0]],
+            ],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [10, 20],
+            'table' => [
+                ['dimensionLabel' => 'A', 'groupLabel' => 'G10', 'value' => 1, 'percent' => 50.0, 'isTotal' => false],
+                ['dimensionLabel' => 'A', 'groupLabel' => 'G20', 'value' => 1, 'percent' => 50.0, 'isTotal' => false],
+                ['dimensionLabel' => 'B', 'groupLabel' => 'G10', 'value' => 1, 'percent' => 50.0, 'isTotal' => false],
+                ['dimensionLabel' => 'B', 'groupLabel' => 'G20', 'value' => 1, 'percent' => 50.0, 'isTotal' => false],
+                ['dimensionLabel' => 'Total', 'groupLabel' => null, 'value' => 4, 'percent' => 100.0, 'isTotal' => true],
+            ],
+        ];
+
+        $statRows = [
+            $statRow(1, 10, 3),
+            $statRow(1, 20, 0),
+            $statRow(2, 10, 2),
+            $statRow(2, 20, 4),
+        ];
+
+        $overall = [
+            'n' => 9,
+            'mean' => 11.0,
+            'min' => 0,
+            'q1' => 3.0,
+            'median' => 6.0,
+            'q3' => 9.0,
+            'max' => 12,
+        ];
+
+        $merged = new DistributionNumericMetricMerge()->mergeBoxplotTable($distribution, $statRows, $overall);
+
+        self::assertSame(3, $merged['table'][0]['metricN']);
+        self::assertSame(0, $merged['table'][1]['metricN']);
+        self::assertNull($merged['table'][1]['metricMean']);
+        self::assertSame(9, $merged['table'][4]['metricN']);
+        self::assertSame(11.0, $merged['table'][4]['metricMean']);
+    }
+
+    public function testMergeBoxplotTableWithNullOverallUsesEmptyMetricCellsOnTotal(): void
+    {
+        $distribution = [
+            'labels' => ['A'],
+            'series' => [['name' => 'Gesamt', 'values' => [1], 'percentages' => [100.0]]],
+            'dimensionKeys' => [1],
+            'groupKeys' => [0],
+            'table' => [
+                ['dimensionLabel' => 'A', 'groupLabel' => null, 'value' => 1, 'percent' => 100.0, 'isTotal' => false],
+                ['dimensionLabel' => 'Total', 'groupLabel' => null, 'value' => 1, 'percent' => 100.0, 'isTotal' => true],
+            ],
+        ];
+
+        $statRows = [[
+            'dimension_key' => 1,
+            'group_key' => null,
+            'n' => 2,
+            'mean' => 4.0,
+            'min' => 1,
+            'q1' => 2.0,
+            'median' => 3.0,
+            'q3' => 5.0,
+            'max' => 6,
+        ]];
+
+        $merged = new DistributionNumericMetricMerge()->mergeBoxplotTable($distribution, $statRows, null);
+
+        self::assertSame(2, $merged['table'][0]['metricN']);
+        self::assertSame(0, $merged['table'][1]['metricN']);
+        self::assertNull($merged['table'][1]['metricMean']);
+    }
 }

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionPageConfigResolverTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionPageConfigResolverTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Panel\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use App\Tests\Statistics\Fixtures\DistributionPanelFixtures;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+final class DistributionPageConfigResolverTest extends TestCase
+{
+    public function testResolveReturnsPageConfigForValidOptions(): void
+    {
+        $config = new DistributionPageConfigResolver()->resolve(DistributionPanelFixtures::sampleUrgencyPageOptions());
+
+        self::assertSame('app_stats_distribution_urgency', $config->routeName);
+        self::assertCount(1, $config->panels);
+        self::assertSame('urgency', $config->panels[0]->key);
+    }
+
+    public function testResolveRejectsEmptyRouteName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('route_name must be non-empty.');
+
+        new DistributionPageConfigResolver()->resolve([
+            'route_name' => '   ',
+            'section_key' => 'urgency',
+            'panels' => [DistributionPanelFixtures::urgencyPanelOptions()],
+        ]);
+    }
+
+    public function testResolveRejectsEmptyPanelsList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('panels must contain at least one panel.');
+
+        new DistributionPageConfigResolver()->resolve([
+            'route_name' => 'app_stats_distribution_urgency',
+            'section_key' => 'urgency',
+            'panels' => [],
+        ]);
+    }
+
+    public function testResolveRejectsEmptySectionKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('section_key must be non-empty.');
+
+        new DistributionPageConfigResolver()->resolve([
+            'route_name' => 'app_stats_distribution_urgency',
+            'section_key' => '',
+            'panels' => [DistributionPanelFixtures::urgencyPanelOptions()],
+        ]);
+    }
+
+    public function testCreatePanelDefinitionRejectsUnknownDimensionKind(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $opts = DistributionPanelFixtures::urgencyPanelOptions();
+        $opts['dimension_kind'] = 'not_a_kind';
+
+        new DistributionPageConfigResolver()->createPanelDefinition($opts);
+    }
+
+    public function testCreatePanelDefinitionRejectsUnknownAverageMetric(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown average_metric "weight".');
+
+        $opts = DistributionPanelFixtures::urgencyPanelOptions();
+        $opts['average_metric'] = 'weight';
+
+        new DistributionPageConfigResolver()->createPanelDefinition($opts);
+    }
+
+    public function testResolvePropagatesOptionsResolverExceptionForMissingPanelKey(): void
+    {
+        $this->expectException(ExceptionInterface::class);
+
+        $opts = DistributionPanelFixtures::urgencyPanelOptions();
+        unset($opts['key']);
+
+        new DistributionPageConfigResolver()->resolve([
+            'route_name' => 'app_stats_distribution_urgency',
+            'section_key' => 'urgency',
+            'panels' => [$opts],
+        ]);
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionPanelNumericMetricPolicyTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionPanelNumericMetricPolicyTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Panel\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
+use App\Statistics\Application\Panel\Distribution\DistributionPanelNumericMetricPolicy;
+use App\Statistics\Application\Panel\PanelDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class DistributionPanelNumericMetricPolicyTest extends TestCase
+{
+    public function testHasConfiguredMetricAndMetricWhenUnset(): void
+    {
+        $p = $this->panel(averageMetric: null);
+        $policy = DistributionPanelNumericMetricPolicy::for($p);
+
+        self::assertFalse($policy->hasConfiguredMetric());
+        self::assertNull($policy->metric());
+    }
+
+    public function testMetricReturnsAgeEnum(): void
+    {
+        $p = $this->panel(averageMetric: 'age');
+        $policy = DistributionPanelNumericMetricPolicy::for($p);
+
+        self::assertTrue($policy->hasConfiguredMetric());
+        self::assertSame(DistributionNumericMetric::Age, $policy->metric());
+    }
+
+    public function testAllowsAverageBarsDependsOnControl(): void
+    {
+        $off = $this->panel(averageMetric: 'age', controls: ['allow_bar_basis_average' => false]);
+        $on = $this->panel(averageMetric: 'age', controls: ['allow_bar_basis_average' => true]);
+
+        self::assertFalse(DistributionPanelNumericMetricPolicy::for($off)->allowsAverageBars());
+        self::assertTrue(DistributionPanelNumericMetricPolicy::for($on)->allowsAverageBars());
+    }
+
+    public function testAllowsBoxplotRequiresMetricAndControl(): void
+    {
+        $noMetric = $this->panel(averageMetric: null, controls: ['allow_chart_type_boxplot' => true]);
+        $metricNoControl = $this->panel(averageMetric: 'age', controls: ['allow_chart_type_boxplot' => false]);
+        $full = $this->panel(averageMetric: 'age', controls: ['allow_chart_type_boxplot' => true]);
+
+        self::assertFalse(DistributionPanelNumericMetricPolicy::for($noMetric)->allowsBoxplotChart());
+        self::assertFalse(DistributionPanelNumericMetricPolicy::for($metricNoControl)->allowsBoxplotChart());
+        self::assertTrue(DistributionPanelNumericMetricPolicy::for($full)->allowsBoxplotChart());
+    }
+
+    public function testNeedsNumericQueryOnlyForBoxplotWithMetric(): void
+    {
+        $with = $this->panel(averageMetric: 'age', controls: ['allow_chart_type_boxplot' => true]);
+        $policy = DistributionPanelNumericMetricPolicy::for($with);
+
+        self::assertFalse($policy->needsNumericQuery('bar'));
+        self::assertTrue($policy->needsNumericQuery('boxplot'));
+    }
+
+    public function testNeedsNumericQueryFalseWithoutMetric(): void
+    {
+        $p = $this->panel(averageMetric: null);
+        $policy = DistributionPanelNumericMetricPolicy::for($p);
+
+        self::assertFalse($policy->needsNumericQuery('boxplot'));
+    }
+
+    public function testProjectionColumnSql(): void
+    {
+        self::assertSame('', DistributionPanelNumericMetricPolicy::for($this->panel(averageMetric: null))->projectionColumnSql());
+        self::assertSame('age', DistributionPanelNumericMetricPolicy::for($this->panel(averageMetric: 'age'))->projectionColumnSql());
+    }
+
+    public function testShowChartTypeAndBarBasisControls(): void
+    {
+        $box = $this->panel(averageMetric: 'age', controls: ['allow_chart_type_boxplot' => true]);
+        $avg = $this->panel(averageMetric: null, controls: ['allow_bar_basis_average' => true]);
+
+        self::assertTrue(DistributionPanelNumericMetricPolicy::for($box)->showChartTypeControl());
+        self::assertTrue(DistributionPanelNumericMetricPolicy::for($avg)->showBarBasisControl());
+    }
+
+    public function testShowMeanColumnInBarTable(): void
+    {
+        $p = $this->panel();
+        $policy = DistributionPanelNumericMetricPolicy::for($p);
+
+        self::assertTrue($policy->showMeanColumnInBarTable('bar', 'average'));
+        self::assertFalse($policy->showMeanColumnInBarTable('bar', 'counts'));
+        self::assertFalse($policy->showMeanColumnInBarTable('boxplot', 'average'));
+    }
+
+    public function testIsBoxplotTable(): void
+    {
+        $p = $this->panel();
+        self::assertTrue(DistributionPanelNumericMetricPolicy::for($p)->isBoxplotTable('boxplot'));
+        self::assertFalse(DistributionPanelNumericMetricPolicy::for($p)->isBoxplotTable('bar'));
+    }
+
+    /**
+     * @param array<string, bool> $controls
+     */
+    private function panel(?string $averageMetric = 'age', array $controls = []): PanelDefinition
+    {
+        $base = [
+            'allow_view_mode_toggle' => true,
+            'allow_group_by' => true,
+            'allow_bar_basis_average' => true,
+            'allow_chart_type_boxplot' => true,
+        ];
+
+        return new PanelDefinition(
+            key: 'urgency',
+            type: 'distribution',
+            dimensionKind: DimensionKind::Column,
+            dimensionField: 'urgency_code',
+            dimensionLabel: 'statistics.distribution.dim.urgency',
+            groupByField: 'hospital_tier_code',
+            groupByLabel: 'statistics.distribution.dim.hospital_tier',
+            filters: ['date_range', 'hospital_tier', 'hospital_location'],
+            options: ['default_view' => 'grouped', 'show_percent' => true],
+            controls: array_replace($base, $controls),
+            filterDefaults: [],
+            averageMetric: $averageMetric,
+        );
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionTransformerTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionTransformerTest.php
@@ -20,8 +20,8 @@ final class DistributionTransformerTest extends TestCase
 
         $result = $transformer->transform(
             [
-                ['dimension_key' => 1, 'group_key' => null, 'value' => 25],
-                ['dimension_key' => 2, 'group_key' => null, 'value' => 75],
+                ['dimension_key' => 1, 'group_key' => null, 'value' => 25, 'distinct_hospitals' => 5],
+                ['dimension_key' => 2, 'group_key' => null, 'value' => 75, 'distinct_hospitals' => 10],
             ],
             $primary,
             null,
@@ -36,6 +36,9 @@ final class DistributionTransformerTest extends TestCase
         self::assertSame('Total', $result['table'][2]['dimensionLabel']);
         self::assertTrue($result['table'][2]['isTotal']);
         self::assertSame(100, $result['table'][2]['value']);
+        self::assertSame([1, 2], $result['dimensionKeys']);
+        self::assertSame([0], $result['groupKeys']);
+        self::assertSame([0 => [1 => 5, 2 => 10]], $result['hospitalDistinctMatrix']);
     }
 
     public function testGroupedPercentagesArePerPrimaryCategory(): void
@@ -69,6 +72,15 @@ final class DistributionTransformerTest extends TestCase
         self::assertSame([75.0, 50.0], $byName['G20']['percentages']);
         self::assertCount(5, $result['table']);
         self::assertTrue($result['table'][4]['isTotal']);
+        self::assertSame([1, 2], $result['dimensionKeys']);
+        self::assertSame([10, 20], $result['groupKeys']);
+        self::assertSame(
+            [
+                10 => [1 => 0, 2 => 0],
+                20 => [1 => 0, 2 => 0],
+            ],
+            $result['hospitalDistinctMatrix'],
+        );
     }
 
     /**

--- a/tests/Statistics/Unit/Panel/Distribution/RendererTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/RendererTest.php
@@ -175,6 +175,69 @@ final class RendererTest extends TestCase
         self::assertSame('G20', $chart['series'][1]['name']);
     }
 
+    public function testBoxPlotFallsBackWhenStatsStructureMissing(): void
+    {
+        $distribution = [
+            'labels' => ['A'],
+            'series' => [['name' => 'Gesamt', 'values' => [1], 'percentages' => [100.0]]],
+            'table' => [],
+        ];
+
+        $chart = $this->renderer()->render($distribution, 'absolute', 'boxplot', 'counts', DistributionNumericMetric::Age)['chart'];
+
+        self::assertSame('boxPlot', $chart['chart']['type']);
+        self::assertSame([], $chart['series']);
+        self::assertSame(
+            'statistics.distribution.metric.age.yaxis',
+            $chart['yaxis']['title']['text'],
+        );
+    }
+
+    public function testBoxPlotFallsBackWhenAllSeriesWouldBeEmpty(): void
+    {
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [['name' => 'Gesamt', 'values' => [1, 1], 'percentages' => [50.0, 50.0]]],
+            'table' => [],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [0],
+            'statsByDimensionGroup' => [
+                1 => [0 => ['n' => 0, 'mean' => 0.0, 'min' => 0, 'q1' => 0.0, 'median' => 0.0, 'q3' => 0.0, 'max' => 0]],
+                2 => [0 => ['n' => 0, 'mean' => 0.0, 'min' => 0, 'q1' => 0.0, 'median' => 0.0, 'q3' => 0.0, 'max' => 0]],
+            ],
+        ];
+
+        $chart = $this->renderer()->render($distribution, 'absolute', 'boxplot', 'counts', null)['chart'];
+
+        self::assertSame([], $chart['series']);
+        self::assertSame(
+            'statistics.distribution.boxplot.yaxis_generic',
+            $chart['yaxis']['title']['text'],
+        );
+    }
+
+    public function testBarAverageUsesZeroWhenStatsMapMissingEntries(): void
+    {
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [
+                ['name' => 'Gesamt', 'values' => [1, 2], 'percentages' => [33.33, 66.67]],
+            ],
+            'table' => [],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [0],
+            'statsByDimensionGroup' => [],
+        ];
+
+        $result = $this->renderer()->render($distribution, 'absolute', 'bar', 'average', null);
+
+        self::assertSame([0.0, 0.0], $result['chart']['series'][0]['data']);
+        self::assertSame(
+            'statistics.distribution.bar_basis.average.yaxis_per_hospital',
+            $result['chart']['yaxis']['title']['text'],
+        );
+    }
+
     private function renderer(): Renderer
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/tests/Statistics/Unit/Panel/Distribution/RendererTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/RendererTest.php
@@ -4,48 +4,183 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Unit\Panel\Distribution;
 
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
 use App\Statistics\Application\Panel\Distribution\Renderer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class RendererTest extends TestCase
 {
-    public function testRenderAbsoluteUsesValuesAndNoPercentYAxis(): void
+    public function testRenderAbsoluteBarCountsUsesValuesAndTableModeBarCounts(): void
     {
-        $result = new Renderer()->render($this->distribution(), 'absolute');
+        $result = $this->renderer()->render($this->distribution(), 'absolute', 'bar', 'counts', null);
 
+        self::assertSame('bar_counts', $result['tableMode']);
         self::assertFalse($result['chart']['chart']['stacked']);
         self::assertNull($result['chart']['chart']['stackType']);
         self::assertSame([], $result['chart']['yaxis']);
         self::assertSame([10, 20], $result['chart']['series'][0]['data']);
+        self::assertSame('bar', $result['chart']['chart']['type']);
     }
 
-    public function testRenderPercentOfTotalUsesPercentagesWithoutStacking(): void
+    public function testRenderPercentOfTotalBarCountsUsesPercentages(): void
     {
-        $result = new Renderer()->render($this->distribution(), 'percent_of_total');
+        $result = $this->renderer()->render($this->distribution(), 'percent_of_total', 'bar', 'counts', null);
 
+        self::assertSame('bar_counts', $result['tableMode']);
         self::assertFalse($result['chart']['chart']['stacked']);
         self::assertNull($result['chart']['chart']['stackType']);
         self::assertSame(['max' => 100], $result['chart']['yaxis']);
         self::assertSame([25.0, 50.0], $result['chart']['series'][0]['data']);
     }
 
-    public function testRenderStackedUsesValuesWithStackedBars(): void
+    public function testRenderStackedBarCountsUsesValuesWithStackedBars(): void
     {
-        $result = new Renderer()->render($this->distribution(), 'stacked');
+        $result = $this->renderer()->render($this->distribution(), 'stacked', 'bar', 'counts', null);
 
+        self::assertSame('bar_counts', $result['tableMode']);
         self::assertTrue($result['chart']['chart']['stacked']);
         self::assertNull($result['chart']['chart']['stackType']);
         self::assertSame([10, 20], $result['chart']['series'][0]['data']);
     }
 
-    public function testRenderPercentUsesPercentagesWithHundredPercentStack(): void
+    public function testRenderPercentBarCountsUsesHundredPercentStack(): void
     {
-        $result = new Renderer()->render($this->distribution(), 'percent');
+        $result = $this->renderer()->render($this->distribution(), 'percent', 'bar', 'counts', null);
 
+        self::assertSame('bar_counts', $result['tableMode']);
         self::assertTrue($result['chart']['chart']['stacked']);
         self::assertSame('100%', $result['chart']['chart']['stackType']);
         self::assertSame(['max' => 100], $result['chart']['yaxis']);
         self::assertSame([25.0, 50.0], $result['chart']['series'][0]['data']);
+    }
+
+    public function testBarAverageUsesStatsMeanAndPerHospitalYAxisLabel(): void
+    {
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [
+                ['name' => 'Gesamt', 'values' => [10, 20], 'percentages' => [25.0, 50.0]],
+            ],
+            'table' => [],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [0],
+            'statsByDimensionGroup' => [
+                1 => [0 => ['n' => 10, 'mean' => 2.5, 'min' => 0, 'q1' => 0.0, 'median' => 0.0, 'q3' => 0.0, 'max' => 0]],
+                2 => [0 => ['n' => 8, 'mean' => 2.0, 'min' => 0, 'q1' => 0.0, 'median' => 0.0, 'q3' => 0.0, 'max' => 0]],
+            ],
+        ];
+
+        $result = $this->renderer()->render($distribution, 'absolute', 'bar', 'average', null);
+
+        self::assertSame('bar_average', $result['tableMode']);
+        self::assertSame([2.5, 2.0], $result['chart']['series'][0]['data']);
+        self::assertSame(
+            'statistics.distribution.bar_basis.average.yaxis_per_hospital',
+            $result['chart']['yaxis']['title']['text'],
+        );
+    }
+
+    public function testBoxPlotSingleSeriesWhenNotGrouped(): void
+    {
+        $distribution = [
+            'labels' => ['A', 'B'],
+            'series' => [
+                [
+                    'name' => 'Gesamt',
+                    'values' => [10, 20],
+                    'percentages' => [25.0, 50.0],
+                ],
+            ],
+            'table' => [],
+            'dimensionKeys' => [1, 2],
+            'groupKeys' => [0],
+            'statsByDimensionGroup' => [
+                1 => [
+                    0 => [
+                        'n' => 5,
+                        'mean' => 40.0,
+                        'min' => 30,
+                        'q1' => 35.0,
+                        'median' => 40.0,
+                        'q3' => 45.0,
+                        'max' => 50,
+                    ],
+                ],
+                2 => [
+                    0 => [
+                        'n' => 3,
+                        'mean' => 60.0,
+                        'min' => 55,
+                        'q1' => 57.0,
+                        'median' => 60.0,
+                        'q3' => 62.0,
+                        'max' => 65,
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->renderer()->render($distribution, 'absolute', 'boxplot', 'counts', DistributionNumericMetric::Age);
+        $chart = $result['chart'];
+
+        self::assertSame('boxplot', $result['tableMode']);
+        self::assertSame('boxPlot', $chart['chart']['type']);
+        self::assertCount(1, $chart['series']);
+        self::assertSame('boxPlot', $chart['series'][0]['type']);
+        self::assertSame('Gesamt', $chart['series'][0]['name']);
+        self::assertCount(2, $chart['series'][0]['data']);
+        self::assertSame([30.0, 35.0, 40.0, 45.0, 50.0], $chart['series'][0]['data'][0]['y']);
+    }
+
+    public function testBoxPlotMultipleSeriesWhenGrouped(): void
+    {
+        $distribution = [
+            'labels' => ['U1'],
+            'series' => [
+                ['name' => 'G10', 'values' => [10], 'percentages' => [50.0]],
+                ['name' => 'G20', 'values' => [30], 'percentages' => [50.0]],
+            ],
+            'table' => [],
+            'dimensionKeys' => [1],
+            'groupKeys' => [10, 20],
+            'statsByDimensionGroup' => [
+                1 => [
+                    10 => [
+                        'n' => 2,
+                        'mean' => 20.0,
+                        'min' => 18,
+                        'q1' => 19.0,
+                        'median' => 20.0,
+                        'q3' => 21.0,
+                        'max' => 22,
+                    ],
+                    20 => [
+                        'n' => 2,
+                        'mean' => 70.0,
+                        'min' => 68,
+                        'q1' => 69.0,
+                        'median' => 70.0,
+                        'q3' => 71.0,
+                        'max' => 72,
+                    ],
+                ],
+            ],
+        ];
+
+        $chart = $this->renderer()->render($distribution, 'grouped', 'boxplot', 'counts', DistributionNumericMetric::Age)['chart'];
+
+        self::assertCount(2, $chart['series']);
+        self::assertSame('G10', $chart['series'][0]['name']);
+        self::assertSame('G20', $chart['series'][1]['name']);
+    }
+
+    private function renderer(): Renderer
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $key): string => $key);
+
+        return new Renderer($translator);
     }
 
     /**

--- a/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
+++ b/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Statistics\Unit\Query;
 
 use App\Statistics\Application\Filter\FilterRegistry;
 use App\Statistics\Application\Filter\FilterState;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
 use App\Statistics\Infrastructure\Query\DistributionPanelQuery;
 use App\Statistics\Infrastructure\Query\SqlFilterBuilder;
 use App\Tests\Statistics\Fixtures\DistributionPanelFixtures;
@@ -30,6 +31,7 @@ final class DistributionPanelQueryTest extends TestCase
             ->with(
                 self::logicalAnd(
                     self::stringContains('GROUP BY urgency_code, hospital_tier_code'),
+                    self::stringContains('COUNT(DISTINCT hospital_id)'),
                     self::stringContains('created_at >= :date_from AND created_at <= :date_to')
                 ),
                 [
@@ -39,16 +41,16 @@ final class DistributionPanelQueryTest extends TestCase
                 []
             )
             ->willReturn([
-                ['dimension_key' => '1', 'group_key' => '2', 'value' => '10'],
-                ['dimension_key' => '2', 'group_key' => null, 'value' => '5'],
+                ['dimension_key' => '1', 'group_key' => '2', 'value' => '10', 'distinct_hospitals' => '3'],
+                ['dimension_key' => '2', 'group_key' => null, 'value' => '5', 'distinct_hospitals' => '2'],
             ]);
 
         $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
         $out = $query->fetchDistribution($panel, $state, 'hospital_tier_code');
 
         self::assertSame([
-            ['dimension_key' => 1, 'group_key' => 2, 'value' => 10],
-            ['dimension_key' => 2, 'group_key' => null, 'value' => 5],
+            ['dimension_key' => 1, 'group_key' => 2, 'value' => 10, 'distinct_hospitals' => 3],
+            ['dimension_key' => 2, 'group_key' => null, 'value' => 5, 'distinct_hospitals' => 2],
         ], $out);
     }
 
@@ -65,15 +67,22 @@ final class DistributionPanelQueryTest extends TestCase
 
         $connection->expects(self::once())
             ->method('fetchAllAssociative')
-            ->with(self::stringContains('NULL AS group_key'), [], [])
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('NULL AS group_key'),
+                    self::stringContains('COUNT(DISTINCT hospital_id)')
+                ),
+                [],
+                []
+            )
             ->willReturn([
-                ['dimension_key' => '1', 'group_key' => null, 'value' => '3'],
+                ['dimension_key' => '1', 'group_key' => null, 'value' => '3', 'distinct_hospitals' => '2'],
             ]);
 
         $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
         $out = $query->fetchDistribution($panel, $state);
 
-        self::assertSame([['dimension_key' => 1, 'group_key' => null, 'value' => 3]], $out);
+        self::assertSame([['dimension_key' => 1, 'group_key' => null, 'value' => 3, 'distinct_hospitals' => 2]], $out);
     }
 
     public function testFetchAgeCohortUsesCaseExpression(): void
@@ -92,7 +101,8 @@ final class DistributionPanelQueryTest extends TestCase
             ->with(
                 self::logicalAnd(
                     self::stringContains('WHEN age IS NULL THEN -1'),
-                    self::stringContains('GROUP BY (CASE')
+                    self::stringContains('GROUP BY (CASE'),
+                    self::stringContains('COUNT(DISTINCT hospital_id)')
                 ),
                 [],
                 []
@@ -101,5 +111,135 @@ final class DistributionPanelQueryTest extends TestCase
 
         $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
         $query->fetchDistribution($panel, $state);
+    }
+
+    public function testFetchNumericDistributionStatsAppendsColumnNotNullAndPercentiles(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::urgency();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('age IS NOT NULL'),
+                    self::stringContains('percentile_cont(0.25) WITHIN GROUP (ORDER BY age)'),
+                    self::stringContains('GROUP BY urgency_code')
+                ),
+                [],
+                []
+            )
+            ->willReturn([
+                [
+                    'dimension_key' => '1',
+                    'group_key' => null,
+                    'n' => '4',
+                    'mean_val' => '40.5',
+                    'min_val' => '18',
+                    'q1_val' => '30',
+                    'median_val' => '40',
+                    'q3_val' => '50',
+                    'max_val' => '60',
+                ],
+            ]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        $out = $query->fetchNumericDistributionStats($panel, $state, DistributionNumericMetric::Age);
+
+        self::assertSame([
+            [
+                'dimension_key' => 1,
+                'group_key' => null,
+                'n' => 4,
+                'mean' => 40.5,
+                'min' => 18,
+                'q1' => 30.0,
+                'median' => 40.0,
+                'q3' => 50.0,
+                'max' => 60,
+            ],
+        ], $out);
+    }
+
+    public function testFetchOverallNumericStatsReturnsNullWhenNoRows(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::urgency();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'n' => '0',
+                'mean_val' => null,
+                'min_val' => null,
+                'q1_val' => null,
+                'median_val' => null,
+                'q3_val' => null,
+                'max_val' => null,
+            ]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        self::assertNull($query->fetchOverallNumericStats($panel, $state, DistributionNumericMetric::Age));
+    }
+
+    public function testFetchOverallHospitalParticipationReturnsRatioInputs(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::urgency();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('COUNT(DISTINCT hospital_id)'),
+                    self::stringContains('COUNT(*) AS allocations')
+                ),
+                [],
+                []
+            )
+            ->willReturn(['allocations' => '100', 'distinct_hospitals' => '4']);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        self::assertSame(
+            ['allocations' => 100, 'distinct_hospitals' => 4],
+            $query->fetchOverallHospitalParticipation($panel, $state),
+        );
+    }
+
+    public function testFetchOverallHospitalParticipationReturnsNullWhenNoAllocations(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::urgency();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn(['allocations' => '0', 'distinct_hospitals' => '0']);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        self::assertNull($query->fetchOverallHospitalParticipation($panel, $state));
     }
 }

--- a/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
+++ b/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
@@ -194,6 +194,44 @@ final class DistributionPanelQueryTest extends TestCase
         self::assertNull($query->fetchOverallNumericStats($panel, $state, DistributionNumericMetric::Age));
     }
 
+    public function testFetchOverallNumericStatsReturnsParsedRowWhenPresent(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::urgency();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'n' => '12',
+                'mean_val' => '41.25',
+                'min_val' => '20',
+                'q1_val' => '35',
+                'median_val' => '40',
+                'q3_val' => '48',
+                'max_val' => '70',
+            ]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        self::assertSame(
+            [
+                'n' => 12,
+                'mean' => 41.25,
+                'min' => 20,
+                'q1' => 35.0,
+                'median' => 40.0,
+                'q3' => 48.0,
+                'max' => 70,
+            ],
+            $query->fetchOverallNumericStats($panel, $state, DistributionNumericMetric::Age),
+        );
+    }
+
     public function testFetchOverallHospitalParticipationReturnsRatioInputs(): void
     {
         $connection = $this->createMock(Connection::class);

--- a/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
+++ b/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
@@ -186,7 +186,7 @@ final class DistributionPanelComponentTest extends TestCase
     public function testMountFallsBackToDefaultPanelForUnknownKey(): void
     {
         $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
-        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['panel' => 'unknown']));
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', Request::METHOD_GET, ['panel' => 'unknown']));
         $c->mount($opts);
 
         self::assertSame('urgency', $c->panelKey);
@@ -197,7 +197,7 @@ final class DistributionPanelComponentTest extends TestCase
         $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
         $opts['panels'][0]['controls']['allow_group_by'] = false;
 
-        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['grouped_by' => 'tier']));
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', Request::METHOD_GET, ['grouped_by' => 'tier']));
         $c->mount($opts);
 
         self::assertSame('none', $c->groupedBy);
@@ -206,7 +206,7 @@ final class DistributionPanelComponentTest extends TestCase
     public function testMountReadsChartTypeAndNormalizesInvalidValue(): void
     {
         $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
-        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['chart_type' => 'pie']));
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', Request::METHOD_GET, ['chart_type' => 'pie']));
         $c->mount($opts);
 
         self::assertSame('bar', $c->chartType);
@@ -215,7 +215,7 @@ final class DistributionPanelComponentTest extends TestCase
     public function testMountReadsBarBasisFromQuery(): void
     {
         $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
-        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['bar_basis' => 'average']));
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', Request::METHOD_GET, ['bar_basis' => 'average']));
         $c->mount($opts);
 
         self::assertSame('average', $c->barBasis);

--- a/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
+++ b/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
@@ -76,6 +76,216 @@ final class DistributionPanelComponentTest extends TestCase
         self::assertSame('all_cases', $state['f']['date_range']);
     }
 
+    public function testGetUrlStateIncludesChartTypeAndBarBasis(): void
+    {
+        $component = $this->component();
+        $component->chartType = 'boxplot';
+        $component->barBasis = 'counts';
+
+        $state = $component->getUrlState();
+
+        self::assertSame('boxplot', $state['chart_type']);
+        self::assertSame('counts', $state['bar_basis']);
+    }
+
+    public function testGetCrossSectionQueryParamsIncludesChartTypeAndBarBasis(): void
+    {
+        $component = $this->component();
+        $component->chartType = 'bar';
+        $component->barBasis = 'average';
+
+        $params = $component->getCrossSectionQueryParams();
+
+        self::assertSame('bar', $params['chart_type']);
+        self::assertSame('average', $params['bar_basis']);
+    }
+
+    public function testGetRenderedDataBarCountsCallsDistributionQueryOnly(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                ['dimension_key' => '1', 'group_key' => null, 'value' => '5', 'distinct_hospitals' => '2'],
+            ]);
+        $connection->expects(self::never())->method('fetchAssociative');
+
+        $component = $this->componentWithConnection($connection);
+        $component->distributionPageOptions = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $component->chartType = 'bar';
+        $component->barBasis = 'counts';
+
+        $data = $component->getRenderedData();
+
+        self::assertSame('bar_counts', $data['tableMode']);
+        self::assertSame('bar', $data['chart']['chart']['type']);
+    }
+
+    public function testGetRenderedDataBarAverageMergesHospitalParticipation(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                ['dimension_key' => '1', 'group_key' => null, 'value' => '4', 'distinct_hospitals' => '2'],
+            ]);
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn(['allocations' => '8', 'distinct_hospitals' => '2']);
+
+        $component = $this->componentWithConnection($connection);
+        $component->distributionPageOptions = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $component->chartType = 'bar';
+        $component->barBasis = 'average';
+
+        $data = $component->getRenderedData();
+
+        self::assertSame('bar_average', $data['tableMode']);
+        self::assertSame(2.0, $data['chart']['series'][0]['data'][0]);
+    }
+
+    public function testGetRenderedDataBoxplotLoadsNumericStats(): void
+    {
+        $dbNumericRow = [
+            'dimension_key' => '1',
+            'group_key' => null,
+            'n' => '4',
+            'mean_val' => '40',
+            'min_val' => '30',
+            'q1_val' => '35',
+            'median_val' => '40',
+            'q3_val' => '45',
+            'max_val' => '50',
+        ];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))
+            ->method('fetchAllAssociative')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    ['dimension_key' => '1', 'group_key' => null, 'value' => '10', 'distinct_hospitals' => '2'],
+                ],
+                [$dbNumericRow],
+            );
+        $connection->expects(self::once())
+            ->method('fetchAssociative')
+            ->willReturn($dbNumericRow);
+
+        $component = $this->componentWithConnection($connection);
+        $component->distributionPageOptions = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $component->chartType = 'boxplot';
+        $component->barBasis = 'counts';
+
+        $data = $component->getRenderedData();
+
+        self::assertSame('boxplot', $data['tableMode']);
+        self::assertSame('boxPlot', $data['chart']['chart']['type']);
+        self::assertNotEmpty($data['chart']['series']);
+    }
+
+    public function testMountFallsBackToDefaultPanelForUnknownKey(): void
+    {
+        $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['panel' => 'unknown']));
+        $c->mount($opts);
+
+        self::assertSame('urgency', $c->panelKey);
+    }
+
+    public function testMountForcesGroupedByNoneWhenPanelDisallowsGrouping(): void
+    {
+        $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $opts['panels'][0]['controls']['allow_group_by'] = false;
+
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['grouped_by' => 'tier']));
+        $c->mount($opts);
+
+        self::assertSame('none', $c->groupedBy);
+    }
+
+    public function testMountReadsChartTypeAndNormalizesInvalidValue(): void
+    {
+        $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['chart_type' => 'pie']));
+        $c->mount($opts);
+
+        self::assertSame('bar', $c->chartType);
+    }
+
+    public function testMountReadsBarBasisFromQuery(): void
+    {
+        $opts = DistributionPanelFixtures::sampleUrgencyPageOptions();
+        $c = $this->componentForRequest(Request::create('/statistics/distribution/urgency', 'GET', ['bar_basis' => 'average']));
+        $c->mount($opts);
+
+        self::assertSame('average', $c->barBasis);
+    }
+
+    public function testShowChartTypeControlReflectsPolicy(): void
+    {
+        $c = $this->component();
+        self::assertTrue($c->showChartTypeControl());
+    }
+
+    public function testShowBarBasisControlWhenBarChart(): void
+    {
+        $c = $this->component();
+        $c->chartType = 'bar';
+        self::assertTrue($c->showBarBasisControl());
+
+        $c->chartType = 'boxplot';
+        self::assertFalse($c->showBarBasisControl());
+    }
+
+    public function testUseYAxisPercentFormatterForPercentViewModes(): void
+    {
+        $c = $this->component();
+        $c->chartType = 'bar';
+        $c->barBasis = 'counts';
+        $c->viewMode = 'percent';
+        self::assertTrue($c->useYAxisPercentFormatter());
+
+        $c->viewMode = 'absolute';
+        self::assertFalse($c->useYAxisPercentFormatter());
+    }
+
+    public function testGetAllowedViewModesForBoxplotIsAbsoluteOnly(): void
+    {
+        $c = $this->component();
+        $c->chartType = 'boxplot';
+        self::assertSame(['absolute'], $c->getAllowedViewModes());
+    }
+
+    public function testGetAllowedViewModesForBarAverageWhenGrouped(): void
+    {
+        $c = $this->component();
+        $c->chartType = 'bar';
+        $c->barBasis = 'average';
+        $c->groupedBy = 'tier';
+        self::assertSame(['grouped'], $c->getAllowedViewModes());
+    }
+
+    public function testGetDistributionSectionNavMarksActiveRoute(): void
+    {
+        $nav = $this->component()->getDistributionSectionNav();
+        self::assertNotEmpty($nav);
+        $active = array_values(array_filter($nav, static fn (array $i): bool => true === $i['active']));
+        self::assertCount(1, $active);
+        self::assertSame('app_stats_distribution_urgency', $active[0]['route']);
+    }
+
+    public function testFilterHelpersExposeOptionsAndSelections(): void
+    {
+        $c = $this->component();
+        self::assertNotEmpty($c->getHospitalTierFilterOptions());
+        self::assertNotEmpty($c->getHospitalLocationFilterOptions());
+        self::assertCount(3, $c->getActivePanelFilters());
+        self::assertSame('all_cases', $c->getDateRangePreset());
+
+        $c->filterValues['hospital_tier'] = 'not-an-array';
+        self::assertSame([], $c->getHospitalTierSelection());
+    }
+
     private function component(): DistributionPanelComponent
     {
         $c = $this->bareComponent();
@@ -86,11 +296,7 @@ final class DistributionPanelComponentTest extends TestCase
 
     private function bareComponent(): DistributionPanelComponent
     {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator->method('trans')->willReturnCallback(static fn (string $key): string => $key);
-
         $filterRegistry = new FilterRegistry();
-        $resolver = new QueryStateResolver($filterRegistry);
         $query = new DistributionPanelQuery(
             $this->createMock(Connection::class),
             new SqlFilterBuilder($filterRegistry),
@@ -98,6 +304,40 @@ final class DistributionPanelComponentTest extends TestCase
 
         $stack = new RequestStack();
         $stack->push(Request::create('/statistics/distribution/urgency'));
+
+        return $this->buildComponent($query, $stack);
+    }
+
+    private function componentForRequest(Request $request): DistributionPanelComponent
+    {
+        $filterRegistry = new FilterRegistry();
+        $query = new DistributionPanelQuery(
+            $this->createMock(Connection::class),
+            new SqlFilterBuilder($filterRegistry),
+        );
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        return $this->buildComponent($query, $stack);
+    }
+
+    private function componentWithConnection(Connection $connection): DistributionPanelComponent
+    {
+        $filterRegistry = new FilterRegistry();
+        $query = new DistributionPanelQuery($connection, new SqlFilterBuilder($filterRegistry));
+        $stack = new RequestStack();
+        $stack->push(Request::create('/statistics/distribution/urgency'));
+
+        return $this->buildComponent($query, $stack);
+    }
+
+    private function buildComponent(DistributionPanelQuery $query, RequestStack $stack): DistributionPanelComponent
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $key): string => $key);
+
+        $filterRegistry = new FilterRegistry();
+        $resolver = new QueryStateResolver($filterRegistry);
 
         return new DistributionPanelComponent(
             new DistributionSectionNavProvider(),

--- a/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
+++ b/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
@@ -10,6 +10,7 @@ use App\Statistics\Application\Mapping\GenderValueMapper;
 use App\Statistics\Application\Mapping\HospitalLocationValueMapper;
 use App\Statistics\Application\Mapping\HospitalTypeValueMapper;
 use App\Statistics\Application\Mapping\TriageValueMapper;
+use App\Statistics\Application\Panel\Distribution\DistributionNumericMetricMerge;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
 use App\Statistics\Application\Panel\Distribution\DistributionSectionNavProvider;
 use App\Statistics\Application\Panel\Distribution\DistributionTransformer;
@@ -104,7 +105,8 @@ final class DistributionPanelComponentTest extends TestCase
             $resolver,
             $query,
             new DistributionTransformer(),
-            new Renderer(),
+            new DistributionNumericMetricMerge(),
+            new Renderer($translator),
             new TriageValueMapper($translator),
             new GenderValueMapper($translator),
             new HospitalTypeValueMapper($translator),

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -877,6 +877,10 @@
         <source>statistics.distribution.table.percent</source>
         <target>Percent</target>
       </trans-unit>
+      <trans-unit id="d1strP9a" resname="statistics.distribution.table.mean_age">
+        <source>statistics.distribution.table.mean_age</source>
+        <target>Mean age (years)</target>
+      </trans-unit>
       <trans-unit id="d1strPa" resname="statistics.distribution.empty">
         <source>statistics.distribution.empty</source>
         <target>The projection has no rows yet. Import data and rebuild the allocation stats projection to see charts here.</target>
@@ -1009,6 +1013,86 @@
         <source>statistics.distribution.chart_mode.percent_of_total</source>
         <target>Percent of total</target>
       </trans-unit>
+      <trans-unit id="d1strCht1" resname="statistics.distribution.chart_type">
+        <source>statistics.distribution.chart_type</source>
+        <target>Chart type</target>
+      </trans-unit>
+      <trans-unit id="d1strCht2" resname="statistics.distribution.chart_type.bar">
+        <source>statistics.distribution.chart_type.bar</source>
+        <target>Bar chart</target>
+      </trans-unit>
+      <trans-unit id="d1strCht3" resname="statistics.distribution.chart_type.boxplot">
+        <source>statistics.distribution.chart_type.boxplot</source>
+        <target>Box plot</target>
+      </trans-unit>
+      <trans-unit id="d1strBb1" resname="statistics.distribution.bar_basis">
+        <source>statistics.distribution.bar_basis</source>
+        <target>Bar values</target>
+      </trans-unit>
+      <trans-unit id="d1strBb2" resname="statistics.distribution.bar_basis.counts">
+        <source>statistics.distribution.bar_basis.counts</source>
+        <target>Counts / share</target>
+      </trans-unit>
+      <trans-unit id="d1strBb3" resname="statistics.distribution.bar_basis.average">
+        <source>statistics.distribution.bar_basis.average</source>
+        <target>Average per hospital</target>
+      </trans-unit>
+      <trans-unit id="d1strBbYax" resname="statistics.distribution.bar_basis.average.yaxis_per_hospital">
+        <source>statistics.distribution.bar_basis.average.yaxis_per_hospital</source>
+        <target>Avg. cases per hospital</target>
+      </trans-unit>
+      <trans-unit id="d1strBbTbl" resname="statistics.distribution.bar_basis.average.table_mean_per_hospital">
+        <source>statistics.distribution.bar_basis.average.table_mean_per_hospital</source>
+        <target>Avg. cases per hospital</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrN" resname="statistics.distribution.table.metric_n">
+        <source>statistics.distribution.table.metric_n</source>
+        <target>n (with value)</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrMin" resname="statistics.distribution.table.metric_min">
+        <source>statistics.distribution.table.metric_min</source>
+        <target>Min</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrQ1" resname="statistics.distribution.table.metric_q1">
+        <source>statistics.distribution.table.metric_q1</source>
+        <target>Q1</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrMed" resname="statistics.distribution.table.metric_median">
+        <source>statistics.distribution.table.metric_median</source>
+        <target>Median</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrQ3" resname="statistics.distribution.table.metric_q3">
+        <source>statistics.distribution.table.metric_q3</source>
+        <target>Q3</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrMax" resname="statistics.distribution.table.metric_max">
+        <source>statistics.distribution.table.metric_max</source>
+        <target>Max</target>
+      </trans-unit>
+      <trans-unit id="d1strMtrMean" resname="statistics.distribution.table.metric_mean">
+        <source>statistics.distribution.table.metric_mean</source>
+        <target>Mean</target>
+      </trans-unit>
+      <trans-unit id="d1strMetAgeY" resname="statistics.distribution.metric.age.yaxis">
+        <source>statistics.distribution.metric.age.yaxis</source>
+        <target>Age (years)</target>
+      </trans-unit>
+      <trans-unit id="d1strMetAgeT" resname="statistics.distribution.metric.age.table_mean">
+        <source>statistics.distribution.metric.age.table_mean</source>
+        <target>Mean age</target>
+      </trans-unit>
+      <trans-unit id="d1strMetTtY" resname="statistics.distribution.metric.transport_time_minutes.yaxis">
+        <source>statistics.distribution.metric.transport_time_minutes.yaxis</source>
+        <target>Transport time (minutes)</target>
+      </trans-unit>
+      <trans-unit id="d1strMetTtT" resname="statistics.distribution.metric.transport_time_minutes.table_mean">
+        <source>statistics.distribution.metric.transport_time_minutes.table_mean</source>
+        <target>Avg. transport time</target>
+      </trans-unit>
+      <trans-unit id="d1strBoxYGen" resname="statistics.distribution.boxplot.yaxis_generic">
+        <source>statistics.distribution.boxplot.yaxis_generic</source>
+        <target>Value</target>
+      </trans-unit>
       <trans-unit id="d1strPu" resname="statistics.distribution.filter.date_range">
         <source>statistics.distribution.filter.date_range</source>
         <target>Date range</target>
@@ -1040,6 +1124,26 @@
       <trans-unit id="d1strPk" resname="statistics.distribution.import_name">
         <source>statistics.distribution.import_name</source>
         <target>Name</target>
+      </trans-unit>
+      <trans-unit id="d1strBox1" resname="statistics.distribution.boxplot.title">
+        <source>statistics.distribution.boxplot.title</source>
+        <target>Age distribution by category (min, quartiles, median, max)</target>
+      </trans-unit>
+      <trans-unit id="d1strBox2" resname="statistics.distribution.boxplot.yaxis_age">
+        <source>statistics.distribution.boxplot.yaxis_age</source>
+        <target>Age (years)</target>
+      </trans-unit>
+      <trans-unit id="d1strBox3" resname="statistics.distribution.boxplot.empty">
+        <source>statistics.distribution.boxplot.empty</source>
+        <target>No rows with known age for this selection; box plot is not shown.</target>
+      </trans-unit>
+      <trans-unit id="d1strDashAge1" resname="statistics.distribution.dashboard_age_cohort_link">
+        <source>statistics.distribution.dashboard_age_cohort_link</source>
+        <target>Detailed cohort distribution (mean age &amp; box plot)</target>
+      </trans-unit>
+      <trans-unit id="d1strDashAge2" resname="statistics.distribution.dashboard_age_cohort_link_hint">
+        <source>statistics.distribution.dashboard_age_cohort_link_hint</source>
+        <target>Statistics → Distribution → Age cohorts: table, filters, and box plot by category.</target>
       </trans-unit>
       <trans-unit id="wQKGxus" resname="link.users">
         <source>link.users</source>


### PR DESCRIPTION
### Summary

- Added **distribution visualizations per hospital**  
- Implemented **bar charts** to display aggregated values per hospital  
- Added **boxplot visualizations** to show distribution and spread of values per hospital  
- Integrated new visualizations into existing distribution pages and dashboard  
- Extended statistics pipeline to support per-hospital aggregation and grouping  
- Updated templates and components to render both chart types  
- Added tests to ensure correctness of aggregation and rendering logic  

### Motivation

- Provide a more detailed view of data **grouped by hospital**  
- Enable comparison between hospitals using both aggregated values (bar chart) and distributions (boxplot)  
- Improve analytical depth by visualizing spread, median, and outliers in the data  
- Boxplots allow quick identification of distribution characteristics such as median and variability
- Lay the groundwork for more advanced multi-dimensional comparisons in the dashboard  

### Notes for Reviewers

- Verify correctness of per-hospital aggregation and grouping logic  
- Review boxplot calculations (median, quartiles, outliers) and ensure they match expectations  
- Check UI integration — both bar and boxplot charts should align with existing dashboard styling  
- Ensure performance remains acceptable when multiple hospitals are displayed  
- Confirm no regressions in existing distribution panels or statistics views  