### PR TITLE
feat: Add case ID hashing and allocation notes import support

### DIFF
--- a/migrations/Version20260512181200.php
+++ b/migrations/Version20260512181200.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260512181200 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional case_id_hash and notes on allocation.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE allocation ADD case_id_hash BYTEA DEFAULT NULL');
+        $this->addSql('ALTER TABLE allocation ADD notes VARCHAR(255) DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_allocation_case_id_hash ON allocation (case_id_hash)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_allocation_case_id_hash');
+        $this->addSql('ALTER TABLE allocation DROP case_id_hash');
+        $this->addSql('ALTER TABLE allocation DROP notes');
+    }
+}

--- a/src/Allocation/Domain/Entity/Allocation.php
+++ b/src/Allocation/Domain/Entity/Allocation.php
@@ -10,6 +10,7 @@ use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Infrastructure\Repository\AllocationRepository;
 use App\Import\Domain\Entity\Import;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[Audit\Audited]
@@ -121,6 +122,14 @@ class Allocation
 
     #[ORM\OneToOne(Assessment::class, cascade: ['persist', 'remove'])]
     private ?Assessment $assessment = null;
+
+    #[Audit\AuditIgnore]
+    #[ORM\Column(type: Types::BINARY, length: 32, nullable: true)]
+    private ?string $caseIdHash = null;
+
+    #[Audit\AuditIgnore]
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $notes = null;
 
     public function getId(): ?int
     {
@@ -491,5 +500,29 @@ class Allocation
     public function setAssessment(?Assessment $assessment): void
     {
         $this->assessment = $assessment;
+    }
+
+    public function getCaseIdHash(): ?string
+    {
+        return $this->caseIdHash;
+    }
+
+    public function setCaseIdHash(?string $caseIdHash): static
+    {
+        $this->caseIdHash = $caseIdHash;
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): static
+    {
+        $this->notes = $notes;
+
+        return $this;
     }
 }

--- a/src/Import/Application/DTO/AllocationRowDTO.php
+++ b/src/Import/Application/DTO/AllocationRowDTO.php
@@ -119,4 +119,9 @@ final class AllocationRowDTO
     public ?string $assessmentCirculation = null;
 
     public ?string $assessmentDisability = null;
+
+    public ?string $caseId = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $notes = null;
 }

--- a/src/Import/Infrastructure/CaseId/CaseIdHasher.php
+++ b/src/Import/Infrastructure/CaseId/CaseIdHasher.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\CaseId;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class CaseIdHasher
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        #[Autowire('%kernel.secret%')]
+        private string $secret,
+    ) {
+    }
+
+    public function normalize(?string $raw): ?string
+    {
+        if (null === $raw) {
+            return null;
+        }
+
+        $digits = preg_replace('/\D+/', '', $raw) ?? '';
+
+        return '' === $digits ? null : $digits;
+    }
+
+    public function hashFrom(?string $raw): ?string
+    {
+        $normalized = $this->normalize($raw);
+
+        if (null === $normalized) {
+            return null;
+        }
+
+        return hash_hmac('sha256', $normalized, $this->secret, true);
+    }
+}

--- a/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
@@ -104,6 +104,9 @@ final class AllocationRowMapper implements RowToDtoMapperInterface
             self::getStringOrNull($row, 'disability')
         );
 
+        $dto->caseId = self::getStringOrNull($row, 'enr');
+        $dto->notes = self::getStringOrNull($row, 'freitext');
+
         return $dto;
     }
 }

--- a/src/Import/Infrastructure/Resolver/AllocationSupplementaryFieldsResolver.php
+++ b/src/Import/Infrastructure/Resolver/AllocationSupplementaryFieldsResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Resolver;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Import\Application\Contracts\AllocationEntityResolverInterface;
+use App\Import\Application\DTO\AllocationRowDTO;
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
+
+final readonly class AllocationSupplementaryFieldsResolver implements AllocationEntityResolverInterface
+{
+    public function __construct(
+        private CaseIdHasher $caseIdHasher,
+    ) {
+    }
+
+    #[\Override]
+    public function warm(): void
+    {
+    }
+
+    #[\Override]
+    public function supports(Allocation $entity, AllocationRowDTO $dto): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function apply(Allocation $entity, AllocationRowDTO $dto): void
+    {
+        $entity->setCaseIdHash($this->caseIdHasher->hashFrom($dto->caseId));
+        $entity->setNotes($dto->notes);
+    }
+}

--- a/tests/Import/Integration/Entity/AllocationOrmTest.php
+++ b/tests/Import/Integration/Entity/AllocationOrmTest.php
@@ -31,6 +31,7 @@ use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\User\Domain\Factory\UserFactory;
 use Doctrine\ORM\EntityManagerInterface;
@@ -162,6 +163,76 @@ final class AllocationOrmTest extends KernelTestCase
         self::assertSame('Test Infection', $object->getInfection()->getName());
         self::assertSame('Test IndicationRaw', $object->getIndicationRaw()->getName());
         self::assertSame('Test IndicationNormalized', $object->getIndicationNormalized()->getName());
+    }
+
+    public function testCaseIdHashAndNotesPersistAndHydrate(): void
+    {
+        UserFactory::createOne(['username' => 'allocation-orm-supplementary-'.bin2hex(random_bytes(6))]);
+
+        $state = StateFactory::createOne();
+        $area = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne(['state' => $state, 'dispatchArea' => $area]);
+        $import = ImportFactory::createOne(['name' => 'Test Import']);
+        $speciality = SpecialityFactory::createOne(['name' => 'Speciality']);
+        $department = DepartmentFactory::createOne(['name' => 'Department']);
+        $assignment = AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        $occasion = OccasionFactory::createOne(['name' => 'Test Occasion']);
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'Test IndicationRaw']);
+
+        $state = $this->em->getRepository(State::class)->find($state->getId());
+        $area = $this->em->getRepository(DispatchArea::class)->find($area->getId());
+        $hospital = $this->em->getRepository(Hospital::class)->find($hospital->getId());
+        $import = $this->em->getRepository(Import::class)->find($import->getId());
+        $speciality = $this->em->getRepository(Speciality::class)->find($speciality->getId());
+        $department = $this->em->getRepository(Department::class)->find($department->getId());
+        $assignment = $this->em->getRepository(Assignment::class)->find($assignment->getId());
+        $occasion = $this->em->getRepository(Occasion::class)->find($occasion->getId());
+        $indicationRaw = $this->em->getRepository(IndicationRaw::class)->find($indicationRaw->getId());
+
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        $caseIdHash = $hasher->hashFrom('987654');
+        $notes = 'Follow-up requested';
+
+        $allocation = new Allocation()
+            ->setHospital($hospital)
+            ->setDispatchArea($area)
+            ->setState($state)
+            ->setImport($import)
+            ->setCreatedAt(new \DateTimeImmutable('now'))
+            ->setArrivalAt(new \DateTimeImmutable('+10 minutes'))
+            ->setGender(AllocationGender::MALE)
+            ->setAge(45)
+            ->setRequiresResus(false)
+            ->setRequiresCathlab(false)
+            ->setIsCPR(false)
+            ->setIsVentilated(false)
+            ->setIsShock(false)
+            ->setIsPregnant(false)
+            ->setIsWorkAccident(false)
+            ->setIsWithPhysician(false)
+            ->setTransportType(AllocationTransportType::GROUND)
+            ->setUrgency(AllocationUrgency::EMERGENCY)
+            ->setSpeciality($speciality)
+            ->setDepartment($department)
+            ->setDepartmentWasClosed(false)
+            ->setAssignment($assignment)
+            ->setOccasion($occasion)
+            ->setIndicationRaw($indicationRaw)
+            ->setCaseIdHash($caseIdHash)
+            ->setNotes($notes)
+        ;
+
+        $this->em->persist($allocation);
+        $this->em->flush();
+        $id = $allocation->getId();
+
+        $this->em->clear();
+
+        /** @var Allocation $object */
+        $object = $this->em->getRepository(Allocation::class)->find($id);
+
+        self::assertSame($caseIdHash, $object->getCaseIdHash());
+        self::assertSame($notes, $object->getNotes());
     }
 
     public function testTransportTypeAndInfectionCanBeNull(): void

--- a/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
+++ b/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
@@ -19,6 +19,7 @@ use App\Import\Application\Exception\InvalidDateException;
 use App\Import\Application\Exception\InvalidEnumException;
 use App\Import\Application\Exception\ReferenceNotFoundException;
 use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\Import\Infrastructure\Mapping\AllocationImportFactory;
 use App\User\Domain\Factory\UserFactory;
@@ -119,6 +120,26 @@ final class AllocationImportFactoryTest extends KernelTestCase
         self::assertSame('Test Indication', $allocation->getIndicationRaw()->getName());
         self::assertNotNull($allocation->getSecondaryTransport());
         self::assertSame('Kapazitätsengpass', $allocation->getSecondaryTransport()->getName());
+    }
+
+    public function testSupplementaryFieldsAreMappedFromDto(): void
+    {
+        $allocation = $this->factory->fromDto($this->makeDto([
+            'caseId' => '123456',
+            'notes' => 'Unstructured note',
+        ]), $this->import);
+
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        self::assertSame($hasher->hashFrom('123456'), $allocation->getCaseIdHash());
+        self::assertSame('Unstructured note', $allocation->getNotes());
+    }
+
+    public function testSupplementaryFieldsRemainNullWhenOmitted(): void
+    {
+        $allocation = $this->factory->fromDto($this->makeDto(), $this->import);
+
+        self::assertNull($allocation->getCaseIdHash());
+        self::assertNull($allocation->getNotes());
     }
 
     public function testUnknownDispatchAreaThrows(): void

--- a/tests/Import/Unit/Infrastructure/CaseId/CaseIdHasherTest.php
+++ b/tests/Import/Unit/Infrastructure/CaseId/CaseIdHasherTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Infrastructure\CaseId;
+
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CaseIdHasherTest extends TestCase
+{
+    private CaseIdHasher $hasher;
+
+    protected function setUp(): void
+    {
+        $this->hasher = new CaseIdHasher('$ecretf0rt3st');
+    }
+
+    public function testHashFromReturnsNullForNullOrEmptyInput(): void
+    {
+        self::assertNull($this->hasher->hashFrom(null));
+        self::assertNull($this->hasher->hashFrom(''));
+        self::assertNull($this->hasher->hashFrom('   '));
+        self::assertNull($this->hasher->hashFrom('abc'));
+    }
+
+    #[DataProvider('normalizeProvider')]
+    public function testNormalizeKeepsDigitsOnly(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, $this->hasher->normalize($input));
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?string}>
+     */
+    public static function normalizeProvider(): iterable
+    {
+        yield 'digits only' => ['123456', '123456'];
+        yield 'leading zeros' => ['00123', '00123'];
+        yield 'non digits stripped' => ['ENR-12-34', '1234'];
+        yield 'empty after strip' => ['---', null];
+    }
+
+    public function testHashFromIsDeterministicForSameInput(): void
+    {
+        $first = $this->hasher->hashFrom('123456');
+        $second = $this->hasher->hashFrom('123456');
+
+        self::assertNotNull($first);
+        self::assertSame($first, $second);
+    }
+
+    public function testHashFromNormalizesBeforeHashing(): void
+    {
+        self::assertSame(
+            $this->hasher->hashFrom('123456'),
+            $this->hasher->hashFrom('ENR-123-456'),
+        );
+    }
+
+    public function testHashFromReturnsThirtyTwoRawBytes(): void
+    {
+        $hash = $this->hasher->hashFrom('42');
+
+        self::assertNotNull($hash);
+        self::assertSame(32, strlen($hash));
+    }
+
+    public function testDifferentSecretsProduceDifferentHashes(): void
+    {
+        $otherHasher = new CaseIdHasher('another-secret');
+
+        self::assertNotSame(
+            $this->hasher->hashFrom('123456'),
+            $otherHasher->hashFrom('123456'),
+        );
+    }
+}

--- a/tests/Import/Unit/Service/DTO/AllocationRowDTOTest.php
+++ b/tests/Import/Unit/Service/DTO/AllocationRowDTOTest.php
@@ -199,6 +199,24 @@ final class AllocationRowDTOTest extends TestCase
         self::assertCount(0, $this->validator->validate($dto));
     }
 
+    public function testCaseIdAndNotesAreOptional(): void
+    {
+        $dto = $this->makeValidDto();
+
+        self::assertCount(0, $this->validator->validate($dto));
+    }
+
+    public function testNotesMaxLengthIsValidated(): void
+    {
+        $dto = $this->makeValidDto();
+        $dto->notes = str_repeat('a', 256);
+
+        $violations = $this->validator->validate($dto);
+        $paths = array_map(static fn (ConstraintViolationInterface $v): string => $v->getPropertyPath(), iterator_to_array($violations));
+
+        self::assertContains('notes', $paths);
+    }
+
     public function testSecondaryIndicationCodeOutOfRangeFails(): void
     {
         $dto = $this->makeValidDto();

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperSupplementaryFieldsTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperSupplementaryFieldsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use App\Import\Infrastructure\Mapping\AllocationRowMapper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationRowMapperSupplementaryFieldsTest extends TestCase
+{
+    private AllocationRowMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AllocationRowMapper();
+    }
+
+    public function testMapsEnrAndFreitextToCaseIdAndNotes(): void
+    {
+        $dto = $this->mapper->mapAssoc([
+            'enr' => '123456',
+            'freitext' => 'Patient mit Begleitung',
+        ]);
+
+        self::assertSame('123456', $dto->caseId);
+        self::assertSame('Patient mit Begleitung', $dto->notes);
+    }
+
+    /**
+     * @param array<string, string> $row
+     */
+    #[DataProvider('emptySupplementaryFieldProvider')]
+    public function testEmptyOrMissingSupplementaryFieldsMapToNull(array $row): void
+    {
+        $dto = $this->mapper->mapAssoc($row);
+
+        self::assertNull($dto->caseId);
+        self::assertNull($dto->notes);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function emptySupplementaryFieldProvider(): iterable
+    {
+        yield 'missing keys' => [[]];
+        yield 'blank values' => [['enr' => '', 'freitext' => '   ']];
+    }
+}


### PR DESCRIPTION
### Summary

- Added optional `case_id_hash` and `notes` fields to allocations
- Introduced `CaseIdHasher` using HMAC-SHA256 for normalized case/ENR values
- Mapped CSV `ENR` values into hashed case IDs during allocation import
- Mapped CSV free-text fields into allocation notes
- Extended import DTOs, resolver logic, factory resolution, and persistence for the new fields
- Added unit and integration tests for hashing, CSV mapping, validation, factory resolution, and ORM persistence

### Motivation

- Enable reliable import-side matching using case identifiers without exposing raw case IDs
- Preserve relevant free-text notes from imported allocation data
- Keep sensitive identifiers protected by storing only hashed values
- Prepare allocation data for future analysis and reconciliation workflows

### Notes for Reviewers

- Verify `CaseIdHasher` normalization and HMAC behavior
- Check CSV mapping for `ENR` and free-text/note fields
- Ensure raw case IDs are not exposed in UI or persisted directly
- Review migration/schema changes for nullable field handling
- Confirm new tests cover both hashing and import persistence paths