### PR TITLE
fix: Fixed blank page path error handling

### DIFF
--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -7,6 +7,7 @@ namespace App\Admin\UI\Http\Controller\Page;
 use App\Admin\UI\Form\PageContentBlockType;
 use App\Content\Application\Page\PageContentSanitizer;
 use App\Content\Application\Page\PageContentValidator;
+use App\Content\Application\Page\PagePathResolver;
 use App\Content\Domain\Entity\Page;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -14,7 +15,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
@@ -23,6 +27,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -35,6 +42,7 @@ final class PageCrudController extends AbstractCrudController
     public function __construct(
         private readonly PageContentValidator $pageContentValidator,
         private readonly PageContentSanitizer $pageContentSanitizer,
+        private readonly PagePathResolver $pagePathResolver,
     ) {
     }
 
@@ -131,6 +139,32 @@ final class PageCrudController extends AbstractCrudController
         yield DateTimeField::new('updatedAt', 'label.updated')->hideOnForm();
     }
 
+    /**
+     * @return FormBuilderInterface<Page>
+     */
+    #[\Override]
+    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        $builder = parent::createNewFormBuilder($entityDto, $formOptions, $context);
+        $this->addPathSynchronizationListener($builder);
+
+        return $builder;
+    }
+
+    /**
+     * @return FormBuilderInterface<Page>
+     */
+    #[\Override]
+    public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        /** @psalm-suppress ArgumentTypeCoercion */
+        $builder = parent::createEditFormBuilder($entityDto, $formOptions, $context);
+        $this->addPathSynchronizationListener($builder);
+
+        return $builder;
+    }
+
     #[\Override]
     public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
     {
@@ -158,5 +192,20 @@ final class PageCrudController extends AbstractCrudController
         $content = $page->getContent();
         $this->pageContentValidator->assertValid($content);
         $page->setContent($this->pageContentSanitizer->sanitize($content));
+    }
+
+    /**
+     * @param FormBuilderInterface<Page> $builder
+     */
+    private function addPathSynchronizationListener(FormBuilderInterface $builder): void
+    {
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event): void {
+            $page = $event->getData();
+            if (!$page instanceof Page) {
+                return;
+            }
+
+            $this->pagePathResolver->synchronize($page);
+        });
     }
 }

--- a/src/Content/Application/Page/PagePathResolver.php
+++ b/src/Content/Application/Page/PagePathResolver.php
@@ -26,6 +26,12 @@ final readonly class PagePathResolver
         return $slug;
     }
 
+    public function synchronize(Page $page): void
+    {
+        $page->setSlug($this->normalizeSlug($page->getSlug()));
+        $page->setPath($this->buildPath($page));
+    }
+
     public function buildPath(Page $page): string
     {
         $slug = $this->normalizeSlug($page->getSlug());

--- a/src/Content/Infrastructure/Doctrine/PagePathSubscriber.php
+++ b/src/Content/Infrastructure/Doctrine/PagePathSubscriber.php
@@ -53,8 +53,7 @@ final readonly class PagePathSubscriber
         }
 
         foreach ($pagesToUpdate as $page) {
-            $page->setSlug($this->pathResolver->normalizeSlug($page->getSlug()));
-            $page->setPath($this->pathResolver->buildPath($page));
+            $this->pathResolver->synchronize($page);
             $uow->recomputeSingleEntityChangeSet($metadata, $page);
         }
     }

--- a/tests/Admin/Functional/Controller/PageCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/PageCrudControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageCrudControllerTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testAdminCanOpenPageIndexAndNewForm(): void
+    {
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'page-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin/page')
+            ->assertSuccessful()
+            ->assertSee('Pages')
+            ->visit('/admin/page/new')
+            ->assertSuccessful()
+            ->assertSee('Create Page')
+        ;
+    }
+
+    public function testNonAdminUserGetsForbiddenOnPageIndex(): void
+    {
+        $user = UserFactory::createOne([
+            'username' => 'page-regular-'.bin2hex(random_bytes(4)),
+        ]);
+
+        $this->browser()
+            ->actingAs($user)
+            ->visit('/admin/page')
+            ->assertStatus(403)
+        ;
+    }
+}

--- a/tests/Content/Integration/Page/PagePathSynchronizationValidationTest.php
+++ b/tests/Content/Integration/Page/PagePathSynchronizationValidationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PagePathResolver;
+use App\Content\Domain\Entity\Page;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class PagePathSynchronizationValidationTest extends KernelTestCase
+{
+    public function testPathNotBlankPassesAfterSynchronize(): void
+    {
+        self::bootKernel();
+
+        $resolver = self::getContainer()->get(PagePathResolver::class);
+        $validator = self::getContainer()->get(ValidatorInterface::class);
+
+        $page = new Page();
+        $page
+            ->setTitle('Test 123')
+            ->setSlug('test-123')
+            ->setStatus(Page::STATUS_DRAFT)
+            ->setVisibility(Page::VISIBILITY_PUBLIC);
+
+        $violationsBefore = $validator->validate($page);
+        self::assertNotEmpty($violationsBefore);
+        self::assertSame('path', (string) $violationsBefore->get(0)->getPropertyPath());
+
+        $resolver->synchronize($page);
+
+        $violationsAfter = $validator->validate($page);
+        self::assertCount(0, $violationsAfter);
+        self::assertSame('/test-123', $page->getPath());
+    }
+}

--- a/tests/Content/Unit/Page/PagePathResolverTest.php
+++ b/tests/Content/Unit/Page/PagePathResolverTest.php
@@ -38,4 +38,18 @@ final class PagePathResolverTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $resolver->buildPath($first);
     }
+
+    public function testSynchronizeNormalizesSlugAndSetsPath(): void
+    {
+        $resolver = new PagePathResolver(new AsciiSlugger());
+
+        $page = new Page()
+            ->setTitle('Test 123')
+            ->setSlug('Test-123');
+
+        $resolver->synchronize($page);
+
+        self::assertSame('test-123', $page->getSlug());
+        self::assertSame('/test-123', $page->getPath());
+    }
 }


### PR DESCRIPTION
### Summary

- Fixed an error related to blank or empty page paths
- Improved page path handling and validation
- Prevented failures when rendering or resolving pages without a valid path
- Added or adjusted tests to cover the edge case

### Motivation

- Avoid runtime errors caused by empty page path values
- Improve robustness of page/content routing
- Ensure invalid or incomplete page data is handled safely

### Notes for Reviewers

- Verify blank or missing page paths no longer trigger errors
- Check existing page routing and rendering behavior for regressions
- Confirm tests cover the affected edge case