### PR TITLE
feat: Add work accident flag across allocations, imports, and statistics

### DIFF
--- a/migrations/Version20260507073623.php
+++ b/migrations/Version20260507073623.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260507073623 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_work_accident to allocation and allocation_stats_projection.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE allocation ADD is_work_accident BOOLEAN DEFAULT FALSE NOT NULL');
+        $this->addSql('ALTER TABLE allocation_stats_projection ADD is_work_accident BOOLEAN DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_asp_is_work_accident ON allocation_stats_projection (is_work_accident)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_asp_is_work_accident');
+        $this->addSql('ALTER TABLE allocation_stats_projection DROP is_work_accident');
+        $this->addSql('ALTER TABLE allocation DROP is_work_accident');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
+++ b/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
@@ -89,6 +89,8 @@ final class AllocationCrudController extends AbstractCrudController
             ->hideOnIndex();
         yield BooleanField::new('isPregnant', 'Pregnant')
             ->hideOnIndex();
+        yield BooleanField::new('isWorkAccident', 'Work Accident')
+            ->hideOnIndex();
         yield BooleanField::new('isWithPhysician', 'With Physician')
             ->hideOnIndex();
         yield ChoiceField::new('transportType', 'Transport Type')

--- a/src/Allocation/Domain/Entity/Allocation.php
+++ b/src/Allocation/Domain/Entity/Allocation.php
@@ -67,6 +67,9 @@ class Allocation
     #[ORM\Column]
     private ?bool $isPregnant = null;
 
+    #[ORM\Column(options: ['default' => false])]
+    private ?bool $isWorkAccident = null;
+
     #[ORM\Column]
     private ?bool $isWithPhysician = null;
 
@@ -289,6 +292,18 @@ class Allocation
     public function setIsPregnant(bool $isPregnant): static
     {
         $this->isPregnant = $isPregnant;
+
+        return $this;
+    }
+
+    public function isWorkAccident(): ?bool
+    {
+        return $this->isWorkAccident;
+    }
+
+    public function setIsWorkAccident(bool $isWorkAccident): static
+    {
+        $this->isWorkAccident = $isWorkAccident;
 
         return $this;
     }

--- a/src/Allocation/Infrastructure/Factory/AllocationFactory.php
+++ b/src/Allocation/Infrastructure/Factory/AllocationFactory.php
@@ -45,6 +45,7 @@ final class AllocationFactory extends PersistentProxyObjectFactory
             'isShock' => self::faker()->boolean(),
             'isVentilated' => self::faker()->boolean(),
             'isWithPhysician' => self::faker()->boolean(13),
+            'isWorkAccident' => self::faker()->boolean(8),
             'requiresCathlab' => self::faker()->boolean(1),
             'requiresResus' => self::faker()->boolean(5),
             'transportType' => self::faker()->randomElement(AllocationTransportType::cases()),

--- a/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
+++ b/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
@@ -32,7 +32,7 @@ final readonly class ListAllocationsQuery
         $qb = $this->entityManager->createQueryBuilder();
         $qb->select('a.id, a.createdAt, a.arrivalAt, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
                 h.id as hospital_id, h.name as hospital, h.tier, h.size, h.location, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock,
-                a.isPregnant, a.isWithPhysician, a.urgency, i.name as infection, iraw.name as indicationRawName, iraw.code indicationRawCode,
+                a.isPregnant, a.isWorkAccident, a.isWithPhysician, a.urgency, i.name as infection, iraw.name as indicationRawName, iraw.code indicationRawCode,
                 inor.name as indicationNormalizedName, inor.code as indicationNormalizedCode')
             ->from(Allocation::class, 'a')
             ->leftJoin(

--- a/src/Allocation/UI/Twig/templates/allocations/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/list.html.twig
@@ -221,6 +221,9 @@
                                 {% if allocation.isPregnant %}
                                     {{ 'label.pregnant'|trans }}
                                 {% endif %}
+                                {% if allocation.isWorkAccident %}
+                                    {{ 'BG+'|trans }}
+                                {% endif %}
                             </span>
                         </td>
                         <td>

--- a/src/Allocation/UI/Twig/templates/allocations/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/show.html.twig
@@ -183,6 +183,16 @@
                                 {% endif %}
                             </div>
                         </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">{{ 'allocations.field.isWorkAccident'|trans }}</div>
+                            <div class="datagrid-content">
+                                {% if allocation.isWorkAccident %}
+                                    <span class="status status-green">{{ 'field.true'|trans }}</span>
+                                {% else %}
+                                    <span class="status status-red">{{ 'field.false'|trans }}</span>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </twig:Card>
             </div>

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -65,7 +65,6 @@ final class AppFixtures extends Fixture
 
         IndicationRawFactory::createMany(25);
         IndicationNormalizedFactory::createMany(20);
-
         $faker = \Faker\Factory::create();
         AllocationFactory::createMany(random_int(250, 500), static function (int $_) use ($faker): array {
             $createdAt = \DateTimeImmutable::createFromMutable(

--- a/src/Import/Application/DTO/AllocationRowDTO.php
+++ b/src/Import/Application/DTO/AllocationRowDTO.php
@@ -64,6 +64,10 @@ final class AllocationRowDTO
 
     #[Assert\NotNull]
     #[Assert\Type('bool')]
+    public ?bool $isWorkAccident = null;
+
+    #[Assert\NotNull]
+    #[Assert\Type('bool')]
     public ?bool $isWithPhysician = null;
 
     #[Assert\Choice(choices: ['G', 'A'], message: 'Unknown transport')]

--- a/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
@@ -62,6 +62,7 @@ final class AllocationRowMapper implements RowToDtoMapperInterface
         $dto->isVentilated = self::normalizeBoolean(self::getStringOrNull($row, 'beatmet') ?? 'false');
         $dto->isShock = self::normalizeBoolean(self::getStringOrNull($row, 'schock') ?? 'false');
         $dto->isPregnant = self::normalizeBoolean(self::getStringOrNull($row, 'schwanger') ?? 'false');
+        $dto->isWorkAccident = self::normalizeBoolean(self::getStringOrNull($row, 'arbeits_wege_schulunfall') ?? 'false');
         $dto->isWithPhysician = self::normalizeBoolean(self::getStringOrNull($row, 'arztbegleitet') ?? 'false');
         $dto->transportType = self::normalizeTransportType(self::getStringOrNull($row, 'transportmittel'));
         $dto->urgency = self::normalizeUrgencyFromPZC(self::getStringOrNull($row, 'pzc'));

--- a/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
+++ b/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
@@ -8,8 +8,8 @@ final class FlagMappingStrategy
 {
     /**
      * @param object $entity must expose setRequiresResus(), setRequiresCathlab(), setIsCPR(), setIsVentilated(),
-     *                       setIsShock(), setIsPregnant(), setIsWithPhysician()
-     * @param object $dto    must expose requiresResus, requiresCathlab, isCPR, isVentilated, isShock, isPregnant, isWithPhysician
+     *                       setIsShock(), setIsPregnant(), setIsWorkAccident(), setIsWithPhysician()
+     * @param object $dto    must expose requiresResus, requiresCathlab, isCPR, isVentilated, isShock, isPregnant, isWorkAccident, isWithPhysician
      */
     public function apply(object $entity, object $dto, bool $defaultNullToFalse): void
     {
@@ -20,6 +20,7 @@ final class FlagMappingStrategy
         $isVentilated = $defaultNullToFalse ? ($dto->isVentilated ?? false) : $dto->isVentilated;
         $isShock = $defaultNullToFalse ? ($dto->isShock ?? false) : $dto->isShock;
         $isPregnant = $defaultNullToFalse ? ($dto->isPregnant ?? false) : $dto->isPregnant;
+        $isWorkAccident = $defaultNullToFalse ? ($dto->isWorkAccident ?? false) : $dto->isWorkAccident;
         $isWithPhysician = $defaultNullToFalse ? ($dto->isWithPhysician ?? false) : $dto->isWithPhysician;
 
         $entity->setRequiresResus($requiresResus);
@@ -29,6 +30,7 @@ final class FlagMappingStrategy
         $entity->setIsVentilated($isVentilated);
         $entity->setIsShock($isShock);
         $entity->setIsPregnant($isPregnant);
+        $entity->setIsWorkAccident($isWorkAccident);
         $entity->setIsWithPhysician($isWithPhysician);
     }
 }

--- a/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
+++ b/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
@@ -33,7 +33,6 @@ final class FlagMappingStrategy
 
         // Allocation-only feature: do not require MciCase to support it.
         if (property_exists($dto, 'isWorkAccident') && method_exists($entity, 'setIsWorkAccident')) {
-            /** @var mixed $raw */
             $raw = $dto->isWorkAccident;
             $isWorkAccident = $defaultNullToFalse ? ($raw ?? false) : $raw;
             $entity->setIsWorkAccident((bool) $isWorkAccident);

--- a/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
+++ b/src/Import/Infrastructure/Resolver/Strategy/FlagMappingStrategy.php
@@ -8,8 +8,8 @@ final class FlagMappingStrategy
 {
     /**
      * @param object $entity must expose setRequiresResus(), setRequiresCathlab(), setIsCPR(), setIsVentilated(),
-     *                       setIsShock(), setIsPregnant(), setIsWorkAccident(), setIsWithPhysician()
-     * @param object $dto    must expose requiresResus, requiresCathlab, isCPR, isVentilated, isShock, isPregnant, isWorkAccident, isWithPhysician
+     *                       setIsShock(), setIsPregnant(), setIsWithPhysician()
+     * @param object $dto    must expose requiresResus, requiresCathlab, isCPR, isVentilated, isShock, isPregnant, isWithPhysician
      */
     public function apply(object $entity, object $dto, bool $defaultNullToFalse): void
     {
@@ -20,7 +20,6 @@ final class FlagMappingStrategy
         $isVentilated = $defaultNullToFalse ? ($dto->isVentilated ?? false) : $dto->isVentilated;
         $isShock = $defaultNullToFalse ? ($dto->isShock ?? false) : $dto->isShock;
         $isPregnant = $defaultNullToFalse ? ($dto->isPregnant ?? false) : $dto->isPregnant;
-        $isWorkAccident = $defaultNullToFalse ? ($dto->isWorkAccident ?? false) : $dto->isWorkAccident;
         $isWithPhysician = $defaultNullToFalse ? ($dto->isWithPhysician ?? false) : $dto->isWithPhysician;
 
         $entity->setRequiresResus($requiresResus);
@@ -30,7 +29,14 @@ final class FlagMappingStrategy
         $entity->setIsVentilated($isVentilated);
         $entity->setIsShock($isShock);
         $entity->setIsPregnant($isPregnant);
-        $entity->setIsWorkAccident($isWorkAccident);
         $entity->setIsWithPhysician($isWithPhysician);
+
+        // Allocation-only feature: do not require MciCase to support it.
+        if (property_exists($dto, 'isWorkAccident') && method_exists($entity, 'setIsWorkAccident')) {
+            /** @var mixed $raw */
+            $raw = $dto->isWorkAccident;
+            $isWorkAccident = $defaultNullToFalse ? ($raw ?? false) : $raw;
+            $entity->setIsWorkAccident((bool) $isWorkAccident);
+        }
     }
 }

--- a/src/LegacyMigration/Application/Service/LegacyMigrationProgressReporter.php
+++ b/src/LegacyMigration/Application/Service/LegacyMigrationProgressReporter.php
@@ -36,6 +36,7 @@ final class LegacyMigrationProgressReporter
         $this->progressBar?->advance($step);
     }
 
+    /** @psalm-suppress PossiblyUnusedMethod */
     public function writeBatch(SymfonyStyle $io, int $legacyImportId, int $batchSize, ?int $lastAllocationId, int $migratedCount): void
     {
         $elapsedMinutes = max((time() - $this->startedAt) / 60, 0.1);

--- a/src/LegacyMigration/Infrastructure/Mapper/LegacyAllocationRowMapper.php
+++ b/src/LegacyMigration/Infrastructure/Mapper/LegacyAllocationRowMapper.php
@@ -29,6 +29,7 @@ final class LegacyAllocationRowMapper
         $dto->isVentilated = $this->toBool($row['is_ventilated'] ?? null);
         $dto->isShock = $this->toBool($row['is_shock'] ?? null);
         $dto->isPregnant = $this->toBool($row['is_pregnant'] ?? null);
+        $dto->isWorkAccident = $this->toBool($row['is_work_accident'] ?? null);
         $dto->isWithPhysician = $this->toBool($row['is_with_physician'] ?? null);
         $dto->transportType = self::normalizeTransportType(self::getStringOrNull($row, 'mode_of_transport'));
         $dto->urgency = self::getIntOrNull($row, 'urgency');

--- a/src/Statistics/Application/AllocationsByMonthQuery.php
+++ b/src/Statistics/Application/AllocationsByMonthQuery.php
@@ -94,6 +94,7 @@ final readonly class AllocationsByMonthQuery
         ['key' => 'ventilated', 'labelKey' => 'statistics.distribution.dim.is_ventilated'],
         ['key' => 'shock', 'labelKey' => 'stats.analysis.feature.is_shock'],
         ['key' => 'pregnant', 'labelKey' => 'stats.analysis.feature.is_pregnant'],
+        ['key' => 'work_accident', 'labelKey' => 'stats.analysis.feature.is_work_accident'],
         ['key' => 'infectious', 'labelKey' => 'field.infection'],
     ];
 
@@ -325,9 +326,9 @@ final readonly class AllocationsByMonthQuery
     }
 
     /**
-     * @param list<string>                                                                                                                    $labels
-     * @param list<string>                                                                                                                    $monthKeys
-     * @param array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets
+     * @param list<string>                                                                                                                                        $labels
+     * @param list<string>                                                                                                                                        $monthKeys
+     * @param array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, work_accident: int, infectious: int, with_any: int}> $buckets
      */
     private function mapClinicalFeaturesBucketsToSeries(array $labels, array $monthKeys, array $buckets): AllocationsOverTimeSeries
     {

--- a/src/Statistics/Application/ClinicalFeaturesQuery.php
+++ b/src/Statistics/Application/ClinicalFeaturesQuery.php
@@ -17,6 +17,7 @@ final readonly class ClinicalFeaturesQuery
         ['key' => 'ventilated', 'labelTranslationKey' => 'statistics.distribution.dim.is_ventilated'],
         ['key' => 'shock', 'labelTranslationKey' => 'stats.analysis.feature.is_shock'],
         ['key' => 'pregnant', 'labelTranslationKey' => 'stats.analysis.feature.is_pregnant'],
+        ['key' => 'work_accident', 'labelTranslationKey' => 'stats.analysis.feature.is_work_accident'],
         ['key' => 'infectious', 'labelTranslationKey' => 'field.infection'],
     ];
 
@@ -80,7 +81,7 @@ final readonly class ClinicalFeaturesQuery
     }
 
     /**
-     * @return array{0:int,1:array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int},2:array{cathlab:int,resus:int}}
+     * @return array{0:int,1:array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int},2:array{cathlab:int,resus:int}}
      */
     private function loadCounts(StatisticsContext $context): array
     {

--- a/src/Statistics/Application/ComparisonScopeResolver.php
+++ b/src/Statistics/Application/ComparisonScopeResolver.php
@@ -50,7 +50,7 @@ final readonly class ComparisonScopeResolver
             $comparisonQuery['state'] = (string) $comparisonStateId;
         } else {
             $comparisonQuery['scope'] = StatisticsFilterScope::HospitalCohort->value;
-            $comparisonQuery['cohort'] = $comparisonCohort ?? HospitalCohortType::cases()[0]->value;
+            $comparisonQuery['cohort'] = $comparisonCohort;
         }
         if ((StatisticsFilterPeriod::Year === $comparisonPeriod || StatisticsFilterPeriod::Month === $comparisonPeriod) && (null !== $comparisonYear && $comparisonYear > 0)) {
             $comparisonQuery['year'] = (string) $comparisonYear;

--- a/src/Statistics/Infrastructure/Entity/AllocationStatsProjection.php
+++ b/src/Statistics/Infrastructure/Entity/AllocationStatsProjection.php
@@ -119,6 +119,9 @@ class AllocationStatsProjection
     private ?bool $isPregnant = null;
 
     #[ORM\Column(nullable: true)]
+    private ?bool $isWorkAccident = null;
+
+    #[ORM\Column(nullable: true)]
     private ?bool $isWithPhysician = null;
 
     public function getId(): int
@@ -284,6 +287,11 @@ class AllocationStatsProjection
     public function isPregnant(): ?bool
     {
         return $this->isPregnant;
+    }
+
+    public function isWorkAccident(): ?bool
+    {
+        return $this->isWorkAccident;
     }
 
     public function isWithPhysician(): ?bool

--- a/src/Statistics/Infrastructure/Query/AllocationStatsProjectionRebuilder.php
+++ b/src/Statistics/Infrastructure/Query/AllocationStatsProjectionRebuilder.php
@@ -67,6 +67,7 @@ SELECT
   a.is_ventilated,
   a.is_shock,
   a.is_pregnant,
+  a.is_work_accident,
   a.is_with_physician,
   h.tier AS hospital_tier,
   h.location AS hospital_location
@@ -118,7 +119,7 @@ SQL,
             'created_day', 'created_weekday', 'created_hour',
             'transport_time_minutes',
             'age', 'gender_code', 'urgency_code', 'transport_type_code', 'hospital_tier_code', 'hospital_location_code',
-            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_with_physician',
+            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_work_accident', 'is_with_physician',
         ];
 
         $params = [];
@@ -157,7 +158,7 @@ SQL,
     {
         return match ($column) {
             'created_at', 'arrival_at' => Types::STRING,
-            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_with_physician' => Types::BOOLEAN,
+            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_work_accident', 'is_with_physician' => Types::BOOLEAN,
             default => Types::INTEGER,
         };
     }
@@ -227,6 +228,7 @@ SQL,
             'is_ventilated' => $this->nullableBool($row['is_ventilated'] ?? null),
             'is_shock' => $this->nullableBool($row['is_shock'] ?? null),
             'is_pregnant' => $this->nullableBool($row['is_pregnant'] ?? null),
+            'is_work_accident' => $this->nullableBool($row['is_work_accident'] ?? null),
             'is_with_physician' => $this->nullableBool($row['is_with_physician'] ?? null),
         ];
     }

--- a/src/Statistics/Infrastructure/Query/ProjectionFeatureQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionFeatureQuery.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\QueryBuilder;
 
 final class ProjectionFeatureQuery
 {
-    private ?bool $hasShockPregnantColumns = null;
+    private ?bool $hasExtendedClinicalFeatureColumns = null;
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -21,13 +21,14 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      *
-     * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int}
+     * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int}
      */
     public function clinicalFeatureCounts(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
-        $hasShockPregnant = $this->hasShockPregnantColumns();
-        $shockExpr = $hasShockPregnant ? 'SUM(CASE WHEN p.isShock = true THEN 1 ELSE 0 END) AS shock' : '0 AS shock';
-        $pregnantExpr = $hasShockPregnant ? 'SUM(CASE WHEN p.isPregnant = true THEN 1 ELSE 0 END) AS pregnant' : '0 AS pregnant';
+        $hasExtendedClinicalFeatures = $this->hasExtendedClinicalFeatureColumns();
+        $shockExpr = $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isShock = true THEN 1 ELSE 0 END) AS shock' : '0 AS shock';
+        $pregnantExpr = $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isPregnant = true THEN 1 ELSE 0 END) AS pregnant' : '0 AS pregnant';
+        $workAccidentExpr = $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isWorkAccident = true THEN 1 ELSE 0 END) AS work_accident' : '0 AS work_accident';
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select(
                 'SUM(CASE WHEN p.isWithPhysician = true THEN 1 ELSE 0 END) AS with_physician',
@@ -35,10 +36,11 @@ final class ProjectionFeatureQuery
                 'SUM(CASE WHEN p.isVentilated = true THEN 1 ELSE 0 END) AS ventilated',
                 $shockExpr,
                 $pregnantExpr,
+                $workAccidentExpr,
                 'SUM(CASE WHEN p.infectionId IS NOT NULL THEN 1 ELSE 0 END) AS infectious',
             );
 
-        /** @var array{with_physician:numeric-string|int|null,cpr:numeric-string|int|null,ventilated:numeric-string|int|null,shock:numeric-string|int|null,pregnant:numeric-string|int|null,infectious:numeric-string|int|null} $row */
+        /** @var array{with_physician:numeric-string|int|null,cpr:numeric-string|int|null,ventilated:numeric-string|int|null,shock:numeric-string|int|null,pregnant:numeric-string|int|null,work_accident:numeric-string|int|null,infectious:numeric-string|int|null} $row */
         $row = $qb->getQuery()->getSingleResult();
 
         return [
@@ -47,6 +49,7 @@ final class ProjectionFeatureQuery
             'ventilated' => (int) ($row['ventilated'] ?? 0),
             'shock' => (int) ($row['shock'] ?? 0),
             'pregnant' => (int) ($row['pregnant'] ?? 0),
+            'work_accident' => (int) ($row['work_accident'] ?? 0),
             'infectious' => (int) ($row['infectious'] ?? 0),
         ];
     }
@@ -76,7 +79,7 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      *
-     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
+     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
     public function bucketClinicalFeaturesByMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
@@ -86,7 +89,7 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      *
-     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
+     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
     public function bucketClinicalFeaturesByDay(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
@@ -96,7 +99,7 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      *
-     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
+     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
     public function bucketClinicalFeaturesByCalendarMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
@@ -149,21 +152,22 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      *
-     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
+     * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
     private function bucketClinicalFeatures(string $mode, \DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
-        $hasShockPregnant = $this->hasShockPregnantColumns();
+        $hasExtendedClinicalFeatures = $this->hasExtendedClinicalFeatureColumns();
         [$bucketFields, $bucketGroupBy, $bucketKeyFromRow] = $this->bucketSpec($mode);
         $select = array_merge($bucketFields, [
             'SUM(CASE WHEN p.isWithPhysician = true THEN 1 ELSE 0 END) AS with_physician',
             'SUM(CASE WHEN p.isCpr = true THEN 1 ELSE 0 END) AS cpr',
             'SUM(CASE WHEN p.isVentilated = true THEN 1 ELSE 0 END) AS ventilated',
-            $hasShockPregnant ? 'SUM(CASE WHEN p.isShock = true THEN 1 ELSE 0 END) AS shock' : '0 AS shock',
-            $hasShockPregnant ? 'SUM(CASE WHEN p.isPregnant = true THEN 1 ELSE 0 END) AS pregnant' : '0 AS pregnant',
+            $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isShock = true THEN 1 ELSE 0 END) AS shock' : '0 AS shock',
+            $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isPregnant = true THEN 1 ELSE 0 END) AS pregnant' : '0 AS pregnant',
+            $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isWorkAccident = true THEN 1 ELSE 0 END) AS work_accident' : '0 AS work_accident',
             'SUM(CASE WHEN p.infectionId IS NOT NULL THEN 1 ELSE 0 END) AS infectious',
-            $hasShockPregnant
-                ? 'SUM(CASE WHEN (p.isWithPhysician = true OR p.isCpr = true OR p.isVentilated = true OR p.isShock = true OR p.isPregnant = true OR p.infectionId IS NOT NULL) THEN 1 ELSE 0 END) AS with_any'
+            $hasExtendedClinicalFeatures
+                ? 'SUM(CASE WHEN (p.isWithPhysician = true OR p.isCpr = true OR p.isVentilated = true OR p.isShock = true OR p.isPregnant = true OR p.isWorkAccident = true OR p.infectionId IS NOT NULL) THEN 1 ELSE 0 END) AS with_any'
                 : 'SUM(CASE WHEN (p.isWithPhysician = true OR p.isCpr = true OR p.isVentilated = true OR p.infectionId IS NOT NULL) THEN 1 ELSE 0 END) AS with_any',
         ]);
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
@@ -181,6 +185,7 @@ final class ProjectionFeatureQuery
                 'ventilated' => (int) ($row['ventilated'] ?? 0),
                 'shock' => (int) ($row['shock'] ?? 0),
                 'pregnant' => (int) ($row['pregnant'] ?? 0),
+                'work_accident' => (int) ($row['work_accident'] ?? 0),
                 'infectious' => (int) ($row['infectious'] ?? 0),
                 'with_any' => (int) ($row['with_any'] ?? 0),
             ];
@@ -249,15 +254,31 @@ final class ProjectionFeatureQuery
         };
     }
 
-    private function hasShockPregnantColumns(): bool
+    private function hasExtendedClinicalFeatureColumns(): bool
     {
-        if (\is_bool($this->hasShockPregnantColumns)) {
-            return $this->hasShockPregnantColumns;
+        if (\is_bool($this->hasExtendedClinicalFeatureColumns)) {
+            return $this->hasExtendedClinicalFeatureColumns;
         }
 
-        $columns = $this->entityManager->getConnection()->createSchemaManager()->listTableColumns('allocation_stats_projection');
-        $this->hasShockPregnantColumns = isset($columns['is_shock'], $columns['is_pregnant']);
+        $rows = $this->entityManager->getConnection()->fetchFirstColumn(
+            <<<'SQL'
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = :tableName
+  AND column_name IN (:columnNames)
+SQL,
+            [
+                'tableName' => 'allocation_stats_projection',
+                'columnNames' => ['is_shock', 'is_pregnant', 'is_work_accident'],
+            ],
+            [
+                'columnNames' => \Doctrine\DBAL\ArrayParameterType::STRING,
+            ]
+        );
+        $columnSet = array_fill_keys(array_map(static fn (mixed $value): string => (string) $value, $rows), true);
+        $this->hasExtendedClinicalFeatureColumns = isset($columnSet['is_shock'], $columnSet['is_pregnant'], $columnSet['is_work_accident']);
 
-        return $this->hasShockPregnantColumns;
+        return $this->hasExtendedClinicalFeatureColumns;
     }
 }

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -53,9 +53,6 @@ final readonly class ProjectionTimeSeriesQuery
             return null;
         }
 
-        if ($value instanceof \DateTimeImmutable) {
-            return $value;
-        }
         if ($value instanceof \DateTimeInterface) {
             return \DateTimeImmutable::createFromInterface($value);
         }
@@ -146,7 +143,7 @@ final readonly class ProjectionTimeSeriesQuery
             ->select('p.genderCode AS genderCode', 'COUNT(p.id) AS count')
             ->groupBy('genderCode');
 
-        /** @var list<array{genderCode:int|null,count:numeric-string|int}> $rows */
+        /** @var list<array{genderCode:numeric-string|int|null,count:numeric-string|int}> $rows */
         $rows = $qb->getQuery()->getArrayResult();
         $out = [];
         foreach ($rows as $row) {

--- a/tests/Import/Integration/Entity/AllocationOrmTest.php
+++ b/tests/Import/Integration/Entity/AllocationOrmTest.php
@@ -101,6 +101,7 @@ final class AllocationOrmTest extends KernelTestCase
             ->setIsVentilated(true)
             ->setIsShock(false)
             ->setIsPregnant(false)
+            ->setIsWorkAccident(true)
             ->setIsWithPhysician(true)
             ->setTransportType(AllocationTransportType::GROUND)
             ->setUrgency(AllocationUrgency::EMERGENCY)
@@ -139,6 +140,7 @@ final class AllocationOrmTest extends KernelTestCase
         self::assertTrue($object->isVentilated());
         self::assertFalse($object->isShock());
         self::assertFalse($object->isPregnant());
+        self::assertTrue($object->isWorkAccident());
         self::assertTrue($object->isWithPhysician());
         self::assertSame(AllocationUrgency::EMERGENCY, $object->getUrgency());
         self::assertFalse($object->isDepartmentWasClosed());
@@ -211,6 +213,7 @@ final class AllocationOrmTest extends KernelTestCase
             ->setIsVentilated(false)
             ->setIsShock(false)
             ->setIsPregnant(false)
+            ->setIsWorkAccident(false)
             ->setIsWithPhysician(false)
             ->setTransportType(null)
             ->setUrgency(AllocationUrgency::EMERGENCY)

--- a/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
+++ b/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
@@ -75,6 +75,7 @@ final class AllocationImportFactoryTest extends KernelTestCase
         $dto->isVentilated = false;
         $dto->isShock = false;
         $dto->isPregnant = false;
+        $dto->isWorkAccident = true;
         $dto->isWithPhysician = true;
         $dto->transportType = 'G';
         $dto->urgency = 1;
@@ -110,6 +111,7 @@ final class AllocationImportFactoryTest extends KernelTestCase
         self::assertFalse($allocation->isVentilated());
         self::assertFalse($allocation->isShock());
         self::assertFalse($allocation->isPregnant());
+        self::assertTrue($allocation->isWorkAccident());
         self::assertTrue($allocation->isWithPhysician());
 
         self::assertSame(AllocationTransportType::tryFrom('G'), $allocation->getTransportType());

--- a/tests/Import/Unit/Service/DTO/AllocationRowDTOTest.php
+++ b/tests/Import/Unit/Service/DTO/AllocationRowDTOTest.php
@@ -37,6 +37,7 @@ final class AllocationRowDTOTest extends TestCase
         $dto->isVentilated = false;
         $dto->isShock = false;
         $dto->isPregnant = false;
+        $dto->isWorkAccident = false;
         $dto->isWithPhysician = true;
         $dto->transportType = 'G';
         $dto->urgency = 1;

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperBooleanTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperBooleanTest.php
@@ -22,6 +22,8 @@ final class AllocationRowMapperBooleanTest extends TestCase
     {
         yield 'suffix plus' => ['S+', true];
         yield 'suffix minus' => ['S-', false];
+        yield 'work accident plus' => ['BG+', true];
+        yield 'work accident minus' => ['BG-', false];
         yield 'German yes' => ['ja', true];
         yield 'German no' => ['nein', false];
         yield '1' => ['1', true];

--- a/tests/Seed/Functional/Command/SeedProjectionCommandTest.php
+++ b/tests/Seed/Functional/Command/SeedProjectionCommandTest.php
@@ -54,7 +54,7 @@ final class SeedProjectionCommandTest extends KernelTestCase
         AllocationFactory::createOne($this->allocationDefaults($seed, $importB, 40, '2025-03-02 08:00:00', '2025-03-02 09:15:00'));
 
         $connection->executeStatement(
-            'INSERT INTO allocation_stats_projection (id, import_id, hospital_id, state_id, dispatch_area_id, speciality_id, department_id, occasion_id, assignment_id, infection_id, indication_normalized_id, created_at, arrival_at, created_year, created_quarter, created_month, created_week, created_day, created_weekday, created_hour, transport_time_minutes, age, gender_code, urgency_code, transport_type_code, requires_resus, requires_cathlab, is_cpr, is_ventilated, is_with_physician) VALUES (999999, 999999, 1, 1, 1, 1, 1, NULL, 1, NULL, NULL, NOW(), NOW(), 2025, 1, 1, 1, 1, 1, 1, 10, 10, 1, 1, 1, false, false, false, false, false)'
+            'INSERT INTO allocation_stats_projection (id, import_id, hospital_id, state_id, dispatch_area_id, speciality_id, department_id, occasion_id, assignment_id, infection_id, indication_normalized_id, created_at, arrival_at, created_year, created_quarter, created_month, created_week, created_day, created_weekday, created_hour, transport_time_minutes, age, gender_code, urgency_code, transport_type_code, requires_resus, requires_cathlab, is_cpr, is_ventilated, is_work_accident, is_with_physician) VALUES (999999, 999999, 1, 1, 1, 1, 1, NULL, 1, NULL, NULL, NOW(), NOW(), 2025, 1, 1, 1, 1, 1, 1, 10, 10, 1, 1, 1, false, false, false, false, false, false)'
         );
 
         $command = self::getContainer()->get(SeedProjectionCommand::class);
@@ -159,6 +159,7 @@ final class SeedProjectionCommandTest extends KernelTestCase
             'requiresCathlab' => true,
             'isCPR' => false,
             'isVentilated' => true,
+            'isWorkAccident' => false,
             'isWithPhysician' => true,
             'isShock' => false,
             'isPregnant' => false,

--- a/tests/Statistics/Functional/Controller/DashboardControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerTest.php
@@ -184,7 +184,7 @@ class DashboardControllerTest extends WebTestCase
         $crawler = $client->request(Request::METHOD_GET, '/statistics/?scope=public&period=month&year=2025&month=6');
 
         $this->assertResponseIsSuccessful();
-        $this->assertCount(6, $crawler->filter('[data-testid="stats-overview-features"] .progress'));
+        $this->assertCount(7, $crawler->filter('[data-testid="stats-overview-features"] .progress'));
         $this->assertCount(2, $crawler->filter('[data-testid="stats-overview-resources"] .progress'));
 
         $featuresLink = $crawler->filter('[data-testid="stats-cross-nav-overview-features"]')->link();

--- a/tests/Statistics/Integration/Query/AllocationStatsProjectionRebuilderTest.php
+++ b/tests/Statistics/Integration/Query/AllocationStatsProjectionRebuilderTest.php
@@ -88,6 +88,7 @@ final class AllocationStatsProjectionRebuilderTest extends KernelTestCase
             'requiresCathlab' => false,
             'isCPR' => false,
             'isVentilated' => true,
+            'isWorkAccident' => true,
             'isWithPhysician' => false,
             'occasion' => null,
             'infection' => null,
@@ -139,6 +140,7 @@ final class AllocationStatsProjectionRebuilderTest extends KernelTestCase
         self::assertFalse($this->toBool($row['requires_cathlab']));
         self::assertFalse($this->toBool($row['is_cpr']));
         self::assertTrue($this->toBool($row['is_ventilated']));
+        self::assertTrue($this->toBool($row['is_work_accident']));
         self::assertFalse($this->toBool($row['is_with_physician']));
 
         $repo = self::getContainer()->get(AllocationStatsProjectionRepository::class);
@@ -179,6 +181,7 @@ final class AllocationStatsProjectionRebuilderTest extends KernelTestCase
         self::assertFalse($projection->isRequiresCathlab());
         self::assertFalse($projection->isCpr());
         self::assertTrue($projection->isVentilated());
+        self::assertTrue($projection->isWorkAccident());
         self::assertFalse($projection->isWithPhysician());
     }
 
@@ -201,6 +204,7 @@ final class AllocationStatsProjectionRebuilderTest extends KernelTestCase
             'requiresCathlab' => true,
             'isCPR' => false,
             'isVentilated' => false,
+            'isWorkAccident' => false,
             'isWithPhysician' => true,
             'occasion' => null,
             'infection' => null,

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -41,6 +41,10 @@
         <source>allocations.field.isPregnant</source>
         <target>Is Pregnant</target>
       </trans-unit>
+      <trans-unit id="allocIsWorkAcc" resname="allocations.field.isWorkAccident">
+        <source>allocations.field.isWorkAccident</source>
+        <target>Work Accident</target>
+      </trans-unit>
       <trans-unit id="T4rWOlm" resname="allocations.field.isShock">
         <source>allocations.field.isShock</source>
         <target>Is in Shock</target>
@@ -880,6 +884,10 @@
       <trans-unit id="dzmkSoD" resname="label.pregnant">
         <source>label.pregnant</source>
         <target>Pregnant</target>
+      </trans-unit>
+      <trans-unit id="lblWorkAccident" resname="label.work_accident">
+        <source>label.work_accident</source>
+        <target>Work Accident</target>
       </trans-unit>
       <trans-unit id="qRwFlMY" resname="label.previous">
         <source>label.previous</source>
@@ -2410,6 +2418,10 @@
       <trans-unit id="statsAnFeatPrg" resname="stats.analysis.feature.is_pregnant">
         <source>stats.analysis.feature.is_pregnant</source>
         <target>Pregnant</target>
+      </trans-unit>
+      <trans-unit id="statsAnFeatWrkAcc" resname="stats.analysis.feature.is_work_accident">
+        <source>stats.analysis.feature.is_work_accident</source>
+        <target>Work accident</target>
       </trans-unit>
       <trans-unit id="statsAnTblMo" resname="stats.analysis.table.month">
         <source>stats.analysis.table.month</source>


### PR DESCRIPTION
### Summary

- Added an `is_work_accident` flag to the allocation domain  
- Integrated work accident handling into CSV and legacy import mapping  
- Updated statistics projection/rebuild logic and clinical feature aggregations  
- Extended fixtures to seed work accident cases with a defined probability  
- Added a `BG+` marker in the explore allocations list when the flag is set  
- Addressed related Psalm type and unused warnings  

### Motivation

- Capture work accident information as a dedicated allocation attribute  
- Make work accident data available across imports, UI, and statistics  
- Improve clinical and operational analytics by including this additional classification  
- Ensure test and demo data better reflects real-world allocation scenarios  

### Notes for Reviewers

- Verify that `is_work_accident` is mapped correctly in both CSV and legacy import flows  
- Check that statistics projections and rebuilds include the new flag as expected  
- Review the `BG+` marker in the allocation list for clarity and consistency  
- Confirm fixture seeding behaves as intended and does not skew unrelated tests  
- Psalm-related changes should be type-safety/style only, without runtime behavior changes  