### PR TITLE
refactor: Optimize statistics overview queries and dashboard metrics loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ to make query and presentation layers testable:
    `AnalysisRequestModelFactory`, `ReportsRequestModelFactory`).
 2. Application definitions/queries build widget domain data from
    `allocation_stats_projection`.
+   After bulk projection rebuilds, refresh materialized views with
+   `php bin/console app:statistics:refresh-mviews` (all groups)
+   or `php bin/console app:statistics:refresh-mviews --overview`.
 3. Page presenters map domain output to Twig view models
    (`StatisticsPageViewModel`, `AnalysisPageViewModel`, `ReportsPageViewModel`).
 4. Twig templates render view models only; no SQL, no business logic.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $ php bin/console app:seed:projection
 
 ## Statistics architecture overview
 
+For projection tables, materialized views, Foundry test resets, and refresh commands, see [docs/statistics/projection-and-materialized-views.md](docs/statistics/projection-and-materialized-views.md).
+
 The statistics pages follow a strict read path to keep controller code slim and
 to make query and presentation layers testable:
 

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -65,6 +65,10 @@ doctrine:
                 prefix: 'App\Statistics\Infrastructure\Entity'
         controller_resolver:
             auto_mapping: false
+        schema_ignore_classes:
+            - App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount
+            - App\Statistics\Infrastructure\Entity\ProjectionDispatchAreaHospitalCount
+            - App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension
 
 when@test:
     doctrine:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 
 imports:
     - { resource: services/foundry.yaml }
+    - { resource: services/foundry_test.yaml }
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,6 +45,11 @@ services:
     App\LegacyMigration\Application\Contract\LegacyAllocationImportFactoryInterface: '@App\LegacyMigration\Infrastructure\Adapter\AllocationImportFactoryAdapter'
     App\Statistics\Application\Contract\HospitalAccessInterface: '@App\Statistics\Infrastructure\Adapter\DoctrineHospitalAccess'
     App\Statistics\Application\Contract\ImportTimelineInterface: '@App\Statistics\Infrastructure\Adapter\DoctrineImportTimeline'
+
+    App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller:
+        public: true
+        arguments:
+            $kernelEnvironment: '%kernel.environment%'
     _instanceof:
         App\Statistics\Application\Analysis\AnalysisDefinitionInterface:
             tags: ['app.statistics.analysis_definition']

--- a/config/services/foundry_test.yaml
+++ b/config/services/foundry_test.yaml
@@ -1,0 +1,9 @@
+# Foundry database reset: drop statistics materialized views before doctrine:schema:drop (test only).
+when@test:
+    services:
+        App\Tests\Support\Foundry\MaterializedViewAwareOrmResetter:
+            decorates: Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter
+            arguments:
+                $decorated: '@.inner'
+                $materializedViewDropper: '@App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewDropper'
+                $materializedViewsInstaller: '@App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller'

--- a/docs/statistics/projection-and-materialized-views.md
+++ b/docs/statistics/projection-and-materialized-views.md
@@ -1,0 +1,161 @@
+# Statistics projection and materialized views
+
+This document explains how allocation statistics are stored, how PostgreSQL materialized views fit into the read path, and how database resets work in the **test** environment (Zenstruck Foundry).
+
+## Data layers
+
+Statistics reads are built on two PostgreSQL layers:
+
+| Layer | Relation | Role |
+|-------|----------|------|
+| **Projection table** | `allocation_stats_projection` | Denormalized facts per allocation (hospital, state, dispatch area, urgency, etc.). Rebuilt from imports via `AllocationStatsProjectionRebuilder`. |
+| **Materialized views** | `mv_projection_*` | Pre-aggregated snapshots derived from the projection table for fast overview and scope checks. |
+
+The projection table is the **source of truth** for analytics queries that scan raw facts. Materialized views are **caches**: they must be refreshed after the projection changes, or reads will see stale counts and hospital lists.
+
+### Overview materialized views
+
+Registered under group `overview` in `StatisticsMaterializedViewGroups`:
+
+| View | Purpose |
+|------|---------|
+| `mv_projection_state_hospital_count` | Distinct hospital count per `state_id` |
+| `mv_projection_dispatch_area_hospital_count` | Distinct hospital count per `dispatch_area_id` |
+| `mv_projection_hospital_dimensions` | One row per `hospital_id` with state, dispatch area, location, and tier codes |
+
+Doctrine maps these views to read-only entities under `App\Statistics\Infrastructure\Entity\Projection*`.
+
+They are created by migration `Version20260519125102` (with unique indexes required for `REFRESH MATERIALIZED VIEW CONCURRENTLY` in production).
+
+## Read path in the application
+
+Typical flow:
+
+1. Controllers resolve filters (`StatisticsFilterFactory`, `ComparisonScopeResolver`).
+2. Scope resolution may use **materialized views** (e.g. `CountDistinctHospitalsForStateQuery`, `GetDistinctHospitalIdsByStateQuery`) to enforce rules such as “state scope requires at least two hospitals”.
+3. Dashboard and overview queries often read from the views for performance.
+4. Deeper or legacy comparisons may still use `AllocationStatsProjectionScopeQuery`, which queries `allocation_stats_projection` directly.
+
+Because of this split, **the projection table and the materialized views can disagree** until a refresh runs. That is expected; only the projection is updated automatically on import rebuild.
+
+## Production and development operations
+
+### Rebuild projection data
+
+After imports or seeding projection data:
+
+```bash
+php bin/console app:seed:projection
+```
+
+Or rely on the async handler that calls `AllocationStatsProjectionRebuilder::rebuildForImport()` per import.
+
+Rebuilding the projection **does not** refresh materialized views.
+
+### Refresh materialized views
+
+After bulk projection changes:
+
+```bash
+# All registered groups (currently: overview)
+php bin/console app:statistics:refresh-mviews
+
+# Overview group only
+php bin/console app:statistics:refresh-mviews --overview
+```
+
+Implementation: `MaterializedViewRefresher` (DBAL `Connection`). The console command uses **`REFRESH MATERIALIZED VIEW CONCURRENTLY`** by default (requires the unique indexes from the migration).
+
+If views are missing after a fresh database, run Doctrine migrations first; the migration creates the views and runs an initial non-concurrent refresh.
+
+### Install / repair views in test only
+
+`OverviewMaterializedViewsInstaller::ensureInstalled()` recreates overview views when they are missing **only in `APP_ENV=test`**. In other environments it throws and directs you to migrations or `app:statistics:refresh-mviews --overview`.
+
+## Why tests need special handling
+
+### Foundry `ResetDatabase` and PostgreSQL
+
+Tests use [Zenstruck Foundry](https://github.com/zenstruck/foundry) with ORM reset mode **`schema`** (`config/packages/zenstruck_foundry.yaml`). Between tests, Foundry runs:
+
+```text
+doctrine:schema:drop --force --full-database
+doctrine:schema:update --force
+```
+
+PostgreSQL blocks dropping tables that are still referenced by materialized views. The overview views depend on `allocation_stats_projection`, so a plain schema drop fails with dependency errors.
+
+### Test-only reset decorator
+
+Registered only when `APP_ENV=test` (`config/services/foundry_test.yaml`):
+
+**`MaterializedViewAwareOrmResetter`** decorates `Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter` and wraps each reset:
+
+1. **Before reset** — `StatisticsMaterializedViewDropper` runs:
+   ```sql
+   DROP MATERIALIZED VIEW IF EXISTS <view> CASCADE;
+   ```
+   for each overview view, then `OverviewMaterializedViewsInstaller::resetInstallationState()` clears the in-memory “already installed” flag.
+
+2. **Foundry reset** — inner resetter drops and recreates the schema as usual.
+
+3. **After reset** — `OverviewMaterializedViewsInstaller::ensureInstalled()` recreates the overview views (same SQL as migrations) if they are absent.
+
+This wiring does **not** run in `prod` or `dev`; it does not change runtime behaviour outside tests.
+
+### Refresh after test fixtures
+
+Foundry creates allocations and rebuilds the projection in many integration tests. That updates `allocation_stats_projection` but leaves materialized views at their **previous snapshot** (often empty right after reset).
+
+Symptoms in tests:
+
+- `AllocationStatsProjectionScopeQuery` returns correct counts (reads the table).
+- `StatisticsFilterFactory` downgrades `state` scope to `public` because `CountDistinctHospitalsForStateQuery` reads the view and sees `0` hospitals.
+
+**Fix in tests:** refresh views after rebuilding projection data.
+
+Use the shared trait:
+
+```php
+use App\Tests\Support\MaterializedView\RefreshesStatisticsMaterializedViewsTrait;
+
+final class MyStatisticsTest extends KernelTestCase
+{
+    use RefreshesStatisticsMaterializedViewsTrait;
+
+    public function testSomething(): void
+    {
+        // ... create data, rebuild projection ...
+        $this->refreshStatisticsMaterializedViews();
+        // ... assertions using MV-backed queries or filter factory ...
+    }
+}
+```
+
+The trait calls `MaterializedViewRefresher` with `concurrently: false` (plain `REFRESH MATERIALIZED VIEW`), which is appropriate for the isolated test database.
+
+Alternatively:
+
+```php
+self::getContainer()
+    ->get(OverviewMaterializedViewsInstaller::class)
+    ->refreshIfInstalled();
+```
+
+## Component reference
+
+| Component | Location | Notes |
+|-----------|----------|--------|
+| View registry | `StatisticsMaterializedViewGroups` | Groups and view names |
+| Drop before reset | `StatisticsMaterializedViewDropper` | Test reset hook (DBAL) |
+| Foundry decorator | `App\Tests\Support\Foundry\MaterializedViewAwareOrmResetter` | Test env only |
+| Install / refresh helper | `OverviewMaterializedViewsInstaller` | Test install + `refreshIfInstalled()` |
+| Refresh service | `MaterializedViewRefresher` | Used by console command and test trait |
+| Console command | `app:statistics:refresh-mviews` | Production refresh |
+| Projection rebuilder | `AllocationStatsProjectionRebuilder` | Does not refresh MVs |
+| Test trait | `RefreshesStatisticsMaterializedViewsTrait` | `tests/Support/MaterializedView/` |
+
+## Related documentation
+
+- [Statistics architecture (README)](../../README.md#statistics-architecture-overview) — controller and query overview
+- [Distribution panel reference](distribution-panel-reference.md) — UI-facing statistics concepts

--- a/migrations/Version20260519125102.php
+++ b/migrations/Version20260519125102.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519125102 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create overview materialized views for projection hospital counts and dimensions.';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_state_hospital_count AS
+SELECT state_id, COUNT(DISTINCT hospital_id)::int AS hospital_count
+FROM allocation_stats_projection
+WHERE state_id IS NOT NULL
+GROUP BY state_id
+SQL);
+        $this->addSql('CREATE UNIQUE INDEX idx_mv_projection_state_hospital_count_state ON mv_projection_state_hospital_count (state_id)');
+
+        $this->addSql(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_dispatch_area_hospital_count AS
+SELECT dispatch_area_id, COUNT(DISTINCT hospital_id)::int AS hospital_count
+FROM allocation_stats_projection
+WHERE dispatch_area_id IS NOT NULL
+GROUP BY dispatch_area_id
+SQL);
+        $this->addSql('CREATE UNIQUE INDEX idx_mv_projection_dispatch_area_hospital_count_area ON mv_projection_dispatch_area_hospital_count (dispatch_area_id)');
+
+        $this->addSql(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_hospital_dimensions AS
+SELECT
+    hospital_id,
+    MIN(state_id) AS state_id,
+    MIN(dispatch_area_id) AS dispatch_area_id,
+    MIN(hospital_location_code) AS hospital_location_code,
+    MIN(hospital_tier_code) AS hospital_tier_code
+FROM allocation_stats_projection
+GROUP BY hospital_id
+SQL);
+        $this->addSql('CREATE UNIQUE INDEX idx_mv_projection_hospital_dimensions_hospital ON mv_projection_hospital_dimensions (hospital_id)');
+
+        $this->addSql('REFRESH MATERIALIZED VIEW mv_projection_state_hospital_count');
+        $this->addSql('REFRESH MATERIALIZED VIEW mv_projection_dispatch_area_hospital_count');
+        $this->addSql('REFRESH MATERIALIZED VIEW mv_projection_hospital_dimensions');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP MATERIALIZED VIEW IF EXISTS mv_projection_hospital_dimensions');
+        $this->addSql('DROP MATERIALIZED VIEW IF EXISTS mv_projection_dispatch_area_hospital_count');
+        $this->addSql('DROP MATERIALIZED VIEW IF EXISTS mv_projection_state_hospital_count');
+    }
+}

--- a/migrations/Version20260519125523.php
+++ b/migrations/Version20260519125523.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519125523 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add composite indexes on allocation_stats_projection for overview analytics.';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asp_location_tier_hospital ON allocation_stats_projection (hospital_location_code, hospital_tier_code, hospital_id)');
+        $this->addSql('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asp_state_hospital ON allocation_stats_projection (state_id, hospital_id)');
+        $this->addSql('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asp_dispatch_area_hospital ON allocation_stats_projection (dispatch_area_id, hospital_id)');
+        $this->addSql('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_asp_hospital_created ON allocation_stats_projection (hospital_id, created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX CONCURRENTLY IF EXISTS idx_asp_hospital_created');
+        $this->addSql('DROP INDEX CONCURRENTLY IF EXISTS idx_asp_dispatch_area_hospital');
+        $this->addSql('DROP INDEX CONCURRENTLY IF EXISTS idx_asp_state_hospital');
+        $this->addSql('DROP INDEX CONCURRENTLY IF EXISTS idx_asp_location_tier_hospital');
+    }
+}

--- a/src/Statistics/Application/AllocationsByMonthQuery.php
+++ b/src/Statistics/Application/AllocationsByMonthQuery.php
@@ -224,6 +224,7 @@ final readonly class AllocationsByMonthQuery
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
         $start = $bounds->from;
         $toExclusive = $bounds->toExclusive;
+        \assert($start instanceof \DateTimeImmutable);
         \assert($toExclusive instanceof \DateTimeImmutable);
 
         $monthKeys = [];
@@ -266,6 +267,7 @@ final readonly class AllocationsByMonthQuery
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
         $start = $bounds->from;
         $toExclusive = $bounds->toExclusive;
+        \assert($start instanceof \DateTimeImmutable);
         \assert($toExclusive instanceof \DateTimeImmutable);
 
         $monthKeys = [];
@@ -286,17 +288,20 @@ final readonly class AllocationsByMonthQuery
     private function effectiveAllTimeQueryStart(StatisticsContext $context): \DateTimeImmutable
     {
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $start = $bounds->from;
         if ($bounds->toExclusive instanceof \DateTimeImmutable) {
             throw new \LogicException('all_time expects open-ended upper bound.');
         }
 
+        $start = $bounds->from;
         $earliest = $this->timeSeriesQuery->getEarliestCreatedAt();
         if ($earliest instanceof \DateTimeImmutable) {
             $firstMonth = $earliest->modify('first day of this month')->setTime(0, 0, 0);
-            if ($firstMonth > $start) {
+            if (!$start instanceof \DateTimeImmutable || $firstMonth > $start) {
                 $start = $firstMonth;
             }
+        }
+        if (!$start instanceof \DateTimeImmutable) {
+            $start = new \DateTimeImmutable('first day of this month')->setTime(0, 0, 0);
         }
 
         return $start;
@@ -395,6 +400,7 @@ final readonly class AllocationsByMonthQuery
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
         $start = $bounds->from;
         $toExclusive = $bounds->toExclusive;
+        \assert($start instanceof \DateTimeImmutable);
         \assert($toExclusive instanceof \DateTimeImmutable);
 
         $monthKeys = [];

--- a/src/Statistics/Application/ClinicalFeaturesProvider.php
+++ b/src/Statistics/Application/ClinicalFeaturesProvider.php
@@ -10,6 +10,7 @@ use App\Statistics\Application\DTO\StatisticWidgetNavigationTarget;
 use App\Statistics\Application\DTO\StatisticWidgetType;
 use App\Statistics\Application\DTO\WidgetPayload\DistributionWidgetPayload;
 use App\Statistics\Application\DTO\WidgetPayload\WidgetPayloadNormalizer;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
 
 final readonly class ClinicalFeaturesProvider
 {
@@ -25,7 +26,7 @@ final readonly class ClinicalFeaturesProvider
     /**
      * @return list<StatisticWidget>
      */
-    public function build(StatisticsContext $context): array
+    public function build(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
     {
         return [
             new StatisticWidget(
@@ -33,7 +34,7 @@ final readonly class ClinicalFeaturesProvider
                 'clinical_resources_distribution',
                 $this->widgetPayloadNormalizer->normalize(new DistributionWidgetPayload(
                     'stats.analysis.dimension.resources',
-                    $this->clinicalFeaturesQuery->fetchResourceRows($context),
+                    $this->clinicalFeaturesQuery->fetchResourceRows($context, $metrics),
                     [
                         'testId' => 'stats-overview-resources',
                         'actionTestId' => 'stats-cross-nav-overview-resources',
@@ -56,7 +57,7 @@ final readonly class ClinicalFeaturesProvider
                 'clinical_features_distribution',
                 $this->widgetPayloadNormalizer->normalize(new DistributionWidgetPayload(
                     'stats.analysis.dimension.features',
-                    $this->clinicalFeaturesQuery->fetchClinicalRows($context),
+                    $this->clinicalFeaturesQuery->fetchClinicalRows($context, $metrics),
                     [
                         'testId' => 'stats-overview-features',
                         'actionTestId' => 'stats-cross-nav-overview-features',

--- a/src/Statistics/Application/ClinicalFeaturesQuery.php
+++ b/src/Statistics/Application/ClinicalFeaturesQuery.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace App\Statistics\Application;
 
 use App\Statistics\Application\DTO\StatisticsContext;
-use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
-use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
 
 final readonly class ClinicalFeaturesQuery
 {
@@ -27,20 +26,13 @@ final readonly class ClinicalFeaturesQuery
         ['key' => 'resus_required', 'labelTranslationKey' => 'statistics.distribution.dim.requires_resus'],
     ];
 
-    public function __construct(
-        private StatisticsScopeResolver $scopeResolver,
-        private ProjectionTimeSeriesQuery $timeSeriesQuery,
-        private ProjectionFeatureQuery $featureQuery,
-    ) {
-    }
-
     /**
      * @return list<array{labelTranslationKey: string, count: int, percent: float}>
      */
-    public function fetchClinicalRows(StatisticsContext $context): array
+    public function fetchClinicalRows(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
     {
-        [$totalAllocations, $clinicalCounts] = $this->loadCounts($context);
-        $totalAllocationsFloat = (float) $totalAllocations;
+        $clinicalCounts = $metrics->clinicalCounts();
+        $totalAllocationsFloat = (float) $metrics->scopedTotal;
 
         $rows = [];
         foreach (self::CLINICAL_FEATURE_DEFINITIONS as $definition) {
@@ -48,7 +40,7 @@ final readonly class ClinicalFeaturesQuery
             $rows[] = [
                 'labelTranslationKey' => $definition['labelTranslationKey'],
                 'count' => $count,
-                'percent' => $totalAllocations > 0 ? round(((float) $count / $totalAllocationsFloat) * 100.0, 1) : 0.0,
+                'percent' => $metrics->scopedTotal > 0 ? round(((float) $count / $totalAllocationsFloat) * 100.0, 1) : 0.0,
             ];
         }
 
@@ -58,10 +50,10 @@ final readonly class ClinicalFeaturesQuery
     /**
      * @return list<array{labelTranslationKey: string, count: int, percent: float}>
      */
-    public function fetchResourceRows(StatisticsContext $context): array
+    public function fetchResourceRows(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
     {
-        [$totalAllocations, , $resourceCounts] = $this->loadCounts($context);
-        $totalAllocationsFloat = (float) $totalAllocations;
+        $resourceCounts = $metrics->resourceCounts();
+        $totalAllocationsFloat = (float) $metrics->scopedTotal;
         $resourceCountByDefinitionKey = [
             'cathlab_required' => $resourceCounts['cathlab'] ?? 0,
             'resus_required' => $resourceCounts['resus'] ?? 0,
@@ -73,25 +65,10 @@ final readonly class ClinicalFeaturesQuery
             $rows[] = [
                 'labelTranslationKey' => $definition['labelTranslationKey'],
                 'count' => $count,
-                'percent' => $totalAllocations > 0 ? round(((float) $count / $totalAllocationsFloat) * 100.0, 1) : 0.0,
+                'percent' => $metrics->scopedTotal > 0 ? round(((float) $count / $totalAllocationsFloat) * 100.0, 1) : 0.0,
             ];
         }
 
         return $rows;
-    }
-
-    /**
-     * @return array{0:int,1:array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int},2:array{cathlab:int,resus:int}}
-     */
-    private function loadCounts(StatisticsContext $context): array
-    {
-        $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
-        $hospitalIds = $scopeCriteria->hospitalIds;
-        $totalAllocations = $this->timeSeriesQuery->countCreatedInPeriod($bounds->from, $bounds->toExclusive, $hospitalIds);
-        $clinicalCounts = $this->featureQuery->clinicalFeatureCounts($bounds->from, $bounds->toExclusive, $hospitalIds);
-        $resourceCounts = $this->featureQuery->resourceFeatureCounts($bounds->from, $bounds->toExclusive, $hospitalIds);
-
-        return [$totalAllocations, $clinicalCounts, $resourceCounts];
     }
 }

--- a/src/Statistics/Application/Cohort/HospitalCohortEligibilityChecker.php
+++ b/src/Statistics/Application/Cohort/HospitalCohortEligibilityChecker.php
@@ -4,17 +4,28 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application\Cohort;
 
-use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
+use App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsByCohortQuery;
 
-final readonly class HospitalCohortEligibilityChecker
+final class HospitalCohortEligibilityChecker
 {
+    /** @var array<string, bool> */
+    private array $memo = [];
+
     public function __construct(
-        private AllocationStatsProjectionScopeQuery $projectionScopeQuery,
+        private readonly CountDistinctHospitalsByCohortQuery $countDistinctHospitalsByCohortQuery,
     ) {
     }
 
     public function hasMinimumParticipants(HospitalCohort $cohort, int $minimumParticipants = 2): bool
     {
-        return $this->projectionScopeQuery->countDistinctHospitalsForCohort($cohort) >= $minimumParticipants;
+        $cacheKey = $cohort->type->value.'|'.$minimumParticipants;
+        if (\array_key_exists($cacheKey, $this->memo)) {
+            return $this->memo[$cacheKey];
+        }
+
+        $eligible = ($this->countDistinctHospitalsByCohortQuery)($cohort) >= $minimumParticipants;
+        $this->memo[$cacheKey] = $eligible;
+
+        return $eligible;
     }
 }

--- a/src/Statistics/Application/DTO/StatisticsPeriodBounds.php
+++ b/src/Statistics/Application/DTO/StatisticsPeriodBounds.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Statistics\Application\DTO;
 
 /**
- * Half-open interval [from, toExclusive) for createdAt filtering;
- * toExclusive null means lower bound only (rolling window style).
+ * Half-open interval [from, toExclusive) for createdAt filtering.
+ *
+ * from null: no lower bound (all_time without pseudo-dates).
+ * toExclusive null: open-ended upper bound (rolling window style).
  */
 final readonly class StatisticsPeriodBounds
 {
     public function __construct(
-        public \DateTimeImmutable $from,
+        public ?\DateTimeImmutable $from,
         public ?\DateTimeImmutable $toExclusive = null,
     ) {
     }

--- a/src/Statistics/Application/HospitalSummaryProvider.php
+++ b/src/Statistics/Application/HospitalSummaryProvider.php
@@ -14,6 +14,7 @@ use App\Statistics\Application\DTO\StatisticWidgetNavigationTarget;
 use App\Statistics\Application\DTO\StatisticWidgetType;
 use App\Statistics\Application\DTO\WidgetPayload\SummaryDeckWidgetPayload;
 use App\Statistics\Application\DTO\WidgetPayload\WidgetPayloadNormalizer;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
 
 final readonly class HospitalSummaryProvider
 {
@@ -50,9 +51,9 @@ final readonly class HospitalSummaryProvider
     /**
      * @return list<StatisticWidget>
      */
-    public function build(StatisticsContext $context): array
+    public function build(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
     {
-        $data = $this->hospitalSummaryQuery->summarize($context);
+        $data = $this->hospitalSummaryQuery->summarize($context, $metrics);
 
         return [
             $this->summaryDeckWidget($data),

--- a/src/Statistics/Application/HospitalSummaryQuery.php
+++ b/src/Statistics/Application/HospitalSummaryQuery.php
@@ -9,93 +9,26 @@ use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Statistics\Application\DTO\HospitalSummaryData;
 use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
-use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
 
 final readonly class HospitalSummaryQuery
 {
     public function __construct(
         private StatisticsScopeResolver $scopeResolver,
-        private ProjectionTimeSeriesQuery $timeSeriesQuery,
     ) {
     }
 
-    public function summarize(StatisticsContext $context): HospitalSummaryData
+    public function summarize(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): HospitalSummaryData
     {
-        $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $from = $bounds->from;
-        $to = $bounds->toExclusive;
-
-        $totalAllocations = $this->timeSeriesQuery->countCreatedInPeriod($from, $to, null);
-
         $scope = $context->filter->scope;
+        $usedUnscopedFallback = StatisticsFilterScope::Public !== $scope
+            && null === $this->scopeResolver->resolveCriteria($context)->hospitalIds;
 
-        if (StatisticsFilterScope::Public === $scope) {
-            return $this->buildDataForPublicSlice($totalAllocations, $from, $to);
-        }
-
-        if (StatisticsFilterScope::Hospital === $scope && null !== $context->filter->hospitalId) {
-            $ids = [$context->filter->hospitalId];
-
-            return $this->buildDataForHospitalIds(
-                $totalAllocations,
-                $from,
-                $to,
-                $ids,
-                usedUnscopedFallback: false,
-            );
-        }
-
-        $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
-        if (null === $hospitalIds) {
-            return $this->buildDataForPublicSlice($totalAllocations, $from, $to, usedUnscopedFallback: true);
-        }
-
-        return $this->buildDataForHospitalIds(
-            $totalAllocations,
-            $from,
-            $to,
-            $hospitalIds,
-            usedUnscopedFallback: false,
-        );
-    }
-
-    /**
-     * @param list<int> $ids
-     */
-    private function buildDataForHospitalIds(
-        int $totalAllocations,
-        \DateTimeImmutable $from,
-        ?\DateTimeImmutable $to,
-        array $ids,
-        bool $usedUnscopedFallback,
-    ): HospitalSummaryData {
-        $userAllocations = $this->timeSeriesQuery->countCreatedInPeriod($from, $to, $ids);
-        $genderRaw = $this->timeSeriesQuery->countGroupedByGenderInPeriod($from, $to, $ids);
-        $urgencyRaw = $this->timeSeriesQuery->countGroupedByUrgencyInPeriod($from, $to, $ids);
-
-        return $this->assembleHospitalSummaryData(
-            $totalAllocations,
-            $userAllocations,
-            $genderRaw,
-            $urgencyRaw,
-            $usedUnscopedFallback,
-        );
-    }
-
-    private function buildDataForPublicSlice(
-        int $totalAllocations,
-        \DateTimeImmutable $from,
-        ?\DateTimeImmutable $to,
-        bool $usedUnscopedFallback = false,
-    ): HospitalSummaryData {
-        $genderRaw = $this->timeSeriesQuery->countGroupedByGenderInPeriod($from, $to, null);
-        $urgencyRaw = $this->timeSeriesQuery->countGroupedByUrgencyInPeriod($from, $to, null);
-
-        return $this->assembleHospitalSummaryData(
-            $totalAllocations,
-            $totalAllocations,
-            $genderRaw,
-            $urgencyRaw,
+        return $this->buildDataFromDistributions(
+            $metrics->platformTotal,
+            $metrics->scopedTotal,
+            $metrics->genderCounts,
+            $metrics->urgencyCounts,
             $usedUnscopedFallback,
         );
     }
@@ -104,7 +37,7 @@ final readonly class HospitalSummaryQuery
      * @param array<string, int> $genderRaw
      * @param array<int, int>    $urgencyRaw
      */
-    private function assembleHospitalSummaryData(
+    private function buildDataFromDistributions(
         int $totalAllocations,
         int $userAllocations,
         array $genderRaw,

--- a/src/Statistics/Application/OverviewDashboardProvider.php
+++ b/src/Statistics/Application/OverviewDashboardProvider.php
@@ -120,6 +120,7 @@ final readonly class OverviewDashboardProvider
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
         $start = $bounds->from;
         $toExclusive = $bounds->toExclusive;
+        \assert($start instanceof \DateTimeImmutable);
         \assert($toExclusive instanceof \DateTimeImmutable);
 
         $monthKeys = [];
@@ -159,17 +160,20 @@ final readonly class OverviewDashboardProvider
     private function buildAllTimeCharts(StatisticsContext $context): array
     {
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $start = $bounds->from;
         if ($bounds->toExclusive instanceof \DateTimeImmutable) {
             throw new \LogicException('all_time charts expect an open-ended upper bound.');
         }
 
+        $start = $bounds->from;
         $earliest = $this->timeSeriesQuery->getEarliestCreatedAt();
         if ($earliest instanceof \DateTimeImmutable) {
             $firstMonth = $earliest->modify('first day of this month')->setTime(0, 0, 0);
-            if ($firstMonth > $start) {
+            if (!$start instanceof \DateTimeImmutable || $firstMonth > $start) {
                 $start = $firstMonth;
             }
+        }
+        if (!$start instanceof \DateTimeImmutable) {
+            $start = new \DateTimeImmutable('first day of this month')->setTime(0, 0, 0);
         }
 
         $currentYear = (int) new \DateTimeImmutable('now')->format('Y');
@@ -188,8 +192,8 @@ final readonly class OverviewDashboardProvider
             $labels[] = $key;
         }
 
-        $rangeStart = (new \DateTimeImmutable(sprintf('%04d-01-01 00:00:00', $startYear)));
-        $allocationRows = $this->timeSeriesQuery->countByYearInPeriod($rangeStart, null, null);
+        $rangeStart = new \DateTimeImmutable(sprintf('%04d-01-01 00:00:00', $startYear));
+        $allocationRows = $this->timeSeriesQuery->countGroupedByCreatedYear($startYear, null, null);
         $importRows = $this->importTimeline->countByYearInRange($rangeStart, null);
 
         return $this->assembleChartPayload(
@@ -197,7 +201,7 @@ final readonly class OverviewDashboardProvider
             $labels,
             $this->chartBucketMapper->yearRowsToBucketCounts($allocationRows),
             $this->chartBucketMapper->yearRowsToBucketCounts($importRows),
-            $rangeStart
+            $this->timeSeriesQuery->countWithCreatedYearBefore($startYear),
         );
     }
 
@@ -217,11 +221,13 @@ final readonly class OverviewDashboardProvider
         array $labels,
         array $allocationBucketCounts,
         array $importBucketCounts,
-        \DateTimeImmutable $rangeStartForCumulative,
+        \DateTimeImmutable|int $cumulativeBaseline,
     ): array {
         $allocationMonthlyCounts = $this->chartBucketMapper->mapMonthlyCounts($bucketKeys, $allocationBucketCounts);
         $importMonthlyCounts = $this->chartBucketMapper->mapMonthlyCounts($bucketKeys, $importBucketCounts);
-        $initialAllocations = $this->timeSeriesQuery->countBefore($rangeStartForCumulative);
+        $initialAllocations = \is_int($cumulativeBaseline)
+            ? $cumulativeBaseline
+            : $this->timeSeriesQuery->countBefore($cumulativeBaseline);
 
         $allocationCumulativeCounts = [];
         $runningTotal = $initialAllocations;

--- a/src/Statistics/Application/StatisticsFilterFactory.php
+++ b/src/Statistics/Application/StatisticsFilterFactory.php
@@ -13,7 +13,8 @@ use App\Statistics\Application\DTO\StatisticsFilterInput;
 use App\Statistics\Application\DTO\StatisticsFilterNotice;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
-use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
+use App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForDispatchAreaQuery;
+use App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForStateQuery;
 use App\User\Domain\Entity\User;
 
 final readonly class StatisticsFilterFactory
@@ -22,7 +23,8 @@ final readonly class StatisticsFilterFactory
         private HospitalAccessInterface $hospitalAccess,
         private HospitalCohortResolver $hospitalCohortResolver,
         private HospitalCohortEligibilityChecker $hospitalCohortEligibilityChecker,
-        private AllocationStatsProjectionScopeQuery $projectionScopeQuery,
+        private CountDistinctHospitalsForStateQuery $countDistinctHospitalsForStateQuery,
+        private CountDistinctHospitalsForDispatchAreaQuery $countDistinctHospitalsForDispatchAreaQuery,
     ) {
     }
 
@@ -84,14 +86,14 @@ final readonly class StatisticsFilterFactory
             }
         }
 
-        if (StatisticsFilterScope::State === $scope && (null === $stateId || $this->projectionScopeQuery->countDistinctHospitalsForState($stateId) < 2)) {
+        if (StatisticsFilterScope::State === $scope && (null === $stateId || ($this->countDistinctHospitalsForStateQuery)($stateId) < 2)) {
             $scope = StatisticsFilterScope::Public;
             $stateId = null;
             $notice = StatisticsFilterNotice::StateInvalid;
             $requiresPublicRedirect = true;
         }
 
-        if (StatisticsFilterScope::DispatchArea === $scope && (null === $dispatchAreaId || $this->projectionScopeQuery->countDistinctHospitalsForDispatchArea($dispatchAreaId) < 2)) {
+        if (StatisticsFilterScope::DispatchArea === $scope && (null === $dispatchAreaId || ($this->countDistinctHospitalsForDispatchAreaQuery)($dispatchAreaId) < 2)) {
             $scope = StatisticsFilterScope::Public;
             $dispatchAreaId = null;
             $notice = StatisticsFilterNotice::DispatchAreaInvalid;

--- a/src/Statistics/Application/StatisticsPeriodResolver.php
+++ b/src/Statistics/Application/StatisticsPeriodResolver.php
@@ -14,12 +14,10 @@ use App\Statistics\Application\DTO\StatisticsPeriodBounds;
  * period=all matches the overview: rolling 12 months from {@see StatisticsPeriod::overviewPeriodStart()},
  * with no explicit upper bound (only createdAt >= from).
  *
- * period=all_time: half-open interval from a fixed early lower bound until now (no upper bound in queries).
+ * period=all_time: no created_at lower bound in queries; callers use earliest row when a start label is needed.
  */
 final class StatisticsPeriodResolver
 {
-    private const string ALL_TIME_LOWER_BOUND = '1970-01-01 00:00:00';
-
     public static function resolve(StatisticsFilter $filter): StatisticsPeriodBounds
     {
         $now = new \DateTimeImmutable('now');
@@ -28,9 +26,7 @@ final class StatisticsPeriodResolver
             StatisticsFilterPeriod::All => new StatisticsPeriodBounds(
                 StatisticsPeriod::overviewPeriodStart(),
             ),
-            StatisticsFilterPeriod::AllTime => new StatisticsPeriodBounds(
-                new \DateTimeImmutable(self::ALL_TIME_LOWER_BOUND),
-            ),
+            StatisticsFilterPeriod::AllTime => new StatisticsPeriodBounds(null),
             StatisticsFilterPeriod::Year => self::resolveYear($filter, $now),
             StatisticsFilterPeriod::Month => self::resolveMonth($filter, $now),
         };

--- a/src/Statistics/Application/StatisticsScopeResolver.php
+++ b/src/Statistics/Application/StatisticsScopeResolver.php
@@ -9,15 +9,23 @@ use App\Statistics\Application\Cohort\HospitalCohortResolver;
 use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\Application\DTO\StatisticsScopeCriteria;
-use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByCohortQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByDispatchAreaQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery;
 use App\User\Domain\Entity\User;
 
-final readonly class StatisticsScopeResolver
+final class StatisticsScopeResolver
 {
+    private ?string $resolvedCacheKey = null;
+
+    private ?StatisticsScopeCriteria $resolvedCriteria = null;
+
     public function __construct(
-        private HospitalRepository $hospitalRepository,
-        private HospitalCohortResolver $hospitalCohortResolver,
-        private AllocationStatsProjectionScopeQuery $projectionScopeQuery,
+        private readonly HospitalRepository $hospitalRepository,
+        private readonly HospitalCohortResolver $hospitalCohortResolver,
+        private readonly GetDistinctHospitalIdsByStateQuery $distinctHospitalIdsByStateQuery,
+        private readonly GetDistinctHospitalIdsByDispatchAreaQuery $distinctHospitalIdsByDispatchAreaQuery,
+        private readonly GetDistinctHospitalIdsByCohortQuery $distinctHospitalIdsByCohortQuery,
     ) {
     }
 
@@ -35,42 +43,60 @@ final readonly class StatisticsScopeResolver
 
     public function resolveCriteria(StatisticsContext $context): StatisticsScopeCriteria
     {
+        $cacheKey = $this->cacheKey($context);
+        if ($cacheKey === $this->resolvedCacheKey && $this->resolvedCriteria instanceof StatisticsScopeCriteria) {
+            return $this->resolvedCriteria;
+        }
+
         $filter = $context->filter;
 
         if (StatisticsFilterScope::Public === $filter->scope) {
-            return StatisticsScopeCriteria::public();
-        }
+            $criteria = StatisticsScopeCriteria::public();
+        } elseif (StatisticsFilterScope::Hospital === $filter->scope && null !== $filter->hospitalId) {
+            $criteria = new StatisticsScopeCriteria([$filter->hospitalId]);
+        } elseif (StatisticsFilterScope::State === $filter->scope && null !== $filter->stateId) {
+            $hospitalIds = ($this->distinctHospitalIdsByStateQuery)($filter->stateId);
 
-        if (StatisticsFilterScope::Hospital === $filter->scope && null !== $filter->hospitalId) {
-            return new StatisticsScopeCriteria([$filter->hospitalId]);
-        }
-        if (StatisticsFilterScope::State === $filter->scope && null !== $filter->stateId) {
-            $hospitalIds = $this->projectionScopeQuery->distinctHospitalIdsForState($filter->stateId);
+            $criteria = new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
+        } elseif (StatisticsFilterScope::DispatchArea === $filter->scope && null !== $filter->dispatchAreaId) {
+            $hospitalIds = ($this->distinctHospitalIdsByDispatchAreaQuery)($filter->dispatchAreaId);
 
-            return new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
-        }
-
-        if (StatisticsFilterScope::DispatchArea === $filter->scope && null !== $filter->dispatchAreaId) {
-            $hospitalIds = $this->projectionScopeQuery->distinctHospitalIdsForDispatchArea($filter->dispatchAreaId);
-
-            return new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
-        }
-
-        if (StatisticsFilterScope::HospitalCohort === $filter->scope && $filter->cohortType instanceof Cohort\HospitalCohortType) {
+            $criteria = new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
+        } elseif (StatisticsFilterScope::HospitalCohort === $filter->scope && $filter->cohortType instanceof Cohort\HospitalCohortType) {
             $cohort = $this->hospitalCohortResolver->resolve($filter->cohortType);
-            $hospitalIds = $this->projectionScopeQuery->distinctHospitalIdsForCohort($cohort);
+            $hospitalIds = ($this->distinctHospitalIdsByCohortQuery)($cohort);
 
-            return new StatisticsScopeCriteria(
+            $criteria = new StatisticsScopeCriteria(
                 [] === $hospitalIds ? null : $hospitalIds,
                 $cohort->locationCodeValues(),
                 $cohort->tierCodeValues(),
                 $filter->cohortType,
             );
+        } else {
+            $ids = $this->resolveMyHospitalIds($context->user);
+
+            $criteria = [] === $ids ? StatisticsScopeCriteria::public() : new StatisticsScopeCriteria($ids);
         }
 
-        $ids = $this->resolveMyHospitalIds($context->user);
+        $this->resolvedCacheKey = $cacheKey;
+        $this->resolvedCriteria = $criteria;
 
-        return [] === $ids ? StatisticsScopeCriteria::public() : new StatisticsScopeCriteria($ids);
+        return $criteria;
+    }
+
+    private function cacheKey(StatisticsContext $context): string
+    {
+        $filter = $context->filter;
+        $userId = $context->user?->getId();
+
+        return implode('|', [
+            $filter->scope->value,
+            (string) ($filter->hospitalId ?? ''),
+            $filter->cohortType instanceof Cohort\HospitalCohortType ? $filter->cohortType->value : '',
+            (string) ($filter->stateId ?? ''),
+            (string) ($filter->dispatchAreaId ?? ''),
+            null === $userId ? 'anon' : (string) $userId,
+        ]);
     }
 
     /**

--- a/src/Statistics/Infrastructure/Entity/ProjectionDispatchAreaHospitalCount.php
+++ b/src/Statistics/Infrastructure/Entity/ProjectionDispatchAreaHospitalCount.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Read-only materialized view: distinct hospitals per dispatch area in allocation_stats_projection.
+ *
+ * @psalm-suppress MissingConstructor
+ * @psalm-suppress ClassMustBeFinal Not final: Doctrine may generate proxies for entities.
+ */
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'mv_projection_dispatch_area_hospital_count')]
+class ProjectionDispatchAreaHospitalCount
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'dispatch_area_id')]
+    private int $dispatchAreaId;
+
+    #[ORM\Column(name: 'hospital_count')]
+    private int $hospitalCount;
+
+    public function getDispatchAreaId(): int
+    {
+        return $this->dispatchAreaId;
+    }
+
+    public function getHospitalCount(): int
+    {
+        return $this->hospitalCount;
+    }
+}

--- a/src/Statistics/Infrastructure/Entity/ProjectionHospitalDimension.php
+++ b/src/Statistics/Infrastructure/Entity/ProjectionHospitalDimension.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Read-only materialized view: one row per hospital with projection dimension codes.
+ *
+ * @psalm-suppress MissingConstructor
+ * @psalm-suppress ClassMustBeFinal Not final: Doctrine may generate proxies for entities.
+ */
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'mv_projection_hospital_dimensions')]
+class ProjectionHospitalDimension
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'hospital_id')]
+    private int $hospitalId;
+
+    #[ORM\Column(name: 'state_id', nullable: true)]
+    private ?int $stateId = null;
+
+    #[ORM\Column(name: 'dispatch_area_id', nullable: true)]
+    private ?int $dispatchAreaId = null;
+
+    #[ORM\Column(name: 'hospital_location_code', nullable: true)]
+    private ?int $hospitalLocationCode = null;
+
+    #[ORM\Column(name: 'hospital_tier_code', nullable: true)]
+    private ?int $hospitalTierCode = null;
+
+    public function getHospitalId(): int
+    {
+        return $this->hospitalId;
+    }
+
+    public function getStateId(): ?int
+    {
+        return $this->stateId;
+    }
+
+    public function getDispatchAreaId(): ?int
+    {
+        return $this->dispatchAreaId;
+    }
+
+    public function getHospitalLocationCode(): ?int
+    {
+        return $this->hospitalLocationCode;
+    }
+
+    public function getHospitalTierCode(): ?int
+    {
+        return $this->hospitalTierCode;
+    }
+}

--- a/src/Statistics/Infrastructure/Entity/ProjectionStateHospitalCount.php
+++ b/src/Statistics/Infrastructure/Entity/ProjectionStateHospitalCount.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Read-only materialized view: distinct hospitals per state in allocation_stats_projection.
+ *
+ * @psalm-suppress MissingConstructor
+ * @psalm-suppress ClassMustBeFinal Not final: Doctrine may generate proxies for entities.
+ */
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'mv_projection_state_hospital_count')]
+class ProjectionStateHospitalCount
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'state_id')]
+    private int $stateId;
+
+    #[ORM\Column(name: 'hospital_count')]
+    private int $hospitalCount;
+
+    public function getStateId(): int
+    {
+        return $this->stateId;
+    }
+
+    public function getHospitalCount(): int
+    {
+        return $this->hospitalCount;
+    }
+}

--- a/src/Statistics/Infrastructure/MaterializedView/MaterializedViewRefresher.php
+++ b/src/Statistics/Infrastructure/MaterializedView/MaterializedViewRefresher.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\MaterializedView;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+
+final readonly class MaterializedViewRefresher
+{
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param list<string> $groups empty = all registered groups
+     *
+     * @return list<array{view: string, success: bool, message: string}>
+     */
+    public function refresh(array $groups = [], bool $concurrently = true): array
+    {
+        $results = [];
+        foreach (StatisticsMaterializedViewGroups::viewsForGroups($groups) as $viewName) {
+            $results[] = $this->refreshView($viewName, $concurrently);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array{view: string, success: bool, message: string}
+     */
+    private function refreshView(string $viewName, bool $concurrently): array
+    {
+        $sql = $concurrently
+            ? sprintf('REFRESH MATERIALIZED VIEW CONCURRENTLY %s', $viewName)
+            : sprintf('REFRESH MATERIALIZED VIEW %s', $viewName);
+
+        try {
+            $this->connection->executeStatement($sql);
+
+            return [
+                'view' => $viewName,
+                'success' => true,
+                'message' => sprintf('Refreshed %s', $viewName),
+            ];
+        } catch (\Throwable $exception) {
+            $this->logger->error('statistics_materialized_view.refresh_failed', [
+                'view' => $viewName,
+                'exception' => $exception,
+            ]);
+
+            return [
+                'view' => $viewName,
+                'success' => false,
+                'message' => sprintf('Failed to refresh %s: %s', $viewName, $exception->getMessage()),
+            ];
+        }
+    }
+}

--- a/src/Statistics/Infrastructure/MaterializedView/StatisticsMaterializedViewDropper.php
+++ b/src/Statistics/Infrastructure/MaterializedView/StatisticsMaterializedViewDropper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\MaterializedView;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Drops statistics materialized views so Doctrine schema tooling can reset the database.
+ *
+ * Used from the test environment only (Foundry ORM reset decorator).
+ */
+final readonly class StatisticsMaterializedViewDropper
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function dropAllForSchemaReset(): void
+    {
+        foreach (StatisticsMaterializedViewGroups::allViews() as $viewName) {
+            $this->connection->executeStatement(
+                sprintf('DROP MATERIALIZED VIEW IF EXISTS %s CASCADE', $viewName),
+            );
+        }
+    }
+}

--- a/src/Statistics/Infrastructure/MaterializedView/StatisticsMaterializedViewGroups.php
+++ b/src/Statistics/Infrastructure/MaterializedView/StatisticsMaterializedViewGroups.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\MaterializedView;
+
+/**
+ * Registry of statistics materialized view groups for install/refresh commands.
+ */
+final class StatisticsMaterializedViewGroups
+{
+    public const string OVERVIEW = 'overview';
+
+    /** @var array<string, list<string>> */
+    private const array GROUPS = [
+        self::OVERVIEW => [
+            'mv_projection_state_hospital_count',
+            'mv_projection_dispatch_area_hospital_count',
+            'mv_projection_hospital_dimensions',
+        ],
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function knownGroups(): array
+    {
+        return array_keys(self::GROUPS);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function viewsForGroup(string $group): array
+    {
+        if (!isset(self::GROUPS[$group])) {
+            throw new \InvalidArgumentException(sprintf('Unknown materialized view group "%s". Known groups: %s', $group, implode(', ', self::knownGroups())));
+        }
+
+        return self::GROUPS[$group];
+    }
+
+    /**
+     * @param list<string> $groups empty = all groups
+     *
+     * @return list<string>
+     */
+    public static function viewsForGroups(array $groups): array
+    {
+        if ([] === $groups) {
+            return self::allViews();
+        }
+
+        $views = [];
+        foreach ($groups as $group) {
+            foreach (self::viewsForGroup($group) as $viewName) {
+                $views[] = $viewName;
+            }
+        }
+
+        return array_values(array_unique($views));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allViews(): array
+    {
+        return self::viewsForGroups(self::knownGroups());
+    }
+}

--- a/src/Statistics/Infrastructure/Query/AllocationPivotQuery.php
+++ b/src/Statistics/Infrastructure/Query/AllocationPivotQuery.php
@@ -23,7 +23,7 @@ final readonly class AllocationPivotQuery
      * @return list<array{row_key: string, col_key: string, value: float, row_label?: string, col_label?: string}>
      */
     public function fetchCells(
-        \DateTimeImmutable $from,
+        ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         AllocationPivotDimension $rows,

--- a/src/Statistics/Infrastructure/Query/HospitalPivotQuery.php
+++ b/src/Statistics/Infrastructure/Query/HospitalPivotQuery.php
@@ -24,7 +24,7 @@ final readonly class HospitalPivotQuery
      * @return list<array{row_key: string, col_key: string, value: float}>
      */
     public function fetchCells(
-        \DateTimeImmutable $from,
+        ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         HospitalPivotDimension $rows,
@@ -41,13 +41,23 @@ final readonly class HospitalPivotQuery
         $this->filterApplier->applyHospitalScope($qb, 'h.id', $hospitalIds);
 
         $qb->leftJoin('h.state', 's')
-            ->leftJoin('h.dispatchArea', 'da')
-            ->leftJoin(\App\Statistics\Infrastructure\Entity\AllocationStatsProjection::class, 'a', 'WITH', 'a.hospitalId = h.id AND a.createdAt >= :from');
-        $qb->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
-        if ($toExclusive instanceof \DateTimeImmutable) {
-            $qb->andWhere('a.createdAt < :toExclusive OR a.id IS NULL')
-                ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
+            ->leftJoin('h.dispatchArea', 'da');
+
+        $allocationJoinConditions = ['a.hospitalId = h.id'];
+        if ($from instanceof \DateTimeImmutable) {
+            $allocationJoinConditions[] = 'a.createdAt >= :from';
+            $qb->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
         }
+        if ($toExclusive instanceof \DateTimeImmutable) {
+            $allocationJoinConditions[] = 'a.createdAt < :toExclusive';
+            $qb->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
+        }
+        $qb->leftJoin(
+            \App\Statistics\Infrastructure\Entity\AllocationStatsProjection::class,
+            'a',
+            'WITH',
+            implode(' AND ', $allocationJoinConditions),
+        );
 
         $rowExpr = $this->dimensionExpression($rows);
         $colExpr = $this->dimensionExpression($cols);
@@ -74,7 +84,7 @@ final readonly class HospitalPivotQuery
      * @return list<array<string,mixed>>
      */
     private function fetchLegacyAllocationRows(
-        \DateTimeImmutable $from,
+        ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         HospitalPivotDimension $rows,
@@ -83,9 +93,18 @@ final readonly class HospitalPivotQuery
         $qb = $this->entityManager->createQueryBuilder()
             ->from(Hospital::class, 'h')
             ->leftJoin('h.state', 's')
-            ->leftJoin('h.dispatchArea', 'da')
-            ->leftJoin(\App\Allocation\Domain\Entity\Allocation::class, 'a', 'WITH', 'a.hospital = h AND a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
+            ->leftJoin('h.dispatchArea', 'da');
+
+        $legacyJoinConditions = ['a.hospital = h'];
+        if ($from instanceof \DateTimeImmutable) {
+            $legacyJoinConditions[] = 'a.createdAt >= :from';
+            $qb->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
+        }
+        if ($toExclusive instanceof \DateTimeImmutable) {
+            $legacyJoinConditions[] = 'a.createdAt < :toExclusive';
+            $qb->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
+        }
+        $qb->leftJoin(\App\Allocation\Domain\Entity\Allocation::class, 'a', 'WITH', implode(' AND ', $legacyJoinConditions));
 
         $this->filterApplier->applyHospitalScope($qb, 'h.id', $hospitalIds);
         if ($toExclusive instanceof \DateTimeImmutable) {

--- a/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsByCohortQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsByCohortQuery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\Cohort\HospitalCohort;
+use App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class CountDistinctHospitalsByCohortQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    public function __invoke(HospitalCohort $cohort): int
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        return (int) $this->entityManager->createQueryBuilder()
+            ->from(ProjectionHospitalDimension::class, 'h')
+            ->select('COUNT(h.hospitalId)')
+            ->andWhere('h.hospitalLocationCode IN (:locationCodes)')
+            ->andWhere('h.hospitalTierCode IN (:tierCodes)')
+            ->setParameter('locationCodes', $cohort->locationCodeValues())
+            ->setParameter('tierCodes', $cohort->tierCodeValues())
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsForDispatchAreaQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsForDispatchAreaQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionDispatchAreaHospitalCount;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class CountDistinctHospitalsForDispatchAreaQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    public function __invoke(int $dispatchAreaId): int
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        $row = $this->entityManager->find(ProjectionDispatchAreaHospitalCount::class, $dispatchAreaId);
+
+        return $row?->getHospitalCount() ?? 0;
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsForStateQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/CountDistinctHospitalsForStateQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class CountDistinctHospitalsForStateQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    public function __invoke(int $stateId): int
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        $row = $this->entityManager->find(ProjectionStateHospitalCount::class, $stateId);
+
+        return $row?->getHospitalCount() ?? 0;
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewDashboardMetricsResult.php
+++ b/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewDashboardMetricsResult.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview\Dto;
+
+final readonly class OverviewDashboardMetricsResult
+{
+    public function __construct(
+        public int $platformTotal,
+        public int $scopedTotal,
+        public int $withPhysician,
+        public int $cpr,
+        public int $ventilated,
+        public int $shock,
+        public int $pregnant,
+        public int $workAccident,
+        public int $infectious,
+        public int $cathlab,
+        public int $resus,
+        /** @var array<string, int> */
+        public array $genderCounts,
+        /** @var array<int, int> */
+        public array $urgencyCounts,
+    ) {
+    }
+
+    public function toSummaryResult(): OverviewSummaryResult
+    {
+        return new OverviewSummaryResult(
+            $this->scopedTotal,
+            $this->withPhysician,
+            $this->cpr,
+            $this->ventilated,
+            $this->shock,
+            $this->pregnant,
+            $this->workAccident,
+            $this->infectious,
+            $this->cathlab,
+            $this->resus,
+        );
+    }
+
+    /**
+     * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int}
+     */
+    public function clinicalCounts(): array
+    {
+        return $this->toSummaryResult()->clinicalCounts();
+    }
+
+    /**
+     * @return array{cathlab:int,resus:int}
+     */
+    public function resourceCounts(): array
+    {
+        return $this->toSummaryResult()->resourceCounts();
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewScopedTotalsResult.php
+++ b/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewScopedTotalsResult.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview\Dto;
+
+final readonly class OverviewScopedTotalsResult
+{
+    public function __construct(
+        public int $platformTotal,
+        public int $scopedTotal,
+    ) {
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewSummaryResult.php
+++ b/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewSummaryResult.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview\Dto;
+
+final readonly class OverviewSummaryResult
+{
+    public function __construct(
+        public int $total,
+        public int $withPhysician,
+        public int $cpr,
+        public int $ventilated,
+        public int $shock,
+        public int $pregnant,
+        public int $workAccident,
+        public int $infectious,
+        public int $cathlab,
+        public int $resus,
+    ) {
+    }
+
+    /**
+     * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int}
+     */
+    public function clinicalCounts(): array
+    {
+        return [
+            'with_physician' => $this->withPhysician,
+            'cpr' => $this->cpr,
+            'ventilated' => $this->ventilated,
+            'shock' => $this->shock,
+            'pregnant' => $this->pregnant,
+            'work_accident' => $this->workAccident,
+            'infectious' => $this->infectious,
+        ];
+    }
+
+    /**
+     * @return array{cathlab:int,resus:int}
+     */
+    public function resourceCounts(): array
+    {
+        return [
+            'cathlab' => $this->cathlab,
+            'resus' => $this->resus,
+        ];
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByCohortQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByCohortQuery.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\Cohort\HospitalCohort;
+use App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class GetDistinctHospitalIdsByCohortQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function __invoke(HospitalCohort $cohort): array
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        /** @var list<int|string> $raw */
+        $raw = $this->entityManager->createQueryBuilder()
+            ->from(ProjectionHospitalDimension::class, 'h')
+            ->select('h.hospitalId')
+            ->andWhere('h.hospitalLocationCode IN (:locationCodes)')
+            ->andWhere('h.hospitalTierCode IN (:tierCodes)')
+            ->setParameter('locationCodes', $cohort->locationCodeValues())
+            ->setParameter('tierCodes', $cohort->tierCodeValues())
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $raw);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByDispatchAreaQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByDispatchAreaQuery.php
@@ -27,6 +27,7 @@ final readonly class GetDistinctHospitalIdsByDispatchAreaQuery
             ->from(ProjectionHospitalDimension::class, 'h')
             ->select('h.hospitalId')
             ->andWhere('h.dispatchAreaId = :dispatchAreaId')
+            ->orderBy('h.hospitalId', 'ASC')
             ->setParameter('dispatchAreaId', $dispatchAreaId)
             ->getQuery()
             ->getSingleColumnResult();

--- a/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByDispatchAreaQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByDispatchAreaQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class GetDistinctHospitalIdsByDispatchAreaQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function __invoke(int $dispatchAreaId): array
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        /** @var list<int|string> $raw */
+        $raw = $this->entityManager->createQueryBuilder()
+            ->from(ProjectionHospitalDimension::class, 'h')
+            ->select('h.hospitalId')
+            ->andWhere('h.dispatchAreaId = :dispatchAreaId')
+            ->setParameter('dispatchAreaId', $dispatchAreaId)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $raw);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByStateQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByStateQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class GetDistinctHospitalIdsByStateQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function __invoke(int $stateId): array
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        /** @var list<int|string> $raw */
+        $raw = $this->entityManager->createQueryBuilder()
+            ->from(ProjectionHospitalDimension::class, 'h')
+            ->select('h.hospitalId')
+            ->andWhere('h.stateId = :stateId')
+            ->setParameter('stateId', $stateId)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $raw);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByStateQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetDistinctHospitalIdsByStateQuery.php
@@ -27,6 +27,7 @@ final readonly class GetDistinctHospitalIdsByStateQuery
             ->from(ProjectionHospitalDimension::class, 'h')
             ->select('h.hospitalId')
             ->andWhere('h.stateId = :stateId')
+            ->orderBy('h.hospitalId', 'ASC')
             ->setParameter('stateId', $stateId)
             ->getQuery()
             ->getSingleColumnResult();

--- a/src/Statistics/Infrastructure/Query/Overview/GetEligibleDispatchAreaIdsQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetEligibleDispatchAreaIdsQuery.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionDispatchAreaHospitalCount;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class GetEligibleDispatchAreaIdsQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function __invoke(int $minimumParticipants = 2): array
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        /** @var list<int|string> $raw */
+        $raw = $this->entityManager->createQueryBuilder()
+            ->from(ProjectionDispatchAreaHospitalCount::class, 'd')
+            ->select('d.dispatchAreaId')
+            ->andWhere('d.hospitalCount >= :min')
+            ->orderBy('d.dispatchAreaId', 'ASC')
+            ->setParameter('min', $minimumParticipants)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $raw);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetEligibleStateIdsQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetEligibleStateIdsQuery.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class GetEligibleStateIdsQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function __invoke(int $minimumParticipants = 2): array
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+
+        /** @var list<int|string> $raw */
+        $raw = $this->entityManager->createQueryBuilder()
+            ->from(ProjectionStateHospitalCount::class, 's')
+            ->select('s.stateId')
+            ->andWhere('s.hospitalCount >= :min')
+            ->orderBy('s.stateId', 'ASC')
+            ->setParameter('min', $minimumParticipants)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $raw);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetOverviewDashboardMetricsQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetOverviewDashboardMetricsQuery.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsUrgencyProjectionCode;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
+use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
+use Doctrine\DBAL\Connection;
+
+final readonly class GetOverviewDashboardMetricsQuery
+{
+    public function __construct(
+        private Connection $connection,
+        private ProjectionFeatureQuery $projectionFeatureQuery,
+    ) {
+    }
+
+    public function __invoke(OverviewQueryCriteria $criteria): OverviewDashboardMetricsResult
+    {
+        if ($criteria->hasEmptyHospitalScope()) {
+            return new OverviewDashboardMetricsResult(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, [], []);
+        }
+
+        $hasExtended = $this->projectionFeatureQuery->hasExtendedClinicalFeatureColumns();
+        $scopedHospitalSql = $this->scopedHospitalSql($criteria->hospitalIds);
+
+        $shockExpr = $hasExtended
+            ? $this->scopedCountFilter('is_shock = true', $scopedHospitalSql)
+            : '0';
+        $pregnantExpr = $hasExtended
+            ? $this->scopedCountFilter('is_pregnant = true', $scopedHospitalSql)
+            : '0';
+        $workAccidentExpr = $hasExtended
+            ? $this->scopedCountFilter('is_work_accident = true', $scopedHospitalSql)
+            : '0';
+
+        $genderSelects = [];
+        foreach (AllocationStatsGenderProjectionCode::cases() as $code) {
+            $alias = match ($code) {
+                AllocationStatsGenderProjectionCode::Male => 'gender_m',
+                AllocationStatsGenderProjectionCode::Female => 'gender_f',
+                AllocationStatsGenderProjectionCode::Other => 'gender_x',
+            };
+            $genderSelects[] = sprintf(
+                '%s::int AS %s',
+                $this->scopedCountFilter(sprintf('gender_code = %d', $code->value), $scopedHospitalSql),
+                $alias,
+            );
+        }
+
+        $urgencySelects = [];
+        foreach (AllocationStatsUrgencyProjectionCode::cases() as $code) {
+            $urgencySelects[] = sprintf(
+                '%s::int AS urgency_%d',
+                $this->scopedCountFilter(sprintf('urgency_code = %d', $code->value), $scopedHospitalSql),
+                $code->value,
+            );
+        }
+
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+
+        $sql = sprintf(
+            <<<'SQL'
+SELECT
+    COUNT(*)::int AS platform_total,
+    %s::int AS scoped_total,
+    %s::int AS with_physician,
+    %s::int AS cpr,
+    %s::int AS ventilated,
+    %s::int AS shock,
+    %s::int AS pregnant,
+    %s::int AS work_accident,
+    %s::int AS infectious,
+    %s::int AS cathlab,
+    %s::int AS resus,
+    %s
+FROM allocation_stats_projection
+WHERE %s
+SQL,
+            $this->scopedCountFilter('true', $scopedHospitalSql),
+            $this->scopedCountFilter('is_with_physician = true', $scopedHospitalSql),
+            $this->scopedCountFilter('is_cpr = true', $scopedHospitalSql),
+            $this->scopedCountFilter('is_ventilated = true', $scopedHospitalSql),
+            $shockExpr,
+            $pregnantExpr,
+            $workAccidentExpr,
+            $this->scopedCountFilter('infection_id IS NOT NULL', $scopedHospitalSql),
+            $this->scopedCountFilter('requires_cathlab = true', $scopedHospitalSql),
+            $this->scopedCountFilter('requires_resus = true', $scopedHospitalSql),
+            implode(",\n    ", [...$genderSelects, ...$urgencySelects]),
+            $where,
+        );
+
+        $fetched = $this->connection->fetchAssociative($sql, $params);
+        /** @var array<string, int|string|null> $row */
+        $row = false === $fetched ? [] : $fetched;
+
+        return new OverviewDashboardMetricsResult(
+            (int) ($row['platform_total'] ?? 0),
+            (int) ($row['scoped_total'] ?? 0),
+            (int) ($row['with_physician'] ?? 0),
+            (int) ($row['cpr'] ?? 0),
+            (int) ($row['ventilated'] ?? 0),
+            (int) ($row['shock'] ?? 0),
+            (int) ($row['pregnant'] ?? 0),
+            (int) ($row['work_accident'] ?? 0),
+            (int) ($row['infectious'] ?? 0),
+            (int) ($row['cathlab'] ?? 0),
+            (int) ($row['resus'] ?? 0),
+            [
+                'M' => (int) ($row['gender_m'] ?? 0),
+                'F' => (int) ($row['gender_f'] ?? 0),
+                'X' => (int) ($row['gender_x'] ?? 0),
+            ],
+            [
+                AllocationStatsUrgencyProjectionCode::Emergency->value => (int) ($row['urgency_1'] ?? 0),
+                AllocationStatsUrgencyProjectionCode::Inpatient->value => (int) ($row['urgency_2'] ?? 0),
+                AllocationStatsUrgencyProjectionCode::Outpatient->value => (int) ($row['urgency_3'] ?? 0),
+            ],
+        );
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     */
+    private function scopedHospitalSql(?array $hospitalIds): ?string
+    {
+        if (null === $hospitalIds) {
+            return null;
+        }
+
+        $ids = array_map(static fn (int $id): int => $id, $hospitalIds);
+
+        return 'hospital_id IN ('.implode(',', $ids).')';
+    }
+
+    private function scopedCountFilter(string $condition, ?string $scopedHospitalSql): string
+    {
+        if (null === $scopedHospitalSql) {
+            return sprintf('COUNT(*) FILTER (WHERE %s)', $condition);
+        }
+
+        return sprintf('COUNT(*) FILTER (WHERE %s AND %s)', $condition, $scopedHospitalSql);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetOverviewGenderDistributionQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetOverviewGenderDistributionQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
+use Doctrine\DBAL\Connection;
+
+final readonly class GetOverviewGenderDistributionQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, int> keys M, F, X
+     */
+    public function __invoke(OverviewQueryCriteria $criteria): array
+    {
+        if ($criteria->hasEmptyHospitalScope()) {
+            return [];
+        }
+
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+        $sql = <<<SQL
+SELECT gender_code AS code, COUNT(*)::int AS count
+FROM allocation_stats_projection
+WHERE {$where}
+GROUP BY gender_code
+SQL;
+
+        /** @var list<array{code: int|string|null, count: int|string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        $out = [];
+        foreach ($rows as $row) {
+            if (null === $row['code']) {
+                continue;
+            }
+            $key = match ((int) $row['code']) {
+                AllocationStatsGenderProjectionCode::Male->value => 'M',
+                AllocationStatsGenderProjectionCode::Female->value => 'F',
+                AllocationStatsGenderProjectionCode::Other->value => 'X',
+                default => null,
+            };
+            if (null !== $key) {
+                $out[$key] = (int) $row['count'];
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetOverviewScopedTotalsQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetOverviewScopedTotalsQuery.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewScopedTotalsResult;
+use Doctrine\DBAL\Connection;
+
+final readonly class GetOverviewScopedTotalsQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param non-empty-list<int> $scopedHospitalIds
+     */
+    public function __invoke(OverviewQueryCriteria $periodCriteria, array $scopedHospitalIds): OverviewScopedTotalsResult
+    {
+        $platformCriteria = new OverviewQueryCriteria(
+            $periodCriteria->from,
+            $periodCriteria->toExclusive,
+            null,
+        );
+        $scopedCriteria = new OverviewQueryCriteria(
+            $periodCriteria->from,
+            $periodCriteria->toExclusive,
+            $scopedHospitalIds,
+        );
+
+        return new OverviewScopedTotalsResult(
+            $this->countRows($platformCriteria),
+            $this->countRows($scopedCriteria),
+        );
+    }
+
+    private function countRows(OverviewQueryCriteria $criteria): int
+    {
+        if ($criteria->hasEmptyHospitalScope()) {
+            return 0;
+        }
+
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+        $sql = sprintf('SELECT COUNT(*)::int AS cnt FROM allocation_stats_projection WHERE %s', $where);
+
+        return (int) $this->connection->fetchOne($sql, $params);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetOverviewSummaryQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetOverviewSummaryQuery.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewSummaryResult;
+use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
+use Doctrine\DBAL\Connection;
+
+final readonly class GetOverviewSummaryQuery
+{
+    public function __construct(
+        private Connection $connection,
+        private ProjectionFeatureQuery $projectionFeatureQuery,
+    ) {
+    }
+
+    public function __invoke(OverviewQueryCriteria $criteria): OverviewSummaryResult
+    {
+        if ($criteria->hasEmptyHospitalScope()) {
+            return new OverviewSummaryResult(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        }
+
+        $hasExtended = $this->projectionFeatureQuery->hasExtendedClinicalFeatureColumns();
+        $shockExpr = $hasExtended ? 'COUNT(*) FILTER (WHERE is_shock = true)' : '0';
+        $pregnantExpr = $hasExtended ? 'COUNT(*) FILTER (WHERE is_pregnant = true)' : '0';
+        $workAccidentExpr = $hasExtended ? 'COUNT(*) FILTER (WHERE is_work_accident = true)' : '0';
+
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+
+        $sql = <<<SQL
+SELECT
+    COUNT(*)::int AS total,
+    COUNT(*) FILTER (WHERE is_with_physician = true)::int AS with_physician,
+    COUNT(*) FILTER (WHERE is_cpr = true)::int AS cpr,
+    COUNT(*) FILTER (WHERE is_ventilated = true)::int AS ventilated,
+    {$shockExpr}::int AS shock,
+    {$pregnantExpr}::int AS pregnant,
+    {$workAccidentExpr}::int AS work_accident,
+    COUNT(*) FILTER (WHERE infection_id IS NOT NULL)::int AS infectious,
+    COUNT(*) FILTER (WHERE requires_cathlab = true)::int AS cathlab,
+    COUNT(*) FILTER (WHERE requires_resus = true)::int AS resus
+FROM allocation_stats_projection
+WHERE {$where}
+SQL;
+
+        $fetched = $this->connection->fetchAssociative($sql, $params);
+        /** @var array<string, int|string|null> $row */
+        $row = false === $fetched ? [] : $fetched;
+
+        return new OverviewSummaryResult(
+            (int) ($row['total'] ?? 0),
+            (int) ($row['with_physician'] ?? 0),
+            (int) ($row['cpr'] ?? 0),
+            (int) ($row['ventilated'] ?? 0),
+            (int) ($row['shock'] ?? 0),
+            (int) ($row['pregnant'] ?? 0),
+            (int) ($row['work_accident'] ?? 0),
+            (int) ($row['infectious'] ?? 0),
+            (int) ($row['cathlab'] ?? 0),
+            (int) ($row['resus'] ?? 0),
+        );
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/GetOverviewUrgencyDistributionQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/GetOverviewUrgencyDistributionQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\Mapping\AllocationStatsUrgencyProjectionCode;
+use Doctrine\DBAL\Connection;
+
+final readonly class GetOverviewUrgencyDistributionQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<int, int> urgency code => count
+     */
+    public function __invoke(OverviewQueryCriteria $criteria): array
+    {
+        if ($criteria->hasEmptyHospitalScope()) {
+            return [];
+        }
+
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+        $sql = <<<SQL
+SELECT urgency_code AS code, COUNT(*)::int AS count
+FROM allocation_stats_projection
+WHERE {$where}
+GROUP BY urgency_code
+SQL;
+
+        /** @var list<array{code: int|string, count: int|string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        $out = [];
+        foreach ($rows as $row) {
+            $urgency = (int) $row['code'];
+            if (null !== AllocationStatsUrgencyProjectionCode::tryFrom($urgency)) {
+                $out[$urgency] = (int) $row['count'];
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Ensures overview materialized views exist (required when the test DB is reset via schema tooling).
+ */
+final class OverviewMaterializedViewsInstaller
+{
+    private static bool $ensured = false;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly MaterializedViewRefresher $materializedViewRefresher,
+        private readonly string $kernelEnvironment,
+    ) {
+    }
+
+    public function ensureInstalled(): void
+    {
+        if (self::$ensured) {
+            return;
+        }
+
+        $overviewViews = StatisticsMaterializedViewGroups::viewsForGroup(StatisticsMaterializedViewGroups::OVERVIEW);
+        $probeView = $overviewViews[0];
+
+        if ($this->isMaterializedViewInstalled($probeView)) {
+            self::$ensured = true;
+
+            return;
+        }
+
+        if ($this->isWrongRelationKind($probeView)) {
+            foreach ($overviewViews as $viewName) {
+                $this->dropWrongRelation($viewName);
+            }
+        }
+
+        if ('test' !== $this->kernelEnvironment) {
+            throw new \RuntimeException('Overview materialized views are missing. Run doctrine migrations or app:statistics:refresh-mviews --overview.');
+        }
+
+        $this->connection->executeStatement(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_state_hospital_count AS
+SELECT state_id, COUNT(DISTINCT hospital_id)::int AS hospital_count
+FROM allocation_stats_projection
+WHERE state_id IS NOT NULL
+GROUP BY state_id
+SQL);
+        $this->connection->executeStatement('CREATE UNIQUE INDEX idx_mv_projection_state_hospital_count_state ON mv_projection_state_hospital_count (state_id)');
+
+        $this->connection->executeStatement(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_dispatch_area_hospital_count AS
+SELECT dispatch_area_id, COUNT(DISTINCT hospital_id)::int AS hospital_count
+FROM allocation_stats_projection
+WHERE dispatch_area_id IS NOT NULL
+GROUP BY dispatch_area_id
+SQL);
+        $this->connection->executeStatement('CREATE UNIQUE INDEX idx_mv_projection_dispatch_area_hospital_count_area ON mv_projection_dispatch_area_hospital_count (dispatch_area_id)');
+
+        $this->connection->executeStatement(<<<'SQL'
+CREATE MATERIALIZED VIEW mv_projection_hospital_dimensions AS
+SELECT
+    hospital_id,
+    MIN(state_id) AS state_id,
+    MIN(dispatch_area_id) AS dispatch_area_id,
+    MIN(hospital_location_code) AS hospital_location_code,
+    MIN(hospital_tier_code) AS hospital_tier_code
+FROM allocation_stats_projection
+GROUP BY hospital_id
+SQL);
+        $this->connection->executeStatement('CREATE UNIQUE INDEX idx_mv_projection_hospital_dimensions_hospital ON mv_projection_hospital_dimensions (hospital_id)');
+
+        self::$ensured = true;
+    }
+
+    public function refreshIfInstalled(): void
+    {
+        $this->ensureInstalled();
+
+        $overviewViews = StatisticsMaterializedViewGroups::viewsForGroup(StatisticsMaterializedViewGroups::OVERVIEW);
+        if (!$this->isMaterializedViewInstalled($overviewViews[0])) {
+            return;
+        }
+
+        $this->materializedViewRefresher->refresh(
+            [StatisticsMaterializedViewGroups::OVERVIEW],
+            concurrently: false,
+        );
+    }
+
+    private function isMaterializedViewInstalled(string $viewName): bool
+    {
+        return 'm' === $this->relationKind($viewName);
+    }
+
+    private function isWrongRelationKind(string $viewName): bool
+    {
+        $kind = $this->relationKind($viewName);
+
+        return null !== $kind && 'm' !== $kind;
+    }
+
+    private function relationKind(string $relationName): ?string
+    {
+        $kind = $this->connection->fetchOne(
+            'SELECT relkind FROM pg_class WHERE oid = to_regclass(:relation)',
+            ['relation' => $relationName],
+        );
+
+        return \is_string($kind) ? $kind : null;
+    }
+
+    private function dropWrongRelation(string $relationName): void
+    {
+        if (null === $this->relationKind($relationName)) {
+            return;
+        }
+
+        $this->connection->executeStatement(sprintf('DROP TABLE IF EXISTS %s CASCADE', $relationName));
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
@@ -22,6 +22,11 @@ final class OverviewMaterializedViewsInstaller
     ) {
     }
 
+    public function resetInstallationState(): void
+    {
+        self::$ensured = false;
+    }
+
     public function ensureInstalled(): void
     {
         if (self::$ensured) {

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewProjectionSqlFilter.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewProjectionSqlFilter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+/**
+ * Builds SQL WHERE fragments and DBAL parameters for allocation_stats_projection reads.
+ */
+final class OverviewProjectionSqlFilter
+{
+    /**
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    public static function buildWhereClause(OverviewQueryCriteria $criteria, string $tableAlias = ''): array
+    {
+        $prefix = '' === $tableAlias ? '' : $tableAlias.'.';
+        $conditions = ['1 = 1'];
+        $params = [];
+
+        if ($criteria->from instanceof \DateTimeImmutable) {
+            $conditions[] = sprintf('%screated_at >= :from', $prefix);
+            $params['from'] = $criteria->from->format('Y-m-d H:i:s');
+        }
+
+        if ($criteria->toExclusive instanceof \DateTimeImmutable) {
+            $conditions[] = sprintf('%screated_at < :to_exclusive', $prefix);
+            $params['to_exclusive'] = $criteria->toExclusive->format('Y-m-d H:i:s');
+        }
+
+        if (\is_array($criteria->hospitalIds)) {
+            $ids = array_map(static fn (int $id): int => $id, $criteria->hospitalIds);
+            $conditions[] = sprintf('%shospital_id IN (%s)', $prefix, implode(',', $ids));
+        }
+
+        return [implode(' AND ', $conditions), $params];
+    }
+}

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewQueryCriteria.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewQueryCriteria.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\Overview;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+
+final readonly class OverviewQueryCriteria
+{
+    /**
+     * @param list<int>|null $hospitalIds null = no hospital filter; empty list = no matching rows
+     */
+    public function __construct(
+        public ?\DateTimeImmutable $from,
+        public ?\DateTimeImmutable $toExclusive,
+        public ?array $hospitalIds,
+    ) {
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     */
+    public static function fromPeriodBounds(StatisticsPeriodBounds $bounds, ?array $hospitalIds): self
+    {
+        return new self($bounds->from, $bounds->toExclusive, $hospitalIds);
+    }
+
+    public function hasEmptyHospitalScope(): bool
+    {
+        return \is_array($this->hospitalIds) && [] === $this->hospitalIds;
+    }
+}

--- a/src/Statistics/Infrastructure/Query/PivotAllocationAggregationQuery.php
+++ b/src/Statistics/Infrastructure/Query/PivotAllocationAggregationQuery.php
@@ -30,7 +30,7 @@ final readonly class PivotAllocationAggregationQuery
      * @return list<PivotCell>
      */
     public function fetchCells(
-        \DateTimeImmutable $from,
+        ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         PivotRowAxis $row,

--- a/src/Statistics/Infrastructure/Query/ProjectionDiagnosisQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionDiagnosisQuery.php
@@ -21,7 +21,7 @@ final readonly class ProjectionDiagnosisQuery
      *
      * @return list<array{label:string,count:int}>
      */
-    public function fetchTopDiagnosisAggregates(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, int $limit): array
+    public function fetchTopDiagnosisAggregates(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, int $limit): array
     {
         $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds)
             ->leftJoin(\App\Allocation\Domain\Entity\IndicationNormalized::class, 'inorm', 'WITH', 'inorm.id = p.indicationNormalizedId')
@@ -43,7 +43,7 @@ final readonly class ProjectionDiagnosisQuery
     /**
      * @param list<int>|null $hospitalIds
      */
-    private function createBaseQb(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
+    private function createBaseQb(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');

--- a/src/Statistics/Infrastructure/Query/ProjectionFeatureQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionFeatureQuery.php
@@ -23,7 +23,7 @@ final class ProjectionFeatureQuery
      *
      * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int}
      */
-    public function clinicalFeatureCounts(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function clinicalFeatureCounts(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $hasExtendedClinicalFeatures = $this->hasExtendedClinicalFeatureColumns();
         $shockExpr = $hasExtendedClinicalFeatures ? 'SUM(CASE WHEN p.isShock = true THEN 1 ELSE 0 END) AS shock' : '0 AS shock';
@@ -59,7 +59,7 @@ final class ProjectionFeatureQuery
      *
      * @return array{cathlab:int,resus:int}
      */
-    public function resourceFeatureCounts(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function resourceFeatureCounts(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select(
@@ -81,7 +81,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketClinicalFeatures('month', $from, $toExclusive, $hospitalIds);
     }
@@ -91,7 +91,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByDay(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByDay(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketClinicalFeatures('day', $from, $toExclusive, $hospitalIds);
     }
@@ -101,7 +101,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByCalendarMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByCalendarMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketClinicalFeatures('calendar', $from, $toExclusive, $hospitalIds);
     }
@@ -111,7 +111,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketResources('month', $from, $toExclusive, $hospitalIds);
     }
@@ -121,7 +121,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByDay(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByDay(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketResources('day', $from, $toExclusive, $hospitalIds);
     }
@@ -131,7 +131,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByCalendarMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByCalendarMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketResources('calendar', $from, $toExclusive, $hospitalIds);
     }
@@ -139,7 +139,7 @@ final class ProjectionFeatureQuery
     /**
      * @param list<int>|null $hospitalIds
      */
-    private function createBaseCountQb(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
+    private function createBaseCountQb(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');
@@ -154,7 +154,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,work_accident:int,infectious:int,with_any:int}>
      */
-    private function bucketClinicalFeatures(string $mode, \DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    private function bucketClinicalFeatures(string $mode, ?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $hasExtendedClinicalFeatures = $this->hasExtendedClinicalFeatureColumns();
         [$bucketFields, $bucketGroupBy, $bucketKeyFromRow] = $this->bucketSpec($mode);
@@ -199,7 +199,7 @@ final class ProjectionFeatureQuery
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    private function bucketResources(string $mode, \DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    private function bucketResources(string $mode, ?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         [$bucketFields, $bucketGroupBy, $bucketKeyFromRow] = $this->bucketSpec($mode);
         $select = array_merge($bucketFields, [
@@ -254,7 +254,7 @@ final class ProjectionFeatureQuery
         };
     }
 
-    private function hasExtendedClinicalFeatureColumns(): bool
+    public function hasExtendedClinicalFeatureColumns(): bool
     {
         if (\is_bool($this->hasExtendedClinicalFeatureColumns)) {
             return $this->hasExtendedClinicalFeatureColumns;

--- a/src/Statistics/Infrastructure/Query/ProjectionFilterApplier.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionFilterApplier.php
@@ -13,11 +13,13 @@ final class ProjectionFilterApplier
     public function applyCreatedAtRange(
         QueryBuilder $qb,
         string $field,
-        \DateTimeImmutable $from,
+        ?\DateTimeImmutable $from,
         ?\DateTimeImmutable $toExclusive,
     ): void {
-        $qb->andWhere(sprintf('%s >= :from', $field))
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
+        if ($from instanceof \DateTimeImmutable) {
+            $qb->andWhere(sprintf('%s >= :from', $field))
+                ->setParameter('from', $from, Types::DATETIME_IMMUTABLE);
+        }
 
         if ($toExclusive instanceof \DateTimeImmutable) {
             $qb->andWhere(sprintf('%s < :toExclusive', $field))

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -22,7 +22,7 @@ final readonly class ProjectionTimeSeriesQuery
     /**
      * @param list<int>|null $hospitalIds
      */
-    public function countCreatedInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): int
+    public function countCreatedInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): int
     {
         return (int) $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('COUNT(p.id)')
@@ -89,7 +89,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return list<array{year:int,month:int,count:int}>
      */
-    public function countByMonthInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByMonthInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdYear AS year', 'p.createdMonth AS month', 'COUNT(p.id) AS count')
@@ -115,7 +115,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return list<array{year:int,count:int}>
      */
-    public function countByYearInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByYearInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdYear AS year', 'COUNT(p.id) AS count')
@@ -137,9 +137,63 @@ final readonly class ProjectionTimeSeriesQuery
     /**
      * @param list<int>|null $hospitalIds
      *
+     * @return list<array{year:int,count:int}>
+     */
+    public function countGroupedByCreatedYear(int $startYear, ?int $endYearExclusive, ?array $hospitalIds): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->from(AllocationStatsProjection::class, 'p')
+            ->andWhere('p.createdYear >= :startYear')
+            ->setParameter('startYear', $startYear)
+            ->select('p.createdYear AS year', 'COUNT(p.id) AS count')
+            ->groupBy('year')
+            ->orderBy('year', 'ASC');
+
+        if (null !== $endYearExclusive) {
+            $qb->andWhere('p.createdYear < :endYearExclusive')
+                ->setParameter('endYearExclusive', $endYearExclusive);
+        }
+
+        $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+
+        /** @var list<array{year:numeric-string|int,count:numeric-string|int}> $raw */
+        $raw = $qb->getQuery()->getArrayResult();
+
+        return array_map(
+            static fn (array $row): array => [
+                'year' => (int) $row['year'],
+                'count' => (int) $row['count'],
+            ],
+            $raw,
+        );
+    }
+
+    public function countWithCreatedYearBefore(int $beforeYear): int
+    {
+        static $cache = [];
+        if (\array_key_exists($beforeYear, $cache)) {
+            return $cache[$beforeYear];
+        }
+
+        $count = (int) $this->entityManager->createQueryBuilder()
+            ->from(AllocationStatsProjection::class, 'p')
+            ->select('COUNT(p.id)')
+            ->where('p.createdYear < :beforeYear')
+            ->setParameter('beforeYear', $beforeYear)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        $cache[$beforeYear] = $count;
+
+        return $count;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
      * @return array<string,int>
      */
-    public function countByDayInPeriod(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByDayInPeriod(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdYear AS year', 'p.createdMonth AS month', 'p.createdDay AS day', 'COUNT(p.id) AS count')
@@ -163,7 +217,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,int>
      */
-    public function countByCalendarMonthInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByCalendarMonthInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdMonth AS month', 'COUNT(p.id) AS count')
@@ -185,7 +239,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,int>
      */
-    public function countGroupedByGenderInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countGroupedByGenderInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.genderCode AS genderCode', 'COUNT(p.id) AS count')
@@ -215,7 +269,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<int,int>
      */
-    public function countGroupedByUrgencyInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countGroupedByUrgencyInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.urgencyCode AS urgencyCode', 'COUNT(p.id) AS count')
@@ -239,7 +293,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByMonthAndGender(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByMonthAndGender(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByMonthCode('genderCode', $from, $toExclusive, $hospitalIds, static fn (int $code): ?string => match ($code) {
             AllocationStatsGenderProjectionCode::Male->value => 'M',
@@ -254,7 +308,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByMonthAndUrgency(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByMonthAndUrgency(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByMonthCode('urgencyCode', $from, $toExclusive, $hospitalIds, static fn (int $code): string => (string) $code);
     }
@@ -264,7 +318,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByDayAndGender(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByDayAndGender(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByDayCode('genderCode', $from, $toExclusive, $hospitalIds, static fn (int $code): ?string => match ($code) {
             AllocationStatsGenderProjectionCode::Male->value => 'M',
@@ -279,7 +333,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByDayAndUrgency(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByDayAndUrgency(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByDayCode('urgencyCode', $from, $toExclusive, $hospitalIds, static fn (int $code): string => (string) $code);
     }
@@ -289,7 +343,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByCalendarMonthAndGender(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByCalendarMonthAndGender(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByCalendarMonthCode('genderCode', $from, $toExclusive, $hospitalIds, static fn (int $code): ?string => match ($code) {
             AllocationStatsGenderProjectionCode::Male->value => 'M',
@@ -304,7 +358,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    public function bucketByCalendarMonthAndUrgency(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByCalendarMonthAndUrgency(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->bucketByCalendarMonthCode('urgencyCode', $from, $toExclusive, $hospitalIds, static fn (int $code): string => (string) $code);
     }
@@ -312,7 +366,7 @@ final readonly class ProjectionTimeSeriesQuery
     /**
      * @param list<int>|null $hospitalIds
      */
-    private function createBaseCountQb(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
+    private function createBaseCountQb(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
     {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');
@@ -328,7 +382,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    private function bucketByMonthCode(string $field, \DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
+    private function bucketByMonthCode(string $field, ?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdYear AS year', 'p.createdMonth AS month', sprintf('p.%s AS code', $field), 'COUNT(p.id) AS count')
@@ -358,7 +412,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    private function bucketByDayCode(string $field, \DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
+    private function bucketByDayCode(string $field, ?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdYear AS year', 'p.createdMonth AS month', 'p.createdDay AS day', sprintf('p.%s AS code', $field), 'COUNT(p.id) AS count')
@@ -388,7 +442,7 @@ final readonly class ProjectionTimeSeriesQuery
      *
      * @return array<string,array<string,int>>
      */
-    private function bucketByCalendarMonthCode(string $field, \DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
+    private function bucketByCalendarMonthCode(string $field, ?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, \Closure $keyMapper): array
     {
         $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
             ->select('p.createdMonth AS month', sprintf('p.%s AS code', $field), 'COUNT(p.id) AS count')

--- a/src/Statistics/Infrastructure/Repository/AllocationStatsProjectionRepository.php
+++ b/src/Statistics/Infrastructure/Repository/AllocationStatsProjectionRepository.php
@@ -28,7 +28,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
     /**
      * @param list<int>|null $hospitalIds
      */
-    public function countCreatedInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): int
+    public function countCreatedInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): int
     {
         return $this->timeSeriesQuery->countCreatedInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -48,7 +48,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return list<array{year:int,month:int,count:int}>
      */
-    public function countByMonthInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByMonthInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->countByMonthInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -58,7 +58,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,int>
      */
-    public function countByDayInPeriod(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByDayInPeriod(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->countByDayInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -68,7 +68,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,int>
      */
-    public function countByCalendarMonthInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countByCalendarMonthInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->countByCalendarMonthInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -78,7 +78,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,int>
      */
-    public function countGroupedByGenderInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countGroupedByGenderInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->countGroupedByGenderInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -88,7 +88,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<int,int>
      */
-    public function countGroupedByUrgencyInPeriod(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function countGroupedByUrgencyInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->countGroupedByUrgencyInPeriod($from, $toExclusive, $hospitalIds);
     }
@@ -98,7 +98,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByMonthAndGender(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByMonthAndGender(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByMonthAndGender($from, $toExclusive, $hospitalIds);
     }
@@ -108,7 +108,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByMonthAndUrgency(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByMonthAndUrgency(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByMonthAndUrgency($from, $toExclusive, $hospitalIds);
     }
@@ -118,7 +118,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByDayAndGender(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByDayAndGender(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByDayAndGender($from, $toExclusive, $hospitalIds);
     }
@@ -128,7 +128,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByDayAndUrgency(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByDayAndUrgency(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByDayAndUrgency($from, $toExclusive, $hospitalIds);
     }
@@ -138,7 +138,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByCalendarMonthAndGender(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByCalendarMonthAndGender(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByCalendarMonthAndGender($from, $toExclusive, $hospitalIds);
     }
@@ -148,7 +148,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string, array<string,int>>
      */
-    public function bucketByCalendarMonthAndUrgency(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketByCalendarMonthAndUrgency(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->timeSeriesQuery->bucketByCalendarMonthAndUrgency($from, $toExclusive, $hospitalIds);
     }
@@ -158,7 +158,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int}
      */
-    public function clinicalFeatureCounts(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function clinicalFeatureCounts(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->clinicalFeatureCounts($from, $toExclusive, $hospitalIds);
     }
@@ -168,7 +168,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array{cathlab:int,resus:int}
      */
-    public function resourceFeatureCounts(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function resourceFeatureCounts(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->resourceFeatureCounts($from, $toExclusive, $hospitalIds);
     }
@@ -178,7 +178,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketClinicalFeaturesByMonth($from, $toExclusive, $hospitalIds);
     }
@@ -188,7 +188,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByDay(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByDay(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketClinicalFeaturesByDay($from, $toExclusive, $hospitalIds);
     }
@@ -198,7 +198,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{with_physician:int,cpr:int,ventilated:int,shock:int,pregnant:int,infectious:int,with_any:int}>
      */
-    public function bucketClinicalFeaturesByCalendarMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketClinicalFeaturesByCalendarMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketClinicalFeaturesByCalendarMonth($from, $toExclusive, $hospitalIds);
     }
@@ -208,7 +208,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketResourcesByMonth($from, $toExclusive, $hospitalIds);
     }
@@ -218,7 +218,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByDay(\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByDay(?\DateTimeImmutable $from, \DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketResourcesByDay($from, $toExclusive, $hospitalIds);
     }
@@ -228,7 +228,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return array<string,array{cathlab:int,resus:int,with_any:int}>
      */
-    public function bucketResourcesByCalendarMonth(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
+    public function bucketResourcesByCalendarMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
     {
         return $this->featureQuery->bucketResourcesByCalendarMonth($from, $toExclusive, $hospitalIds);
     }
@@ -238,7 +238,7 @@ final class AllocationStatsProjectionRepository extends ServiceEntityRepository
      *
      * @return list<array{label:string,count:int}>
      */
-    public function fetchTopDiagnosisAggregates(\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, int $limit): array
+    public function fetchTopDiagnosisAggregates(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, int $limit): array
     {
         return $this->diagnosisQuery->fetchTopDiagnosisAggregates($from, $toExclusive, $hospitalIds, $limit);
     }

--- a/src/Statistics/UI/Console/Command/RefreshMaterializedViewsCommand.php
+++ b/src/Statistics/UI/Console/Command/RefreshMaterializedViewsCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Console\Command;
+
+use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:statistics:refresh-mviews',
+    description: 'Refresh statistics materialized views (all groups by default).',
+)]
+final class RefreshMaterializedViewsCommand extends Command
+{
+    public function __construct(
+        private readonly MaterializedViewRefresher $materializedViewRefresher,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            'overview',
+            null,
+            InputOption::VALUE_NONE,
+            'Refresh only overview materialized views (state/dispatch hospital counts and hospital dimensions)',
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $groups = $input->getOption('overview')
+            ? [StatisticsMaterializedViewGroups::OVERVIEW]
+            : [];
+
+        $label = [] === $groups
+            ? 'all statistics materialized views'
+            : sprintf('materialized views for group(s): %s', implode(', ', $groups));
+
+        $io->title(sprintf('Refreshing %s', $label));
+
+        $failed = false;
+        foreach ($this->materializedViewRefresher->refresh($groups) as $result) {
+            $io->section($result['view']);
+            if ($result['success']) {
+                $io->success($result['message']);
+            } else {
+                $failed = true;
+                $io->error($result['message']);
+            }
+        }
+
+        return $failed ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/src/Statistics/UI/Http/Controller/DashboardController.php
+++ b/src/Statistics/UI/Http/Controller/DashboardController.php
@@ -10,6 +10,10 @@ use App\Statistics\Application\DTO\StatisticWidgetType;
 use App\Statistics\Application\HospitalSummaryProvider;
 use App\Statistics\Application\OverviewDashboardProvider;
 use App\Statistics\Application\StatisticsContextFactory;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Application\StatisticsScopeResolver;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewDashboardMetricsQuery;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +33,8 @@ final class DashboardController extends AbstractController
         private readonly StatisticsPublicScopeRedirector $publicScopeRedirector,
         private readonly StatisticsExplorerViewModelFactory $statisticsExplorerViewModelFactory,
         private readonly StatisticsFilterDrawerStateFactory $statisticsFilterDrawerStateFactory,
+        private readonly StatisticsScopeResolver $statisticsScopeResolver,
+        private readonly GetOverviewDashboardMetricsQuery $overviewDashboardMetricsQuery,
     ) {
     }
 
@@ -48,6 +54,10 @@ final class DashboardController extends AbstractController
         }
 
         $context = $this->statisticsContextFactory->create($user, $filter);
+        $overviewMetrics = ($this->overviewDashboardMetricsQuery)(OverviewQueryCriteria::fromPeriodBounds(
+            StatisticsPeriodResolver::resolve($filter),
+            $this->statisticsScopeResolver->resolveCriteria($context)->hospitalIds,
+        ));
         $pageViewModel = $this->statisticsPageViewModelFactory->create(
             $request,
             'app_stats_dashboard',
@@ -63,8 +73,8 @@ final class DashboardController extends AbstractController
 
         return $this->render('@Statistics/dashboard/index.html.twig', [
             'chartPairWidget' => $chartPairWidget,
-            'hospitalSummaryWidgets' => $this->hospitalSummaryProvider->build($context),
-            'clinicalFeatureWidgets' => $this->clinicalFeaturesProvider->build($context),
+            'hospitalSummaryWidgets' => $this->hospitalSummaryProvider->build($context, $overviewMetrics),
+            'clinicalFeatureWidgets' => $this->clinicalFeaturesProvider->build($context, $overviewMetrics),
             'statisticsFilter' => $pageViewModel->filter,
             'statsScopeUrls' => $pageViewModel->scopeUrls,
             'statsHospitalUrls' => $pageViewModel->hospitalUrls,

--- a/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
@@ -13,7 +13,8 @@ use App\Statistics\Application\Cohort\HospitalCohortType;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
-use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetEligibleDispatchAreaIdsQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery;
 use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
 use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
 use App\User\Domain\Entity\User;
@@ -28,7 +29,8 @@ final readonly class StatisticsPageViewModelFactory
         private HospitalCohortEligibilityChecker $hospitalCohortEligibilityChecker,
         private TranslatorInterface $translator,
         private StatisticsNavigationUrlBuilder $statisticsNavigationUrlBuilder,
-        private AllocationStatsProjectionScopeQuery $projectionScopeQuery,
+        private GetEligibleStateIdsQuery $eligibleStateIdsQuery,
+        private GetEligibleDispatchAreaIdsQuery $eligibleDispatchAreaIdsQuery,
         private StateRepository $stateRepository,
         private DispatchAreaRepository $dispatchAreaRepository,
     ) {
@@ -236,7 +238,7 @@ final readonly class StatisticsPageViewModelFactory
      */
     private function eligibleStateRows(): array
     {
-        $ids = $this->projectionScopeQuery->stateIdsWithAtLeastDistinctHospitals(2);
+        $ids = ($this->eligibleStateIdsQuery)(2);
         $rows = [];
         foreach ($ids as $stateId) {
             $state = $this->stateRepository->findById($stateId);
@@ -256,7 +258,7 @@ final readonly class StatisticsPageViewModelFactory
      */
     private function eligibleDispatchAreaRows(): array
     {
-        $ids = $this->projectionScopeQuery->dispatchAreaIdsWithAtLeastDistinctHospitals(2);
+        $ids = ($this->eligibleDispatchAreaIdsQuery)(2);
         $rows = [];
         foreach ($ids as $dispatchAreaId) {
             $area = $this->dispatchAreaRepository->findById($dispatchAreaId);

--- a/tests/Statistics/Integration/Query/AllocationStatsProjectionScopeQueryTest.php
+++ b/tests/Statistics/Integration/Query/AllocationStatsProjectionScopeQueryTest.php
@@ -33,6 +33,7 @@ use App\Statistics\Application\Mapping\AllocationStatsHospitalTierProjectionCode
 use App\Statistics\Application\StatisticsScopeResolver;
 use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
 use App\Statistics\UI\Http\Controller\StatisticsPageViewModelFactory;
+use App\Tests\Support\MaterializedView\RefreshesStatisticsMaterializedViewsTrait;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +43,7 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 final class AllocationStatsProjectionScopeQueryTest extends KernelTestCase
 {
     use Factories;
+    use RefreshesStatisticsMaterializedViewsTrait;
     use ResetDatabase;
 
     public function testResolvesDistinctHospitalsForStateAndDispatchArea(): void
@@ -105,6 +107,8 @@ final class AllocationStatsProjectionScopeQueryTest extends KernelTestCase
         $rebuilder->rebuildForImport($importA->getId());
         $rebuilder->rebuildForImport($importB->getId());
 
+        $this->refreshStatisticsMaterializedViews();
+
         $query = self::getContainer()->get(AllocationStatsProjectionScopeQuery::class);
         $stateId = $state->getId();
         $dispatchAreaId = $dispatchArea->getId();
@@ -154,7 +158,10 @@ final class AllocationStatsProjectionScopeQueryTest extends KernelTestCase
             ),
         );
 
-        self::assertSame([$hospitalA->getId(), $hospitalB->getId()], $scopeCriteria->hospitalIds);
+        self::assertEqualsCanonicalizing(
+            [$hospitalA->getId(), $hospitalB->getId()],
+            $scopeCriteria->hospitalIds,
+        );
 
         $pageModel = self::getContainer()->get(StatisticsPageViewModelFactory::class)->create(
             new Request(query: ['scope' => sprintf('state:%d', $stateId), 'period' => 'all']),

--- a/tests/Statistics/Integration/Query/Overview/GetOverviewDashboardMetricsQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/GetOverviewDashboardMetricsQueryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\Overview;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewDashboardMetricsQuery;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class GetOverviewDashboardMetricsQueryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testBundleMatchesLegacyOverviewQueriesForScopedHospital(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'dashboard-metrics-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DashboardMetricsState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'DashboardMetricsDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'DashboardMetricsHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'DashboardMetricsSpec']);
+        DepartmentFactory::createOne(['name' => 'DashboardMetricsDept']);
+        AssignmentFactory::createOne(['name' => 'DashboardMetricsAssign']);
+        OccasionFactory::createOne(['name' => 'DashboardMetricsOcc']);
+        SecondaryTransportFactory::createOne(['name' => 'DashboardMetricsSec']);
+        InfectionFactory::createOne(['name' => 'DashboardMetricsInf']);
+        IndicationRawFactory::createOne(['name' => 'DashboardMetricsRaw', 'code' => 912_350]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'DashboardMetricsNorm']);
+
+        $import = ImportFactory::createOne(['name' => 'DashboardMetricsImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => 40,
+            'requiresResus' => true,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => true,
+            'isWorkAccident' => false,
+            'isWithPhysician' => true,
+            'occasion' => null,
+            'infection' => null,
+            'indicationNormalized' => $indicationNormalized,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+        ]);
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($import->getId());
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospital->getId(),
+            null,
+            StatisticsFilterPeriod::All,
+        );
+        $bounds = StatisticsPeriodResolver::resolve($filter);
+        $hospitalIds = [$hospital->getId()];
+        $scopedCriteria = OverviewQueryCriteria::fromPeriodBounds($bounds, $hospitalIds);
+        $periodCriteria = OverviewQueryCriteria::fromPeriodBounds($bounds, null);
+
+        $container = self::getContainer();
+        $legacy = new OverviewLegacyQueryFactory(
+            $container->get(Connection::class),
+            $container->get(ProjectionFeatureQuery::class),
+        );
+
+        $bundle = (new GetOverviewDashboardMetricsQuery(
+            $container->get(Connection::class),
+            $container->get(ProjectionFeatureQuery::class),
+        ))($scopedCriteria);
+
+        $summary = $legacy->summary()($scopedCriteria);
+        $totals = $legacy->scopedTotals()($periodCriteria, $hospitalIds);
+        $gender = $legacy->gender()($scopedCriteria);
+        $urgency = $legacy->urgency()($scopedCriteria);
+
+        self::assertSame($totals->platformTotal, $bundle->platformTotal);
+        self::assertSame($totals->scopedTotal, $bundle->scopedTotal);
+        self::assertSame($summary->total, $bundle->scopedTotal);
+        self::assertSame($summary->withPhysician, $bundle->withPhysician);
+        self::assertSame($summary->cpr, $bundle->cpr);
+        self::assertSame($summary->ventilated, $bundle->ventilated);
+        self::assertSame($summary->infectious, $bundle->infectious);
+        self::assertSame($summary->cathlab, $bundle->cathlab);
+        self::assertSame($summary->resus, $bundle->resus);
+        self::assertSame($this->normalizedGender($gender), $bundle->genderCounts);
+        self::assertSame($this->normalizedUrgency($urgency), $bundle->urgencyCounts);
+    }
+
+    /**
+     * @param array<string, int> $raw
+     *
+     * @return array<string, int>
+     */
+    private function normalizedGender(array $raw): array
+    {
+        return [
+            'M' => $raw['M'] ?? 0,
+            'F' => $raw['F'] ?? 0,
+            'X' => $raw['X'] ?? 0,
+        ];
+    }
+
+    /**
+     * @param array<int, int> $raw
+     *
+     * @return array<int, int>
+     */
+    private function normalizedUrgency(array $raw): array
+    {
+        return [
+            1 => $raw[1] ?? 0,
+            2 => $raw[2] ?? 0,
+            3 => $raw[3] ?? 0,
+        ];
+    }
+}

--- a/tests/Statistics/Integration/Query/Overview/GetOverviewSummaryQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/GetOverviewSummaryQueryTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\Overview;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class GetOverviewSummaryQueryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testSummaryMatchesLegacyQueriesForPeriodAndScope(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'overview-summary-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'OverviewSummaryState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'OverviewSummaryDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'OverviewSummaryHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'OverviewSummarySpec']);
+        DepartmentFactory::createOne(['name' => 'OverviewSummaryDept']);
+        AssignmentFactory::createOne(['name' => 'OverviewSummaryAssign']);
+        OccasionFactory::createOne(['name' => 'OverviewSummaryOcc']);
+        SecondaryTransportFactory::createOne(['name' => 'OverviewSummarySec']);
+        InfectionFactory::createOne(['name' => 'OverviewSummaryInf']);
+        IndicationRawFactory::createOne(['name' => 'OverviewSummaryRaw', 'code' => 912_348]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'OverviewSummaryNorm']);
+
+        $import = ImportFactory::createOne(['name' => 'OverviewSummaryImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => 40,
+            'requiresResus' => true,
+            'requiresCathlab' => false,
+            'isCPR' => true,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => true,
+            'occasion' => null,
+            'infection' => null,
+            'indicationNormalized' => $indicationNormalized,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+        ]);
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($import->getId());
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospital->getId(),
+            null,
+            StatisticsFilterPeriod::All,
+        );
+        $bounds = StatisticsPeriodResolver::resolve($filter);
+        $criteria = OverviewQueryCriteria::fromPeriodBounds($bounds, [$hospital->getId()]);
+
+        $container = self::getContainer();
+        $legacy = new OverviewLegacyQueryFactory(
+            $container->get(Connection::class),
+            $container->get(ProjectionFeatureQuery::class),
+        );
+        $summary = $legacy->summary()($criteria);
+
+        $timeSeries = self::getContainer()->get(ProjectionTimeSeriesQuery::class);
+        $features = self::getContainer()->get(ProjectionFeatureQuery::class);
+
+        self::assertSame(
+            $timeSeries->countCreatedInPeriod($bounds->from, $bounds->toExclusive, [$hospital->getId()]),
+            $summary->total,
+        );
+
+        $clinical = $features->clinicalFeatureCounts($bounds->from, $bounds->toExclusive, [$hospital->getId()]);
+        self::assertSame($clinical['with_physician'], $summary->withPhysician);
+        self::assertSame($clinical['cpr'], $summary->cpr);
+        self::assertSame($clinical['ventilated'], $summary->ventilated);
+        self::assertSame($clinical['infectious'], $summary->infectious);
+
+        $resources = $features->resourceFeatureCounts($bounds->from, $bounds->toExclusive, [$hospital->getId()]);
+        self::assertSame($resources['cathlab'], $summary->cathlab);
+        self::assertSame($resources['resus'], $summary->resus);
+    }
+
+    public function testAllTimeCriteriaOmitsCreatedAtLowerBound(): void
+    {
+        self::bootKernel();
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Public,
+            null,
+            null,
+            StatisticsFilterPeriod::AllTime,
+        );
+        $bounds = StatisticsPeriodResolver::resolve($filter);
+        self::assertNull($bounds->from);
+
+        $criteria = OverviewQueryCriteria::fromPeriodBounds($bounds, null);
+        $container = self::getContainer();
+        $legacy = new OverviewLegacyQueryFactory(
+            $container->get(Connection::class),
+            $container->get(ProjectionFeatureQuery::class),
+        );
+        $summary = $legacy->summary()($criteria);
+
+        self::assertGreaterThanOrEqual(0, $summary->total);
+    }
+}

--- a/tests/Statistics/Integration/Query/Overview/OverviewLegacyQueryFactory.php
+++ b/tests/Statistics/Integration/Query/Overview/OverviewLegacyQueryFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\Overview;
+
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewGenderDistributionQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewScopedTotalsQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewSummaryQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewUrgencyDistributionQuery;
+use App\Statistics\Infrastructure\Query\ProjectionFeatureQuery;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Legacy overview queries are no longer wired in the application container; tests construct them directly.
+ */
+final readonly class OverviewLegacyQueryFactory
+{
+    public function __construct(
+        private Connection $connection,
+        private ProjectionFeatureQuery $projectionFeatureQuery,
+    ) {
+    }
+
+    public function summary(): GetOverviewSummaryQuery
+    {
+        return new GetOverviewSummaryQuery($this->connection, $this->projectionFeatureQuery);
+    }
+
+    public function gender(): GetOverviewGenderDistributionQuery
+    {
+        return new GetOverviewGenderDistributionQuery($this->connection);
+    }
+
+    public function urgency(): GetOverviewUrgencyDistributionQuery
+    {
+        return new GetOverviewUrgencyDistributionQuery($this->connection);
+    }
+
+    public function scopedTotals(): GetOverviewScopedTotalsQuery
+    {
+        return new GetOverviewScopedTotalsQuery($this->connection);
+    }
+}

--- a/tests/Statistics/Integration/Query/Overview/OverviewMaterializedViewQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/OverviewMaterializedViewQueryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\Overview;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount;
+use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
+use App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForStateQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery;
+use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class OverviewMaterializedViewQueryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testMaterializedViewQueriesMatchProjectionScopeAfterRefresh(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'mv-overview-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'MvOverviewState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'MvOverviewDispatch', 'state' => $state]);
+        $hospitalA = HospitalFactory::createOne([
+            'name' => 'MvOverviewHospitalA',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $hospitalB = HospitalFactory::createOne([
+            'name' => 'MvOverviewHospitalB',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'MvOverviewSpec']);
+        DepartmentFactory::createOne(['name' => 'MvOverviewDept']);
+        AssignmentFactory::createOne(['name' => 'MvOverviewAssign']);
+        OccasionFactory::createOne(['name' => 'MvOverviewOcc']);
+        SecondaryTransportFactory::createOne(['name' => 'MvOverviewSec']);
+        InfectionFactory::createOne(['name' => 'MvOverviewInf']);
+        IndicationRawFactory::createOne(['name' => 'MvOverviewRaw', 'code' => 912_349]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'MvOverviewNorm']);
+
+        $importA = ImportFactory::createOne(['name' => 'MvOverviewImportA', 'hospital' => $hospitalA, 'createdBy' => $user]);
+        $importB = ImportFactory::createOne(['name' => 'MvOverviewImportB', 'hospital' => $hospitalB, 'createdBy' => $user]);
+
+        $allocationDefaults = [
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => 40,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => false,
+            'occasion' => null,
+            'infection' => null,
+            'indicationNormalized' => $indicationNormalized,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+        ];
+
+        AllocationFactory::createOne(array_merge($allocationDefaults, ['import' => $importA, 'hospital' => $hospitalA]));
+        AllocationFactory::createOne(array_merge($allocationDefaults, ['import' => $importB, 'hospital' => $hospitalB]));
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($importA->getId());
+        $rebuilder->rebuildForImport($importB->getId());
+
+        self::getContainer()->get(OverviewMaterializedViewsInstaller::class)->refreshIfInstalled();
+
+        $legacy = self::getContainer()->get(AllocationStatsProjectionScopeQuery::class);
+        $stateId = $state->getId();
+
+        self::assertSame(
+            $legacy->stateIdsWithAtLeastDistinctHospitals(2),
+            self::getContainer()->get(GetEligibleStateIdsQuery::class)(2),
+        );
+        $legacyHospitalIds = $legacy->distinctHospitalIdsForState($stateId);
+        $mvHospitalIds = self::getContainer()->get(GetDistinctHospitalIdsByStateQuery::class)($stateId);
+        sort($legacyHospitalIds);
+        sort($mvHospitalIds);
+        self::assertSame($legacyHospitalIds, $mvHospitalIds);
+        self::assertSame(
+            2,
+            self::getContainer()->get(CountDistinctHospitalsForStateQuery::class)($stateId),
+        );
+
+        $entity = self::getContainer()->get(EntityManagerInterface::class)
+            ->find(ProjectionStateHospitalCount::class, $stateId);
+        self::assertInstanceOf(ProjectionStateHospitalCount::class, $entity);
+        self::assertSame(2, $entity->getHospitalCount());
+    }
+}

--- a/tests/Statistics/Integration/Query/Overview/OverviewMaterializedViewQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/OverviewMaterializedViewQueryTest.php
@@ -28,7 +28,7 @@ use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
 use App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForStateQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery;
-use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
+use App\Tests\Support\MaterializedView\RefreshesStatisticsMaterializedViewsTrait;
 use App\User\Domain\Factory\UserFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -38,6 +38,7 @@ use Zenstruck\Foundry\Test\ResetDatabase;
 final class OverviewMaterializedViewQueryTest extends KernelTestCase
 {
     use Factories;
+    use RefreshesStatisticsMaterializedViewsTrait;
     use ResetDatabase;
 
     public function testMaterializedViewQueriesMatchProjectionScopeAfterRefresh(): void
@@ -101,7 +102,7 @@ final class OverviewMaterializedViewQueryTest extends KernelTestCase
         $rebuilder->rebuildForImport($importA->getId());
         $rebuilder->rebuildForImport($importB->getId());
 
-        self::getContainer()->get(OverviewMaterializedViewsInstaller::class)->refreshIfInstalled();
+        $this->refreshStatisticsMaterializedViews();
 
         $legacy = self::getContainer()->get(AllocationStatsProjectionScopeQuery::class);
         $stateId = $state->getId();

--- a/tests/Statistics/Integration/Query/ProjectionTimeSeriesCreatedYearQueryTest.php
+++ b/tests/Statistics/Integration/Query/ProjectionTimeSeriesCreatedYearQueryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ProjectionTimeSeriesCreatedYearQueryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testCountGroupedByCreatedYearMatchesCountByYearInPeriodForCalendarYearStart(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'created-year-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'CreatedYearState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'CreatedYearDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'CreatedYearHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'CreatedYearSpec']);
+        DepartmentFactory::createOne(['name' => 'CreatedYearDept']);
+        AssignmentFactory::createOne(['name' => 'CreatedYearAssign']);
+        OccasionFactory::createOne(['name' => 'CreatedYearOcc']);
+        SecondaryTransportFactory::createOne(['name' => 'CreatedYearSec']);
+        InfectionFactory::createOne(['name' => 'CreatedYearInf']);
+        IndicationRawFactory::createOne(['name' => 'CreatedYearRaw', 'code' => 912_351]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'CreatedYearNorm']);
+
+        $import = ImportFactory::createOne(['name' => 'CreatedYearImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => 40,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => false,
+            'occasion' => null,
+            'infection' => null,
+            'indicationNormalized' => $indicationNormalized,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+        ]);
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($import->getId());
+
+        $query = self::getContainer()->get(ProjectionTimeSeriesQuery::class);
+        $startYear = 2025;
+        $fromDate = new \DateTimeImmutable(sprintf('%04d-01-01 00:00:00', $startYear));
+
+        $byYearColumn = $query->countGroupedByCreatedYear($startYear, null, null);
+        $byCreatedAt = $query->countByYearInPeriod($fromDate, null, null);
+
+        self::assertSame($byCreatedAt, $byYearColumn);
+        self::assertSame($query->countBefore($fromDate), $query->countWithCreatedYearBefore($startYear));
+    }
+}

--- a/tests/Statistics/Unit/Infrastructure/Query/OverviewProjectionSqlFilterTest.php
+++ b/tests/Statistics/Unit/Infrastructure/Query/OverviewProjectionSqlFilterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Infrastructure\Query;
+
+use App\Statistics\Infrastructure\Query\Overview\OverviewProjectionSqlFilter;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use PHPUnit\Framework\TestCase;
+
+final class OverviewProjectionSqlFilterTest extends TestCase
+{
+    public function testOmitsCreatedAtWhenFromIsNull(): void
+    {
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause(
+            new OverviewQueryCriteria(null, null, null),
+        );
+
+        self::assertStringNotContainsString('created_at', $where);
+        self::assertArrayNotHasKey('from', $params);
+    }
+
+    public function testAddsCreatedAtWhenFromIsSet(): void
+    {
+        $from = new \DateTimeImmutable('2025-01-01 00:00:00');
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause(
+            new OverviewQueryCriteria($from, null, null),
+        );
+
+        self::assertStringContainsString('created_at >= :from', $where);
+        self::assertSame('2025-01-01 00:00:00', $params['from']);
+        self::assertStringNotContainsString('1970', $params['from']);
+    }
+}

--- a/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
+++ b/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\Foundry;
+
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewDropper;
+use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
+
+/**
+ * Drops statistics materialized views before Foundry's schema reset and recreates them afterwards.
+ *
+ * @see tests/Support/MaterializedView/README.md
+ */
+final readonly class MaterializedViewAwareOrmResetter implements OrmResetter
+{
+    public function __construct(
+        private OrmResetter $decorated,
+        private StatisticsMaterializedViewDropper $materializedViewDropper,
+        private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+    ) {
+    }
+
+    public function resetBeforeFirstTest(KernelInterface $kernel): void
+    {
+        $this->prepareSchemaReset();
+        $this->decorated->resetBeforeFirstTest($kernel);
+        $this->finishSchemaReset();
+    }
+
+    public function resetBeforeEachTest(KernelInterface $kernel): void
+    {
+        $this->prepareSchemaReset();
+        $this->decorated->resetBeforeEachTest($kernel);
+        $this->finishSchemaReset();
+    }
+
+    private function prepareSchemaReset(): void
+    {
+        $this->materializedViewDropper->dropAllForSchemaReset();
+        $this->materializedViewsInstaller->resetInstallationState();
+    }
+
+    private function finishSchemaReset(): void
+    {
+        $this->materializedViewsInstaller->ensureInstalled();
+    }
+}

--- a/tests/Support/MaterializedView/README.md
+++ b/tests/Support/MaterializedView/README.md
@@ -1,0 +1,8 @@
+# Materialized views in tests
+
+See the full guide: [docs/statistics/projection-and-materialized-views.md](../../../docs/statistics/projection-and-materialized-views.md).
+
+Quick reminders:
+
+- **DROP before Foundry reset** — test-only `MaterializedViewAwareOrmResetter` drops `mv_projection_*` so `doctrine:schema:drop --full-database` can succeed.
+- **REFRESH after fixtures** — use `RefreshesStatisticsMaterializedViewsTrait::refreshStatisticsMaterializedViews()` when assertions use MV-backed queries or `StatisticsFilterFactory` state/dispatch scopes.

--- a/tests/Support/MaterializedView/RefreshesStatisticsMaterializedViewsTrait.php
+++ b/tests/Support/MaterializedView/RefreshesStatisticsMaterializedViewsTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\MaterializedView;
+
+use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Refreshes overview statistics materialized views after test fixtures were created.
+ *
+ * @phpstan-require-extends KernelTestCase
+ */
+trait RefreshesStatisticsMaterializedViewsTrait
+{
+    protected function refreshStatisticsMaterializedViews(): void
+    {
+        self::getContainer()->get(MaterializedViewRefresher::class)->refresh(
+            [StatisticsMaterializedViewGroups::OVERVIEW],
+            concurrently: false,
+        );
+    }
+}


### PR DESCRIPTION
### Summary

- Optimized statistics overview queries for dashboard and analytics workloads
- Added support for all-time periods without applying a synthetic lower `created_at` bound
- Introduced projection-backed materialized views for scope and hospital dimension reads
- Routed scope, cohort, pivot, and filter eligibility through dedicated overview queries
- Bundled summary, gender, urgency, and scoped totals into a single dashboard metrics query
- Improved all-time year chart aggregation using `created_year`
- Added `app:statistics:refresh-mviews` command for refreshing materialized views
- Added integration tests for overview queries, bundled dashboard metrics, materialized view reads, and time-series aggregation

### Motivation

- Improve performance of statistics overview and dashboard loading
- Reduce repeated ad-hoc scans across projection data
- Make all-time statistics semantically cleaner by avoiding artificial date bounds
- Provide more reliable and reusable query paths for scopes, cohorts, pivots, and filters
- Strengthen confidence in optimized query behavior through integration test coverage

### Notes for Reviewers

- Review all-time period handling and confirm nullable lower bounds behave as expected
- Check materialized view definitions and refresh command behavior
- Verify bundled dashboard metrics match the previous separate-query results
- Ensure scope, cohort, pivot, and filter eligibility still return correct options
- Review integration tests for parity with legacy query behavior and edge cases