### PR TITLE
feat: Add support for disabling user accounts

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,4 +1,5 @@
 security:
+    expose_security_errors: account_status
     # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
@@ -17,6 +18,7 @@ security:
             lazy: true
             provider: app_user_provider
             custom_authenticator: App\User\Infrastructure\Security\LoginFormAuthenticator
+            user_checker: App\User\Infrastructure\Security\UserAccountStatusChecker
 
             logout:
                 path: app_logout

--- a/migrations/Version20260512202205.php
+++ b/migrations/Version20260512202205.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260512202205 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_enabled flag to user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD is_enabled BOOLEAN DEFAULT TRUE NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP is_enabled');
+    }
+}

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -15,17 +15,21 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<User>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class UserCrudController extends AbstractCrudController
 {
     public function __construct(
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly AuditContext $auditContext,
+        private readonly Security $security,
     ) {
     }
 
@@ -62,6 +66,8 @@ final class UserCrudController extends AbstractCrudController
         yield TextField::new('email');
         yield BooleanField::new('isVerified');
         yield BooleanField::new('credentialsExpired');
+        yield BooleanField::new('isEnabled')
+            ->renderAsSwitch();
         yield ChoiceField::new('roles')
             ->setChoices([
                 'Admin' => 'ROLE_ADMIN',
@@ -87,6 +93,7 @@ final class UserCrudController extends AbstractCrudController
     {
         $user = new User();
         $user->setCredentialsExpired(true);
+        $user->setIsEnabled(true);
 
         return $user;
     }
@@ -122,6 +129,15 @@ final class UserCrudController extends AbstractCrudController
 
         $this->auditContext->beginIntent('user.admin.updated', ['source' => 'easyadmin']);
         try {
+            $currentUser = $this->security->getUser();
+            if (
+                $currentUser instanceof User
+                && $entityInstance->getId() === $currentUser->getId()
+                && !$entityInstance->isEnabled()
+            ) {
+                throw new \LogicException('You cannot disable your own account.');
+            }
+
             $plainPassword = $entityInstance->getPassword() ?? '';
             if ('' === $plainPassword) {
                 $originalData = $entityManager->getUnitOfWork()->getOriginalEntityData($entityInstance);

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -29,6 +29,7 @@ final class UserFixtures extends Fixture
             $user->setEmail($email);
             $user->setIsVerified($isVerified);
             $user->setCredentialsExpired(false);
+            $user->setIsEnabled(true);
 
             $manager->persist($user);
 

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -55,6 +55,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     #[ORM\Column(options: ['default' => false])]
     private bool $credentialsExpired = false;
 
+    #[ORM\Column(options: ['default' => true])]
+    private bool $isEnabled = true;
+
     /**
      * @var Collection<int, Hospital>
      */
@@ -172,6 +175,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     public function setCredentialsExpired(bool $credentialsExpired): static
     {
         $this->credentialsExpired = $credentialsExpired;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
+    }
+
+    public function setIsEnabled(bool $isEnabled): static
+    {
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }

--- a/src/User/Domain/Factory/UserFactory.php
+++ b/src/User/Domain/Factory/UserFactory.php
@@ -37,6 +37,7 @@ final class UserFactory extends PersistentProxyObjectFactory
         return [
             'credentialsExpired' => false,
             'email' => sprintf('user-%s@example.test', $suffix),
+            'isEnabled' => true,
             'isVerified' => true,
             'password' => 'password',
             'roles' => ['ROLE_USER'],

--- a/src/User/Infrastructure/Security/UserAccountStatusChecker.php
+++ b/src/User/Infrastructure/Security/UserAccountStatusChecker.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+use App\User\Domain\Entity\User;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/** @psalm-suppress UnusedClass */
+final class UserAccountStatusChecker implements UserCheckerInterface
+{
+    #[\Override]
+    public function checkPreAuth(UserInterface $user): void
+    {
+        $this->assertAccountEnabled($user);
+    }
+
+    #[\Override]
+    public function checkPostAuth(UserInterface $user): void
+    {
+        $this->assertAccountEnabled($user);
+    }
+
+    private function assertAccountEnabled(UserInterface $user): void
+    {
+        if (!$user instanceof User || $user->isEnabled()) {
+            return;
+        }
+
+        throw new CustomUserMessageAccountStatusException('Account is disabled.');
+    }
+}

--- a/src/User/UI/Http/Controller/ResetPasswordController.php
+++ b/src/User/UI/Http/Controller/ResetPasswordController.php
@@ -96,6 +96,12 @@ final class ResetPasswordController extends AbstractController
             throw new \LogicException('Unsupported user returned by reset password helper.');
         }
 
+        if (!$user->isEnabled()) {
+            $this->addFlash('danger', 'flash.reset_password.validation_failed');
+
+            return $this->redirectToRoute('app_forgot_password_request');
+        }
+
         $form = $this->createForm(ResetPasswordFormType::class);
         $form->handleRequest($request);
 
@@ -130,7 +136,7 @@ final class ResetPasswordController extends AbstractController
     private function processSendingPasswordResetEmail(string $emailFormData): RedirectResponse
     {
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => mb_strtolower(trim($emailFormData))]);
-        if (!$user instanceof User || !$user->isVerified()) {
+        if (!$user instanceof User || !$user->isVerified() || !$user->isEnabled()) {
             return $this->redirectToRoute('app_check_email');
         }
 

--- a/tests/Admin/Functional/Controller/UserCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/UserCrudControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class UserCrudControllerTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testAdminCanDisableAndReenableUser(): void
+    {
+        $target = UserFactory::createOne([
+            'username' => 'target-user-'.bin2hex(random_bytes(4)),
+        ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'user-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin/user/'.$target->getId().'/edit')
+            ->assertSuccessful()
+            ->uncheckField('User[isEnabled]')
+            ->click('Save changes')
+            ->assertSuccessful()
+        ;
+
+        $target->_refresh();
+        self::assertFalse($target->isEnabled());
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin/user/'.$target->getId().'/edit')
+            ->assertSuccessful()
+            ->checkField('User[isEnabled]')
+            ->click('Save changes')
+            ->assertSuccessful()
+        ;
+
+        $target->_refresh();
+        self::assertTrue($target->isEnabled());
+    }
+
+    public function testAdminCannotDisableOwnAccount(): void
+    {
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'self-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $adminId = $admin->getId();
+        self::assertNotNull($adminId);
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin/user/'.$adminId.'/edit')
+            ->assertSuccessful()
+            ->uncheckField('User[isEnabled]')
+            ->click('Save changes')
+            ->assertStatus(500)
+        ;
+
+        self::getContainer()->get(EntityManagerInterface::class)->clear();
+        $reloadedAdmin = self::getContainer()->get(UserRepository::class)->find($adminId);
+        self::assertInstanceOf(User::class, $reloadedAdmin);
+        self::assertTrue($reloadedAdmin->isEnabled());
+    }
+
+    public function testNonAdminUserGetsForbiddenOnUserIndex(): void
+    {
+        $user = UserFactory::createOne([
+            'username' => 'user-regular-'.bin2hex(random_bytes(4)),
+        ]);
+
+        $this->browser()
+            ->actingAs($user)
+            ->visit('/admin/user')
+            ->assertStatus(403)
+        ;
+    }
+}

--- a/tests/User/Functional/Controller/ResetPasswordControllerTest.php
+++ b/tests/User/Functional/Controller/ResetPasswordControllerTest.php
@@ -61,6 +61,28 @@ final class ResetPasswordControllerTest extends WebTestCase
         self::assertSame(1, $this->getResetPasswordRequestRepository()->count(['user' => $user]));
     }
 
+    public function testResetRequestIsBlockedForDisabledEmail(): void
+    {
+        UserFactory::new([
+            'email' => 'disabled@example.test',
+            'isEnabled' => false,
+            'isVerified' => true,
+            'username' => 'disabled',
+        ])->create();
+
+        $this->browser()
+            ->visit('/reset-password')
+            ->fillField('Email', 'disabled@example.test')
+            ->click('Send reset email')
+            ->assertSuccessful()
+            ->assertSee('Check your email')
+        ;
+
+        $user = $this->getUserRepository()->findOneBy(['email' => 'disabled@example.test']);
+        self::assertInstanceOf(User::class, $user);
+        self::assertSame(0, $this->getResetPasswordRequestRepository()->count(['user' => $user]));
+    }
+
     private function getUserRepository(): UserRepository
     {
         return self::getContainer()->get(UserRepository::class);

--- a/tests/User/Functional/Controller/SecurityControllerTest.php
+++ b/tests/User/Functional/Controller/SecurityControllerTest.php
@@ -44,4 +44,40 @@ class SecurityControllerTest extends WebTestCase
             ->assertNotSee('foo')
         ;
     }
+
+    public function testDisabledUserCannotLogin(): void
+    {
+        UserFactory::new([
+            'isEnabled' => false,
+            'username' => 'disabled-user',
+        ])->create();
+
+        $this->acceptEssentialCookies($this->browser())
+            ->visit('/login')
+            ->fillField('Username', 'disabled-user')
+            ->fillField('Password', 'password')
+            ->click('Sign in')
+            ->assertSuccessful()
+            ->assertSeeIn('.alert.alert-danger', 'Account is disabled.')
+            ->assertSee('Login')
+        ;
+    }
+
+    public function testDisabledUserIsLoggedOutOnNextRequest(): void
+    {
+        $user = UserFactory::new(['username' => 'session-user'])->create();
+
+        $this->loginWithConsent($this->browser(), 'session-user')
+            ->assertSeeIn('#user_name', 'session-user')
+        ;
+
+        $user->setIsEnabled(false);
+        $user->_save();
+
+        $this->browser()
+            ->visit('/settings')
+            ->assertSuccessful()
+            ->assertSee('Login')
+        ;
+    }
 }

--- a/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
+++ b/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Unit\Infrastructure\Security;
+
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Security\UserAccountStatusChecker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+final class UserAccountStatusCheckerTest extends TestCase
+{
+    private UserAccountStatusChecker $checker;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->checker = new UserAccountStatusChecker();
+    }
+
+    public function testEnabledUserPassesPreAndPostAuthChecks(): void
+    {
+        $user = $this->createUser(true);
+
+        $this->checker->checkPreAuth($user);
+        $this->checker->checkPostAuth($user);
+
+        self::assertTrue($user->isEnabled());
+    }
+
+    public function testDisabledUserFailsPreAuthCheck(): void
+    {
+        $user = $this->createUser(false);
+
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('Account is disabled.');
+
+        $this->checker->checkPreAuth($user);
+    }
+
+    public function testDisabledUserFailsPostAuthCheck(): void
+    {
+        $user = $this->createUser(false);
+
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('Account is disabled.');
+
+        $this->checker->checkPostAuth($user);
+    }
+
+    public function testNonAppUserIsIgnored(): void
+    {
+        $user = new InMemoryUser('other', null);
+
+        $this->checker->checkPreAuth($user);
+        $this->checker->checkPostAuth($user);
+
+        self::assertSame('other', $user->getUserIdentifier());
+    }
+
+    private function createUser(bool $enabled): User
+    {
+        $user = new User();
+        $user->setUsername('status-user');
+        $user->setEmail('status-user@example.test');
+        $user->setPassword('hashed-password');
+        $user->setIsEnabled($enabled);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
### Summary

- Added support for disabling user accounts
- Extended the user domain model with account status handling
- Prevented disabled users from authenticating or accessing protected areas
- Integrated account status management into the admin/backend workflow
- Updated authentication and security-related logic to respect disabled accounts
- Added tests covering disabled account behavior and access restrictions

### Motivation

- Allow administrators to deactivate accounts without permanently deleting users
- Improve security and account lifecycle management
- Provide a safer alternative to hard deletion for inactive or blocked users
- Ensure disabled accounts are consistently handled across authentication and authorization flows

### Notes for Reviewers

- Verify authentication behavior for disabled users
- Check backend/admin integration for enabling/disabling accounts
- Ensure existing login and session flows correctly respect account status
- Confirm tests cover login prevention, access restrictions, and edge cases
- Review migration/schema changes related to the new account status field