### PR TITLE
feat: Add custom Tabler-based error pages

### DIFF
--- a/assets/error-page.js
+++ b/assets/error-page.js
@@ -1,0 +1,5 @@
+/**
+ * Minimal assets for TwigBundle error pages (no Turbo/Stimulus/cookie/feedback).
+ */
+import '@tabler/core/dist/css/tabler.min.css'
+import '@tabler/core'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -45,6 +45,8 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/_error_preview, roles: PUBLIC_ACCESS }
+        - { path: ^/_error/, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/hospitals, roles: ROLE_PARTICIPANT }
         - { path: ^/settings, roles: IS_AUTHENTICATED_FULLY }

--- a/config/routes/error_preview.yaml
+++ b/config/routes/error_preview.yaml
@@ -5,3 +5,11 @@ when@dev:
         methods: [GET]
         requirements:
             code: \d{3}
+
+when@test:
+    app_error_preview:
+        path: /_error_preview/{code}
+        controller: App\Shared\UI\Http\Controller\ErrorPreviewController
+        methods: [GET]
+        requirements:
+            code: \d{3}

--- a/config/routes/error_preview.yaml
+++ b/config/routes/error_preview.yaml
@@ -1,0 +1,7 @@
+when@dev:
+    app_error_preview:
+        path: /_error_preview/{code}
+        controller: App\Shared\UI\Http\Controller\ErrorPreviewController
+        methods: [GET]
+        requirements:
+            code: \d{3}

--- a/importmap.php
+++ b/importmap.php
@@ -16,6 +16,10 @@ return [
         'path' => './assets/app.js',
         'entrypoint' => true,
     ],
+    'error_page' => [
+        'path' => './assets/error-page.js',
+        'entrypoint' => true,
+    ],
     'monitoring' => [
         'path' => './assets/monitoring.js',
         'entrypoint' => true,

--- a/src/Shared/UI/Http/Controller/ErrorPreviewController.php
+++ b/src/Shared/UI/Http/Controller/ErrorPreviewController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Http\Controller;
+
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Twig\Environment;
+
+/**
+ * Renders TwigBundle error templates with the same context as {@see \Symfony\Component\HttpKernel\Controller\ErrorController}.
+ * Only wired from {@code config/routes/error_preview.yaml} (when@dev).
+ */
+#[AsController]
+final readonly class ErrorPreviewController
+{
+    public function __construct(
+        private Environment $twig,
+    ) {
+    }
+
+    public function __invoke(int $code): Response
+    {
+        if ($code < 400 || $code > 599) {
+            throw new NotFoundHttpException('Invalid HTTP status code for error preview.');
+        }
+
+        $throwable = Response::HTTP_FORBIDDEN === $code
+            ? new AccessDeniedException('Preview: Access denied.')
+            : new HttpException($code, \sprintf('Preview HTTP %d', $code));
+
+        // AccessDeniedException is not HttpExceptionInterface; FlattenException would default to 500 without explicit status.
+        $exception = FlattenException::createFromThrowable(
+            $throwable,
+            $throwable instanceof HttpExceptionInterface ? null : $code,
+        );
+
+        $specific = \sprintf('@Twig/Exception/error%d.html.twig', $code);
+        $template = $this->twig->getLoader()->exists($specific)
+            ? $specific
+            : '@Twig/Exception/error.html.twig';
+
+        $html = $this->twig->render($template, [
+            'exception' => $exception,
+            'status_code' => $exception->getStatusCode(),
+            'status_text' => $exception->getStatusText(),
+        ]);
+
+        return new Response($html, Response::HTTP_OK);
+    }
+}

--- a/src/Shared/UI/Http/Controller/ErrorPreviewController.php
+++ b/src/Shared/UI/Http/Controller/ErrorPreviewController.php
@@ -15,7 +15,7 @@ use Twig\Environment;
 
 /**
  * Renders TwigBundle error templates with the same context as {@see \Symfony\Component\HttpKernel\Controller\ErrorController}.
- * Only wired from {@code config/routes/error_preview.yaml} (when@dev).
+ * Wired from {@code config/routes/error_preview.yaml} (when@dev and when@test for automated tests).
  */
 #[AsController]
 final readonly class ErrorPreviewController

--- a/templates/bundles/TwigBundle/Exception/_footer_include.html.twig
+++ b/templates/bundles/TwigBundle/Exception/_footer_include.html.twig
@@ -1,0 +1,3 @@
+{# Footer strings live in the messages domain (same as @Shared/_includes/footer.html.twig). #}
+{% trans_default_domain 'messages' %}
+{{ include('@Shared/_includes/footer.html.twig') }}

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,42 @@
+{% extends '@Twig/Exception/error_base.html.twig' %}
+
+{% trans_default_domain 'errors' %}
+
+{% set code = status_code %}
+
+{% if code == 403 %}
+    {% set error_title = 'messages.403.title'|trans %}
+    {% set error_description = 'messages.403.description'|trans %}
+{% elseif code == 404 %}
+    {% set error_title = 'messages.404.title'|trans %}
+    {% set error_description = 'messages.404.description'|trans %}
+{% elseif code == 405 %}
+    {% set error_title = 'messages.405.title'|trans %}
+    {% set error_description = 'messages.405.description'|trans %}
+{% elseif code == 500 %}
+    {% set error_title = 'messages.500.title'|trans %}
+    {% set error_description = 'messages.500.description'|trans %}
+{% else %}
+    {% set error_title = 'messages.default.title'|trans %}
+    {% set error_description = 'messages.default.description'|trans %}
+{% endif %}
+
+{% block title %}{{ error_title }} — {{ app_title }}{% endblock %}
+
+{% block error_content %}
+    <div class="empty">
+        <div class="empty-header">{{ code }}</div>
+        <p class="empty-title">{{ error_title }}</p>
+        <p class="empty-subtitle text-secondary">{{ error_description }}</p>
+        <div class="empty-action d-flex flex-wrap gap-2 justify-content-center align-items-center">
+            <a href="javascript:history.back()" class="btn btn-primary d-inline-flex align-items-center">
+                <twig:ux:icon name="tabler:arrow-left" class="icon icon-2" />
+                {{ 'cta.back'|trans }}
+            </a>
+            <a href="{{ path('app_default') }}" class="btn btn-outline-secondary d-inline-flex align-items-center">
+                <twig:ux:icon name="tabler:home" class="icon icon-2" />
+                {{ 'cta.home'|trans }}
+            </a>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,0 +1,1 @@
+{% extends '@Twig/Exception/error.html.twig' %}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,1 @@
+{% extends '@Twig/Exception/error.html.twig' %}

--- a/templates/bundles/TwigBundle/Exception/error_base.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error_base.html.twig
@@ -1,0 +1,34 @@
+{% trans_default_domain 'errors' %}
+<!DOCTYPE html>
+<html lang="{{ app.request.locale }}">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+    <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+    <title>{% block title %}{{ 'title.error'|trans }} — {{ app_title }}{% endblock %}</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
+    {% block javascripts %}
+        {{ importmap('error_page') }}
+    {% endblock %}
+</head>
+<body class="d-flex flex-column min-vh-100">
+<div class="page d-flex flex-column flex-grow-1">
+    <header class="navbar navbar-expand-md d-print-none">
+        <div class="container-xl">
+            <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3 mb-0">
+                <a class="text-black" href="{{ path('app_default') }}">{{ app_title }}</a>
+            </h1>
+        </div>
+    </header>
+
+    <div class="page-wrapper d-flex flex-column flex-grow-1">
+        <div class="page-body d-flex flex-grow-1 align-items-center">
+            <div class="container-tight py-4 w-100">
+                {% block error_content %}{% endblock %}
+            </div>
+        </div>
+        {{ include('@Twig/Exception/_footer_include.html.twig') }}
+    </div>
+</div>
+</body>
+</html>

--- a/tests/System/ErrorPreviewPagesTest.php
+++ b/tests/System/ErrorPreviewPagesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\System;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ErrorPreviewPagesTest extends WebTestCase
+{
+    #[DataProvider('providePreviewCodes')]
+    public function testErrorPreviewRendersCustomPage(int $code, string $expectedTitleFragment, string $expectedHeader): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/_error_preview/'.$code);
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $content = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('class="empty"', $content);
+        self::assertStringContainsString('<div class="empty-header">'.$expectedHeader.'</div>', $content);
+        self::assertStringContainsString($expectedTitleFragment, $content);
+        self::assertStringContainsString('btn btn-primary', $content);
+        self::assertStringContainsString('btn btn-outline-secondary', $content);
+        self::assertStringContainsString('javascript:history.back()', $content);
+        self::assertStringContainsString('href="/"', $content);
+    }
+
+    public static function providePreviewCodes(): \Generator
+    {
+        yield '404' => [404, 'Page not found', '404'];
+        yield '403' => [403, 'Access denied', '403'];
+        yield '500' => [500, 'Internal error', '500'];
+    }
+
+    public function testErrorPreviewRejectsNonClientOrServerCodes(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/_error_preview/200');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testErrorPreviewDoesNotRequireAuthentication(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/_error_preview/404');
+
+        self::assertResponseIsSuccessful();
+        self::assertLessThan(
+            Response::HTTP_MULTIPLE_CHOICES,
+            $client->getResponse()->getStatusCode(),
+            'Expected HTML response, not a redirect to login.',
+        );
+    }
+}

--- a/translations/errors+intl-icu.en.xlf
+++ b/translations/errors+intl-icu.en.xlf
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <header>
+      <tool tool-id="symfony" tool-name="Symfony"/>
+    </header>
+    <body>
+      <trans-unit id="errors.title.error" resname="title.error">
+        <source>title.error</source>
+        <target>Something went wrong</target>
+      </trans-unit>
+      <trans-unit id="errors.msg403.title" resname="messages.403.title">
+        <source>messages.403.title</source>
+        <target>Access denied</target>
+      </trans-unit>
+      <trans-unit id="errors.msg403.desc" resname="messages.403.description">
+        <source>messages.403.description</source>
+        <target>Sorry! You do not have permission to view this page.</target>
+      </trans-unit>
+      <trans-unit id="errors.msg404.title" resname="messages.404.title">
+        <source>messages.404.title</source>
+        <target>Page not found</target>
+      </trans-unit>
+      <trans-unit id="errors.msg404.desc" resname="messages.404.description">
+        <source>messages.404.description</source>
+        <target>No content was found at this address. You may have followed an outdated or incorrect link. If you typed the URL yourself, check for typos.</target>
+      </trans-unit>
+      <trans-unit id="errors.msg405.title" resname="messages.405.title">
+        <source>messages.405.title</source>
+        <target>Method not allowed</target>
+      </trans-unit>
+      <trans-unit id="errors.msg405.desc" resname="messages.405.description">
+        <source>messages.405.description</source>
+        <target>The HTTP method used for this request is not supported on this page.</target>
+      </trans-unit>
+      <trans-unit id="errors.msg500.title" resname="messages.500.title">
+        <source>messages.500.title</source>
+        <target>Internal error</target>
+      </trans-unit>
+      <trans-unit id="errors.msg500.desc" resname="messages.500.description">
+        <source>messages.500.description</source>
+        <target>Something went wrong while loading this page. The team has been notified and we will try to fix the problem as soon as possible.</target>
+      </trans-unit>
+      <trans-unit id="errors.msg.default.title" resname="messages.default.title">
+        <source>messages.default.title</source>
+        <target>Error</target>
+      </trans-unit>
+      <trans-unit id="errors.msg.default.desc" resname="messages.default.description">
+        <source>messages.default.description</source>
+        <target>An unexpected error occurred. Please try again or use the buttons below.</target>
+      </trans-unit>
+      <trans-unit id="errors.cta.home" resname="cta.home">
+        <source>cta.home</source>
+        <target>Visit Homepage</target>
+      </trans-unit>
+      <trans-unit id="errors.cta.back" resname="cta.back">
+        <source>cta.back</source>
+        <target>Go back</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
### Summary

- Added custom error pages for common HTTP errors (e.g. 404, 403, 500)
- Integrated the new pages with the existing Tabler-based frontend styling
- Improved error page layout and messaging for a more user-friendly experience
- Added shared templates/components to keep error pages visually consistent
- Updated configuration and rendering behavior where necessary

### Motivation

- Provide a more polished and consistent user experience during error scenarios
- Align error handling pages with the application's overall design language
- Improve usability by replacing default framework error pages with branded alternatives
- Prepare a reusable foundation for future status and maintenance pages

### Notes for Reviewers

- Verify that all configured error pages render correctly for their respective HTTP status codes
- Check styling consistency with the existing Tabler-based frontend
- Ensure error pages work correctly in both development and production environments
- Confirm no sensitive debug information is exposed in production mode