### PR TITLE
feat: Added a very basic install command to setup the admin user.

### DIFF
--- a/src/Install/UI/Console/Command/InstallCommand.php
+++ b/src/Install/UI/Console/Command/InstallCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\UI\Console\Command;
+
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand(
+    name: 'app:install',
+    description: 'Run one-time server bootstrap (initial admin user and future install steps).',
+)]
+final class InstallCommand extends Command
+{
+    private const string BOOTSTRAP_ADMIN_USERNAME = 'admin';
+
+    private const string BOOTSTRAP_ADMIN_EMAIL = 'admin@test.local';
+
+    private const string BOOTSTRAP_ADMIN_PLAIN_PASSWORD = 'Ivena123';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // Add further one-time bootstrap steps here as private methods, in order.
+        $this->ensureBootstrapAdmin($io);
+
+        $io->success('Install finished.');
+
+        return Command::SUCCESS;
+    }
+
+    private function ensureBootstrapAdmin(SymfonyStyle $io): void
+    {
+        $existing = $this->userRepository->findOneBy(['username' => self::BOOTSTRAP_ADMIN_USERNAME]);
+
+        if ($existing instanceof User) {
+            $io->comment(sprintf(
+                'Bootstrap admin user "%s" already exists; skipping user creation.',
+                self::BOOTSTRAP_ADMIN_USERNAME,
+            ));
+
+            return;
+        }
+
+        $user = new User();
+        $user->setUsername(self::BOOTSTRAP_ADMIN_USERNAME);
+        $user->setEmail(self::BOOTSTRAP_ADMIN_EMAIL);
+        $user->setRoles(['ROLE_ADMIN', 'ROLE_USER']);
+        $user->setIsVerified(true);
+        $user->setCredentialsExpired(false);
+        $user->setIsEnabled(true);
+        $user->setPassword(
+            $this->passwordHasher->hashPassword($user, self::BOOTSTRAP_ADMIN_PLAIN_PASSWORD),
+        );
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $io->writeln(sprintf(
+            '<info>Created bootstrap admin user "%s". Change the default password after first login.</info>',
+            self::BOOTSTRAP_ADMIN_USERNAME,
+        ));
+    }
+}

--- a/tests/Install/Functional/Command/InstallCommandTest.php
+++ b/tests/Install/Functional/Command/InstallCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Install\Functional\Command;
+
+use App\Install\UI\Console\Command\InstallCommand;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+#[CoversClass(InstallCommand::class)]
+final class InstallCommandTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    public function testCreatesBootstrapAdminWithExpectedPassword(): void
+    {
+        $tester = $this->runInstallCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $repo = $this->getUserRepository();
+        $admin = $repo->findOneBy(['username' => 'admin']);
+
+        self::assertInstanceOf(User::class, $admin);
+        self::assertSame('admin@test.local', $admin->getEmail());
+        self::assertContains('ROLE_ADMIN', $admin->getRoles());
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        self::assertTrue($hasher->isPasswordValid($admin, 'Ivena123'));
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Created bootstrap admin user', $display);
+    }
+
+    public function testSecondRunIsIdempotent(): void
+    {
+        $first = $this->runInstallCommand();
+        $first->assertCommandIsSuccessful();
+
+        $repo = $this->getUserRepository();
+        self::assertSame(1, $repo->count(['username' => 'admin']));
+
+        $second = $this->runInstallCommand();
+        $second->assertCommandIsSuccessful();
+
+        self::assertSame(1, $repo->count(['username' => 'admin']));
+        self::assertStringContainsString('already exists', $second->getDisplay());
+    }
+
+    private function runInstallCommand(): CommandTester
+    {
+        /** @var InstallCommand $command */
+        $command = self::getContainer()->get(InstallCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        return $tester;
+    }
+
+    private function getUserRepository(): UserRepository
+    {
+        /** @var UserRepository $repo */
+        $repo = self::getContainer()->get(UserRepository::class);
+
+        return $repo;
+    }
+}


### PR DESCRIPTION
### Summary

- Added a basic install command for initial application setup
- Enables creation/setup of the initial admin user
- Added supporting command logic and configuration where needed
- Keeps the setup flow lightweight and focused for now

### Motivation

- Simplify first-time project setup
- Avoid manually creating the initial admin user
- Provide a foundation for future installation/setup automation
- Make local development and deployment onboarding easier

### Notes for Reviewers

- Verify the command creates/configures the admin user as expected
- Check behavior when the admin user already exists
- Ensure the command handles invalid or missing input safely
- This is intentionally a first basic version and can be extended later