### PR TITLE
feat: Implement next dashboard iteration with improved UX and analytics flow

### DIFF
--- a/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
@@ -11,12 +11,53 @@
 {% endblock %}
 
 {% block page_content %}
+    {% set hasOwnedHospitals = app.user and app.user.hospitals|length > 0 %}
+    {% set canViewOwnedHospitals = is_granted('ROLE_PARTICIPANT') and hasOwnedHospitals %}
+    {% set nextSteps = [
+        {
+            title: canViewOwnedHospitals ? 'dashboard.next_steps.hospitals.owned.title' : 'dashboard.next_steps.hospitals.all.title',
+            description: canViewOwnedHospitals ? 'dashboard.next_steps.hospitals.owned.description' : 'dashboard.next_steps.hospitals.all.description',
+            icon: 'tabler:building-hospital',
+            url: canViewOwnedHospitals ? path('app_hospitals_index') : path('app_explore_hospital_list'),
+        },
+        {
+            title: 'dashboard.next_steps.explore.title',
+            description: 'dashboard.next_steps.explore.description',
+            icon: 'tabler:compass',
+            url: path('app_explore_index'),
+        },
+        {
+            title: 'dashboard.next_steps.analysis.title',
+            description: 'dashboard.next_steps.analysis.description',
+            icon: 'tabler:chart-histogram',
+            url: path('app_stats_dashboard'),
+        },
+        {
+            title: canViewOwnedHospitals ? 'dashboard.next_steps.import.title' : 'dashboard.next_steps.blog.title',
+            description: canViewOwnedHospitals ? 'dashboard.next_steps.import.description' : 'dashboard.next_steps.blog.description',
+            icon: canViewOwnedHospitals ? 'tabler:database-import' : 'tabler:notes',
+            url: canViewOwnedHospitals ? path('app_import_new') : path('app_blog_index'),
+        },
+    ] %}
+
     <div class="row g-3 align-items-start">
         <div class="col-12 col-lg-8 d-flex flex-column gap-3">
-            <div class="card">
-                <div class="card-body">
-                    <p class="text-muted mb-0">{{ 'dashboard.empty.description'|trans }}</p>
-                </div>
+            <div class="row row-cards">
+                {% for step in nextSteps %}
+                    <div class="col-12 col-md-6">
+                        <a href="{{ step.url }}" class="card card-link h-100 text-reset text-decoration-none">
+                            <div class="card-body d-flex gap-3">
+                                <span class="avatar avatar-lg bg-primary-lt text-primary flex-shrink-0">
+                                    {{ ux_icon(step.icon, {style: 'height: 1.75em;'}) }}
+                                </span>
+                                <div>
+                                    <h3 class="h4 mb-1">{{ step.title|trans }}</h3>
+                                    <p class="text-secondary mb-0">{{ step.description|trans }}</p>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                {% endfor %}
             </div>
 
             <div class="card">

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -64,10 +64,46 @@ final class DefaultControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, '/');
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorTextContains('body', 'This is your personal workspace.');
+        self::assertSelectorTextContains('body', 'View all Hospitals');
+        self::assertSelectorTextContains('body', 'Explore our Data');
+        self::assertSelectorTextContains('body', 'Analyze your Data');
+        self::assertSelectorTextContains('body', 'Read the Blog');
+        self::assertSelectorExists('a[href="/explore/hospital"]');
+        self::assertSelectorExists('a[href="/explore"]');
+        self::assertSelectorExists('a[href="/statistics/"]');
+        self::assertSelectorExists('a[href="/blog"]');
         self::assertSelectorTextContains('body', 'Latest blog posts');
         self::assertSelectorTextContains('body', 'Pages');
         self::assertSelectorTextContains('body', 'No published posts yet.');
         self::assertSelectorTextContains('body', 'No pages available.');
+    }
+
+    public function testParticipantUsersWithHospitalsSeeOwnedHospitalsAndImportActions(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne([
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+            'username' => 'participant-dashboard-user',
+        ]);
+        $state = StateFactory::createOne(['createdBy' => $user]);
+        $dispatchArea = DispatchAreaFactory::createOne([
+            'createdBy' => $user,
+            'state' => $state,
+        ]);
+        HospitalFactory::createOne([
+            'createdBy' => $user,
+            'dispatchArea' => $dispatchArea,
+            'owner' => $user,
+            'state' => $state,
+        ]);
+
+        $client->loginUser($user->_real());
+        $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', 'View your Hospitals');
+        self::assertSelectorTextContains('body', 'Import new Allocations');
+        self::assertSelectorExists('a[href="/hospitals"]');
+        self::assertSelectorExists('a[href="/import/new"]');
     }
 }

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -121,13 +121,53 @@
         <source>cookie.preferences.title</source>
         <target>Cookie preferences</target>
       </trans-unit>
-      <trans-unit id="WbCJOyn" resname="dashboard.empty.description">
-        <source>dashboard.empty.description</source>
-        <target>This is your personal workspace. Use the navigation above to explore data, statistics, and imports.</target>
+      <trans-unit id="dshNxtHospOwnTit" resname="dashboard.next_steps.hospitals.owned.title">
+        <source>dashboard.next_steps.hospitals.owned.title</source>
+        <target>View your Hospitals</target>
       </trans-unit>
-      <trans-unit id="DZA3KTc" resname="dashboard.empty.title">
-        <source>dashboard.empty.title</source>
-        <target>Your dashboard is ready</target>
+      <trans-unit id="dshNxtHospOwnDesc" resname="dashboard.next_steps.hospitals.owned.description">
+        <source>dashboard.next_steps.hospitals.owned.description</source>
+        <target>Review participating hospitals and jump into their latest allocation details.</target>
+      </trans-unit>
+      <trans-unit id="dshNxtHospAllTit" resname="dashboard.next_steps.hospitals.all.title">
+        <source>dashboard.next_steps.hospitals.all.title</source>
+        <target>View all Hospitals</target>
+      </trans-unit>
+      <trans-unit id="dshNxtHospAllDesc" resname="dashboard.next_steps.hospitals.all.description">
+        <source>dashboard.next_steps.hospitals.all.description</source>
+        <target>Browse the full hospital directory and discover participating facilities.</target>
+      </trans-unit>
+      <trans-unit id="dshNxtExplTit" resname="dashboard.next_steps.explore.title">
+        <source>dashboard.next_steps.explore.title</source>
+        <target>Explore our Data</target>
+      </trans-unit>
+      <trans-unit id="dshNxtExplDesc" resname="dashboard.next_steps.explore.description">
+        <source>dashboard.next_steps.explore.description</source>
+        <target>Browse allocations, indications, transports, and other source data in one place.</target>
+      </trans-unit>
+      <trans-unit id="dshNxtAnlyTit" resname="dashboard.next_steps.analysis.title">
+        <source>dashboard.next_steps.analysis.title</source>
+        <target>Analyze your Data</target>
+      </trans-unit>
+      <trans-unit id="dshNxtAnlyDesc" resname="dashboard.next_steps.analysis.description">
+        <source>dashboard.next_steps.analysis.description</source>
+        <target>Start with the statistics overview before diving into detailed analyses.</target>
+      </trans-unit>
+      <trans-unit id="dshNxtImptTit" resname="dashboard.next_steps.import.title">
+        <source>dashboard.next_steps.import.title</source>
+        <target>Import new Allocations</target>
+      </trans-unit>
+      <trans-unit id="dshNxtImptDesc" resname="dashboard.next_steps.import.description">
+        <source>dashboard.next_steps.import.description</source>
+        <target>Upload a new allocation import and keep your dataset up to date.</target>
+      </trans-unit>
+      <trans-unit id="dshNxtBlogTit" resname="dashboard.next_steps.blog.title">
+        <source>dashboard.next_steps.blog.title</source>
+        <target>Read the Blog</target>
+      </trans-unit>
+      <trans-unit id="dshNxtBlogDesc" resname="dashboard.next_steps.blog.description">
+        <source>dashboard.next_steps.blog.description</source>
+        <target>Follow updates, guidance, and background stories from the project team.</target>
       </trans-unit>
       <trans-unit id="dshPgTit" resname="dashboard.pages.card_title">
         <source>dashboard.pages.card_title</source>


### PR DESCRIPTION
Show a 2x2 grid of next-step cards on the authenticated dashboard instead of the previous placeholder text. Hospital and import cards adapt to the user: participants with owned hospitals are linked to their hospital management and import pages, while everyone else is pointed at the public hospital directory and the blog as an alternative call-to-action.