### PR TITLE
feat: Add admin user impersonation support

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -36,7 +36,9 @@ security:
             # https://symfony.com/doc/current/security.html#the-firewall
 
             # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
+            switch_user:
+                role: ROLE_ADMIN
+                target_route: app_default
 
         secure_area:
             form_login:

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -18,6 +18,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
@@ -30,6 +31,7 @@ final class UserCrudController extends AbstractCrudController
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly AuditContext $auditContext,
         private readonly Security $security,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -54,7 +56,33 @@ final class UserCrudController extends AbstractCrudController
     {
         return $actions
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
+            ->add(Crud::PAGE_INDEX, $this->createImpersonateAction())
+            ->add(Crud::PAGE_DETAIL, $this->createImpersonateAction())
             ->add(Crud::PAGE_EDIT, Action::INDEX);
+    }
+
+    private function createImpersonateAction(): Action
+    {
+        return Action::new('impersonate', 'label.impersonate', 'fas fa-user-secret')
+            ->linkToUrl(fn (User $user): string => $this->urlGenerator->generate('app_default', [
+                '_switch_user' => $user->getUserIdentifier(),
+            ]))
+            ->displayIf(function (User $user): bool {
+                if (!$user->isEnabled()) {
+                    return false;
+                }
+
+                if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+                    return false;
+                }
+
+                $currentUser = $this->security->getUser();
+                if (!$currentUser instanceof User) {
+                    return false;
+                }
+
+                return $user->getId() !== $currentUser->getId();
+            });
     }
 
     #[\Override]

--- a/src/Admin/UI/Twig/templates/_includes/navbar_admin_user.html.twig
+++ b/src/Admin/UI/Twig/templates/_includes/navbar_admin_user.html.twig
@@ -7,9 +7,7 @@
                     <path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
                 </svg>
             </span>
-        <div class="d-none d-xl-block ps-2">
-            <div id="user_name">{{ app.user.userIdentifier }}</div>
-        </div>
+        {{ include('@Shared/_includes/navbar_impersonation_username.html.twig') }}
     </a>
     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
         <a href="{{ path('app_default') }}" class="dropdown-item">
@@ -22,6 +20,7 @@
             &nbsp;{{ 'link.back_to_frontend'|trans({}, 'admin') }}
         </a>
         <div class="dropdown-divider mt-1 mb-1"></div>
+        {{ include('@Shared/_includes/navbar_impersonation_menu_exit.html.twig', {exit_route: 'app_admin_dashboard'}) }}
         <a href="{{ path('app_logout') }}" class="dropdown-item">
             <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-logout" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"/>

--- a/src/LegacyMigration/Application/Service/LegacyMigrationRunControl.php
+++ b/src/LegacyMigration/Application/Service/LegacyMigrationRunControl.php
@@ -30,10 +30,12 @@ final class LegacyMigrationRunControl
 
     public function throwIfStopRequested(): void
     {
-        if (!$this->stopRequested) {
+        if (!$this->isStopRequested()) {
             return;
         }
 
-        throw new LegacyMigrationInterruptedException($this->signal ?? 0, sprintf('Legacy migration interrupted by signal %d.', $this->signal ?? 0));
+        $signal = $this->getSignal() ?? 0;
+
+        throw new LegacyMigrationInterruptedException($signal, sprintf('Legacy migration interrupted by signal %d.', $signal));
     }
 }

--- a/src/Shared/Infrastructure/Audit/AuditContext.php
+++ b/src/Shared/Infrastructure/Audit/AuditContext.php
@@ -6,6 +6,7 @@ namespace App\Shared\Infrastructure\Audit;
 
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 final class AuditContext
@@ -73,7 +74,12 @@ final class AuditContext
 
     public function applySecurityUser(Security $security): void
     {
-        $user = $security->getUser();
+        $token = $security->getToken();
+        if ($token instanceof SwitchUserToken) {
+            $user = $token->getOriginalToken()->getUser();
+        } else {
+            $user = $security->getUser();
+        }
 
         if (!$user instanceof User) {
             return;

--- a/src/Shared/UI/Twig/templates/_includes/navbar_impersonation_menu_exit.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/navbar_impersonation_menu_exit.html.twig
@@ -1,0 +1,12 @@
+{% if is_granted('IS_IMPERSONATOR') %}
+    <a href="{{ impersonation_exit_path(path(exit_route)) }}" class="dropdown-item text-warning">
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-user-off" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+            <path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />
+            <path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+            <path d="M3 3l18 18" />
+        </svg>
+        {{ 'label.exit_impersonation'|trans }}
+    </a>
+    <div class="dropdown-divider mt-1 mb-1"></div>
+{% endif %}

--- a/src/Shared/UI/Twig/templates/_includes/navbar_impersonation_username.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/navbar_impersonation_username.html.twig
@@ -1,0 +1,10 @@
+{% if is_granted('IS_IMPERSONATOR') %}
+    <div class="d-none d-xl-block ps-2">
+        <div class="text-warning small">{{ 'label.impersonation_active'|trans }}</div>
+        <div id="user_name" class="fw-bold text-warning">{{ app.user.userIdentifier }}</div>
+    </div>
+{% else %}
+    <div class="d-none d-xl-block ps-2">
+        <div id="user_name">{{ app.user.userIdentifier }}</div>
+    </div>
+{% endif %}

--- a/src/Shared/UI/Twig/templates/_includes/navbar_user.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/navbar_user.html.twig
@@ -8,9 +8,7 @@
                     <path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
                 </svg>
             </span>
-            <div class="d-none d-xl-block ps-2">
-                <div id="user_name">{{ app.user.userIdentifier }}</div>
-            </div>
+            {{ include('@Shared/_includes/navbar_impersonation_username.html.twig') }}
         </a>
         <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
             {% if is_granted('ROLE_ADMIN') %}
@@ -51,6 +49,7 @@
                 </svg>
                 {{ 'label.settings'|trans }}
             </a>
+            {{ include('@Shared/_includes/navbar_impersonation_menu_exit.html.twig', {exit_route: 'app_default'}) }}
             <a href="{{ path('app_logout') }}" class="dropdown-item">
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-logout" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <path stroke="none" d="M0 0h24v24H0z" fill="none"/>

--- a/src/User/Infrastructure/Security/SwitchUserSubscriber.php
+++ b/src/User/Infrastructure/Security/SwitchUserSubscriber.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @psalm-suppress UnusedClass
+ */
+final readonly class SwitchUserSubscriber
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private AuditContext $auditContext,
+        private Security $security,
+    ) {
+    }
+
+    #[AsEventListener(event: SecurityEvents::SWITCH_USER)]
+    public function onSwitchUser(SwitchUserEvent $event): void
+    {
+        $token = $event->getToken();
+        if (!$token instanceof \Symfony\Component\Security\Core\Authentication\Token\TokenInterface) {
+            return;
+        }
+
+        if ($token instanceof SwitchUserToken) {
+            $this->assertCanImpersonate($token, $event->getTargetUser());
+            $this->recordImpersonationAudit('impersonate', $token, $event->getTargetUser());
+
+            return;
+        }
+
+        $impersonatedUser = $this->security->getUser();
+        $this->recordImpersonationAudit('impersonate_exit', $token, $event->getTargetUser(), $impersonatedUser);
+    }
+
+    private function assertCanImpersonate(SwitchUserToken $token, object $targetUser): void
+    {
+        if (!$targetUser instanceof User) {
+            throw new AccessDeniedException('Switch user failed.');
+        }
+
+        $impersonator = $token->getOriginalToken()->getUser();
+        if (!$impersonator instanceof User) {
+            throw new AccessDeniedException('Switch user failed.');
+        }
+
+        if ($targetUser->getUserIdentifier() === $impersonator->getUserIdentifier()) {
+            throw new AccessDeniedException('You cannot impersonate yourself.');
+        }
+
+        if (!$targetUser->isEnabled()) {
+            throw new AccessDeniedException('Cannot impersonate a disabled account.');
+        }
+
+        if (\in_array('ROLE_ADMIN', $targetUser->getRoles(), true)) {
+            throw new AccessDeniedException('Cannot impersonate administrators.');
+        }
+    }
+
+    private function recordImpersonationAudit(
+        string $action,
+        object $token,
+        object $targetUser,
+        ?object $impersonatedUser = null,
+    ): void {
+        $actor = $this->resolveActor($token, $targetUser);
+        if (!$actor instanceof User) {
+            return;
+        }
+
+        $subject = $this->resolveSubject($action, $targetUser, $impersonatedUser);
+        if (!$subject instanceof User) {
+            return;
+        }
+
+        $requestId = $this->auditContext->ensureRequestId(static fn (): string => Uuid::v7()->toRfc4122());
+        $origin = $this->auditContext->getOrigin() ?? AuditContext::ORIGIN_HTTP;
+
+        $metadata = [
+            'impersonatorUsername' => $actor->getUserIdentifier(),
+            'targetUsername' => $subject->getUserIdentifier(),
+        ];
+
+        $subjectId = $subject->getId();
+        if (null !== $subjectId) {
+            $metadata['targetUserId'] = $subjectId;
+        }
+
+        $actorId = $actor->getId();
+        if (null !== $actorId) {
+            $metadata['impersonatorUserId'] = $actorId;
+        }
+
+        $clientIp = $this->auditContext->getClientIp();
+        if (null !== $clientIp && '' !== $clientIp) {
+            $metadata['clientIp'] = $clientIp;
+        }
+
+        $userAgent = $this->auditContext->getUserAgent();
+        if (null !== $userAgent && '' !== $userAgent) {
+            $metadata['userAgent'] = $userAgent;
+        }
+
+        $this->entityManager->persist(new AuditEntry(
+            new \DateTimeImmutable('now'),
+            $requestId,
+            $actor,
+            $origin,
+            $action,
+            User::class,
+            null !== $subjectId ? (string) $subjectId : null,
+            [],
+            $metadata,
+        ));
+        $this->entityManager->flush();
+    }
+
+    private function resolveActor(object $token, object $targetUser): ?User
+    {
+        if ($token instanceof SwitchUserToken) {
+            $user = $token->getOriginalToken()->getUser();
+
+            return $user instanceof User ? $user : null;
+        }
+
+        return $targetUser instanceof User ? $targetUser : null;
+    }
+
+    private function resolveSubject(string $action, object $targetUser, ?object $impersonatedUser): ?User
+    {
+        if ('impersonate_exit' === $action) {
+            return $impersonatedUser instanceof User ? $impersonatedUser : null;
+        }
+
+        return $targetUser instanceof User ? $targetUser : null;
+    }
+}

--- a/tests/Admin/Functional/Controller/UserImpersonationTest.php
+++ b/tests/Admin/Functional/Controller/UserImpersonationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Shared\Infrastructure\Audit\Repository\AuditEntryRepository;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class UserImpersonationTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testAdminCanImpersonateParticipant(): void
+    {
+        $target = UserFactory::createOne([
+            'username' => 'participant-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'impersonator-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/?_switch_user='.$target->getUserIdentifier())
+            ->assertSuccessful()
+            ->assertSeeIn('body', 'End impersonation')
+            ->assertSeeIn('body', $target->getUserIdentifier())
+        ;
+    }
+
+    public function testNonAdminCannotImpersonate(): void
+    {
+        $target = UserFactory::createOne([
+            'username' => 'target-'.bin2hex(random_bytes(4)),
+        ]);
+        $user = UserFactory::createOne([
+            'username' => 'regular-'.bin2hex(random_bytes(4)),
+        ]);
+
+        $this->browser()
+            ->actingAs($user)
+            ->visit('/?_switch_user='.$target->getUserIdentifier())
+            ->assertStatus(403)
+        ;
+    }
+
+    public function testAdminCannotImpersonateOtherAdmin(): void
+    {
+        $targetAdmin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'other-admin-'.bin2hex(random_bytes(4)),
+            ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'impersonator-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/?_switch_user='.$targetAdmin->getUserIdentifier())
+            ->assertStatus(403)
+        ;
+    }
+
+    public function testAdminCanExitImpersonation(): void
+    {
+        $target = UserFactory::createOne([
+            'username' => 'exit-target-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'exit-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $browser = $this->browser()
+            ->actingAs($admin)
+            ->visit('/?_switch_user='.$target->getUserIdentifier())
+            ->assertSuccessful()
+            ->assertSeeIn('body', 'End impersonation')
+        ;
+
+        $browser
+            ->visit('/?_switch_user=_exit')
+            ->assertSuccessful()
+            ->assertNotSeeIn('body', 'End impersonation')
+            ->assertSeeIn('body', $admin->getUserIdentifier())
+        ;
+    }
+
+    public function testImpersonationIsRecordedInAuditLog(): void
+    {
+        $target = UserFactory::createOne([
+            'username' => 'audit-target-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'audit-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/?_switch_user='.$target->getUserIdentifier())
+            ->assertSuccessful()
+        ;
+
+        $adminId = $admin->getId();
+        self::assertNotNull($adminId);
+
+        $entries = self::getContainer()->get(AuditEntryRepository::class)->findBy(
+            ['action' => 'impersonate'],
+            ['occurredAt' => 'DESC'],
+            1,
+        );
+
+        self::assertCount(1, $entries);
+        $entry = $entries[0];
+        self::assertSame(User::class, $entry->getEntityClass());
+        self::assertSame((string) $target->getId(), $entry->getEntityId());
+        self::assertNotNull($entry->getActor());
+        self::assertSame($adminId, $entry->getActor()->getId());
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -877,6 +877,18 @@
         <source>label.logout</source>
         <target>Logout</target>
       </trans-unit>
+      <trans-unit id="imp001" resname="label.impersonate">
+        <source>label.impersonate</source>
+        <target>Impersonate user</target>
+      </trans-unit>
+      <trans-unit id="imp002" resname="label.exit_impersonation">
+        <source>label.exit_impersonation</source>
+        <target>End impersonation</target>
+      </trans-unit>
+      <trans-unit id="imp003" resname="label.impersonation_active">
+        <source>label.impersonation_active</source>
+        <target>As:</target>
+      </trans-unit>
       <trans-unit id="IDIV8Sp" resname="label.my_hospitals">
         <source>label.my_hospitals</source>
         <target>My hospitals</target>


### PR DESCRIPTION
### Summary

- Added support for **admin user impersonation**
- Enabled admins to temporarily act as another user for support/debugging purposes
- Integrated impersonation handling into the admin/backend workflow
- Added routing and security handling for starting and ending impersonation sessions
- Updated UI elements where needed to expose impersonation actions safely
- Added or updated tests for impersonation behavior and access control

### Motivation

- Help admins reproduce user-specific issues more easily
- Improve support and troubleshooting workflows without requiring user credentials
- Provide a controlled foundation for user-context debugging
- Keep impersonation limited to authorized admin users only

### Notes for Reviewers

- Verify that only authorized admins can start impersonation
- Check that impersonation can be ended cleanly and returns to the original admin context
- Ensure impersonation state is clearly visible in the UI
- Confirm security rules prevent privilege escalation or unauthorized access
- Review tests for both allowed and denied impersonation scenarios