### PR TITLE
feat: Introduce transactional mail layer with reusable email infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,19 @@ monitoring.
 
 ### Feedback widget
 
-Submissions are stored in the database. When `FEEDBACK_ADMIN_EMAIL` is set, the
-application sends an admin notification via Symfony Mailer.
+Submissions are stored in the database. Admin notifications are sent via
+Symfony Mailer to users who have both `ROLE_ADMIN` and `ROLE_FEEDBACK_RECIPIENT`
+(assign the latter in the admin user UI as “Receives Feedback”). If no such
+user exists, no email is sent (see application logs: `feedback.admin_mail_skipped`).
 
 | Variable | Purpose |
 |----------|---------|
-| `FEEDBACK_ADMIN_EMAIL` | Recipient for feedback notifications; leave empty to skip email |
+| `MAILER_FROM` | Default sender address for transactional mail |
+| `MAILER_REPLY_TO` | Optional reply-to address |
 | `APP_VERSION` | Release label stored with feedback and used as the default Sentry release |
 | `MAILER_DSN` | Mail transport (for example `smtp://user:pass@smtp.example:587`); required for outbound mail |
 
-The default sender address is configured in `config/services.yaml` as
-`app.mailer_from`. Submissions are rate-limited to five per hour per client
+Submissions are rate-limited to five per hour per client
 (`feedback_submit` in `config/packages/rate_limiter.yaml`; relaxed in `test`).
 
 ### Sentry monitoring

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,13 +12,14 @@ parameters:
     app.imports_max_size: '15M'
     app.imports_base_dir: '%kernel.project_dir%/var/imports'
     app.rejects_base_dir: '%kernel.project_dir%/var/imports/rejects'
-    app.mailer_from: 'no-reply@localhost'
-    env(FEEDBACK_ADMIN_EMAIL): ''
+    env(MAILER_FROM): 'no-reply@localhost'
+    env(MAILER_REPLY_TO): ''
+    app.mailer_from: '%env(MAILER_FROM)%'
+    app.mailer_reply_to: '%env(MAILER_REPLY_TO)%'
     env(APP_VERSION): ''
     env(SENTRY_DSN): ''
     env(SENTRY_TRACES_SAMPLE_RATE): '0'
     env(SENTRY_ENABLE_LOGS): 'true'
-    app.feedback.admin_notification_email: '%env(FEEDBACK_ADMIN_EMAIL)%'
     app.feedback.app_version: '%env(APP_VERSION)%'
 
 services:
@@ -98,13 +99,11 @@ services:
         arguments:
             $logger: '@monolog.logger.import'
 
-    App\User\Infrastructure\Security\EmailVerifier:
-        arguments:
-            $mailerFrom: '%app.mailer_from%'
+    App\Shared\Infrastructure\Mail\TransactionalMailer:
+        alias: App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer
 
-    App\User\UI\Http\Controller\ResetPasswordController:
-        arguments:
-            $mailerFrom: '%app.mailer_from%'
+    App\User\Infrastructure\Security\FeedbackRecipientEmailResolver:
+        alias: App\User\Infrastructure\Security\FeedbackRecipientResolver
 
     App\Import\Infrastructure\Adapter\SplCsvRejectWriter:
         arguments:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,8 +22,79 @@ On the server:
 | `APP_DEBUG` | `0` |
 | `APP_SECRET` | Non-empty secret for Symfony |
 | `DATABASE_URL` | PostgreSQL connection |
+| `MAILER_DSN` | Outbound mail transport (SMTP or provider API); see [Transactional mail](#transactional-mail) |
+| `MAILER_FROM` | Default sender address for verification, password reset, and feedback notifications |
+| `MESSENGER_TRANSPORT_DSN` | Queue backend for async jobs and mail (default: `doctrine://default?auto_setup=0`) |
+
+Optional but recommended:
+
+| Variable | Purpose |
+|----------|---------|
+| `MAILER_REPLY_TO` | Reply-to address on transactional mail (leave empty to omit) |
+| `APP_VERSION` | Release label stored with feedback and used as the default Sentry release |
 
 Run database migrations so the `messenger_messages` table exists (included in the default deploy workflow).
+
+## Transactional mail
+
+Registration verification, password reset, and feedback admin notifications are sent through a central mail layer 
+([`TransactionalMailer`](../src/Shared/Infrastructure/Mail/TransactionalMailer.php)). Templates and business logic are 
+unchanged; only transport and configuration are unified.
+
+### Required environment variables
+
+| Variable | Example | Notes |
+|----------|---------|-------|
+| `MAILER_DSN` | `smtp://user:pass@smtp.example.com:587` | **Required in production.** Without a real DSN, no mail leaves the server. Use your provider’s SMTP or native DSN (Mailgun, Brevo, Amazon SES, etc.). |
+| `MAILER_FROM` | `no-reply@your-domain.example` | Sender address on all transactional mail. Defaults to `no-reply@localhost` if unset — set an address your provider allows. |
+
+The **display name** in the From header comes from `app.title` in [`config/packages/app.yaml`](../config/packages/app.yaml), not from an environment variable.
+
+### Optional environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `MAILER_REPLY_TO` | If set, added as Reply-To on all transactional mail |
+
+### Feedback notifications (role-based recipients)
+
+`FEEDBACK_ADMIN_EMAIL` is **no longer used**. Feedback admin mail is sent to application users who have **both**:
+
+- `ROLE_ADMIN`
+- `ROLE_FEEDBACK_RECIPIENT` (shown in EasyAdmin as **“Receives Feedback”**)
+
+Additional requirements: account enabled, email verified, non-empty email address.
+
+If no matching user exists, feedback is still stored but no email is sent. Check application logs for 
+`feedback.admin_mail_skipped` with reason `no_feedback_recipients`.
+
+**After each deploy (or when onboarding admins):** open **Admin → Users**, edit the relevant admin accounts, and assign 
+**Receives Feedback**. Existing admins do not receive this role automatically.
+
+### Async delivery in production
+
+In `prod`, Symfony Mailer dispatches `SendEmailMessage` to the **`async_priority_low`** queue (see 
+[`config/packages/messenger.yaml`](../config/packages/messenger.yaml)). In `dev`, mail is sent synchronously.
+
+That means:
+
+1. **`MESSENGER_TRANSPORT_DSN`** must be configured (Doctrine transport is fine if migrations created `messenger_messages`).
+2. The **Messenger worker** must be running — see [Messenger worker](#messenger-worker-one-time-server-setup) below.
+
+Without a worker, verification, password reset, and feedback emails are queued but never delivered.
+
+### DNS and deliverability
+
+Configure SPF, DKIM, and DMARC for the domain used in `MAILER_FROM`. Use an address and domain your SMTP provider 
+authorizes; otherwise messages often land in spam folders.
+
+### Post-deploy mail checklist
+
+1. Set `MAILER_DSN` and `MAILER_FROM` in server `.env.local`.
+2. Confirm the Messenger worker is active (`systemctl --user status messenger`).
+3. Assign **Receives Feedback** to at least one verified admin (for feedback notifications).
+4. Smoke-test: register a user (verification mail), request a password reset, submit feedback.
+5. If mail does not arrive, check `messenger:stats`, `messenger:failed:show`, and `journalctl --user -u messenger -f`.
 
 ## Messenger worker (one-time server setup)
 
@@ -163,6 +234,9 @@ requires the worker for queued mail.
 |---------|----------------|
 | Deploy fails at `messenger:restart` | Unit missing or wrong name; check `messenger_systemd_service` |
 | Messages stuck in `messenger_messages` | Worker not running; check `systemctl --user status messenger` |
+| No verification / reset / feedback mail | `MAILER_DSN` missing or worker not consuming `async_priority_low` |
+| Feedback saved but no admin email | No user with Admin + Receives Feedback (enabled, verified); see logs for `feedback.admin_mail_skipped` |
+| Mail in spam | SPF/DKIM/DMARC or `MAILER_FROM` not aligned with SMTP provider |
 | Worker runs old code after deploy | `WorkingDirectory` points at a fixed `releases/N` instead of `current` |
 | `too many redirects` / 500 on web | Unrelated to Messenger; ensure `public/.htaccess` exists and `APP_SECRET` is set in `.env.local` |
 | Stop hook skipped | First deploy has no `previous_release`; normal |

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -6,6 +6,7 @@ namespace App\Admin\UI\Http\Controller\User;
 
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
@@ -72,7 +73,7 @@ final class UserCrudController extends AbstractCrudController
                     return false;
                 }
 
-                if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+                if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
                     return false;
                 }
 
@@ -98,15 +99,17 @@ final class UserCrudController extends AbstractCrudController
             ->renderAsSwitch();
         yield ChoiceField::new('roles')
             ->setChoices([
-                'Admin' => 'ROLE_ADMIN',
-                'Participant' => 'ROLE_PARTICIPANT',
-                'User' => 'ROLE_USER',
+                'Admin' => UserRole::ADMIN,
+                'Participant' => UserRole::PARTICIPANT,
+                'User' => UserRole::USER,
+                'Receives Feedback' => UserRole::FEEDBACK_RECIPIENT,
             ])
             ->allowMultipleChoices()
             ->renderAsBadges([
-                'ROLE_ADMIN' => 'danger',
-                'ROLE_PARTICIPANT' => 'warning',
-                'ROLE_USER' => 'primary',
+                UserRole::ADMIN => 'danger',
+                UserRole::PARTICIPANT => 'warning',
+                UserRole::USER => 'primary',
+                UserRole::FEEDBACK_RECIPIENT => 'success',
             ]);
         yield TextField::new('password')
             ->setFormType(PasswordType::class)

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -45,7 +45,7 @@ final class UserFixtures extends Fixture
     public static function getUserData(): array
     {
         return [
-            ['admin', 'password', ['ROLE_ADMIN', 'ROLE_USER'], 'admin@test.local', true],
+            ['admin', 'password', ['ROLE_ADMIN', 'ROLE_FEEDBACK_RECIPIENT', 'ROLE_USER'], 'admin@test.local', true],
             ['foo', 'bar', ['ROLE_USER'], 'foo@bar.local', true],
         ];
     }

--- a/src/Feedback/Application/RecordFeedbackHandler.php
+++ b/src/Feedback/Application/RecordFeedbackHandler.php
@@ -6,27 +6,16 @@ namespace App\Feedback\Application;
 
 use App\Feedback\Domain\Entity\Feedback;
 use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 
 final readonly class RecordFeedbackHandler
 {
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private MailerInterface $mailer,
-        #[Autowire('%app.mailer_from%')]
-        private string $mailerFrom,
-        #[Autowire('%app.feedback.admin_notification_email%')]
-        private string $adminNotificationEmail,
-        private LoggerInterface $logger,
-        #[Autowire('%app.title%')]
-        private string $appTitle,
+        private TransactionalMailer $transactionalMailer,
     ) {
     }
 
@@ -62,32 +51,11 @@ final readonly class RecordFeedbackHandler
         $this->entityManager->persist($feedback);
         $this->entityManager->flush();
 
-        $recipient = trim($this->adminNotificationEmail);
-        if ('' !== $recipient) {
-            $subject = sprintf('[%s] Feedback (%s)', $this->appTitle, $category->value);
-            $this->mailer->send(
-                new TemplatedEmail()
-                    ->from($this->fromAddress())
-                    ->to($recipient)
-                    ->subject($subject)
-                    ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
-                    ->context([
-                        'feedback' => $feedback,
-                        'categoryLabel' => $category->value,
-                        'contextJson' => $this->encodeContextPreview($feedback->getContext()),
-                    ])
-            );
-        } else {
-            $this->logger->info('feedback.admin_mail_skipped', [
-                'reason' => 'empty FEEDBACK_ADMIN_EMAIL',
-                'feedback_id' => $feedback->getId(),
-            ]);
-        }
-    }
-
-    private function fromAddress(): Address
-    {
-        return new Address($this->mailerFrom, $this->appTitle);
+        $this->transactionalMailer->sendAdminFeedbackEmail(
+            $feedback,
+            $category,
+            $this->encodeContextPreview($feedback->getContext()),
+        );
     }
 
     /** @param array<string, mixed>|null $context */

--- a/src/Shared/Infrastructure/Mail/MailConfig.php
+++ b/src/Shared/Infrastructure/Mail/MailConfig.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mail;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class MailConfig
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        #[Autowire('%app.mailer_from%')]
+        public string $fromEmail,
+        #[Autowire('%app.title%')]
+        public string $fromName,
+        #[Autowire('%app.title%')]
+        public string $appName,
+        #[Autowire('%app.mailer_reply_to%')]
+        private string $replyTo,
+    ) {
+    }
+
+    public function replyTo(): ?string
+    {
+        $replyTo = trim($this->replyTo);
+
+        return '' === $replyTo ? null : $replyTo;
+    }
+}

--- a/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mail;
+
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+
+/** @psalm-suppress UnusedClass Wired via services.yaml alias to TransactionalMailer. */
+final readonly class SymfonyTransactionalMailer implements TransactionalMailer
+{
+    private const string SUBJECT_VERIFICATION = 'Please confirm your email address';
+
+    private const string SUBJECT_PASSWORD_RESET = 'Your password reset request';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private MailerInterface $mailer,
+        private MailConfig $mailConfig,
+        private FeedbackRecipientEmailResolver $feedbackRecipientResolver,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $expiresAtMessageData
+     */
+    #[\Override]
+    public function sendVerificationEmail(
+        string $recipientEmail,
+        string $signedUrl,
+        string $expiresAtMessageKey,
+        array $expiresAtMessageData,
+        string $homepageUrl,
+    ): void {
+        $email = $this->createTemplatedEmail()
+            ->to($recipientEmail)
+            ->subject(self::SUBJECT_VERIFICATION)
+            ->htmlTemplate('@User/registration/confirmation_email.html.twig')
+            ->context([
+                'signedUrl' => $signedUrl,
+                'expiresAtMessageKey' => $expiresAtMessageKey,
+                'expiresAtMessageData' => $expiresAtMessageData,
+                'homepageUrl' => $homepageUrl,
+            ]);
+
+        $this->mailer->send($email);
+    }
+
+    #[\Override]
+    public function sendPasswordResetEmail(
+        string $recipientEmail,
+        ResetPasswordToken $resetToken,
+    ): void {
+        $email = $this->createTemplatedEmail()
+            ->to($recipientEmail)
+            ->subject(self::SUBJECT_PASSWORD_RESET)
+            ->htmlTemplate('@User/reset_password/email.html.twig')
+            ->context([
+                'resetToken' => $resetToken,
+            ]);
+
+        $this->mailer->send($email);
+    }
+
+    #[\Override]
+    public function sendAdminFeedbackEmail(
+        Feedback $feedback,
+        FeedbackCategory $category,
+        string $contextJsonPreview,
+    ): void {
+        $recipients = $this->feedbackRecipientResolver->resolveRecipientEmails();
+        if ([] === $recipients) {
+            $this->logger->info('feedback.admin_mail_skipped', [
+                'reason' => 'no_feedback_recipients',
+                'feedback_id' => $feedback->getId(),
+            ]);
+
+            return;
+        }
+
+        $email = $this->createTemplatedEmail()
+            ->to(...$recipients)
+            ->subject(sprintf('[%s] Feedback (%s)', $this->mailConfig->appName, $category->value))
+            ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
+            ->context([
+                'feedback' => $feedback,
+                'categoryLabel' => $category->value,
+                'contextJson' => $contextJsonPreview,
+            ]);
+
+        $this->mailer->send($email);
+    }
+
+    private function createTemplatedEmail(): TemplatedEmail
+    {
+        $email = new TemplatedEmail()
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName));
+
+        $replyTo = $this->mailConfig->replyTo();
+        if (null !== $replyTo) {
+            $email->replyTo($replyTo);
+        }
+
+        return $email;
+    }
+}

--- a/src/Shared/Infrastructure/Mail/TransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/TransactionalMailer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mail;
+
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+
+interface TransactionalMailer
+{
+    /**
+     * @param array<string, mixed> $expiresAtMessageData
+     */
+    public function sendVerificationEmail(
+        string $recipientEmail,
+        string $signedUrl,
+        string $expiresAtMessageKey,
+        array $expiresAtMessageData,
+        string $homepageUrl,
+    ): void;
+
+    public function sendPasswordResetEmail(
+        string $recipientEmail,
+        ResetPasswordToken $resetToken,
+    ): void;
+
+    public function sendAdminFeedbackEmail(
+        Feedback $feedback,
+        FeedbackCategory $category,
+        string $contextJsonPreview,
+    ): void;
+}

--- a/src/User/Domain/Factory/UserFactory.php
+++ b/src/User/Domain/Factory/UserFactory.php
@@ -70,4 +70,10 @@ final class UserFactory extends PersistentProxyObjectFactory
     {
         return $this->with(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
     }
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function asFeedbackRecipient(): self
+    {
+        return $this->with(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_FEEDBACK_RECIPIENT']]);
+    }
 }

--- a/src/User/Domain/Security/UserRole.php
+++ b/src/User/Domain/Security/UserRole.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Security;
+
+final class UserRole
+{
+    public const string USER = 'ROLE_USER';
+
+    public const string PARTICIPANT = 'ROLE_PARTICIPANT';
+
+    public const string ADMIN = 'ROLE_ADMIN';
+
+    public const string FEEDBACK_RECIPIENT = 'ROLE_FEEDBACK_RECIPIENT';
+}

--- a/src/User/Infrastructure/Security/EmailVerifier.php
+++ b/src/User/Infrastructure/Security/EmailVerifier.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
@@ -17,9 +15,8 @@ final readonly class EmailVerifier
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private VerifyEmailHelperInterface $verifyEmailHelper,
-        private MailerInterface $mailer,
+        private TransactionalMailer $transactionalMailer,
         private UrlGeneratorInterface $urlGenerator,
-        private string $mailerFrom,
     ) {
     }
 
@@ -37,17 +34,13 @@ final readonly class EmailVerifier
             ['id' => (string) $user->getId()]
         );
 
-        $this->mailer->send(new TemplatedEmail()
-            ->from(new Address($this->mailerFrom, 'Collaborative IVENA statistics'))
-            ->to($email)
-            ->subject('Please confirm your email address')
-            ->htmlTemplate('@User/registration/confirmation_email.html.twig')
-            ->context([
-                'signedUrl' => $signatureComponents->getSignedUrl(),
-                'expiresAtMessageKey' => $signatureComponents->getExpirationMessageKey(),
-                'expiresAtMessageData' => $signatureComponents->getExpirationMessageData(),
-                'homepageUrl' => $this->urlGenerator->generate('app_default', [], UrlGeneratorInterface::ABSOLUTE_URL),
-            ]));
+        $this->transactionalMailer->sendVerificationEmail(
+            $email,
+            $signatureComponents->getSignedUrl(),
+            $signatureComponents->getExpirationMessageKey(),
+            $signatureComponents->getExpirationMessageData(),
+            $this->urlGenerator->generate('app_default', [], UrlGeneratorInterface::ABSOLUTE_URL),
+        );
     }
 
     public function handleEmailConfirmation(Request $request, User $user): void

--- a/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+interface FeedbackRecipientEmailResolver
+{
+    /**
+     * @return list<string>
+     */
+    public function resolveRecipientEmails(): array;
+}

--- a/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
+use App\User\Infrastructure\Repository\UserRepository;
+
+final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmailResolver
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private UserRepository $userRepository,
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[\Override]
+    public function resolveRecipientEmails(): array
+    {
+        /** @var list<User> $candidates */
+        $candidates = $this->userRepository->createQueryBuilder('u')
+            ->where('u.isEnabled = true')
+            ->andWhere('u.isVerified = true')
+            ->andWhere('u.email IS NOT NULL')
+            ->andWhere("u.email != ''")
+            ->getQuery()
+            ->getResult();
+
+        $emails = [];
+        foreach ($candidates as $user) {
+            $roles = $user->getRoles();
+            if (!\in_array(UserRole::ADMIN, $roles, true) || !\in_array(UserRole::FEEDBACK_RECIPIENT, $roles, true)) {
+                continue;
+            }
+
+            $email = $user->getEmail();
+            if (null === $email || '' === trim($email)) {
+                continue;
+            }
+
+            $emails[] = mb_strtolower(trim($email));
+        }
+
+        return array_values(array_unique($emails));
+    }
+}

--- a/src/User/UI/Http/Controller/ResetPasswordController.php
+++ b/src/User/UI/Http/Controller/ResetPasswordController.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Infrastructure\Audit\AuditContext;
+use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
 use App\User\UI\Form\ResetPasswordFormType;
 use App\User\UI\Form\ResetPasswordRequestFormType;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
@@ -30,9 +28,8 @@ final class ResetPasswordController extends AbstractController
     public function __construct(
         private readonly ResetPasswordHelperInterface $resetPasswordHelper,
         private readonly EntityManagerInterface $entityManager,
-        private readonly MailerInterface $mailer,
+        private readonly TransactionalMailer $transactionalMailer,
         private readonly UserPasswordHasherInterface $passwordHasher,
-        private readonly string $mailerFrom,
         private readonly AuditContext $auditContext,
     ) {
     }
@@ -146,16 +143,7 @@ final class ResetPasswordController extends AbstractController
             return $this->redirectToRoute('app_check_email');
         }
 
-        $email = new TemplatedEmail()
-            ->from(new Address($this->mailerFrom, 'Collaborative IVENA statistics'))
-            ->to((string) $user->getEmail())
-            ->subject('Your password reset request')
-            ->htmlTemplate('@User/reset_password/email.html.twig')
-            ->context([
-                'resetToken' => $resetToken,
-            ]);
-
-        $this->mailer->send($email);
+        $this->transactionalMailer->sendPasswordResetEmail((string) $user->getEmail(), $resetToken);
 
         $this->setTokenObjectInSession($resetToken);
 

--- a/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Infrastructure\Mail;
+
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer;
+use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
+
+final class SymfonyTransactionalMailerTest extends TestCase
+{
+    public function testSendVerificationEmailUsesConfiguredSenderAndRecipient(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame('no-reply@example.test', $email->getFrom()[0]->getAddress());
+                self::assertSame('Test App', $email->getFrom()[0]->getName());
+                self::assertSame(['user@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getTo(),
+                ));
+                self::assertSame('Please confirm your email address', $email->getSubject());
+                self::assertSame('@User/registration/confirmation_email.html.twig', $email->getHtmlTemplate());
+
+                return true;
+            }));
+
+        $this->createMailer($mailer)->sendVerificationEmail(
+            'user@example.test',
+            'https://example.test/verify',
+            'key',
+            ['%count%' => 1],
+            'https://example.test/',
+        );
+    }
+
+    public function testSendPasswordResetEmailUsesConfiguredSender(): void
+    {
+        $resetToken = new ResetPasswordToken(
+            'selector_verifier',
+            new \DateTimeImmutable('+1 hour'),
+            time(),
+        );
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame('no-reply@example.test', $email->getFrom()[0]->getAddress());
+                self::assertSame(['reset@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getTo(),
+                ));
+                self::assertSame('Your password reset request', $email->getSubject());
+                self::assertSame('@User/reset_password/email.html.twig', $email->getHtmlTemplate());
+                self::assertInstanceOf(ResetPasswordToken::class, $email->getContext()['resetToken'] ?? null);
+
+                return true;
+            }));
+
+        $this->createMailer($mailer)->sendPasswordResetEmail('reset@example.test', $resetToken);
+    }
+
+    public function testSendAdminFeedbackEmailUsesAllResolvedRecipients(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientEmails')->willReturn([
+            'admin-a@example.test',
+            'admin-b@example.test',
+        ]);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(
+                    ['admin-a@example.test', 'admin-b@example.test'],
+                    array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
+                );
+                self::assertSame('[Test App] Feedback (bug)', $email->getSubject());
+                self::assertSame('@Feedback/email/admin_feedback_notification.html.twig', $email->getHtmlTemplate());
+
+                return true;
+            }));
+
+        $this->createMailer($mailer, $recipientResolver)->sendAdminFeedbackEmail(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    public function testSendAdminFeedbackEmailSkipsWhenNoRecipients(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientEmails')->willReturn([]);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(
+                'feedback.admin_mail_skipped',
+                self::callback(static fn (array $context): bool => 'no_feedback_recipients' === ($context['reason'] ?? null)),
+            );
+
+        $this->createMailer($mailer, $recipientResolver, $logger)->sendAdminFeedbackEmail(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    public function testReplyToIsAppliedWhenConfigured(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(['support@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getReplyTo(),
+                ));
+
+                return true;
+            }));
+
+        $mailConfig = new MailConfig(
+            fromEmail: 'no-reply@example.test',
+            fromName: 'Test App',
+            appName: 'Test App',
+            replyTo: 'support@example.test',
+        );
+
+        new SymfonyTransactionalMailer(
+            $mailer,
+            $mailConfig,
+            $this->createMock(FeedbackRecipientEmailResolver::class),
+            $this->createMock(LoggerInterface::class),
+        )->sendVerificationEmail(
+            'user@example.test',
+            'https://example.test/verify',
+            'key',
+            [],
+            'https://example.test/',
+        );
+    }
+
+    private function createMailer(
+        MailerInterface $mailer,
+        ?FeedbackRecipientEmailResolver $recipientResolver = null,
+        ?LoggerInterface $logger = null,
+    ): SymfonyTransactionalMailer {
+        return new SymfonyTransactionalMailer(
+            $mailer,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'Test App',
+                appName: 'Test App',
+                replyTo: '',
+            ),
+            $recipientResolver ?? $this->createMock(FeedbackRecipientEmailResolver::class),
+            $logger ?? $this->createMock(LoggerInterface::class),
+        );
+    }
+}

--- a/tests/Shared/Unit/Infrastructure/Mail/TransactionalMailWiringTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/TransactionalMailWiringTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Infrastructure\Mail;
+
+use App\Feedback\Application\RecordFeedbackHandler;
+use App\Shared\Infrastructure\Mail\TransactionalMailer;
+use App\User\Infrastructure\Security\EmailVerifier;
+use App\User\UI\Http\Controller\ResetPasswordController;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+
+final class TransactionalMailWiringTest extends TestCase
+{
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('wiredClassProvider')]
+    public function testClassUsesTransactionalMailerNotMailerInterface(string $className): void
+    {
+        $constructor = new \ReflectionClass($className)->getConstructor();
+        self::assertNotNull($constructor);
+
+        $parameterTypes = array_map(
+            static fn (\ReflectionParameter $parameter): ?string => $parameter->getType() instanceof \ReflectionNamedType
+                ? $parameter->getType()->getName()
+                : null,
+            $constructor->getParameters(),
+        );
+
+        self::assertContains(TransactionalMailer::class, $parameterTypes);
+        self::assertNotContains(MailerInterface::class, $parameterTypes);
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function wiredClassProvider(): iterable
+    {
+        yield EmailVerifier::class => [EmailVerifier::class];
+        yield ResetPasswordController::class => [ResetPasswordController::class];
+        yield RecordFeedbackHandler::class => [RecordFeedbackHandler::class];
+    }
+
+    public function testResetPasswordControllerDoesNotBuildTemplatedEmailDirectly(): void
+    {
+        $source = (string) file_get_contents(
+            new \ReflectionClass(ResetPasswordController::class)->getFileName(),
+        );
+
+        self::assertStringNotContainsString('TemplatedEmail', $source);
+        self::assertStringNotContainsString('MailerInterface', $source);
+    }
+}

--- a/tests/User/Integration/Infrastructure/Security/FeedbackRecipientResolverTest.php
+++ b/tests/User/Integration/Infrastructure/Security/FeedbackRecipientResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\Infrastructure\Security;
+
+use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
+use App\User\Infrastructure\Security\FeedbackRecipientResolver;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class FeedbackRecipientResolverTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testResolvesEnabledVerifiedAdminWithFeedbackRole(): void
+    {
+        UserFactory::new([
+            'email' => 'recipient@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::FEEDBACK_RECIPIENT],
+            'isEnabled' => true,
+            'isVerified' => true,
+        ])->create();
+
+        UserFactory::new([
+            'email' => 'admin-only@example.test',
+            'roles' => [UserRole::ADMIN],
+            'isEnabled' => true,
+            'isVerified' => true,
+        ])->create();
+
+        UserFactory::new([
+            'email' => 'disabled@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::FEEDBACK_RECIPIENT],
+            'isEnabled' => false,
+            'isVerified' => true,
+        ])->create();
+
+        $resolver = self::getContainer()->get(FeedbackRecipientResolver::class);
+
+        self::assertSame(['recipient@example.test'], $resolver->resolveRecipientEmails());
+    }
+
+    public function testDeduplicatesEmails(): void
+    {
+        UserFactory::new([
+            'email' => 'DUPLICATE@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::FEEDBACK_RECIPIENT],
+        ])->create();
+
+        $resolver = self::getContainer()->get(FeedbackRecipientResolver::class);
+
+        self::assertSame(['duplicate@example.test'], $resolver->resolveRecipientEmails());
+    }
+
+    public function testReturnsEmptyListWhenNoMatchingUsers(): void
+    {
+        UserFactory::new([
+            'email' => 'user@example.test',
+            'roles' => [UserRole::USER],
+        ])->create();
+
+        $resolver = self::getContainer()->get(FeedbackRecipientResolver::class);
+
+        self::assertSame([], $resolver->resolveRecipientEmails());
+    }
+}


### PR DESCRIPTION
### Summary

- Introduced a dedicated **transactional mail layer**
- Added reusable abstractions and services for sending application emails
- Improved separation between domain logic and email delivery concerns
- Added shared infrastructure for transactional email handling and rendering
- Integrated the new layer into existing notification and mail workflows
- Updated templates/configuration related to email delivery
- Added or updated tests for transactional mail behavior

### Motivation

- Centralize transactional email handling in a dedicated layer
- Improve maintainability and consistency across outgoing emails
- Reduce duplication in mail rendering and delivery logic
- Prepare the application for future notification and communication features
- Provide a cleaner abstraction between business logic and infrastructure concerns

### Notes for Reviewers

- Review the new transactional mail abstractions and service boundaries
- Verify existing email flows continue to work correctly with the new layer
- Check template rendering and delivery behavior across supported mail types
- Ensure no regressions in notification-related functionality
- Confirm tests adequately cover mail generation and integration behavior