### PR TITLE
fix: Add cachetool integration to deployment workflow

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -3,6 +3,7 @@
 namespace Deployer;
 
 require 'recipe/symfony.php';
+require 'contrib/cachetool.php';
 
 set('repository', 'https://github.com/nplhse/collaborative-ivena-statistics.git');
 set('writable_mode', 'chmod');
@@ -13,6 +14,8 @@ set('env', [
 
 set('messenger_systemd_service', 'messenger.service');
 set('messenger_restart_on_deploy', true);
+
+set('cachetool_args', '--web --web-path={{release_or_current_path}}/public --web-url={{web_url}}');
 
 add('shared_files', [
     '.env.local',
@@ -68,6 +71,8 @@ task('messenger:restart', function () {
 
 // Attach tasks from recipes& contrib to default workflow
 before('deploy:symlink', 'messenger:stop');
+after('deploy:symlink', 'cachetool:clear:opcache');
+
 before('deploy:publish', 'database:migrate');
 after('deploy:publish', 'messenger:restart');
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,7 +113,7 @@ journalctl --user -u messenger -f
    cp hosts.yaml.example hosts.yaml
    ```
 
-   Edit `hosts.yaml` with your hostname, `remote_user`, and `deploy_path`. The real `hosts.yaml` is gitignored.
+   Edit `hosts.yaml` with your hostname, `remote_user`, `deploy_path` and `web_url`. The real `hosts.yaml` is gitignored.
 
 3. Deploy:
 

--- a/hosts.yaml.example
+++ b/hosts.yaml.example
@@ -5,6 +5,7 @@ hosts:
   prod:
     hostname: "asteroid.uberspace.de"
     remote_user: "your-username"
-    deploy_path: "~/html"
+    deploy_path: "/home/your-username/www"
+    web_url: https://your-username.uberspace.de
     messenger_systemd_service: "messenger.service"
     messenger_restart_on_deploy: "true"


### PR DESCRIPTION
### Summary

- Added `cachetool` integration to the deployment workflow
- Improved cache invalidation and cache management during deployments
- Updated deployment configuration/scripts accordingly
- Reduced risk of stale cache issues after releases
- Performed minor cleanup related to deployment handling

### Motivation

- Ensure more reliable deployments by properly clearing/opcaching PHP processes
- Avoid inconsistent runtime behavior caused by outdated caches
- Improve deployment stability and reduce manual maintenance steps
- Prepare deployment workflow for more robust production operations

### Notes for Reviewers

- Review deployment script/configuration changes for correctness
- Verify cachetool execution and integration in the deployment flow
- Ensure deployments still work correctly in environments without cachetool installed
- Confirm no unintended side effects on existing deployment steps