### PR TITLE
feat: Add dedicated homepage and move statistics to their own default entry point

### DIFF
--- a/assets/styles/home.css
+++ b/assets/styles/home.css
@@ -1,0 +1,211 @@
+.hero {
+    text-align: center;
+    padding: 6.5rem 0;
+}
+
+.hero-title {
+    font-size: 3rem;
+    font-weight: var(--tblr-font-weight-black);
+    letter-spacing: -0.04em;
+    line-height: 1.2;
+}
+@media (max-width: 767.98px) {
+    .hero-title {
+        font-size: 2rem;
+    }
+}
+
+.hero-description {
+    color: var(--tblr-secondary);
+    font-size: var(--tblr-font-size-h2);
+    line-height: 1.5;
+    margin: 0 auto;
+    max-width: 45rem;
+}
+@media (max-width: 575.98px) {
+    .hero-description {
+        font-size: var(--tblr-font-size-h3);
+    }
+}
+
+.hero-description-wide {
+    max-width: 61.875rem;
+}
+
+.hero-subheader {
+    font-size: 0.75rem;
+    font-weight: var(--tblr-font-weight-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    line-height: 1rem;
+    color: var(--tblr-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.section {
+    --section-bg: var(--tblr-bg-surface);
+    background: var(--section-bg);
+    position: relative;
+    padding: 5rem 0;
+}
+
+.section-light {
+    --section-bg: var(--tblr-bg-surface-secondary);
+}
+
+.section-header {
+    text-align: center;
+    max-width: 45rem;
+    margin: 0 auto 5rem;
+}
+
+.section-title {
+    font-size: var(--tblr-font-size-h1);
+    font-weight: var(--tblr-font-weight-bold);
+    line-height: 1.2;
+}
+
+.section-title-lg {
+    font-size: 2rem;
+}
+
+.section-description {
+    color: var(--tblr-secondary);
+    font-size: var(--tblr-font-size-h3);
+    line-height: var(--tblr-line-height-h3);
+    margin-top: 1rem;
+}
+
+.section-divider {
+    position: absolute;
+    bottom: 100%;
+    pointer-events: none;
+    height: 5rem;
+    width: 100%;
+}
+
+.section-divider-auto {
+    height: auto;
+}
+
+.shape {
+    --tblr-shape-size: 2.5rem;
+    --tblr-shape-icon-size: 1.5rem;
+    background-color: var(--tblr-primary-lt);
+    color: var(--tblr-primary);
+    border-radius: 35%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--tblr-shape-size);
+    width: var(--tblr-shape-size);
+}
+.shape .icon {
+    width: var(--tblr-shape-icon-size);
+    height: var(--tblr-shape-icon-size);
+}
+
+.shape-xxs {
+    --tblr-shape-size: 1rem;
+    --tblr-shape-icon-size: 0.5rem;
+}
+
+.shape-xs {
+    --tblr-shape-size: 1.25rem;
+    --tblr-shape-icon-size: 0.75rem;
+}
+
+.shape-sm {
+    --tblr-shape-size: 2rem;
+    --tblr-shape-icon-size: 1.5rem;
+}
+
+.shape-md {
+    --tblr-shape-size: 2.5rem;
+    --tblr-shape-icon-size: 1.5rem;
+}
+
+.shape-lg {
+    --tblr-shape-size: 3rem;
+    --tblr-shape-icon-size: 2rem;
+}
+
+.shape-xl {
+    --tblr-shape-size: 5rem;
+    --tblr-shape-icon-size: 3rem;
+}
+
+.shape-2xl {
+    --tblr-shape-size: 7rem;
+    --tblr-shape-icon-size: 5rem;
+}
+
+.shape-blue {
+    background: var(--tblr-blue-lt);
+    color: var(--tblr-blue);
+}
+
+.shape-indigo {
+    background: var(--tblr-indigo-lt);
+    color: var(--tblr-indigo);
+}
+
+.shape-purple {
+    background: var(--tblr-purple-lt);
+    color: var(--tblr-purple);
+}
+
+.shape-pink {
+    background: var(--tblr-pink-lt);
+    color: var(--tblr-pink);
+}
+
+.shape-red {
+    background: var(--tblr-red-lt);
+    color: var(--tblr-red);
+}
+
+.shape-orange {
+    background: var(--tblr-orange-lt);
+    color: var(--tblr-orange);
+}
+
+.shape-yellow {
+    background: var(--tblr-yellow-lt);
+    color: var(--tblr-yellow);
+}
+
+.shape-green {
+    background: var(--tblr-green-lt);
+    color: var(--tblr-green);
+}
+
+.shape-teal {
+    background: var(--tblr-teal-lt);
+    color: var(--tblr-teal);
+}
+
+.shape-cyan {
+    background: var(--tblr-cyan-lt);
+    color: var(--tblr-cyan);
+}
+
+.shape-black {
+    background: var(--tblr-black-lt);
+    color: var(--tblr-black);
+}
+
+.shape-white {
+    background: var(--tblr-white-lt);
+    color: var(--tblr-white);
+}
+
+.shape-gray {
+    background: var(--tblr-gray-lt);
+    color: var(--tblr-gray);
+}
+
+.shape-gray-dark {
+    background: var(--tblr-gray-dark-lt);
+    color: var(--tblr-gray-dark);
+}

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -36,6 +36,15 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
         return $entity instanceof Hospital ? $entity : null;
     }
 
+    public function countParticipating(): int
+    {
+        return $this->createQueryBuilder('h')
+            ->select('COUNT(h.id)')
+            ->andWhere('h.isParticipating = true')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function getQueryBuilderForAccessibleHospitals(User $user): QueryBuilder
     {
         $qb = $this->createQueryBuilder('h')

--- a/src/Content/UI/Http/Controller/DefaultController.php
+++ b/src/Content/UI/Http/Controller/DefaultController.php
@@ -25,98 +25,15 @@ final class DefaultController extends AbstractController
     #[Route('/', name: 'app_default')]
     public function index(): Response
     {
-        $userCount = $this->userRepository->count();
+        if ($this->isGranted('ROLE_USER')) {
+            return $this->render('@Content/dashboard/empty.html.twig');
+        }
 
-        $hospitalCount = $this->hospitalRepository->count();
-        $participatingHospitalCount = $this->hospitalRepository->count(['isParticipating' => true]);
-
-        $importCount = $this->importRepository->count();
-        $allocationCount = $this->allocationRepository->count();
-
-        $charts = $this->buildDashboardCharts();
-
-        return $this->render('@Content/index.html.twig', [
-            'userCount' => $userCount,
-            'hospitalCount' => $hospitalCount,
-            'participatingHospitalCount' => $participatingHospitalCount,
-            'importCount' => $importCount,
-            'allocationCount' => $allocationCount,
-            'allocationChart' => $charts['allocationChart'],
-            'importChart' => $charts['importChart'],
+        return $this->render('@Content/public/home.html.twig', [
+            'userCount' => $this->userRepository->count(),
+            'hospitalCount' => $this->hospitalRepository->countParticipating(),
+            'importCount' => $this->importRepository->count(),
+            'allocationCount' => $this->allocationRepository->count(),
         ]);
-    }
-
-    /**
-     * @return array{
-     *     allocationChart: array{
-     *         labels: string[],
-     *         monthlyCounts: int[],
-     *         cumulativeCounts: int[]
-     *     },
-     *     importChart: array{
-     *         labels: string[],
-     *         monthlyCounts: int[]
-     *     }
-     * }
-     */
-    private function buildDashboardCharts(): array
-    {
-        $currentMonth = new \DateTimeImmutable('first day of this month 00:00:00');
-
-        $start = $currentMonth->modify('-11 months');
-
-        $monthKeys = [];
-        $labels = [];
-
-        $cursor = $start;
-        while ($cursor <= $currentMonth) {
-            $key = $cursor->format('Y-m');
-            $monthKeys[] = $key;
-
-            $labels[] = $cursor->format('M');
-
-            $cursor = $cursor->modify('+1 month');
-        }
-
-        $allocationRaw = $this->allocationRepository->countByMonthLast12Months();
-        $importRaw = $this->importRepository->countByMonthLast12Months();
-
-        $mapMonthlyCounts = function (array $rawRows, array $keys): array {
-            $base = array_fill_keys($keys, 0);
-
-            foreach ($rawRows as $row) {
-                $key = sprintf('%04d-%02d', $row['year'], $row['month']);
-                if (\array_key_exists($key, $base)) {
-                    $base[$key] = (int) $row['count'];
-                }
-            }
-
-            return array_values($base);
-        };
-
-        $allocationMonthlyCounts = $mapMonthlyCounts($allocationRaw, $monthKeys);
-        $importMonthlyCounts = $mapMonthlyCounts($importRaw, $monthKeys);
-
-        $initialAllocations = $this->allocationRepository->countBefore($start);
-
-        $allocationCumulativeCounts = [];
-        $runningTotal = $initialAllocations;
-
-        foreach ($allocationMonthlyCounts as $value) {
-            $runningTotal += $value;
-            $allocationCumulativeCounts[] = $runningTotal;
-        }
-
-        return [
-            'allocationChart' => [
-                'labels' => $labels,
-                'monthlyCounts' => $allocationMonthlyCounts,
-                'cumulativeCounts' => $allocationCumulativeCounts,
-            ],
-            'importChart' => [
-                'labels' => $labels,
-                'monthlyCounts' => $importMonthlyCounts,
-            ],
-        ];
     }
 }

--- a/src/Content/UI/Twig/templates/dashboard/empty.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/empty.html.twig
@@ -1,0 +1,28 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.dashboard'|trans }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    <div class="container-xl">
+        <twig:Breadcrumbs :items="[
+            { label: 'title.dashboard' }
+        ]" />
+
+        <div class="page-header d-print-none">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <div class="page-pretitle">{{ 'title.dashboard'|trans }}</div>
+                    <h2 class="page-title">{{ 'dashboard.empty.title'|trans }}</h2>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block page_content %}
+    <div class="card">
+        <div class="card-body">
+            <p class="text-muted mb-0">{{ 'dashboard.empty.description'|trans }}</p>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Content/UI/Twig/templates/public/home.html.twig
+++ b/src/Content/UI/Twig/templates/public/home.html.twig
@@ -1,0 +1,241 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('styles/home.css') }}">
+{% endblock %}
+
+{% block title %}{{ 'public.home.meta_title'|trans }} - {{ parent() }}{% endblock %}
+
+{% block page_body %}
+    <header class="hero pb-0">
+        <div class="container-xl">
+            <h1 class="hero-title">{{ 'public.home.hero.title'|trans }}</h1>
+            <p class="hero-description mt-4">
+                {{ 'public.home.hero.subtitle'|trans }}
+            </p>
+            <div class="my-5">
+                <div class="row g-3 justify-content-center">
+                    <div class="col-auto">
+                        <a href="{{ path('app_register') }}" class="btn btn-lg">{{ 'public.cta.register'|trans }}</a>
+                    </div>
+                    <div class="col-auto">
+                        <a href="{{ path('app_login') }}" class="btn btn-lg btn-primary">{{ 'public.cta.sign_in'|trans }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <section class="section">
+        <div class="container">
+            <div class="row justify-content-lg-center">
+                <div class="col-sm-6 col-lg-3">
+                    <div class="text-center">
+                        <h2 class="display-5 m-0 fw-bold">{{ userCount|number_format(0, ',', '.') }}</h2>
+                        <p class="text-secondary m-0">{{ 'public.stats.users'|trans }}</p>
+                    </div>
+                </div>
+                <div class="col-sm-6 col-lg-3">
+                    <div class="text-center">
+                        <h2 class="display-5 m-0 fw-bold">{{ hospitalCount|number_format(0, ',', '.') }}</h2>
+                        <p class="text-secondary m-0">{{ 'public.stats.hospitals'|trans }}</p>
+                    </div>
+                </div>
+                <div class="col-sm-6 col-lg-3">
+                    <div class="text-center">
+                        <h2 class="display-5 m-0 fw-bold">{{ allocationCount|number_format(0, ',', '.') }}</h2>
+                        <p class="text-secondary m-0">{{ 'public.stats.allocations'|trans }}</p>
+                    </div>
+                </div>
+                <div class="col-sm-6 col-lg-3">
+                    <div class="text-center">
+                        <h2 class="display-5 m-0 fw-bold">{{ importCount|number_format(0, ',', '.') }}</h2>
+                        <p class="text-secondary m-0">{{ 'public.stats.imports'|trans }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section-light">
+        <div class="container">
+            <div class="row items-center text-center g-lg-10">
+                <div class="col-6 mb-3">
+                    <div class="shape shape-md mb-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-free-rights">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                            <path d="M13.867 9.75c-.246 -.48 -.708 -.769 -1.2 -.75h-1.334c-.736 0 -1.333 .67 -1.333 1.5c0 .827 .597 1.499 1.333 1.499h1.334c.736 0 1.333 .671 1.333 1.5c0 .828 -.597 1.499 -1.333 1.499h-1.334c-.492 .019 -.954 -.27 -1.2 -.75" />
+                            <path d="M12 7v2" />
+                            <path d="M12 15v2" />
+                            <path d="M6 6l1.5 1.5" />
+                            <path d="M16.5 16.5l1.5 1.5" />
+                        </svg>
+                    </div>
+                    <h2 class="h2">{{ 'public.home.features.card.independent.title'|trans }}</h2>
+                    <p class="text-secondary">{{ 'public.home.features.card.independent.text'|trans }}</p>
+                </div>
+                <div class="col-6 mb-3">
+                    <div class="shape shape-md mb-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-building-hospital">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M3 21l18 0" />
+                            <path d="M5 21v-16a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v16" />
+                            <path d="M9 21v-4a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v4" />
+                            <path d="M10 9l4 0" />
+                            <path d="M12 7l0 4" />
+                        </svg>
+                    </div>
+                    <h2 class="h2">{{ 'public.home.features.card.hospital_centered.title'|trans }}</h2>
+                    <p class="text-secondary">
+                        {{ 'public.home.features.card.hospital_centered.text'|trans }}
+                    </p>
+                </div>
+                <div class="col-6">
+                    <div class="shape shape-md mb-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-compass">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M8 16l2 -6l6 -2l-2 6l-6 2" />
+                            <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                            <path d="M12 3l0 2" />
+                            <path d="M12 19l0 2" />
+                            <path d="M3 12l2 0" />
+                            <path d="M19 12l2 0" />
+                        </svg>
+                    </div>
+                    <h2 class="h2">{{ 'public.home.features.card.explore.title'|trans }}</h2>
+                    <p class="text-secondary">{{ 'public.home.features.card.explore.text'|trans }}</p>
+                </div>
+                <div class="col-6">
+                    <div class="shape shape-md mb-3">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-chart-area-line">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M4 19l4 -6l4 2l4 -5l4 4l0 5l-16 0" />
+                            <path d="M4 12l3 -4l4 2l5 -6l4 4" />
+                        </svg>
+                    </div>
+                    <h2 class="h2">{{ 'public.home.features.card.analytics.title'|trans }}</h2>
+                    <p class="text-secondary">{{ 'public.home.features.card.analytics.text'|trans }}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="container-narrow text-center">
+            <h3 class="h1">{{ 'public.home.about.title'|trans }}</h3>
+            <p class="text-secondary">{{ 'public.home.about.p1'|trans }}</p>
+            <p class="text-secondary">{{ 'public.home.about.p2'|trans }}</p>
+            <p class="text-secondary mb-0">{{ 'public.home.about.p3'|trans }}</p>
+        </div>
+    </section>
+
+    <section class="section section-light">
+        <div class="container">
+            <div class="section-header">
+                <h2 class="section-title">{{ 'public.home.features.overview.title'|trans }}</h2>
+                <div class="section-description">
+                    {{ 'public.home.features.overview.subtitle'|trans }}
+                </div>
+            </div>
+            <div class="row g-lg-10">
+                <div class="col-lg-6">
+                    <div class="space-y-6">
+                        <div>
+                            <div class="row">
+                                <div class="col-auto">
+                                    <div class="shape shape-md">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-tool">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M7 10h3v-3l-3.5 -3.5a6 6 0 0 1 8 8l6 6a2 2 0 0 1 -3 3l-6 -6a6 6 0 0 1 -8 -8l3.5 3.5" />
+                                        </svg>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <h3 class="h2 mb-2">{{ 'public.home.features.detail.hospital_management.title'|trans }}</h3>
+                                    <p class="text-secondary m-0">
+                                        {{ 'public.home.features.detail.hospital_management.text'|trans }}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="row">
+                                <div class="col-auto">
+                                    <div class="shape shape-md">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-list-details">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M13 5h8" />
+                                            <path d="M13 9h5" />
+                                            <path d="M13 15h8" />
+                                            <path d="M13 19h5" />
+                                            <path d="M3 5a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1l0 -4" />
+                                            <path d="M3 15a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1l0 -4" />
+                                        </svg>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <h3 class="h2 mb-2">{{ 'public.home.features.detail.data_exploration.title'|trans }}</h3>
+                                    <p class="text-secondary m-0">
+                                        {{ 'public.home.features.detail.data_exploration.text'|trans }}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="row">
+                                <div class="col-auto">
+                                    <div class="shape shape-md">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-list-search">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M11 15a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" />
+                                            <path d="M18.5 18.5l2.5 2.5" />
+                                            <path d="M4 6h16" />
+                                            <path d="M4 12h4" />
+                                            <path d="M4 18h4" />
+                                        </svg>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <h3 class="h2 mb-2">{{ 'public.home.features.detail.statistics.title'|trans }}</h3>
+                                    <p class="text-secondary m-0">
+                                        {{ 'public.home.features.detail.statistics.text'|trans }}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="row">
+                                <div class="col-auto">
+                                    <div class="shape shape-md">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-database-heart">
+                                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                            <path d="M4 6c0 1.657 3.582 3 8 3s8 -1.343 8 -3s-3.582 -3 -8 -3s-8 1.343 -8 3" />
+                                            <path d="M4 6v6c0 1.453 2.755 2.665 6.414 2.941" />
+                                            <path d="M20 11v-5" />
+                                            <path d="M4 12v6c0 1.579 3.253 2.873 7.383 2.991" />
+                                            <path d="M18 22l3.35 -3.284a2.143 2.143 0 0 0 .005 -3.071a2.242 2.242 0 0 0 -3.129 -.006l-.224 .22l-.223 -.22a2.242 2.242 0 0 0 -3.128 -.006a2.143 2.143 0 0 0 -.006 3.071l3.355 3.296" />
+                                        </svg>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <h3 class="h2 mb-2">{{ 'public.home.features.detail.import_export.title'|trans }}</h3>
+                                    <p class="text-secondary m-0">
+                                        {{ 'public.home.features.detail.import_export.text'|trans }}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-6 mt-3 mt-lg-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" width="500" height="400" viewBox="0 0 500 400" fill="transparent" stroke="var(--tblr-border-color, #b8cef1)" style="width: 100%; height: auto">
+                        <rect x=".5" y=".5" width="499" height="399" rx="2"></rect>
+                        <line x1="0" y1="0" x2="500" y2="400"></line>
+                        <line x1="0" y1="400" x2="500" y2="0"></line>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/src/Shared/UI/Twig/templates/_embeds/header.html.twig
+++ b/src/Shared/UI/Twig/templates/_embeds/header.html.twig
@@ -17,30 +17,32 @@
                 <div class="d-flex flex-column flex-md-row flex-fill align-items-stretch align-items-md-center">
                     <ul class="navbar-nav">
                         {% block navbar_links %}
-                            <li class="nav-item {{ route starts with 'app_explore' ? 'active' : '' }}">
-                                <a class="nav-link" href="{{ path('app_explore_index') }}">
-                                    <span class="nav-link-title">
-                                        <twig:ux:icon name="tabler:compass" style="height: 1.5em;" />
-                                        {{ 'link.explore'|trans }}
-                                    </span>
-                                </a>
-                            </li>
-                            <li class="nav-item {{ route starts with 'app_stats' ? 'active' : '' }}">
-                                <a class="nav-link" href="{{ path('app_stats_dashboard') }}">
-                                    <span class="nav-link-title">
-                                        <twig:ux:icon name="tabler:graph" style="height: 1.5em;" />
-                                        {{ 'link.statistics'|trans }}
-                                    </span>
-                                </a>
-                            </li>
-                            <li class="nav-item {{ route starts with 'app_import' ? 'active' : '' }}">
-                                <a class="nav-link" href="{{ path('app_import_index') }}">
-                                    <span class="nav-link-title">
-                                        <twig:ux:icon name="tabler:database-import" style="height: 1.5em;" />
-                                        {{ 'link.import'|trans }}
-                                    </span>
-                                </a>
-                            </li>
+                            {% if is_granted('ROLE_USER') %}
+                                <li class="nav-item {{ route starts with 'app_explore' ? 'active' : '' }}">
+                                    <a class="nav-link" href="{{ path('app_explore_index') }}">
+                                        <span class="nav-link-title">
+                                            <twig:ux:icon name="tabler:compass" style="height: 1.5em;" />
+                                            {{ 'link.explore'|trans }}
+                                        </span>
+                                    </a>
+                                </li>
+                                <li class="nav-item {{ route starts with 'app_stats' ? 'active' : '' }}">
+                                    <a class="nav-link" href="{{ path('app_stats_dashboard') }}">
+                                        <span class="nav-link-title">
+                                            <twig:ux:icon name="tabler:graph" style="height: 1.5em;" />
+                                            {{ 'link.statistics'|trans }}
+                                        </span>
+                                    </a>
+                                </li>
+                                <li class="nav-item {{ route starts with 'app_import' ? 'active' : '' }}">
+                                    <a class="nav-link" href="{{ path('app_import_index') }}">
+                                        <span class="nav-link-title">
+                                            <twig:ux:icon name="tabler:database-import" style="height: 1.5em;" />
+                                            {{ 'link.import'|trans }}
+                                        </span>
+                                    </a>
+                                </li>
+                            {% endif %}
                         {% endblock %}
                     </ul>
                 </div>

--- a/src/Statistics/UI/Http/Controller/DashboardController.php
+++ b/src/Statistics/UI/Http/Controller/DashboardController.php
@@ -4,15 +4,105 @@ declare(strict_types=1);
 
 namespace App\Statistics\UI\Http\Controller;
 
+use App\Allocation\Infrastructure\Repository\AllocationRepository;
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class DashboardController extends AbstractController
 {
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly HospitalRepository $hospitalRepository,
+        private readonly ImportRepository $importRepository,
+        private readonly AllocationRepository $allocationRepository,
+    ) {
+    }
+
     #[Route('/statistics/', name: 'app_stats_dashboard', methods: ['GET'])]
     public function index(): Response
     {
-        return $this->render('@Statistics/dashboard/index.html.twig');
+        $charts = $this->buildDashboardCharts();
+
+        return $this->render('@Statistics/dashboard/index.html.twig', [
+            'userCount' => $this->userRepository->count(),
+            'hospitalCount' => $this->hospitalRepository->count(),
+            'participatingHospitalCount' => $this->hospitalRepository->count(['isParticipating' => true]),
+            'importCount' => $this->importRepository->count(),
+            'allocationCount' => $this->allocationRepository->count(),
+            'allocationChart' => $charts['allocationChart'],
+            'importChart' => $charts['importChart'],
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     allocationChart: array{
+     *         labels: string[],
+     *         monthlyCounts: int[],
+     *         cumulativeCounts: int[]
+     *     },
+     *     importChart: array{
+     *         labels: string[],
+     *         monthlyCounts: int[]
+     *     }
+     * }
+     */
+    private function buildDashboardCharts(): array
+    {
+        $currentMonth = new \DateTimeImmutable('first day of this month 00:00:00');
+        $start = $currentMonth->modify('-11 months');
+
+        $monthKeys = [];
+        $labels = [];
+
+        $cursor = $start;
+        while ($cursor <= $currentMonth) {
+            $monthKeys[] = $cursor->format('Y-m');
+            $labels[] = $cursor->format('M');
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        $allocationRaw = $this->allocationRepository->countByMonthLast12Months();
+        $importRaw = $this->importRepository->countByMonthLast12Months();
+
+        $mapMonthlyCounts = function (array $rawRows, array $keys): array {
+            $base = array_fill_keys($keys, 0);
+
+            foreach ($rawRows as $row) {
+                $key = sprintf('%04d-%02d', $row['year'], $row['month']);
+                if (\array_key_exists($key, $base)) {
+                    $base[$key] = (int) $row['count'];
+                }
+            }
+
+            return array_values($base);
+        };
+
+        $allocationMonthlyCounts = $mapMonthlyCounts($allocationRaw, $monthKeys);
+        $importMonthlyCounts = $mapMonthlyCounts($importRaw, $monthKeys);
+        $initialAllocations = $this->allocationRepository->countBefore($start);
+
+        $allocationCumulativeCounts = [];
+        $runningTotal = $initialAllocations;
+        foreach ($allocationMonthlyCounts as $value) {
+            $runningTotal += $value;
+            $allocationCumulativeCounts[] = $runningTotal;
+        }
+
+        return [
+            'allocationChart' => [
+                'labels' => $labels,
+                'monthlyCounts' => $allocationMonthlyCounts,
+                'cumulativeCounts' => $allocationCumulativeCounts,
+            ],
+            'importChart' => [
+                'labels' => $labels,
+                'monthlyCounts' => $importMonthlyCounts,
+            ],
+        ];
     }
 }

--- a/src/Statistics/UI/Twig/templates/dashboard/index.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/index.html.twig
@@ -10,10 +10,132 @@
     {% endembed %}
 {% endblock %}
 
-{% block page_body %}
+{% block page_header %}
     <div class="container-xl">
         <twig:Breadcrumbs :items="[
-            { label: 'link.statistics' }
+            { label: 'link.statistics' },
+            { label: 'link.stats.dashboard' }
         ]" />
+
+        <div class="page-header d-print-none">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <div class="page-pretitle">
+                        {{ 'link.statistics'|trans }}
+                    </div>
+                    <h2 class="page-title">
+                        {{ 'title.stats.overview'|trans }}
+                    </h2>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block page_content %}
+    <div class="row row-deck row-cards">
+        <div class="col-sm-6 col-lg-3">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="avatar">
+                                <twig:ux:icon name="tabler:list" style="height: 2em;" />
+                            </span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">
+                                {{ allocationCount|number_format(0, ',', '.') }} {{ 'link.allocations'|trans }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-lg-3">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="avatar">
+                                <twig:ux:icon name="tabler:database-import" style="height: 2em;" />
+                            </span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">
+                                {{ importCount|number_format(0, ',', '.') }} {{ 'link.imports'|trans }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-lg-3">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="avatar">
+                                <twig:ux:icon name="tabler:user" style="height: 2em;" />
+                            </span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">
+                                {{ userCount }} {{ 'link.users'|trans }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-lg-3">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-auto">
+                            <span class="avatar">
+                                <twig:ux:icon name="tabler:building-hospital" style="height: 2em;" />
+                            </span>
+                        </div>
+                        <div class="col">
+                            <div class="font-weight-medium">
+                                {{ hospitalCount }} {{ 'link.hospitals'|trans }}
+                            </div>
+                            <div class="text-muted">
+                                {{ 'label.hospitals.participating'|trans }}:
+                                <strong>{{ participatingHospitalCount }}</strong>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row row-cards mt-1"
+         data-controller="dashboard-charts"
+         data-dashboard-charts-allocations-value="{{ allocationChart|json_encode|e('html_attr') }}"
+         data-dashboard-charts-imports-value="{{ importChart|json_encode|e('html_attr') }}"
+    >
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title mb-0">Allocations</h3>
+                    <div data-dashboard-charts-target="allocationsChart" class="chart-lg"></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="card-title mb-0">Imports</h3>
+                    <div data-dashboard-charts-target="importsChart" class="chart-lg"></div>
+                </div>
+            </div>
+        </div>
     </div>
 {% endblock %}

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -52,7 +52,7 @@ final class DefaultControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('body', 'Research Together.');
         self::assertSelectorTextContains('body', 'About us');
-        self::assertSelectorTextContains('body', 'The platform is free of charge.');
+        self::assertSelectorTextContains('body', 'Core platform strengths');
     }
 
     public function testAuthenticatedUsersSeeEmptyDashboardOnHomepage(): void

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -28,7 +28,7 @@ final class DefaultControllerTest extends WebTestCase
     use Factories;
     use ResetDatabase;
 
-    public function testHelloWorldIsDisplayed(): void
+    public function testPublicHomepageIsDisplayedForGuests(): void
     {
         $client = self::createClient();
 
@@ -50,6 +50,20 @@ final class DefaultControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, '/');
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorTextContains('body', 'Hello, world!');
+        self::assertSelectorTextContains('body', 'Research Together.');
+        self::assertSelectorTextContains('body', 'About us');
+        self::assertSelectorTextContains('body', 'The platform is free of charge.');
+    }
+
+    public function testAuthenticatedUsersSeeEmptyDashboardOnHomepage(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['username' => 'dashboard-user'])->_real();
+
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', 'Your dashboard is ready');
     }
 }

--- a/tests/Statistics/Functional/Controller/DashboardControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerTest.php
@@ -8,12 +8,12 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class DashboardControllerTest extends WebTestCase
 {
-    public function testSomething(): void
+    public function testStatisticsOverviewIsDisplayed(): void
     {
         $client = static::createClient();
         $client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/statistics/');
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('title', 'Statistics');
+        $this->assertSelectorTextContains('body', 'Overview');
     }
 }

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -43,6 +43,14 @@ class AppRoutesTest extends WebTestCase
         );
     }
 
+    public function testFeaturesRouteIsNotAvailable(): void
+    {
+        $client = static::createClient();
+        $client->request(Request::METHOD_GET, '/features');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
     public static function getPublicUrls(): \Generator
     {
         yield 'app_default' => ['/'];

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -117,6 +117,14 @@
         <source>cookie.preferences.title</source>
         <target>Cookie preferences</target>
       </trans-unit>
+      <trans-unit id="WbCJOyn" resname="dashboard.empty.description">
+        <source>dashboard.empty.description</source>
+        <target>This is your personal workspace. Use the navigation above to explore data, statistics, and imports.</target>
+      </trans-unit>
+      <trans-unit id="DZA3KTc" resname="dashboard.empty.title">
+        <source>dashboard.empty.title</source>
+        <target>Your dashboard is ready</target>
+      </trans-unit>
       <trans-unit id="EiKSkqu" resname="field.age">
         <source>field.age</source>
         <target>Age</target>
@@ -233,13 +241,13 @@
         <source>flash.reset_password.validation_failed</source>
         <target>There was a problem validating your reset request.</target>
       </trans-unit>
+      <trans-unit id="LkFXLzD" resname="flash.security.cookie_consent_required">
+        <source>flash.security.cookie_consent_required</source>
+        <target>Please confirm your cookie settings before signing in.</target>
+      </trans-unit>
       <trans-unit id="RS3d7CX" resname="flash.security.invalid_csrf">
         <source>flash.security.invalid_csrf</source>
         <target>Invalid CSRF token.</target>
-      </trans-unit>
-      <trans-unit id="zqI8KJ2" resname="flash.security.cookie_consent_required">
-        <source>flash.security.cookie_consent_required</source>
-        <target>Please confirm your cookie settings before signing in.</target>
       </trans-unit>
       <trans-unit id="yPy4.0U" resname="flash.settings.email.already_verified">
         <source>flash.settings.email.already_verified</source>
@@ -1029,6 +1037,10 @@
         <source>label.without_owner</source>
         <target>Without owner</target>
       </trans-unit>
+      <trans-unit id="z3o4rg_" resname="link.about">
+        <source>link.about</source>
+        <target>About</target>
+      </trans-unit>
       <trans-unit id="ZdrXMaQ" resname="link.allocations">
         <source>link.allocations</source>
         <target>Allocations</target>
@@ -1052,6 +1064,10 @@
       <trans-unit id="ojUc4Dn" resname="link.explore">
         <source>link.explore</source>
         <target>Explore</target>
+      </trans-unit>
+      <trans-unit id="DPqI5NZ" resname="link.features">
+        <source>link.features</source>
+        <target>Features</target>
       </trans-unit>
       <trans-unit id="9XmczE8" resname="link.home">
         <source>link.home</source>
@@ -1119,6 +1135,170 @@
       </trans-unit>
       <trans-unit id="wQKGxus" resname="link.users">
         <source>link.users</source>
+        <target>Users</target>
+      </trans-unit>
+      <trans-unit id="ZKHDIRf" resname="public.cta.learn_more">
+        <source>public.cta.learn_more</source>
+        <target>Learn more</target>
+      </trans-unit>
+      <trans-unit id="88M4YBe" resname="public.cta.register">
+        <source>public.cta.register</source>
+        <target>Register</target>
+      </trans-unit>
+      <trans-unit id="MC1jwCz" resname="public.cta.sign_in">
+        <source>public.cta.sign_in</source>
+        <target>Sign in</target>
+      </trans-unit>
+      <trans-unit id="6_P.fwQ" resname="public.home.about.p1">
+        <source>public.home.about.p1</source>
+        <target>Although emergency medical services are among the largest referrers to emergency departments, there are still only few large-scale systematic analyses of EMS patient characteristics. Since 2017, the web-based IVENA system has been used across Germany to digitally register EMS patients at acute care hospitals.</target>
+      </trans-unit>
+      <trans-unit id="aJrjagd" resname="public.home.about.p2">
+        <source>public.home.about.p2</source>
+        <target>For every allocation, an anonymized dataset is created and stored, including variables such as age, sex, coded suspected diagnosis, urgency, assignment pathway, physician accompaniment, CPR, ventilation, infection status, pregnancy, and requested resources like resuscitation room or cath lab.</target>
+      </trans-unit>
+      <trans-unit id="DF5.wOi" resname="public.home.about.p3">
+        <source>public.home.about.p3</source>
+        <target>In early 2021, members of the DGINA working group in Hesse initiated this collaborative platform to merge IVENA allocation data from many hospitals and enable shared statistics and dedicated analyses for specific emergency care research questions.</target>
+      </trans-unit>
+      <trans-unit id="LYDzZRg" resname="public.home.about.title">
+        <source>public.home.about.title</source>
+        <target>About us</target>
+      </trans-unit>
+      <trans-unit id="WuHj_y1" resname="public.home.features.card.analytics.text">
+        <source>public.home.features.card.analytics.text</source>
+        <target>Generate distributions and trend views to support evidence-based emergency care decisions.</target>
+      </trans-unit>
+      <trans-unit id="tjJAU5R" resname="public.home.features.card.analytics.title">
+        <source>public.home.features.card.analytics.title</source>
+        <target>Statistics and benchmarking</target>
+      </trans-unit>
+      <trans-unit id="0PVf_q7" resname="public.home.features.card.explore.text">
+        <source>public.home.features.card.explore.text</source>
+        <target>Inspect records with filters for urgency, transport context, assignment patterns, and clinical characteristics.</target>
+      </trans-unit>
+      <trans-unit id="FTHRlFT" resname="public.home.features.card.explore.title">
+        <source>public.home.features.card.explore.title</source>
+        <target>Explore data</target>
+      </trans-unit>
+      <trans-unit id="dANFfmE" resname="public.home.features.card.hospital_centered.text">
+        <source>public.home.features.card.hospital_centered.text</source>
+        <target>Participating sites can manage institutions, maintain metadata, and work with their own allocation exports.</target>
+      </trans-unit>
+      <trans-unit id="u_l6K6x" resname="public.home.features.card.hospital_centered.title">
+        <source>public.home.features.card.hospital_centered.title</source>
+        <target>Hospital-centered workflows</target>
+      </trans-unit>
+      <trans-unit id="EWBcXbq" resname="public.home.features.card.independent.text">
+        <source>public.home.features.card.independent.text</source>
+        <target>The initiative is run by an independent clinical research network with a clear public-health focus.</target>
+      </trans-unit>
+      <trans-unit id="dxR6rAB" resname="public.home.features.card.independent.title">
+        <source>public.home.features.card.independent.title</source>
+        <target>Independent and non-commercial</target>
+      </trans-unit>
+      <trans-unit id="mr0cgLL" resname="public.home.features.detail.data_exploration.text">
+        <source>public.home.features.detail.data_exploration.text</source>
+        <target>Analyze age, sex, coded suspected diagnosis, priority, assignment pathway, and other operational characteristics across large cohorts.</target>
+      </trans-unit>
+      <trans-unit id="H9s9kYv" resname="public.home.features.detail.data_exploration.title">
+        <source>public.home.features.detail.data_exploration.title</source>
+        <target>Detailed data exploration</target>
+      </trans-unit>
+      <trans-unit id="zeUoGVL" resname="public.home.features.detail.hospital_management.text">
+        <source>public.home.features.detail.hospital_management.text</source>
+        <target>Each hospital can be represented with structured profile data, participation status, and ownership assignments for local administration.</target>
+      </trans-unit>
+      <trans-unit id="MOb1ADP" resname="public.home.features.detail.hospital_management.title">
+        <source>public.home.features.detail.hospital_management.title</source>
+        <target>Hospital management and participation</target>
+      </trans-unit>
+      <trans-unit id="wm3cSki" resname="public.home.features.detail.import_export.text">
+        <source>public.home.features.detail.import_export.text</source>
+        <target>Hospitals can continuously import new IVENA exports and use structured exports for downstream scientific workflows.</target>
+      </trans-unit>
+      <trans-unit id="xN5TuWQ" resname="public.home.features.detail.import_export.title">
+        <source>public.home.features.detail.import_export.title</source>
+        <target>Import and export pipeline</target>
+      </trans-unit>
+      <trans-unit id=".YOlX__" resname="public.home.features.detail.statistics.text">
+        <source>public.home.features.detail.statistics.text</source>
+        <target>Create focused analyses for specific research questions and compare institutional patterns with anonymized clusters.</target>
+      </trans-unit>
+      <trans-unit id="VF9iPLp" resname="public.home.features.detail.statistics.title">
+        <source>public.home.features.detail.statistics.title</source>
+        <target>Shared statistics for targeted questions</target>
+      </trans-unit>
+      <trans-unit id="7xCs85r" resname="public.home.features.overview.subtitle">
+        <source>public.home.features.overview.subtitle</source>
+        <target>Built for hospitals, research teams, and quality improvement initiatives.</target>
+      </trans-unit>
+      <trans-unit id="Jf37X.O" resname="public.home.features.overview.title">
+        <source>public.home.features.overview.title</source>
+        <target>Core platform strengths</target>
+      </trans-unit>
+      <trans-unit id="Axt3js1" resname="public.home.hero.preview_alt">
+        <source>public.home.hero.preview_alt</source>
+        <target>Upcoming homepage preview screenshot placeholder</target>
+      </trans-unit>
+      <trans-unit id="inGjAQS" resname="public.home.hero.preview_note">
+        <source>public.home.hero.preview_note</source>
+        <target>Placeholder image: final visual screenshot will be added next.</target>
+      </trans-unit>
+      <trans-unit id="o35EWat" resname="public.home.hero.preview_text">
+        <source>public.home.hero.preview_text</source>
+        <target>Participating hospitals can combine IVENA allocation data, run shared analyses, and compare anonymized benchmarks in one place.</target>
+      </trans-unit>
+      <trans-unit id="EFn3O.C" resname="public.home.hero.preview_title">
+        <source>public.home.hero.preview_title</source>
+        <target>One collaborative platform</target>
+      </trans-unit>
+      <trans-unit id="abSseey" resname="public.home.hero.subtitle">
+        <source>public.home.hero.subtitle</source>
+        <target>We collaboratively build emergency care research statistics in Germany based on IVENA allocation data.</target>
+      </trans-unit>
+      <trans-unit id="7nDvcYo" resname="public.home.hero.title">
+        <source>public.home.hero.title</source>
+        <target>Research Together.</target>
+      </trans-unit>
+      <trans-unit id="s19o8l1" resname="public.home.meta_title">
+        <source>public.home.meta_title</source>
+        <target>Collaborative Emergency Care Research</target>
+      </trans-unit>
+      <trans-unit id="M6R_RDR" resname="public.home.participation.free_note">
+        <source>public.home.participation.free_note</source>
+        <target>The platform is free of charge.</target>
+      </trans-unit>
+      <trans-unit id="a.wot55" resname="public.home.participation.text">
+        <source>public.home.participation.text</source>
+        <target>Participation is open to interested institutions and users. Register to learn more and access the collaborative workspace.</target>
+      </trans-unit>
+      <trans-unit id="zFXKMOx" resname="public.home.participation.title">
+        <source>public.home.participation.title</source>
+        <target>Join the project</target>
+      </trans-unit>
+      <trans-unit id="VgJqB_Q" resname="public.home.stats.subtitle">
+        <source>public.home.stats.subtitle</source>
+        <target>A quick snapshot of the current collaborative data network.</target>
+      </trans-unit>
+      <trans-unit id="SuNofpS" resname="public.home.stats.title">
+        <source>public.home.stats.title</source>
+        <target>Project overview</target>
+      </trans-unit>
+      <trans-unit id="rJakKKg" resname="public.stats.allocations">
+        <source>public.stats.allocations</source>
+        <target>Allocations</target>
+      </trans-unit>
+      <trans-unit id="n4D_l_N" resname="public.stats.hospitals">
+        <source>public.stats.hospitals</source>
+        <target>Hospitals</target>
+      </trans-unit>
+      <trans-unit id="_oAVFM1" resname="public.stats.imports">
+        <source>public.stats.imports</source>
+        <target>Imports</target>
+      </trans-unit>
+      <trans-unit id="wmaFOpu" resname="public.stats.users">
+        <source>public.stats.users</source>
         <target>Users</target>
       </trans-unit>
       <trans-unit id="NDaPwn5" resname="statistics.distribution.age.18_29">
@@ -1679,6 +1859,10 @@
         <source>title.check_email</source>
         <target>Check your email</target>
       </trans-unit>
+      <trans-unit id="YE7XVBb" resname="title.dashboard">
+        <source>title.dashboard</source>
+        <target>Dashboard</target>
+      </trans-unit>
       <trans-unit id="6k49n8G" resname="title.data">
         <source>title.data</source>
         <target>Data</target>
@@ -1806,6 +1990,10 @@
       <trans-unit id="uhopb3E" resname="title.speciality.list">
         <source>title.speciality.list</source>
         <target>Listing Specialities</target>
+      </trans-unit>
+      <trans-unit id="kCCr8EE" resname="title.stats.overview">
+        <source>title.stats.overview</source>
+        <target>Overview</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/security.en.xlf
+++ b/translations/security.en.xlf
@@ -61,10 +61,6 @@
         <source>No token could be found.</source>
         <target>No token could be found.</target>
       </trans-unit>
-      <trans-unit id="eRzF2kq" resname="flash.security.cookie_consent_required">
-        <source>flash.security.cookie_consent_required</source>
-        <target>Please confirm your cookie settings before signing in.</target>
-      </trans-unit>
       <trans-unit id="6rEex5P" resname="Not privileged to request the resource.">
         <source>Not privileged to request the resource.</source>
         <target>Not privileged to request the resource.</target>
@@ -84,6 +80,10 @@
       <trans-unit id="VZija00" resname="Username could not be found.">
         <source>Username could not be found.</source>
         <target>Username could not be found.</target>
+      </trans-unit>
+      <trans-unit id="LkFXLzD" resname="flash.security.cookie_consent_required">
+        <source>flash.security.cookie_consent_required</source>
+        <target>Please confirm your cookie settings before signing in.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
### Summary

- Added a new dedicated **homepage**
- Moved the previous default landing page to the **statistics** section
- Updated routing and page structure to reflect the new entry points
- Added tests for the new homepage and related behavior

### Motivation

- Introduce a clearer separation between the general application entry point and the statistics area
- Provide a proper homepage as the new default landing page
- Keep statistics accessible while giving them a more focused, dedicated location
- Ensure the new navigation and routing setup is covered by tests

### Notes for Reviewers

- Review the new routing setup and confirm the homepage is now the default entry point
- Check that the statistics page still behaves as expected after being moved
- Verify navigation and template integration for the new homepage
- Ensure the added tests cover the updated routes and rendering behavior