### PR TITLE
feat: Add reusable distribution panels for statistics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 ###> phpunit/phpunit ###
 /phpunit.xml
 /.phpunit.cache/
+.phpunit.result.cache
 ###< phpunit/phpunit ###
 
 ###> symfony/asset-mapper ###

--- a/src/Statistics/Application/Mapping/AssignmentDistributionNameMapper.php
+++ b/src/Statistics/Application/Mapping/AssignmentDistributionNameMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AssignmentDistributionNameMapper implements ValueMapper
+{
+    /** @var array<int, string> */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        if (null === $value || $value <= 0) {
+            return $this->translator->trans('statistics.distribution.assignment.invalid_id');
+        }
+
+        if (!\array_key_exists($value, $this->cache)) {
+            $name = $this->connection->fetchOne(
+                'SELECT name FROM assignment WHERE id = :id',
+                ['id' => $value],
+            );
+            $this->cache[$value] = \is_string($name) && '' !== $name
+                ? $name
+                : $this->translator->trans('statistics.distribution.entity_name_missing', ['id' => $value]);
+        }
+
+        return $this->cache[$value];
+    }
+}

--- a/src/Statistics/Application/Mapping/DistributionDimensionValueMapperResolver.php
+++ b/src/Statistics/Application/Mapping/DistributionDimensionValueMapperResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\PanelDefinition;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class DistributionDimensionValueMapperResolver
+{
+    /** @var array<string, TriStateBoolValueMapper> */
+    private array $triStateMappers = [];
+
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly TriageValueMapper $triageValueMapper,
+        private readonly GenderValueMapper $genderValueMapper,
+        private readonly AgeCohortValueMapper $ageCohortValueMapper,
+        private readonly WeekdayValueMapper $weekdayValueMapper,
+        private readonly HourOfDayValueMapper $hourOfDayValueMapper,
+        private readonly TransportTimeBucketValueMapper $transportTimeBucketValueMapper,
+        private readonly AssignmentDistributionNameMapper $assignmentDistributionNameMapper,
+        private readonly OccasionDistributionNameMapper $occasionDistributionNameMapper,
+    ) {
+    }
+
+    public function forPanel(PanelDefinition $panel): ValueMapper
+    {
+        if (DimensionKind::AgeCohort === $panel->dimensionKind) {
+            return $this->ageCohortValueMapper;
+        }
+
+        return match ($panel->key) {
+            'gender' => $this->genderValueMapper,
+            'assignment' => $this->assignmentDistributionNameMapper,
+            'occasion' => $this->occasionDistributionNameMapper,
+            'weekday' => $this->weekdayValueMapper,
+            'hour' => $this->hourOfDayValueMapper,
+            'transport_time_bucket' => $this->transportTimeBucketValueMapper,
+            'requires_resus' => $this->triState('statistics.distribution.tri.requires_resus'),
+            'requires_cathlab' => $this->triState('statistics.distribution.tri.requires_cathlab'),
+            'is_cpr' => $this->triState('statistics.distribution.tri.is_cpr'),
+            'is_ventilated' => $this->triState('statistics.distribution.tri.is_ventilated'),
+            'is_with_physician' => $this->triState('statistics.distribution.tri.is_with_physician'),
+            default => $this->triageValueMapper,
+        };
+    }
+
+    private function triState(string $prefix): TriStateBoolValueMapper
+    {
+        return $this->triStateMappers[$prefix] ??= new TriStateBoolValueMapper($this->translator, $prefix);
+    }
+}

--- a/src/Statistics/Application/Mapping/HourOfDayValueMapper.php
+++ b/src/Statistics/Application/Mapping/HourOfDayValueMapper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/** Hour 0–23 from created_hour (G format). */
+final readonly class HourOfDayValueMapper implements ValueMapper
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        if (null === $value || $value < 0 || $value > 23) {
+            return $this->translator->trans('statistics.distribution.hour.unknown');
+        }
+
+        return $this->translator->trans('statistics.distribution.hour.slot', [
+            'hour' => sprintf('%02d', $value),
+        ]);
+    }
+}

--- a/src/Statistics/Application/Mapping/OccasionDistributionNameMapper.php
+++ b/src/Statistics/Application/Mapping/OccasionDistributionNameMapper.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class OccasionDistributionNameMapper implements ValueMapper
+{
+    /** @var array<int, string> */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        if (0 === $value) {
+            return $this->translator->trans('statistics.distribution.occasion.none');
+        }
+
+        if (null === $value || $value < 0) {
+            return $this->translator->trans('statistics.distribution.occasion.invalid_id');
+        }
+
+        if (!\array_key_exists($value, $this->cache)) {
+            $name = $this->connection->fetchOne(
+                'SELECT name FROM occasion WHERE id = :id',
+                ['id' => $value],
+            );
+            $this->cache[$value] = \is_string($name) && '' !== $name
+                ? $name
+                : $this->translator->trans('statistics.distribution.entity_name_missing', ['id' => $value]);
+        }
+
+        return $this->cache[$value];
+    }
+}

--- a/src/Statistics/Application/Mapping/TransportTimeBucketValueMapper.php
+++ b/src/Statistics/Application/Mapping/TransportTimeBucketValueMapper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class TransportTimeBucketValueMapper implements ValueMapper
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        $key = match ($value) {
+            TransportTimeBucketExpression::UNDER_10 => 'statistics.distribution.transport_time_bucket.under_10',
+            TransportTimeBucketExpression::MIN_10_TO_20 => 'statistics.distribution.transport_time_bucket.10_20',
+            TransportTimeBucketExpression::MIN_20_TO_30 => 'statistics.distribution.transport_time_bucket.20_30',
+            TransportTimeBucketExpression::MIN_30_TO_40 => 'statistics.distribution.transport_time_bucket.30_40',
+            TransportTimeBucketExpression::MIN_40_TO_50 => 'statistics.distribution.transport_time_bucket.40_50',
+            TransportTimeBucketExpression::MIN_50_TO_60 => 'statistics.distribution.transport_time_bucket.50_60',
+            TransportTimeBucketExpression::OVER_60 => 'statistics.distribution.transport_time_bucket.over_60',
+            TransportTimeBucketExpression::UNKNOWN => 'statistics.distribution.transport_time_bucket.unknown',
+            default => 'statistics.distribution.unknown_code',
+        };
+
+        return $this->translator->trans($key);
+    }
+}

--- a/src/Statistics/Application/Mapping/TriStateBoolValueMapper.php
+++ b/src/Statistics/Application/Mapping/TriStateBoolValueMapper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Maps 0 = unknown (NULL), 1 = no (false), 2 = yes (true) for distribution dimensions.
+ */
+final readonly class TriStateBoolValueMapper implements ValueMapper
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+        private string $translationPrefix,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        $suffix = match ($value) {
+            1 => 'no',
+            2 => 'yes',
+            default => 'unknown',
+        };
+
+        return $this->translator->trans($this->translationPrefix.'.'.$suffix);
+    }
+}

--- a/src/Statistics/Application/Mapping/WeekdayValueMapper.php
+++ b/src/Statistics/Application/Mapping/WeekdayValueMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Mapping;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/** ISO weekday 1 = Monday … 7 = Sunday (see PHP {@see \DateTimeInterface::format} `N`). */
+final readonly class WeekdayValueMapper implements ValueMapper
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function label(?int $value): string
+    {
+        if (null === $value || $value < 1 || $value > 7) {
+            return $this->translator->trans('statistics.distribution.weekday.unknown');
+        }
+
+        return $this->translator->trans('statistics.distribution.weekday.n'.$value);
+    }
+}

--- a/src/Statistics/Application/Panel/Distribution/DistributionSectionNavProvider.php
+++ b/src/Statistics/Application/Panel/Distribution/DistributionSectionNavProvider.php
@@ -13,6 +13,12 @@ final class DistributionSectionNavProvider
             ['route' => 'app_stats_distribution_urgency', 'label' => 'statistics.distribution.section.urgency'],
             ['route' => 'app_stats_distribution_gender', 'label' => 'statistics.distribution.section.gender'],
             ['route' => 'app_stats_distribution_age', 'label' => 'statistics.distribution.section.age'],
+            ['route' => 'app_stats_distribution_assignment', 'label' => 'statistics.distribution.section.assignment'],
+            ['route' => 'app_stats_distribution_occasion', 'label' => 'statistics.distribution.section.occasion'],
+            ['route' => 'app_stats_distribution_time', 'label' => 'statistics.distribution.section.time'],
+            ['route' => 'app_stats_distribution_transport_time', 'label' => 'statistics.distribution.section.transport_time'],
+            ['route' => 'app_stats_distribution_resources', 'label' => 'statistics.distribution.section.resources'],
+            ['route' => 'app_stats_distribution_traits', 'label' => 'statistics.distribution.section.traits'],
         ];
     }
 }

--- a/src/Statistics/Application/Panel/Distribution/TransportTimeBucketExpression.php
+++ b/src/Statistics/Application/Panel/Distribution/TransportTimeBucketExpression.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Panel\Distribution;
+
+/**
+ * Integer codes for transport_time_minutes buckets (GROUP BY / ORDER BY).
+ *
+ * 0–6 minute ranges; 8 = unknown (NULL); negative values map to bucket 6 (over 60).
+ */
+final class TransportTimeBucketExpression
+{
+    public const int UNKNOWN = 8;
+
+    public const int UNDER_10 = 0;
+
+    public const int MIN_10_TO_20 = 1;
+
+    public const int MIN_20_TO_30 = 2;
+
+    public const int MIN_30_TO_40 = 3;
+
+    public const int MIN_40_TO_50 = 4;
+
+    public const int MIN_50_TO_60 = 5;
+
+    public const int OVER_60 = 6;
+
+    /**
+     * @return list<int>
+     */
+    public static function orderedBucketCodes(): array
+    {
+        return [0, 1, 2, 3, 4, 5, 6, self::UNKNOWN];
+    }
+
+    /**
+     * SQL expression for allocation_stats_projection.transport_time_minutes (no user input).
+     */
+    public static function sql(string $column = 'transport_time_minutes'): string
+    {
+        return 'CASE '
+            .'WHEN '.$column.' IS NULL THEN '.self::UNKNOWN.' '
+            .'WHEN '.$column.' < 0 THEN '.self::OVER_60.' '
+            .'WHEN '.$column.' < 10 THEN '.self::UNDER_10.' '
+            .'WHEN '.$column.' < 20 THEN '.self::MIN_10_TO_20.' '
+            .'WHEN '.$column.' < 30 THEN '.self::MIN_20_TO_30.' '
+            .'WHEN '.$column.' < 40 THEN '.self::MIN_30_TO_40.' '
+            .'WHEN '.$column.' < 50 THEN '.self::MIN_40_TO_50.' '
+            .'WHEN '.$column.' < 60 THEN '.self::MIN_50_TO_60.' '
+            .'ELSE '.self::OVER_60.' END';
+    }
+
+    /**
+     * Mirrors {@see self::sql()} for tests and in-app classification (keep branches aligned).
+     */
+    public static function classifyMinutes(?int $minutes): int
+    {
+        if (null === $minutes) {
+            return self::UNKNOWN;
+        }
+        if ($minutes < 0) {
+            return self::OVER_60;
+        }
+        if ($minutes < 10) {
+            return self::UNDER_10;
+        }
+        if ($minutes < 20) {
+            return self::MIN_10_TO_20;
+        }
+        if ($minutes < 30) {
+            return self::MIN_20_TO_30;
+        }
+        if ($minutes < 40) {
+            return self::MIN_30_TO_40;
+        }
+        if ($minutes < 50) {
+            return self::MIN_40_TO_50;
+        }
+        if ($minutes < 60) {
+            return self::MIN_50_TO_60;
+        }
+
+        return self::OVER_60;
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/AssignmentDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/AssignmentDistributionController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/assignment', name: 'app_stats_distribution_assignment', methods: ['GET'])]
+final class AssignmentDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        return [
+            'route_name' => 'app_stats_distribution_assignment',
+            'section_key' => 'assignment',
+            'panels' => [
+                [
+                    'key' => 'assignment',
+                    'type' => 'distribution',
+                    'dimension_kind' => DimensionKind::Column->value,
+                    'dimension_field' => 'assignment_id',
+                    'dimension_label' => 'statistics.distribution.dim.assignment',
+                    'group_by_field' => 'hospital_tier_code',
+                    'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+                    'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+                    'options' => ['default_view' => 'grouped', 'show_percent' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'age',
+                    'filter_defaults' => [
+                        'date_range' => 'all_cases',
+                        'hospital_tier' => [],
+                        'hospital_location' => [],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/OccasionDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/OccasionDistributionController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/occasion', name: 'app_stats_distribution_occasion', methods: ['GET'])]
+final class OccasionDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        return [
+            'route_name' => 'app_stats_distribution_occasion',
+            'section_key' => 'occasion',
+            'panels' => [
+                [
+                    'key' => 'occasion',
+                    'type' => 'distribution',
+                    'dimension_kind' => DimensionKind::Column->value,
+                    'dimension_field' => 'COALESCE(occasion_id, 0)',
+                    'dimension_label' => 'statistics.distribution.dim.occasion',
+                    'group_by_field' => 'hospital_tier_code',
+                    'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+                    'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+                    'options' => ['default_view' => 'grouped', 'show_percent' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'age',
+                    'filter_defaults' => [
+                        'date_range' => 'all_cases',
+                        'hospital_tier' => [],
+                        'hospital_location' => [],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/ResourcesDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/ResourcesDistributionController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/resources', name: 'app_stats_distribution_resources', methods: ['GET'])]
+final class ResourcesDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     *     default_panel_key?: string|null,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        $panelBase = [
+            'type' => 'distribution',
+            'dimension_kind' => DimensionKind::Column->value,
+            'group_by_field' => 'hospital_tier_code',
+            'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+            'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+            'options' => ['default_view' => 'grouped', 'show_percent' => true],
+            'controls' => [
+                'allow_view_mode_toggle' => true,
+                'allow_group_by' => true,
+                'allow_bar_basis_average' => true,
+            ],
+            'average_metric' => 'age',
+            'filter_defaults' => [
+                'date_range' => 'all_cases',
+                'hospital_tier' => [],
+                'hospital_location' => [],
+            ],
+        ];
+
+        return [
+            'route_name' => 'app_stats_distribution_resources',
+            'section_key' => 'resources',
+            'default_panel_key' => 'requires_resus',
+            'panels' => [
+                array_replace($panelBase, [
+                    'key' => 'requires_resus',
+                    'dimension_field' => '(CASE WHEN requires_resus IS NULL THEN 0 WHEN requires_resus = false THEN 1 ELSE 2 END)',
+                    'dimension_label' => 'statistics.distribution.dim.requires_resus',
+                ]),
+                array_replace($panelBase, [
+                    'key' => 'requires_cathlab',
+                    'dimension_field' => '(CASE WHEN requires_cathlab IS NULL THEN 0 WHEN requires_cathlab = false THEN 1 ELSE 2 END)',
+                    'dimension_label' => 'statistics.distribution.dim.requires_cathlab',
+                ]),
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/TimeDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/TimeDistributionController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/time', name: 'app_stats_distribution_time', methods: ['GET'])]
+final class TimeDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     *     default_panel_key?: string|null,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        $panelBase = [
+            'type' => 'distribution',
+            'dimension_kind' => DimensionKind::Column->value,
+            'group_by_field' => 'hospital_tier_code',
+            'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+            'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+            'options' => ['default_view' => 'grouped', 'show_percent' => true],
+            'controls' => [
+                'allow_view_mode_toggle' => true,
+                'allow_group_by' => true,
+                'allow_bar_basis_average' => true,
+            ],
+            'average_metric' => 'age',
+            'filter_defaults' => [
+                'date_range' => 'all_cases',
+                'hospital_tier' => [],
+                'hospital_location' => [],
+            ],
+        ];
+
+        return [
+            'route_name' => 'app_stats_distribution_time',
+            'section_key' => 'time',
+            'default_panel_key' => 'weekday',
+            'panels' => [
+                array_replace($panelBase, [
+                    'key' => 'weekday',
+                    'dimension_field' => 'created_weekday',
+                    'dimension_label' => 'statistics.distribution.dim.weekday',
+                ]),
+                array_replace($panelBase, [
+                    'key' => 'hour',
+                    'dimension_field' => 'created_hour',
+                    'dimension_label' => 'statistics.distribution.dim.hour',
+                ]),
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/TraitsDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/TraitsDistributionController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/traits', name: 'app_stats_distribution_traits', methods: ['GET'])]
+final class TraitsDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     *     default_panel_key?: string|null,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        $panelBase = [
+            'type' => 'distribution',
+            'dimension_kind' => DimensionKind::Column->value,
+            'group_by_field' => 'hospital_tier_code',
+            'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+            'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+            'options' => ['default_view' => 'grouped', 'show_percent' => true],
+            'controls' => [
+                'allow_view_mode_toggle' => true,
+                'allow_group_by' => true,
+                'allow_bar_basis_average' => true,
+            ],
+            'average_metric' => 'age',
+            'filter_defaults' => [
+                'date_range' => 'all_cases',
+                'hospital_tier' => [],
+                'hospital_location' => [],
+            ],
+        ];
+
+        return [
+            'route_name' => 'app_stats_distribution_traits',
+            'section_key' => 'traits',
+            'default_panel_key' => 'is_cpr',
+            'panels' => [
+                array_replace($panelBase, [
+                    'key' => 'is_cpr',
+                    'dimension_field' => '(CASE WHEN is_cpr IS NULL THEN 0 WHEN is_cpr = false THEN 1 ELSE 2 END)',
+                    'dimension_label' => 'statistics.distribution.dim.is_cpr',
+                ]),
+                array_replace($panelBase, [
+                    'key' => 'is_ventilated',
+                    'dimension_field' => '(CASE WHEN is_ventilated IS NULL THEN 0 WHEN is_ventilated = false THEN 1 ELSE 2 END)',
+                    'dimension_label' => 'statistics.distribution.dim.is_ventilated',
+                ]),
+                array_replace($panelBase, [
+                    'key' => 'is_with_physician',
+                    'dimension_field' => '(CASE WHEN is_with_physician IS NULL THEN 0 WHEN is_with_physician = false THEN 1 ELSE 2 END)',
+                    'dimension_label' => 'statistics.distribution.dim.is_with_physician',
+                ]),
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Http/Controller/Distribution/TransportTimeDistributionController.php
+++ b/src/Statistics/UI/Http/Controller/Distribution/TransportTimeDistributionController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DimensionKind;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/statistics/distribution/transport-time', name: 'app_stats_distribution_transport_time', methods: ['GET'])]
+final class TransportTimeDistributionController extends AbstractController
+{
+    public function __construct(
+        private readonly DistributionPageConfigResolver $distributionPageConfigResolver,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $options = $this->pageOptions();
+        $this->distributionPageConfigResolver->resolve($options);
+
+        return $this->render('@Statistics/distribution/index.html.twig', [
+            'distributionPageOptions' => $options,
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     route_name: string,
+     *     section_key: string,
+     *     panels: list<array<string, mixed>>,
+     * }
+     */
+    private function pageOptions(): array
+    {
+        return [
+            'route_name' => 'app_stats_distribution_transport_time',
+            'section_key' => 'transport_time',
+            'panels' => [
+                [
+                    'key' => 'transport_time_bucket',
+                    'type' => 'distribution',
+                    'dimension_kind' => DimensionKind::Column->value,
+                    'dimension_field' => TransportTimeBucketExpression::sql('transport_time_minutes'),
+                    'dimension_label' => 'statistics.distribution.dim.transport_time_bucket',
+                    'group_by_field' => 'hospital_tier_code',
+                    'group_by_label' => 'statistics.distribution.dim.hospital_tier',
+                    'filters' => ['date_range', 'hospital_tier', 'hospital_location'],
+                    'options' => ['default_view' => 'grouped', 'show_percent' => true],
+                    'controls' => [
+                        'allow_view_mode_toggle' => true,
+                        'allow_group_by' => true,
+                        'allow_bar_basis_average' => true,
+                    ],
+                    'average_metric' => 'transport_time_minutes',
+                    'filter_defaults' => [
+                        'date_range' => 'all_cases',
+                        'hospital_tier' => [],
+                        'hospital_location' => [],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Statistics/UI/Live/DistributionPanelComponent.php
+++ b/src/Statistics/UI/Live/DistributionPanelComponent.php
@@ -6,15 +6,12 @@ namespace App\Statistics\UI\Live;
 
 use App\Statistics\Application\Filter\FilterRegistry;
 use App\Statistics\Application\Filter\FilterState;
-use App\Statistics\Application\Mapping\AgeCohortValueMapper;
 use App\Statistics\Application\Mapping\AllocationStatsHospitalLocationProjectionCode;
 use App\Statistics\Application\Mapping\AllocationStatsHospitalTierProjectionCode;
-use App\Statistics\Application\Mapping\GenderValueMapper;
+use App\Statistics\Application\Mapping\DistributionDimensionValueMapperResolver;
 use App\Statistics\Application\Mapping\HospitalLocationValueMapper;
 use App\Statistics\Application\Mapping\HospitalTypeValueMapper;
-use App\Statistics\Application\Mapping\TriageValueMapper;
 use App\Statistics\Application\Mapping\ValueMapper;
-use App\Statistics\Application\Panel\Distribution\DimensionKind;
 use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
 use App\Statistics\Application\Panel\Distribution\DistributionNumericMetricMerge;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfig;
@@ -76,11 +73,9 @@ final class DistributionPanelComponent
         private readonly DistributionTransformer $transformer,
         private readonly DistributionNumericMetricMerge $distributionNumericMetricMerge,
         private readonly Renderer $renderer,
-        private readonly TriageValueMapper $triageMapper,
-        private readonly GenderValueMapper $genderValueMapper,
+        private readonly DistributionDimensionValueMapperResolver $distributionDimensionValueMapperResolver,
         private readonly HospitalTypeValueMapper $hospitalTypeMapper,
         private readonly HospitalLocationValueMapper $hospitalLocationValueMapper,
-        private readonly AgeCohortValueMapper $ageCohortValueMapper,
         private readonly FilterRegistry $filterRegistry,
         private readonly RequestStack $requestStack,
     ) {
@@ -154,7 +149,7 @@ final class DistributionPanelComponent
         $rows = $this->distributionPanelQuery->fetchDistribution($panel, $filterState, $groupByField);
         $distribution = $this->transformer->transform(
             $rows,
-            $this->dimensionMapperFor($panel),
+            $this->distributionDimensionValueMapperResolver->forPanel($panel),
             $this->groupMapperForSelection(),
         );
 
@@ -435,18 +430,6 @@ final class DistributionPanelComponent
         if ('boxplot' === $this->chartType) {
             $this->barBasis = 'counts';
         }
-    }
-
-    private function dimensionMapperFor(PanelDefinition $panel): ValueMapper
-    {
-        if (DimensionKind::AgeCohort === $panel->dimensionKind) {
-            return $this->ageCohortValueMapper;
-        }
-
-        return match ($panel->key) {
-            'gender' => $this->genderValueMapper,
-            default => $this->triageMapper,
-        };
     }
 
     private function groupMapperForSelection(): ?ValueMapper

--- a/tests/Statistics/Fixtures/DistributionPanelFixtures.php
+++ b/tests/Statistics/Fixtures/DistributionPanelFixtures.php
@@ -6,6 +6,7 @@ namespace App\Tests\Statistics\Fixtures;
 
 use App\Statistics\Application\Panel\Distribution\DimensionKind;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
 use App\Statistics\Application\Panel\PanelDefinition;
 
 final class DistributionPanelFixtures
@@ -76,6 +77,135 @@ final class DistributionPanelFixtures
     public static function ageCohort(): PanelDefinition
     {
         return new DistributionPageConfigResolver()->createPanelDefinition(self::ageCohortPanelOptions());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function genderPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'gender',
+            'dimension_field' => 'gender_code',
+            'dimension_label' => 'statistics.distribution.dim.gender',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function createdHourPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'hour',
+            'dimension_field' => 'created_hour',
+            'dimension_label' => 'statistics.distribution.dim.hour',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function weekdayPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'weekday',
+            'dimension_field' => 'created_weekday',
+            'dimension_label' => 'statistics.distribution.dim.weekday',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function assignmentPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'assignment',
+            'dimension_field' => 'assignment_id',
+            'dimension_label' => 'statistics.distribution.dim.assignment',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function occasionPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'occasion',
+            'dimension_field' => 'COALESCE(occasion_id, 0)',
+            'dimension_label' => 'statistics.distribution.dim.occasion',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function requiresCathlabPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'requires_cathlab',
+            'dimension_field' => '(CASE WHEN requires_cathlab IS NULL THEN 0 WHEN requires_cathlab = false THEN 1 ELSE 2 END)',
+            'dimension_label' => 'statistics.distribution.dim.requires_cathlab',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function isCprPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'is_cpr',
+            'dimension_field' => '(CASE WHEN is_cpr IS NULL THEN 0 WHEN is_cpr = false THEN 1 ELSE 2 END)',
+            'dimension_label' => 'statistics.distribution.dim.is_cpr',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function transportTimeBucketPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'transport_time_bucket',
+            'dimension_field' => TransportTimeBucketExpression::sql('transport_time_minutes'),
+            'dimension_label' => 'statistics.distribution.dim.transport_time_bucket',
+            'average_metric' => 'transport_time_minutes',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function requiresResusPanelOptions(): array
+    {
+        return array_replace(self::urgencyPanelOptions(), [
+            'key' => 'requires_resus',
+            'dimension_field' => '(CASE WHEN requires_resus IS NULL THEN 0 WHEN requires_resus = false THEN 1 ELSE 2 END)',
+            'dimension_label' => 'statistics.distribution.dim.requires_resus',
+        ]);
+    }
+
+    public static function gender(): PanelDefinition
+    {
+        return new DistributionPageConfigResolver()->createPanelDefinition(self::genderPanelOptions());
+    }
+
+    public static function createdHour(): PanelDefinition
+    {
+        return new DistributionPageConfigResolver()->createPanelDefinition(self::createdHourPanelOptions());
+    }
+
+    public static function transportTimeBucket(): PanelDefinition
+    {
+        return new DistributionPageConfigResolver()->createPanelDefinition(self::transportTimeBucketPanelOptions());
+    }
+
+    public static function requiresResus(): PanelDefinition
+    {
+        return new DistributionPageConfigResolver()->createPanelDefinition(self::requiresResusPanelOptions());
     }
 
     /**

--- a/tests/Statistics/Functional/Controller/DistributionPagesControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DistributionPagesControllerTest.php
@@ -9,26 +9,27 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class DistributionPagesControllerTest extends WebTestCase
 {
-    public function testUrgencyDistributionPageIsReachable(): void
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function distributionPathsProvider(): \Generator
     {
-        $client = self::createClient();
-        $client->request(Request::METHOD_GET, '/statistics/distribution/urgency');
-
-        self::assertResponseIsSuccessful();
+        yield 'urgency' => ['/statistics/distribution/urgency'];
+        yield 'gender' => ['/statistics/distribution/gender'];
+        yield 'age' => ['/statistics/distribution/age'];
+        yield 'assignment' => ['/statistics/distribution/assignment'];
+        yield 'occasion' => ['/statistics/distribution/occasion'];
+        yield 'time' => ['/statistics/distribution/time'];
+        yield 'transport_time' => ['/statistics/distribution/transport-time'];
+        yield 'resources' => ['/statistics/distribution/resources'];
+        yield 'traits' => ['/statistics/distribution/traits'];
     }
 
-    public function testGenderDistributionPageIsReachable(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('distributionPathsProvider')]
+    public function testDistributionPageIsReachable(string $path): void
     {
         $client = self::createClient();
-        $client->request(Request::METHOD_GET, '/statistics/distribution/gender');
-
-        self::assertResponseIsSuccessful();
-    }
-
-    public function testAgeCohortDistributionPageIsReachable(): void
-    {
-        $client = self::createClient();
-        $client->request(Request::METHOD_GET, '/statistics/distribution/age');
+        $client->request(Request::METHOD_GET, $path);
 
         self::assertResponseIsSuccessful();
     }

--- a/tests/Statistics/Integration/Mapping/DistributionValueMapperTranslationIntegrationTest.php
+++ b/tests/Statistics/Integration/Mapping/DistributionValueMapperTranslationIntegrationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Mapping;
+
+use App\Statistics\Application\Mapping\HourOfDayValueMapper;
+use App\Statistics\Application\Mapping\WeekdayValueMapper;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DistributionValueMapperTranslationIntegrationTest extends KernelTestCase
+{
+    public function testHourSlotResolvesIntlPlaceholderFromMessagesCatalog(): void
+    {
+        self::bootKernel();
+        $translator = self::getContainer()->get('translator');
+
+        $mapper = new HourOfDayValueMapper($translator);
+
+        self::assertSame('07:00', $mapper->label(7));
+        self::assertSame('23:00', $mapper->label(23));
+    }
+
+    public function testWeekdayUsesCatalogEntries(): void
+    {
+        self::bootKernel();
+        $translator = self::getContainer()->get('translator');
+
+        $mapper = new WeekdayValueMapper($translator);
+
+        self::assertSame('Monday', $mapper->label(1));
+        self::assertSame('Sunday', $mapper->label(7));
+    }
+}

--- a/tests/Statistics/Unit/Mapping/AssignmentDistributionNameMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/AssignmentDistributionNameMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\AssignmentDistributionNameMapper;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AssignmentDistributionNameMapperTest extends TestCase
+{
+    public function testLabelFetchesNameOnceAndCaches(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('fetchOne')
+            ->with('SELECT name FROM assignment WHERE id = :id', ['id' => 42])
+            ->willReturn('ALS North');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $mapper = new AssignmentDistributionNameMapper($connection, $translator);
+
+        self::assertSame('ALS North', $mapper->label(42));
+        self::assertSame('ALS North', $mapper->label(42));
+    }
+
+    public function testLabelWithoutFetchWhenInvalidId(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('fetchOne');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.assignment.invalid_id')
+            ->willReturn('Unknown assignment');
+
+        self::assertSame(
+            'Unknown assignment',
+            new AssignmentDistributionNameMapper($connection, $translator)->label(-1),
+        );
+    }
+}

--- a/tests/Statistics/Unit/Mapping/DistributionDimensionValueMapperResolverTest.php
+++ b/tests/Statistics/Unit/Mapping/DistributionDimensionValueMapperResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\AgeCohortValueMapper;
+use App\Statistics\Application\Mapping\AssignmentDistributionNameMapper;
+use App\Statistics\Application\Mapping\DistributionDimensionValueMapperResolver;
+use App\Statistics\Application\Mapping\GenderValueMapper;
+use App\Statistics\Application\Mapping\HourOfDayValueMapper;
+use App\Statistics\Application\Mapping\OccasionDistributionNameMapper;
+use App\Statistics\Application\Mapping\TransportTimeBucketValueMapper;
+use App\Statistics\Application\Mapping\TriageValueMapper;
+use App\Statistics\Application\Mapping\TriStateBoolValueMapper;
+use App\Statistics\Application\Mapping\WeekdayValueMapper;
+use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
+use App\Tests\Statistics\Fixtures\DistributionPanelFixtures;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class DistributionDimensionValueMapperResolverTest extends TestCase
+{
+    private DistributionDimensionValueMapperResolver $resolver;
+
+    private TriageValueMapper $triageMapper;
+
+    private GenderValueMapper $genderMapper;
+
+    private AgeCohortValueMapper $ageCohortMapper;
+
+    private WeekdayValueMapper $weekdayMapper;
+
+    private HourOfDayValueMapper $hourMapper;
+
+    private TransportTimeBucketValueMapper $transportBucketMapper;
+
+    private AssignmentDistributionNameMapper $assignmentMapper;
+
+    private OccasionDistributionNameMapper $occasionMapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $connection = $this->createMock(Connection::class);
+
+        $this->triageMapper = new TriageValueMapper($translator);
+        $this->genderMapper = new GenderValueMapper($translator);
+        $this->ageCohortMapper = new AgeCohortValueMapper($translator);
+        $this->weekdayMapper = new WeekdayValueMapper($translator);
+        $this->hourMapper = new HourOfDayValueMapper($translator);
+        $this->transportBucketMapper = new TransportTimeBucketValueMapper($translator);
+        $this->assignmentMapper = new AssignmentDistributionNameMapper($connection, $translator);
+        $this->occasionMapper = new OccasionDistributionNameMapper($connection, $translator);
+
+        $this->resolver = new DistributionDimensionValueMapperResolver(
+            $translator,
+            $this->triageMapper,
+            $this->genderMapper,
+            $this->ageCohortMapper,
+            $this->weekdayMapper,
+            $this->hourMapper,
+            $this->transportBucketMapper,
+            $this->assignmentMapper,
+            $this->occasionMapper,
+        );
+    }
+
+    public function testForPanelReturnsInjectedMappersByIdentity(): void
+    {
+        $r = new DistributionPageConfigResolver();
+
+        self::assertSame($this->triageMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::urgencyPanelOptions())));
+        self::assertSame($this->genderMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::genderPanelOptions())));
+        self::assertSame($this->ageCohortMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::ageCohortPanelOptions())));
+        self::assertSame($this->weekdayMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::weekdayPanelOptions())));
+        self::assertSame($this->hourMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::createdHourPanelOptions())));
+        self::assertSame($this->transportBucketMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::transportTimeBucketPanelOptions())));
+        self::assertSame($this->assignmentMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::assignmentPanelOptions())));
+        self::assertSame($this->occasionMapper, $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::occasionPanelOptions())));
+    }
+
+    public function testTriStatePanelsYieldDistinctMapperInstancesPerPrefix(): void
+    {
+        $r = new DistributionPageConfigResolver();
+
+        $resus = $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::requiresResusPanelOptions()));
+        $cathlab = $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::requiresCathlabPanelOptions()));
+
+        self::assertInstanceOf(TriStateBoolValueMapper::class, $resus);
+        self::assertInstanceOf(TriStateBoolValueMapper::class, $cathlab);
+        self::assertNotSame($resus, $cathlab);
+    }
+
+    public function testTriStateMapperReusesInstanceForSamePanelKey(): void
+    {
+        $r = new DistributionPageConfigResolver();
+        $opts = DistributionPanelFixtures::requiresResusPanelOptions();
+
+        $a = $this->resolver->forPanel($r->createPanelDefinition($opts));
+        $b = $this->resolver->forPanel($r->createPanelDefinition($opts));
+
+        self::assertSame($a, $b);
+    }
+
+    public function testIsCprAndIsVentilatedAreDistinctTriStateMappers(): void
+    {
+        $r = new DistributionPageConfigResolver();
+
+        $cpr = $this->resolver->forPanel($r->createPanelDefinition(DistributionPanelFixtures::isCprPanelOptions()));
+        $vent = $this->resolver->forPanel($r->createPanelDefinition(array_replace(DistributionPanelFixtures::urgencyPanelOptions(), [
+            'key' => 'is_ventilated',
+            'dimension_field' => '(CASE WHEN is_ventilated IS NULL THEN 0 WHEN is_ventilated = false THEN 1 ELSE 2 END)',
+            'dimension_label' => 'statistics.distribution.dim.is_ventilated',
+        ])));
+
+        self::assertNotSame($cpr, $vent);
+    }
+}

--- a/tests/Statistics/Unit/Mapping/HourOfDayValueMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/HourOfDayValueMapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\HourOfDayValueMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class HourOfDayValueMapperTest extends TestCase
+{
+    public function testLabelPassesZeroPaddedHourToTranslator(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with(
+                'statistics.distribution.hour.slot',
+                ['hour' => '07'],
+            )
+            ->willReturn('07:00');
+
+        $mapper = new HourOfDayValueMapper($translator);
+
+        self::assertSame('07:00', $mapper->label(7));
+    }
+
+    public function testLabelUnknownForOutOfRange(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.hour.unknown')
+            ->willReturn('Unknown');
+
+        $mapper = new HourOfDayValueMapper($translator);
+
+        self::assertSame('Unknown', $mapper->label(24));
+    }
+}

--- a/tests/Statistics/Unit/Mapping/OccasionDistributionNameMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/OccasionDistributionNameMapperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\OccasionDistributionNameMapper;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class OccasionDistributionNameMapperTest extends TestCase
+{
+    public function testLabelZeroMeansNoOccasionWithoutQuery(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('fetchOne');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.occasion.none')
+            ->willReturn('No occasion');
+
+        self::assertSame(
+            'No occasion',
+            new OccasionDistributionNameMapper($connection, $translator)->label(0),
+        );
+    }
+
+    public function testLabelFetchesNameById(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('fetchOne')
+            ->with('SELECT name FROM occasion WHERE id = :id', ['id' => 9])
+            ->willReturn('Storm');
+
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        self::assertSame('Storm', new OccasionDistributionNameMapper($connection, $translator)->label(9));
+    }
+}

--- a/tests/Statistics/Unit/Mapping/TransportTimeBucketValueMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/TransportTimeBucketValueMapperTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\TransportTimeBucketValueMapper;
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TransportTimeBucketValueMapperTest extends TestCase
+{
+    public function testLabelMapsBucketCodesToTranslationKeys(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.transport_time_bucket.10_20')
+            ->willReturn('10–20 min');
+
+        $mapper = new TransportTimeBucketValueMapper($translator);
+
+        self::assertSame('10–20 min', $mapper->label(TransportTimeBucketExpression::MIN_10_TO_20));
+    }
+}

--- a/tests/Statistics/Unit/Mapping/TriStateBoolValueMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/TriStateBoolValueMapperTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\TriStateBoolValueMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TriStateBoolValueMapperTest extends TestCase
+{
+    public function testLabelSuffixes(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::exactly(3))
+            ->method('trans')
+            ->willReturnCallback(static fn (string $id): string => $id);
+
+        $mapper = new TriStateBoolValueMapper($translator, 'statistics.distribution.tri.requires_resus');
+
+        self::assertSame('statistics.distribution.tri.requires_resus.unknown', $mapper->label(0));
+        self::assertSame('statistics.distribution.tri.requires_resus.no', $mapper->label(1));
+        self::assertSame('statistics.distribution.tri.requires_resus.yes', $mapper->label(2));
+    }
+}

--- a/tests/Statistics/Unit/Mapping/WeekdayValueMapperTest.php
+++ b/tests/Statistics/Unit/Mapping/WeekdayValueMapperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Mapping;
+
+use App\Statistics\Application\Mapping\WeekdayValueMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class WeekdayValueMapperTest extends TestCase
+{
+    public function testLabelUsesIsoWeekdayKey(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.weekday.n3')
+            ->willReturn('Wednesday');
+
+        self::assertSame('Wednesday', new WeekdayValueMapper($translator)->label(3));
+    }
+
+    public function testLabelUnknownWhenInvalid(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('statistics.distribution.weekday.unknown')
+            ->willReturn('Unknown');
+
+        self::assertSame('Unknown', new WeekdayValueMapper($translator)->label(0));
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/DistributionSectionNavProviderTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/DistributionSectionNavProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Panel\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\DistributionSectionNavProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DistributionSectionNavProviderTest extends TestCase
+{
+    public function testSectionsContainAllDistributionRoutesInOrder(): void
+    {
+        $sections = new DistributionSectionNavProvider()->sections();
+
+        $routes = array_column($sections, 'route');
+
+        self::assertSame([
+            'app_stats_distribution_urgency',
+            'app_stats_distribution_gender',
+            'app_stats_distribution_age',
+            'app_stats_distribution_assignment',
+            'app_stats_distribution_occasion',
+            'app_stats_distribution_time',
+            'app_stats_distribution_transport_time',
+            'app_stats_distribution_resources',
+            'app_stats_distribution_traits',
+        ], $routes);
+    }
+
+    public function testEachSectionHasTranslationLabelKey(): void
+    {
+        foreach (new DistributionSectionNavProvider()->sections() as $row) {
+            self::assertArrayHasKey('label', $row);
+            self::assertStringStartsWith('statistics.distribution.section.', $row['label']);
+        }
+    }
+}

--- a/tests/Statistics/Unit/Panel/Distribution/TransportTimeBucketExpressionTest.php
+++ b/tests/Statistics/Unit/Panel/Distribution/TransportTimeBucketExpressionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Panel\Distribution;
+
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TransportTimeBucketExpressionTest extends TestCase
+{
+    public function testOrderedBucketCodesIncludesUnknownLastInSequence(): void
+    {
+        self::assertSame([0, 1, 2, 3, 4, 5, 6, 8], TransportTimeBucketExpression::orderedBucketCodes());
+    }
+
+    public function testSqlContainsExpectedThresholds(): void
+    {
+        $sql = TransportTimeBucketExpression::sql('transport_time_minutes');
+        self::assertStringContainsString('< 10', $sql);
+        self::assertStringContainsString('< 20', $sql);
+        self::assertStringContainsString('< 60', $sql);
+        self::assertStringContainsString((string) TransportTimeBucketExpression::UNKNOWN, $sql);
+    }
+
+    /**
+     * @return \Generator<string, array{0: int|null, 1: int}>
+     */
+    public static function minutesToBucketProvider(): \Generator
+    {
+        yield 'null' => [null, TransportTimeBucketExpression::UNKNOWN];
+        yield 'negative' => [-1, TransportTimeBucketExpression::OVER_60];
+        yield '0' => [0, TransportTimeBucketExpression::UNDER_10];
+        yield '9' => [9, TransportTimeBucketExpression::UNDER_10];
+        yield '10' => [10, TransportTimeBucketExpression::MIN_10_TO_20];
+        yield '19' => [19, TransportTimeBucketExpression::MIN_10_TO_20];
+        yield '20' => [20, TransportTimeBucketExpression::MIN_20_TO_30];
+        yield '59' => [59, TransportTimeBucketExpression::MIN_50_TO_60];
+        yield '60' => [60, TransportTimeBucketExpression::OVER_60];
+        yield 'large' => [5000, TransportTimeBucketExpression::OVER_60];
+    }
+
+    #[DataProvider('minutesToBucketProvider')]
+    public function testClassifyMinutesMatchesBucketRules(?int $minutes, int $expected): void
+    {
+        self::assertSame($expected, TransportTimeBucketExpression::classifyMinutes($minutes));
+    }
+
+    public function testSqlUsesSameConstantsAsClassifyMinutes(): void
+    {
+        $sql = TransportTimeBucketExpression::sql('m');
+        foreach ([
+            'NULL' => TransportTimeBucketExpression::UNKNOWN,
+            '< 0' => TransportTimeBucketExpression::OVER_60,
+            '< 10' => TransportTimeBucketExpression::UNDER_10,
+            '< 20' => TransportTimeBucketExpression::MIN_10_TO_20,
+            '< 30' => TransportTimeBucketExpression::MIN_20_TO_30,
+            '< 40' => TransportTimeBucketExpression::MIN_30_TO_40,
+            '< 50' => TransportTimeBucketExpression::MIN_40_TO_50,
+            '< 60' => TransportTimeBucketExpression::MIN_50_TO_60,
+        ] as $fragment => $code) {
+            self::assertStringContainsString('THEN '.$code, $sql, 'Missing branch for '.$fragment);
+        }
+        self::assertStringContainsString('ELSE '.TransportTimeBucketExpression::OVER_60, $sql);
+    }
+}

--- a/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
+++ b/tests/Statistics/Unit/Query/DistributionPanelQueryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Statistics\Unit\Query;
 use App\Statistics\Application\Filter\FilterRegistry;
 use App\Statistics\Application\Filter\FilterState;
 use App\Statistics\Application\Panel\Distribution\DistributionNumericMetric;
+use App\Statistics\Application\Panel\Distribution\TransportTimeBucketExpression;
 use App\Statistics\Infrastructure\Query\DistributionPanelQuery;
 use App\Statistics\Infrastructure\Query\SqlFilterBuilder;
 use App\Tests\Statistics\Fixtures\DistributionPanelFixtures;
@@ -103,6 +104,123 @@ final class DistributionPanelQueryTest extends TestCase
                     self::stringContains('WHEN age IS NULL THEN -1'),
                     self::stringContains('GROUP BY (CASE'),
                     self::stringContains('COUNT(DISTINCT hospital_id)')
+                ),
+                [],
+                []
+            )
+            ->willReturn([]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        $query->fetchDistribution($panel, $state);
+    }
+
+    public function testFetchDistributionGroupsByCreatedHour(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::createdHour();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('SELECT created_hour AS dimension_key'),
+                    self::stringContains('GROUP BY created_hour'),
+                    self::stringContains('ORDER BY created_hour')
+                ),
+                [],
+                []
+            )
+            ->willReturn([]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        $query->fetchDistribution($panel, $state);
+    }
+
+    public function testFetchDistributionGroupsByTransportTimeBucketExpression(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::transportTimeBucket();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $bucketSql = TransportTimeBucketExpression::sql('transport_time_minutes');
+
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('SELECT '.$bucketSql.' AS dimension_key'),
+                    self::stringContains('GROUP BY '.$bucketSql),
+                    self::stringContains('ORDER BY '.$bucketSql)
+                ),
+                [],
+                []
+            )
+            ->willReturn([]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        $query->fetchDistribution($panel, $state);
+    }
+
+    public function testFetchNumericStatsForTransportTimeUsesMetricColumnInGroupBy(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::transportTimeBucket();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $bucketSql = TransportTimeBucketExpression::sql('transport_time_minutes');
+
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('transport_time_minutes IS NOT NULL'),
+                    self::stringContains('GROUP BY '.$bucketSql),
+                    self::stringContains('percentile_cont(0.5) WITHIN GROUP (ORDER BY transport_time_minutes)')
+                ),
+                [],
+                []
+            )
+            ->willReturn([]);
+
+        $query = new DistributionPanelQuery($connection, $sqlFilterBuilder);
+        $query->fetchNumericDistributionStats($panel, $state, DistributionNumericMetric::TransportTimeMinutes);
+    }
+
+    public function testFetchDistributionGroupsByRequiresResusTriState(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $sqlFilterBuilder = new SqlFilterBuilder(new FilterRegistry());
+        $panel = DistributionPanelFixtures::requiresResus();
+        $state = new FilterState([
+            'date_range' => 'all_cases',
+            'hospital_tier' => [],
+            'hospital_location' => [],
+        ]);
+
+        $connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::logicalAnd(
+                    self::stringContains('requires_resus IS NULL THEN 0'),
+                    self::stringContains('requires_resus = false THEN 1'),
+                    self::stringContains('GROUP BY (CASE'),
+                    self::stringContains('ORDER BY (CASE')
                 ),
                 [],
                 []

--- a/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
+++ b/tests/Statistics/Unit/UI/Live/DistributionPanelComponentTest.php
@@ -6,10 +6,16 @@ namespace App\Tests\Statistics\Unit\UI\Live;
 
 use App\Statistics\Application\Filter\FilterRegistry;
 use App\Statistics\Application\Mapping\AgeCohortValueMapper;
+use App\Statistics\Application\Mapping\AssignmentDistributionNameMapper;
+use App\Statistics\Application\Mapping\DistributionDimensionValueMapperResolver;
 use App\Statistics\Application\Mapping\GenderValueMapper;
 use App\Statistics\Application\Mapping\HospitalLocationValueMapper;
 use App\Statistics\Application\Mapping\HospitalTypeValueMapper;
+use App\Statistics\Application\Mapping\HourOfDayValueMapper;
+use App\Statistics\Application\Mapping\OccasionDistributionNameMapper;
+use App\Statistics\Application\Mapping\TransportTimeBucketValueMapper;
 use App\Statistics\Application\Mapping\TriageValueMapper;
+use App\Statistics\Application\Mapping\WeekdayValueMapper;
 use App\Statistics\Application\Panel\Distribution\DistributionNumericMetricMerge;
 use App\Statistics\Application\Panel\Distribution\DistributionPageConfigResolver;
 use App\Statistics\Application\Panel\Distribution\DistributionSectionNavProvider;
@@ -334,10 +340,25 @@ final class DistributionPanelComponentTest extends TestCase
     private function buildComponent(DistributionPanelQuery $query, RequestStack $stack): DistributionPanelComponent
     {
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->method('trans')->willReturnCallback(static fn (string $key): string => $key);
+        $translator->method('trans')->willReturnCallback(static fn (string $key, array $parameters = []): string => $key);
 
         $filterRegistry = new FilterRegistry();
         $resolver = new QueryStateResolver($filterRegistry);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(false);
+
+        $dimensionMapperResolver = new DistributionDimensionValueMapperResolver(
+            $translator,
+            new TriageValueMapper($translator),
+            new GenderValueMapper($translator),
+            new AgeCohortValueMapper($translator),
+            new WeekdayValueMapper($translator),
+            new HourOfDayValueMapper($translator),
+            new TransportTimeBucketValueMapper($translator),
+            new AssignmentDistributionNameMapper($connection, $translator),
+            new OccasionDistributionNameMapper($connection, $translator),
+        );
 
         return new DistributionPanelComponent(
             new DistributionSectionNavProvider(),
@@ -347,11 +368,9 @@ final class DistributionPanelComponentTest extends TestCase
             new DistributionTransformer(),
             new DistributionNumericMetricMerge(),
             new Renderer($translator),
-            new TriageValueMapper($translator),
-            new GenderValueMapper($translator),
+            $dimensionMapperResolver,
             new HospitalTypeValueMapper($translator),
             new HospitalLocationValueMapper($translator),
-            new AgeCohortValueMapper($translator),
             $filterRegistry,
             $stack,
         );

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -929,6 +929,218 @@
         <source>statistics.distribution.section.age</source>
         <target>Age cohorts</target>
       </trans-unit>
+      <trans-unit id="d1strSecAs" resname="statistics.distribution.section.assignment">
+        <source>statistics.distribution.section.assignment</source>
+        <target>Assignments</target>
+      </trans-unit>
+      <trans-unit id="d1strSecOc" resname="statistics.distribution.section.occasion">
+        <source>statistics.distribution.section.occasion</source>
+        <target>Occasions</target>
+      </trans-unit>
+      <trans-unit id="d1strSecTm" resname="statistics.distribution.section.time">
+        <source>statistics.distribution.section.time</source>
+        <target>Weekday &amp; hour</target>
+      </trans-unit>
+      <trans-unit id="d1strSecTt" resname="statistics.distribution.section.transport_time">
+        <source>statistics.distribution.section.transport_time</source>
+        <target>Transport time</target>
+      </trans-unit>
+      <trans-unit id="d1strSecRs" resname="statistics.distribution.section.resources">
+        <source>statistics.distribution.section.resources</source>
+        <target>Resources</target>
+      </trans-unit>
+      <trans-unit id="d1strSecTr" resname="statistics.distribution.section.traits">
+        <source>statistics.distribution.section.traits</source>
+        <target>Clinical traits</target>
+      </trans-unit>
+      <trans-unit id="d1strDimAs" resname="statistics.distribution.dim.assignment">
+        <source>statistics.distribution.dim.assignment</source>
+        <target>Assignment</target>
+      </trans-unit>
+      <trans-unit id="d1strDimOc" resname="statistics.distribution.dim.occasion">
+        <source>statistics.distribution.dim.occasion</source>
+        <target>Occasion</target>
+      </trans-unit>
+      <trans-unit id="d1strDimWd" resname="statistics.distribution.dim.weekday">
+        <source>statistics.distribution.dim.weekday</source>
+        <target>Weekday</target>
+      </trans-unit>
+      <trans-unit id="d1strDimHr" resname="statistics.distribution.dim.hour">
+        <source>statistics.distribution.dim.hour</source>
+        <target>Hour of day</target>
+      </trans-unit>
+      <trans-unit id="d1strDimTtb" resname="statistics.distribution.dim.transport_time_bucket">
+        <source>statistics.distribution.dim.transport_time_bucket</source>
+        <target>Transport time (bucket)</target>
+      </trans-unit>
+      <trans-unit id="d1strDimRr" resname="statistics.distribution.dim.requires_resus">
+        <source>statistics.distribution.dim.requires_resus</source>
+        <target>Resuscitation room required</target>
+      </trans-unit>
+      <trans-unit id="d1strDimRc" resname="statistics.distribution.dim.requires_cathlab">
+        <source>statistics.distribution.dim.requires_cathlab</source>
+        <target>Cath lab required</target>
+      </trans-unit>
+      <trans-unit id="d1strDimCp" resname="statistics.distribution.dim.is_cpr">
+        <source>statistics.distribution.dim.is_cpr</source>
+        <target>CPR</target>
+      </trans-unit>
+      <trans-unit id="d1strDimVe" resname="statistics.distribution.dim.is_ventilated">
+        <source>statistics.distribution.dim.is_ventilated</source>
+        <target>Ventilated</target>
+      </trans-unit>
+      <trans-unit id="d1strDimPh" resname="statistics.distribution.dim.is_with_physician">
+        <source>statistics.distribution.dim.is_with_physician</source>
+        <target>With physician</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB0" resname="statistics.distribution.transport_time_bucket.under_10">
+        <source>statistics.distribution.transport_time_bucket.under_10</source>
+        <target>Under 10 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB1" resname="statistics.distribution.transport_time_bucket.10_20">
+        <source>statistics.distribution.transport_time_bucket.10_20</source>
+        <target>10–20 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB2" resname="statistics.distribution.transport_time_bucket.20_30">
+        <source>statistics.distribution.transport_time_bucket.20_30</source>
+        <target>20–30 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB3" resname="statistics.distribution.transport_time_bucket.30_40">
+        <source>statistics.distribution.transport_time_bucket.30_40</source>
+        <target>30–40 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB4" resname="statistics.distribution.transport_time_bucket.40_50">
+        <source>statistics.distribution.transport_time_bucket.40_50</source>
+        <target>40–50 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB5" resname="statistics.distribution.transport_time_bucket.50_60">
+        <source>statistics.distribution.transport_time_bucket.50_60</source>
+        <target>50–60 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtB6" resname="statistics.distribution.transport_time_bucket.over_60">
+        <source>statistics.distribution.transport_time_bucket.over_60</source>
+        <target>Over 60 min</target>
+      </trans-unit>
+      <trans-unit id="d1strTtBU" resname="statistics.distribution.transport_time_bucket.unknown">
+        <source>statistics.distribution.transport_time_bucket.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriRU" resname="statistics.distribution.tri.requires_resus.unknown">
+        <source>statistics.distribution.tri.requires_resus.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriRN" resname="statistics.distribution.tri.requires_resus.no">
+        <source>statistics.distribution.tri.requires_resus.no</source>
+        <target>No</target>
+      </trans-unit>
+      <trans-unit id="d1strTriRY" resname="statistics.distribution.tri.requires_resus.yes">
+        <source>statistics.distribution.tri.requires_resus.yes</source>
+        <target>Yes</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCU" resname="statistics.distribution.tri.requires_cathlab.unknown">
+        <source>statistics.distribution.tri.requires_cathlab.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCN" resname="statistics.distribution.tri.requires_cathlab.no">
+        <source>statistics.distribution.tri.requires_cathlab.no</source>
+        <target>No</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCY" resname="statistics.distribution.tri.requires_cathlab.yes">
+        <source>statistics.distribution.tri.requires_cathlab.yes</source>
+        <target>Yes</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCpU" resname="statistics.distribution.tri.is_cpr.unknown">
+        <source>statistics.distribution.tri.is_cpr.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCpN" resname="statistics.distribution.tri.is_cpr.no">
+        <source>statistics.distribution.tri.is_cpr.no</source>
+        <target>No</target>
+      </trans-unit>
+      <trans-unit id="d1strTriCpY" resname="statistics.distribution.tri.is_cpr.yes">
+        <source>statistics.distribution.tri.is_cpr.yes</source>
+        <target>Yes</target>
+      </trans-unit>
+      <trans-unit id="d1strTriVeU" resname="statistics.distribution.tri.is_ventilated.unknown">
+        <source>statistics.distribution.tri.is_ventilated.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriVeN" resname="statistics.distribution.tri.is_ventilated.no">
+        <source>statistics.distribution.tri.is_ventilated.no</source>
+        <target>No</target>
+      </trans-unit>
+      <trans-unit id="d1strTriVeY" resname="statistics.distribution.tri.is_ventilated.yes">
+        <source>statistics.distribution.tri.is_ventilated.yes</source>
+        <target>Yes</target>
+      </trans-unit>
+      <trans-unit id="d1strTriPhU" resname="statistics.distribution.tri.is_with_physician.unknown">
+        <source>statistics.distribution.tri.is_with_physician.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strTriPhN" resname="statistics.distribution.tri.is_with_physician.no">
+        <source>statistics.distribution.tri.is_with_physician.no</source>
+        <target>No</target>
+      </trans-unit>
+      <trans-unit id="d1strTriPhY" resname="statistics.distribution.tri.is_with_physician.yes">
+        <source>statistics.distribution.tri.is_with_physician.yes</source>
+        <target>Yes</target>
+      </trans-unit>
+      <trans-unit id="d1strWdUk" resname="statistics.distribution.weekday.unknown">
+        <source>statistics.distribution.weekday.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN1" resname="statistics.distribution.weekday.n1">
+        <source>statistics.distribution.weekday.n1</source>
+        <target>Monday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN2" resname="statistics.distribution.weekday.n2">
+        <source>statistics.distribution.weekday.n2</source>
+        <target>Tuesday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN3" resname="statistics.distribution.weekday.n3">
+        <source>statistics.distribution.weekday.n3</source>
+        <target>Wednesday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN4" resname="statistics.distribution.weekday.n4">
+        <source>statistics.distribution.weekday.n4</source>
+        <target>Thursday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN5" resname="statistics.distribution.weekday.n5">
+        <source>statistics.distribution.weekday.n5</source>
+        <target>Friday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN6" resname="statistics.distribution.weekday.n6">
+        <source>statistics.distribution.weekday.n6</source>
+        <target>Saturday</target>
+      </trans-unit>
+      <trans-unit id="d1strWdN7" resname="statistics.distribution.weekday.n7">
+        <source>statistics.distribution.weekday.n7</source>
+        <target>Sunday</target>
+      </trans-unit>
+      <trans-unit id="d1strHrUk" resname="statistics.distribution.hour.unknown">
+        <source>statistics.distribution.hour.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
+      <trans-unit id="d1strHrSl" resname="statistics.distribution.hour.slot">
+        <source>statistics.distribution.hour.slot</source>
+        <target>{hour}:00</target>
+      </trans-unit>
+      <trans-unit id="d1strOccNone" resname="statistics.distribution.occasion.none">
+        <source>statistics.distribution.occasion.none</source>
+        <target>No occasion</target>
+      </trans-unit>
+      <trans-unit id="d1strOccInv" resname="statistics.distribution.occasion.invalid_id">
+        <source>statistics.distribution.occasion.invalid_id</source>
+        <target>Unknown occasion</target>
+      </trans-unit>
+      <trans-unit id="d1strAsInv" resname="statistics.distribution.assignment.invalid_id">
+        <source>statistics.distribution.assignment.invalid_id</source>
+        <target>Unknown assignment</target>
+      </trans-unit>
+      <trans-unit id="d1strEntMiss" resname="statistics.distribution.entity_name_missing">
+        <source>statistics.distribution.entity_name_missing</source>
+        <target>ID {id}</target>
+      </trans-unit>
       <trans-unit id="d1strAgeU" resname="statistics.distribution.age.unknown">
         <source>statistics.distribution.age.unknown</source>
         <target>Unknown</target>


### PR DESCRIPTION
### Summary

- Introduced reusable **distribution panels** for the statistics dashboard  
- Standardized structure and rendering of distribution-based visualizations  
- Integrated panels into existing statistics and dashboard components  
- Refactored existing distribution logic to align with the new panel abstraction  
- Updated templates and UI components to support consistent panel usage  
- Added tests to ensure correct rendering and data handling  

### Motivation

- Unify how distribution data is presented across the dashboard  
- Reduce duplication by introducing reusable panel components  
- Improve maintainability and scalability of statistics-related UI features  
- Provide a solid foundation for future distribution-based visualizations and extensions  

### Notes for Reviewers

- Review the abstraction and structure of the new distribution panels  
- Verify that existing distribution features were correctly migrated to the new system  
- Check UI consistency across all panels and dashboard views  
- Ensure no regressions in existing statistics or visualization logic  
- Confirm tests adequately cover panel rendering and integration  