### PR TITLE
feat: Enhance allocation explore filters with feature toggles

### DIFF
--- a/assets/controllers/infection-filter_controller.js
+++ b/assets/controllers/infection-filter_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['toggle', 'panel', 'select'];
+
+    connect() {
+        this.sync();
+    }
+
+    sync() {
+        const active = this.toggleTarget.checked;
+        this.panelTarget.classList.toggle('d-none', !active);
+        this.selectTarget.disabled = !active;
+        if (!active) {
+            this.selectTarget.value = '';
+        }
+    }
+}

--- a/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
+++ b/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
@@ -101,7 +101,7 @@ final readonly class ListAllocationsQuery
             ->setParameter('importId', $queryParametersDTO->importId);
         }
 
-        $field = match ($queryParametersDTO->sortBy) {
+        $sortField = match ($queryParametersDTO->sortBy) {
             'arrivalAt' => 'a.arrivalAt',
             'age' => 'a.age',
             default => 'h.'.$queryParametersDTO->sortBy,
@@ -153,6 +153,32 @@ final readonly class ListAllocationsQuery
                 );
         }
 
+        foreach ([
+            'isVentilated' => 'a.isVentilated',
+            'isShock' => 'a.isShock',
+            'isCPR' => 'a.isCPR',
+            'isPregnant' => 'a.isPregnant',
+            'isWorkAccident' => 'a.isWorkAccident',
+        ] as $param => $booleanField) {
+            if (null !== $queryParametersDTO->{$param}) {
+                $qb->andWhere($booleanField.' = :'.$param)
+                    ->setParameter(
+                        $param,
+                        filter_var($queryParametersDTO->{$param}, FILTER_VALIDATE_BOOLEAN)
+                    );
+            }
+        }
+
+        if (null !== $queryParametersDTO->isInfectious) {
+            $isInfectious = filter_var($queryParametersDTO->isInfectious, FILTER_VALIDATE_BOOLEAN);
+            $qb->andWhere($isInfectious ? 'a.infection IS NOT NULL' : 'a.infection IS NULL');
+        }
+
+        if (null !== $queryParametersDTO->infection) {
+            $qb->andWhere('i.id = :infectionId')
+                ->setParameter('infectionId', $queryParametersDTO->infection);
+        }
+
         if (null !== $queryParametersDTO->indication) {
             $qb->andWhere('inor.code = :indication')
                 ->setParameter('indication', $queryParametersDTO->indication);
@@ -187,14 +213,14 @@ final readonly class ListAllocationsQuery
 
             $isDescending = 'desc' === $queryParametersDTO->orderBy;
             $mainComparison = $isDescending
-                ? $qb->expr()->lt($field, ':cursorSortValue')
-                : $qb->expr()->gt($field, ':cursorSortValue');
+                ? $qb->expr()->lt($sortField, ':cursorSortValue')
+                : $qb->expr()->gt($sortField, ':cursorSortValue');
 
             $qb->andWhere(
                 $qb->expr()->orX(
                     $mainComparison,
                     $qb->expr()->andX(
-                        $qb->expr()->eq($field, ':cursorSortValue'),
+                        $qb->expr()->eq($sortField, ':cursorSortValue'),
                         $isDescending
                             ? $qb->expr()->lt('a.id', ':cursorId')
                             : $qb->expr()->gt('a.id', ':cursorId')
@@ -210,7 +236,7 @@ final readonly class ListAllocationsQuery
         }
 
         $qb
-            ->orderBy($field, $queryParametersDTO->orderBy)
+            ->orderBy($sortField, $queryParametersDTO->orderBy)
             ->addOrderBy('a.id', $queryParametersDTO->orderBy)
             ->setMaxResults($queryParametersDTO->limit + 1);
 

--- a/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
+++ b/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
@@ -11,6 +11,7 @@ use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\Infrastructure\Query\ListAllocationsQuery;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
 use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
+use App\Allocation\Infrastructure\Repository\InfectionRepository;
 use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
 use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
@@ -28,6 +29,7 @@ final class ListAllocationsController extends AbstractController
         private readonly StateRepository $stateRepository,
         private readonly IndicationNormalizedRepository $normalizedRepository,
         private readonly SecondaryTransportRepository $secondaryTransportRepository,
+        private readonly InfectionRepository $infectionRepository,
     ) {
     }
 
@@ -51,6 +53,7 @@ final class ListAllocationsController extends AbstractController
             'dispatchAreas' => $this->dispatchAreaRepository->findAll(),
             'indications' => $this->normalizedRepository->findAll(),
             'secondaryTransports' => $this->secondaryTransportRepository->findBy([], ['name' => 'ASC']),
+            'infections' => $this->infectionRepository->findBy([], ['name' => 'ASC']),
         ]);
     }
 
@@ -69,6 +72,13 @@ final class ListAllocationsController extends AbstractController
             'state',
             'requiresResus',
             'requiresCathlab',
+            'isVentilated',
+            'isShock',
+            'isCPR',
+            'isPregnant',
+            'isWorkAccident',
+            'isInfectious',
+            'infection',
         ];
 
         foreach ($filterFields as $field) {

--- a/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
+++ b/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
@@ -46,6 +46,20 @@ final readonly class AllocationQueryParametersDTO
         public ?int $indication = null,
 
         public ?int $secondaryTransport = null,
+
+        public ?int $isVentilated = null,
+
+        public ?int $isShock = null,
+
+        public ?int $isCPR = null,
+
+        public ?int $isPregnant = null,
+
+        public ?int $isWorkAccident = null,
+
+        public ?int $isInfectious = null,
+
+        public ?int $infection = null,
     ) {
     }
 }

--- a/src/Allocation/UI/Twig/templates/allocations/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/list.html.twig
@@ -127,7 +127,7 @@
         {% if activeFilterCount > 0 %}
             <div class="alert alert-info" role="alert">
                 <strong class="text-info">{{ 'label.filters.active'|trans }}:</strong>
-                {{ activeFilters.allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports) }}
+                {{ activeFilters.allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections) }}
             </div>
         {% endif %}
 
@@ -409,44 +409,6 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label">{{ 'label.requires_resus'|trans }}</label>
-                    <select name="requiresResus" class="form-select">
-                        <option value="">{{ 'label.all_modes'|trans }}</option>
-                        <option
-                            value="1"
-                            {{ filters.requiresResus == '1' ? 'selected' }}
-                        >
-                            {{ 'label.resus.is_required'|trans }}
-                        </option>
-                        <option
-                            value="0"
-                            {{ filters.requiresResus == '0' ? 'selected' }}
-                        >
-                            {{ 'label.resus.not_required'|trans }}
-                        </option>
-                    </select>
-                </div>
-
-                <div class="mb-3">
-                    <label class="form-label">{{ 'label.requires_cathlab'|trans }}</label>
-                    <select name="requiresCathlab" class="form-select">
-                        <option value="">{{ 'label.all_modes'|trans }}</option>
-                        <option
-                            value="1"
-                            {{ filters.requiresCathlab == '1' ? 'selected' }}
-                        >
-                            {{ 'label.cathlab.is_required'|trans }}
-                        </option>
-                        <option
-                            value="0"
-                            {{ filters.requiresCathlab == '0' ? 'selected' }}
-                        >
-                            {{ 'label.cathlab.not_required'|trans }}
-                        </option>
-                    </select>
-                </div>
-
-                <div class="mb-3">
                     <label class="form-label">{{ 'label.dispatch_area'|trans }}</label>
                     <select name="dispatchArea" class="form-select">
                         <option value="">{{ 'label.all_dispatch_areas'|trans }}</option>
@@ -474,6 +436,139 @@
                             </option>
                         {% endfor %}
                     </select>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="requiresResus"
+                            value="1"
+                            {{ filters.requiresResus ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.requires_resus'|trans }}</span>
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="requiresCathlab"
+                            value="1"
+                            {{ filters.requiresCathlab ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.requires_cathlab'|trans }}</span>
+                    </label>
+                </div>
+
+                <hr class="my-3">
+
+                <div class="mb-2 fw-semibold">{{ 'label.features'|trans }}</div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isVentilated"
+                            value="1"
+                            {{ filters.isVentilated ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_ventilated'|trans }}</span>
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isShock"
+                            value="1"
+                            {{ filters.isShock ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_shock'|trans }}</span>
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isCPR"
+                            value="1"
+                            {{ filters.isCPR ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_cpr'|trans }}</span>
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isPregnant"
+                            value="1"
+                            {{ filters.isPregnant ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_pregnant'|trans }}</span>
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isWorkAccident"
+                            value="1"
+                            {{ filters.isWorkAccident ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_work_accident'|trans }}</span>
+                    </label>
+                </div>
+
+                <hr class="my-3">
+
+                <div class="mb-3" data-controller="infection-filter">
+                    <label class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            name="isInfectious"
+                            value="1"
+                            data-infection-filter-target="toggle"
+                            data-action="change->infection-filter#sync"
+                            {{ filters.isInfectious ? 'checked' }}
+                        >
+                        <span class="form-check-label">{{ 'label.is_infectious'|trans }}</span>
+                    </label>
+
+                    <div class="mt-2 {{ filters.isInfectious ? '' : 'd-none' }}" data-infection-filter-target="panel">
+                        <label class="form-label" for="allocation-filter-infection">{{ 'label.infection'|trans }}</label>
+                        <select
+                            id="allocation-filter-infection"
+                            name="infection"
+                            class="form-select"
+                            data-infection-filter-target="select"
+                            {{ filters.isInfectious ? '' : 'disabled' }}
+                        >
+                            <option value="">{{ 'label.all_infections'|trans }}</option>
+                            {% for infection in infections %}
+                                <option
+                                    value="{{ infection.id }}"
+                                    {{ filters.infection == infection.id ? 'selected' }}
+                                >
+                                    {{ infection.name }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
                 </div>
 
                 <div class="d-flex gap-2 mt-4">

--- a/src/Shared/UI/Twig/templates/_macros/filters.html.twig
+++ b/src/Shared/UI/Twig/templates/_macros/filters.html.twig
@@ -1,4 +1,4 @@
-{% macro allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports) %}
+{% macro allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections) %}
     {% set rawFilters = [] %}
 
     {# --- Simple string filters --- #}
@@ -34,6 +34,30 @@
 
     {% if filters.requiresCathlab is not null %}
         {% set rawFilters = rawFilters|merge([{key: 'label.requires_cathlab', value: filters.requiresCathlab ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isVentilated is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_ventilated', value: filters.isVentilated ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isShock is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_shock', value: filters.isShock ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isCPR is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_cpr', value: filters.isCPR ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isPregnant is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_pregnant', value: filters.isPregnant ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isWorkAccident is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_work_accident', value: filters.isWorkAccident ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.isInfectious is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'label.is_infectious', value: filters.isInfectious ? 'Yes' : 'No'}]) %}
     {% endif %}
 
     {# --- Lookup: State (id → name) --- #}
@@ -85,6 +109,19 @@
         {% endfor %}
         {% if secondaryTransportName is not null %}
             {% set rawFilters = rawFilters|merge([{key: 'label.secondary_transport', value: secondaryTransportName}]) %}
+        {% endif %}
+    {% endif %}
+
+    {# --- Lookup: Infection (id → name) --- #}
+    {% if filters.infection is not null and infections is defined %}
+        {% set infectionName = null %}
+        {% for inf in infections %}
+            {% if infectionName is null and inf.id == filters.infection %}
+                {% set infectionName = inf.name %}
+            {% endif %}
+        {% endfor %}
+        {% if infectionName is not null %}
+            {% set rawFilters = rawFilters|merge([{key: 'label.infection', value: infectionName}]) %}
         {% endif %}
     {% endif %}
 

--- a/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
@@ -134,6 +134,49 @@ class ListAllocationsControllerTest extends WebTestCase
         self::assertSelectorExists('ul.pagination li.page-item.disabled');
     }
 
+    public function testIsInfectiousAndInfectionFiltersOnlyReturnMatchingAllocations(): void
+    {
+        $client = static::createClient();
+        $this->seedDependencies();
+
+        $targetInfection = InfectionFactory::createOne(['name' => 'Influenza']);
+        $otherInfection = InfectionFactory::createOne(['name' => 'Norovirus']);
+
+        $matchingAllocation = AllocationFactory::createOne(['infection' => $targetInfection]);
+        AllocationFactory::createOne(['infection' => $otherInfection]);
+        AllocationFactory::createOne(['infection' => null]);
+
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            sprintf(
+                '/explore/allocation?isInfectious=1&infection=%d&limit=50',
+                $targetInfection->getId()
+            )
+        );
+
+        self::assertResponseIsSuccessful();
+        $ids = $this->extractAllocationIds($crawler);
+        self::assertSame([(int) $matchingAllocation->getId()], $ids);
+    }
+
+    public function testIsVentilatedFilterOnlyReturnsVentilatedAllocations(): void
+    {
+        $client = static::createClient();
+        $this->seedDependencies();
+
+        $ventilatedAllocation = AllocationFactory::createOne(['isVentilated' => true]);
+        AllocationFactory::createOne(['isVentilated' => false]);
+
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/explore/allocation?isVentilated=1&limit=50'
+        );
+
+        self::assertResponseIsSuccessful();
+        $ids = $this->extractAllocationIds($crawler);
+        self::assertSame([(int) $ventilatedAllocation->getId()], $ids);
+    }
+
     private function seedDependencies(): void
     {
         UserFactory::createOne(['username' => 'area-user']);

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -909,6 +909,42 @@
         <source>label.properties</source>
         <target>Properties</target>
       </trans-unit>
+      <trans-unit id="allocFeatFeatures" resname="label.features">
+        <source>label.features</source>
+        <target>Features</target>
+      </trans-unit>
+      <trans-unit id="allocFeatVent" resname="label.is_ventilated">
+        <source>label.is_ventilated</source>
+        <target>Ventilated</target>
+      </trans-unit>
+      <trans-unit id="allocFeatShock" resname="label.is_shock">
+        <source>label.is_shock</source>
+        <target>Shock</target>
+      </trans-unit>
+      <trans-unit id="allocFeatCpr" resname="label.is_cpr">
+        <source>label.is_cpr</source>
+        <target>CPR</target>
+      </trans-unit>
+      <trans-unit id="allocFeatPreg" resname="label.is_pregnant">
+        <source>label.is_pregnant</source>
+        <target>Pregnant</target>
+      </trans-unit>
+      <trans-unit id="allocFeatWork" resname="label.is_work_accident">
+        <source>label.is_work_accident</source>
+        <target>Work Accident</target>
+      </trans-unit>
+      <trans-unit id="allocFeatInfect" resname="label.is_infectious">
+        <source>label.is_infectious</source>
+        <target>Infectious</target>
+      </trans-unit>
+      <trans-unit id="allocFeatInfection" resname="label.infection">
+        <source>label.infection</source>
+        <target>Infection</target>
+      </trans-unit>
+      <trans-unit id="allocFeatAllInf" resname="label.all_infections">
+        <source>label.all_infections</source>
+        <target>All Infections</target>
+      </trans-unit>
       <trans-unit id="Cn7F.4b" resname="label.register">
         <source>label.register</source>
         <target>Register</target>


### PR DESCRIPTION
### Summary

- Enhanced allocation explore filters with new feature-based filter options
- Switched resuscitation room and cath lab filters to checkbox-based inputs
- Added support for infectious allocation filtering
- Added optional infection-specific drill-down filtering
- Added functional tests for new infectious and ventilated filter combination

### Motivation

- Make allocation exploration more flexible and easier to use
- Allow users to filter allocations by relevant clinical and operational features
- Improve visibility into infectious and ventilation-related allocation cases
- Ensure the new filter combinations are covered by functional tests

### Notes for Reviewers

- Verify that the updated checkbox filters behave correctly in combination with existing filters
- Check infectious filtering and infection-specific drill-down behavior
- Confirm that ventilated filter paths return only matching allocations
- Ensure the explore page UI remains clear and usable with the new filter options