### PR TITLE
feat: Add password confirmation step-up authentication flow

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -17,7 +17,10 @@ security:
         main:
             lazy: true
             provider: app_user_provider
-            custom_authenticator: App\User\Infrastructure\Security\LoginFormAuthenticator
+            entry_point: App\User\Infrastructure\Security\AuthenticationEntryPoint
+            custom_authenticators:
+                - App\User\Infrastructure\Security\LoginFormAuthenticator
+                - App\User\Infrastructure\Security\ConfirmPasswordAuthenticator
             user_checker: App\User\Infrastructure\Security\UserAccountStatusChecker
 
             logout:
@@ -51,7 +54,7 @@ security:
         - { path: ^/_error/, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }
         - { path: ^/hospitals, roles: ROLE_PARTICIPANT }
-        - { path: ^/settings, roles: IS_AUTHENTICATED_FULLY }
+        - { path: ^/login/confirm, roles: IS_AUTHENTICATED_REMEMBERED }
         # - { path: ^/profile, roles: ROLE_USER }
 
     role_hierarchy:
@@ -59,6 +62,10 @@ security:
 
 when@test:
     security:
+        firewalls:
+            main:
+                remember_me:
+                    always_remember_me: true
         password_hashers:
             # By default, password hashers are resource intensive and take time. This is
             # important to generate secure password hashes. In tests however, secure hashes

--- a/src/Statistics/Application/ClinicalFeaturesProvider.php
+++ b/src/Statistics/Application/ClinicalFeaturesProvider.php
@@ -34,7 +34,7 @@ final readonly class ClinicalFeaturesProvider
                 'clinical_resources_distribution',
                 $this->widgetPayloadNormalizer->normalize(new DistributionWidgetPayload(
                     'stats.analysis.dimension.resources',
-                    $this->clinicalFeaturesQuery->fetchResourceRows($context, $metrics),
+                    $this->clinicalFeaturesQuery->fetchResourceRows($metrics),
                     [
                         'testId' => 'stats-overview-resources',
                         'actionTestId' => 'stats-cross-nav-overview-resources',
@@ -57,7 +57,7 @@ final readonly class ClinicalFeaturesProvider
                 'clinical_features_distribution',
                 $this->widgetPayloadNormalizer->normalize(new DistributionWidgetPayload(
                     'stats.analysis.dimension.features',
-                    $this->clinicalFeaturesQuery->fetchClinicalRows($context, $metrics),
+                    $this->clinicalFeaturesQuery->fetchClinicalRows($metrics),
                     [
                         'testId' => 'stats-overview-features',
                         'actionTestId' => 'stats-cross-nav-overview-features',

--- a/src/Statistics/Application/ClinicalFeaturesQuery.php
+++ b/src/Statistics/Application/ClinicalFeaturesQuery.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application;
 
-use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
 
 final readonly class ClinicalFeaturesQuery
@@ -29,7 +28,7 @@ final readonly class ClinicalFeaturesQuery
     /**
      * @return list<array{labelTranslationKey: string, count: int, percent: float}>
      */
-    public function fetchClinicalRows(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
+    public function fetchClinicalRows(OverviewDashboardMetricsResult $metrics): array
     {
         $clinicalCounts = $metrics->clinicalCounts();
         $totalAllocationsFloat = (float) $metrics->scopedTotal;
@@ -50,7 +49,7 @@ final readonly class ClinicalFeaturesQuery
     /**
      * @return list<array{labelTranslationKey: string, count: int, percent: float}>
      */
-    public function fetchResourceRows(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): array
+    public function fetchResourceRows(OverviewDashboardMetricsResult $metrics): array
     {
         $resourceCounts = $metrics->resourceCounts();
         $totalAllocationsFloat = (float) $metrics->scopedTotal;

--- a/src/User/Infrastructure/Security/AuthenticationEntryPoint.php
+++ b/src/User/Infrastructure/Security/AuthenticationEntryPoint.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+/** @psalm-suppress UnusedClass */
+final readonly class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    public function __construct(
+        #[Autowire(service: 'security.authentication.trust_resolver')]
+        private AuthenticationTrustResolverInterface $trustResolver,
+        private TokenStorageInterface $tokenStorage,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    #[\Override]
+    public function start(Request $request, ?AuthenticationException $authException = null): RedirectResponse
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if ($token instanceof \Symfony\Component\Security\Core\Authentication\Token\TokenInterface && $this->trustResolver->isRememberMe($token)) {
+            return new RedirectResponse($this->urlGenerator->generate('app_confirm_password'));
+        }
+
+        return new RedirectResponse($this->urlGenerator->generate('app_login'));
+    }
+}

--- a/src/User/Infrastructure/Security/ConfirmPasswordAuthenticator.php
+++ b/src/User/Infrastructure/Security/ConfirmPasswordAuthenticator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+use App\User\Domain\Entity\User;
+use App\User\UI\Form\ConfirmPasswordType;
+use App\User\UI\Http\DTO\ConfirmPasswordTypeDTO;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+/** @psalm-suppress UnusedClass */
+final class ConfirmPasswordAuthenticator extends AbstractLoginFormAuthenticator
+{
+    use TargetPathTrait;
+
+    public const string LOGIN_ROUTE = 'app_confirm_password';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly TokenStorageInterface $tokenStorage,
+    ) {
+    }
+
+    #[\Override]
+    public function authenticate(Request $request): Passport
+    {
+        $token = $this->tokenStorage->getToken();
+        if (!$token instanceof TokenInterface) {
+            throw new AuthenticationCredentialsNotFoundException('No authenticated user to confirm password for.');
+        }
+
+        $form = $this->formFactory->create(ConfirmPasswordType::class);
+        $form->handleRequest($request);
+
+        /** @var ConfirmPasswordTypeDTO $confirmPasswordDTO */
+        $confirmPasswordDTO = $form->getData();
+
+        return new Passport(
+            new UserBadge($token->getUserIdentifier()),
+            new PasswordCredentials($confirmPasswordDTO->password),
+            [
+                new CsrfTokenBadge('confirm_password', $request->getPayload()->getString('_csrf_token')),
+            ]
+        );
+    }
+
+    #[\Override]
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): RedirectResponse
+    {
+        $user = $token->getUser();
+
+        if ($user instanceof User && $user->isCredentialsExpired()) {
+            return new RedirectResponse($this->urlGenerator->generate('app_force_change_password'));
+        }
+
+        $targetPath = $this->getTargetPath($request->getSession(), $firewallName);
+
+        if (null !== $targetPath) {
+            return new RedirectResponse($targetPath);
+        }
+
+        return new RedirectResponse($this->urlGenerator->generate('app_default'));
+    }
+
+    #[\Override]
+    protected function getLoginUrl(Request $request): string
+    {
+        return $this->urlGenerator->generate(self::LOGIN_ROUTE);
+    }
+}

--- a/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
@@ -8,6 +8,7 @@ use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use App\User\Infrastructure\Repository\UserRepository;
 
+/** @psalm-suppress UnusedClass */
 final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmailResolver
 {
     /** @psalm-suppress PossiblyUnusedMethod */

--- a/src/User/UI/Form/ConfirmPasswordType.php
+++ b/src/User/UI/Form/ConfirmPasswordType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Form;
+
+use App\User\UI\Http\DTO\ConfirmPasswordTypeDTO;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @extends AbstractType<ConfirmPasswordTypeDTO>
+ */
+final class ConfirmPasswordType extends AbstractType
+{
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('password', PasswordType::class, [
+                'label' => 'label.confirm_password',
+                'constraints' => [new NotBlank()],
+            ])
+        ;
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ConfirmPasswordTypeDTO::class,
+        ]);
+    }
+}

--- a/src/User/UI/Http/Controller/SecurityController.php
+++ b/src/User/UI/Http/Controller/SecurityController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Infrastructure\Consent\CookieConsentService;
+use App\User\UI\Form\ConfirmPasswordType;
 use App\User\UI\Form\LoginType;
+use App\User\UI\Http\DTO\ConfirmPasswordTypeDTO;
 use App\User\UI\Http\DTO\LoginTypeDTO;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,6 +30,10 @@ final class SecurityController extends AbstractController
     {
         $user = $this->getUser();
         if ($user instanceof UserInterface) {
+            if (!$this->isGranted('IS_AUTHENTICATED_FULLY')) {
+                return $this->redirectToRoute('app_confirm_password');
+            }
+
             return $this->redirectToRoute('app_default');
         }
 
@@ -46,6 +52,26 @@ final class SecurityController extends AbstractController
             'error' => $error,
             'hasConsentDecision' => $hasConsentDecision,
             'showConsentHint' => $showConsentHint,
+        ]);
+    }
+
+    #[Route(path: '/login/confirm', name: 'app_confirm_password')]
+    public function confirmPassword(): Response
+    {
+        if (!$this->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            return $this->redirectToRoute('app_login');
+        }
+
+        if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return $this->redirectToRoute('app_default');
+        }
+
+        $error = $this->authenticationUtils->getLastAuthenticationError();
+        $form = $this->createForm(ConfirmPasswordType::class, new ConfirmPasswordTypeDTO());
+
+        return $this->render('@User/security/confirm_password.html.twig', [
+            'form' => $form,
+            'error' => $error,
         ]);
     }
 

--- a/src/User/UI/Http/Controller/SettingsController.php
+++ b/src/User/UI/Http/Controller/SettingsController.php
@@ -21,7 +21,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
-#[IsGranted('IS_AUTHENTICATED_FULLY')]
+#[IsGranted('IS_AUTHENTICATED_REMEMBERED')]
 final class SettingsController extends AbstractController
 {
     public function __construct(
@@ -76,6 +76,7 @@ final class SettingsController extends AbstractController
     }
 
     #[Route('/settings/email', name: 'app_settings_email')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function email(Request $request): Response
     {
         $user = $this->requireUser();

--- a/src/User/UI/Http/DTO/ConfirmPasswordTypeDTO.php
+++ b/src/User/UI/Http/DTO/ConfirmPasswordTypeDTO.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Http\DTO;
+
+final class ConfirmPasswordTypeDTO
+{
+    public string $password = '';
+}

--- a/src/User/UI/Twig/templates/security/confirm_password.html.twig
+++ b/src/User/UI/Twig/templates/security/confirm_password.html.twig
@@ -1,0 +1,28 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.confirm_password'|trans }} - {{ parent() }}{% endblock %}
+
+{% block page_body %}
+    <div class="container container-tight py-4">
+        <twig:Card
+            size="md"
+        >
+            <h2 class="text-center mb-4">{{ 'title.confirm_password'|trans }}</h2>
+            <p class="text-secondary text-center mb-4">{{ 'text.confirm_password.intro'|trans }}</p>
+
+            <form method="post">
+                {% if error %}
+                    <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+                {% endif %}
+
+                {{ form_row(form.password) }}
+
+                <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('confirm_password') }}" />
+
+                <div class="form-footer">
+                    <button type="submit" class="btn btn-primary w-100">{{ 'label.confirm_password.submit'|trans }}</button>
+                </div>
+            </form>
+        </twig:Card>
+    </div>
+{% endblock %}

--- a/tests/Support/Browser/CookieConsentTestHelper.php
+++ b/tests/Support/Browser/CookieConsentTestHelper.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Support\Browser;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser as SymfonyKernelBrowser;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Browser\KernelBrowser;
 
 trait CookieConsentTestHelper
@@ -38,5 +40,66 @@ trait CookieConsentTestHelper
             ->fillField('Password', $password)
             ->click('Sign in')
             ->assertSuccessful();
+    }
+
+    protected function loginWithRememberMe(SymfonyKernelBrowser $client, string $username, string $password = 'password'): void
+    {
+        $this->acceptEssentialCookiesOnly($client);
+
+        $crawler = $client->request(Request::METHOD_GET, '/login');
+        $form = $crawler->selectButton('Sign in')->form([
+            'login[username]' => $username,
+            'login[password]' => $password,
+            'login[_remember_me]' => true,
+        ]);
+        $client->submit($form);
+
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+    }
+
+    /**
+     * @return array{rememberMe: \Symfony\Component\BrowserKit\Cookie, consentSubject: ?\Symfony\Component\BrowserKit\Cookie}
+     */
+    protected function extractRememberMeSessionCookies(SymfonyKernelBrowser $client): array
+    {
+        $rememberMe = $client->getCookieJar()->get('REMEMBERME');
+        if (!$rememberMe instanceof \Symfony\Component\BrowserKit\Cookie) {
+            self::fail('REMEMBERME cookie was not set after login with remember me.');
+        }
+
+        return [
+            'rememberMe' => $rememberMe,
+            'consentSubject' => $client->getCookieJar()->get('consent_subject_id'),
+        ];
+    }
+
+    protected function useRememberMeSessionOnly(
+        SymfonyKernelBrowser $client,
+        \Symfony\Component\BrowserKit\Cookie $rememberMeCookie,
+        ?\Symfony\Component\BrowserKit\Cookie $consentSubjectCookie = null,
+    ): SymfonyKernelBrowser {
+        $client->getCookieJar()->clear();
+        $client->getCookieJar()->set($rememberMeCookie);
+
+        if ($consentSubjectCookie instanceof \Symfony\Component\BrowserKit\Cookie) {
+            $client->getCookieJar()->set($consentSubjectCookie);
+        }
+
+        return $client;
+    }
+
+    protected function acceptEssentialCookiesOnly(SymfonyKernelBrowser $client): void
+    {
+        $client->request(Request::METHOD_GET, '/');
+
+        $crawler = $client->getCrawler();
+        $hasBannerButton = $crawler->filter('form[action="/cookies/banner"] button[name="cookie_consent_banner[essential]"]')->count() > 0;
+
+        if ($hasBannerButton) {
+            $form = $crawler->selectButton('Essential Cookies Only')->form();
+            $client->submit($form);
+        }
     }
 }

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -55,6 +55,7 @@ class AppRoutesTest extends WebTestCase
     {
         yield 'app_default' => ['/'];
         yield 'app_login' => ['/login'];
+        yield 'app_confirm_password' => ['/login/confirm'];
         yield 'app_register' => ['/register'];
         yield 'app_forgot_password_request' => ['/reset-password'];
         yield 'app_check_email' => ['/reset-password/check-email'];

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -55,7 +55,6 @@ class AppRoutesTest extends WebTestCase
     {
         yield 'app_default' => ['/'];
         yield 'app_login' => ['/login'];
-        yield 'app_confirm_password' => ['/login/confirm'];
         yield 'app_register' => ['/register'];
         yield 'app_forgot_password_request' => ['/reset-password'];
         yield 'app_check_email' => ['/reset-password/check-email'];
@@ -67,6 +66,7 @@ class AppRoutesTest extends WebTestCase
     public static function getSecureUrls(): \Generator
     {
         yield 'app_admin_dashboard' => ['/admin/'];
+        yield 'app_confirm_password' => ['/login/confirm'];
         yield 'app_settings_index' => ['/settings'];
         yield 'app_settings_email' => ['/settings/email'];
         yield 'app_settings_password' => ['/settings/password'];

--- a/tests/User/Functional/Controller/ConfirmPasswordControllerTest.php
+++ b/tests/User/Functional/Controller/ConfirmPasswordControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Functional\Controller;
+
+use App\Tests\Support\Browser\CookieConsentTestHelper;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ConfirmPasswordControllerTest extends WebTestCase
+{
+    use CookieConsentTestHelper;
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testRememberMeUserCanAccessSettingsOverviewWithoutConfirm(): void
+    {
+        UserFactory::new([
+            'email' => 'remember@example.test',
+            'isVerified' => true,
+            'username' => 'remember-user',
+        ])->create();
+
+        $client = $this->createRememberMeOnlyClient('remember-user');
+
+        $client->request(Request::METHOD_GET, '/settings');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Account Settings');
+        self::assertStringNotContainsString('Confirm your password', (string) $client->getResponse()->getContent());
+    }
+
+    public function testRememberMeUserCanAccessChangePasswordWithoutConfirm(): void
+    {
+        UserFactory::new([
+            'email' => 'remember-pwd@example.test',
+            'isVerified' => true,
+            'username' => 'remember-pwd-user',
+        ])->create();
+
+        $client = $this->createRememberMeOnlyClient('remember-pwd-user');
+
+        $client->request(Request::METHOD_GET, '/settings/password');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Change password');
+        self::assertStringNotContainsString('Confirm your password', (string) $client->getResponse()->getContent());
+    }
+
+    public function testRememberMeUserIsRedirectedToConfirmPasswordWhenAccessingChangeEmail(): void
+    {
+        UserFactory::new([
+            'email' => 'remember-email@example.test',
+            'isVerified' => true,
+            'username' => 'remember-email-user',
+        ])->create();
+
+        $client = $this->createRememberMeOnlyClient('remember-email-user');
+
+        $client->request(Request::METHOD_GET, '/settings/email');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Confirm your password');
+    }
+
+    public function testRememberMeUserCanConfirmPasswordAndAccessChangeEmail(): void
+    {
+        UserFactory::new([
+            'email' => 'remember-ok@example.test',
+            'isVerified' => true,
+            'username' => 'remember-ok-user',
+        ])->create();
+
+        $client = $this->createRememberMeOnlyClient('remember-ok-user');
+
+        $client->request(Request::METHOD_GET, '/settings/email');
+        self::assertSelectorTextContains('h2', 'Confirm your password');
+
+        $crawler = $client->getCrawler();
+        $csrfToken = $crawler->filter('input[name="_csrf_token"]')->attr('value');
+        self::assertIsString($csrfToken);
+
+        $client->request(Request::METHOD_POST, '/login/confirm', [
+            'confirm_password' => [
+                'password' => 'password',
+            ],
+            '_csrf_token' => $csrfToken,
+        ]);
+
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Change email');
+    }
+
+    public function testWrongPasswordShowsErrorOnConfirmPage(): void
+    {
+        UserFactory::new([
+            'email' => 'remember-bad@example.test',
+            'isVerified' => true,
+            'username' => 'remember-bad-user',
+        ])->create();
+
+        $client = $this->createRememberMeOnlyClient('remember-bad-user');
+
+        $client->request(Request::METHOD_GET, '/login/confirm');
+
+        $csrfToken = $client->getCrawler()->filter('input[name="_csrf_token"]')->attr('value');
+        self::assertIsString($csrfToken);
+
+        $client->request(Request::METHOD_POST, '/login/confirm', [
+            'confirm_password' => [
+                'password' => 'wrong-password',
+            ],
+            '_csrf_token' => $csrfToken,
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Confirm your password');
+        self::assertSelectorExists('.alert.alert-danger');
+    }
+
+    public function testFullyAuthenticatedUserIsRedirectedAwayFromConfirmPage(): void
+    {
+        UserFactory::new([
+            'email' => 'full-auth@example.test',
+            'isVerified' => true,
+            'username' => 'full-auth-user',
+        ])->create();
+
+        $client = $this->browser()->client();
+        $this->acceptEssentialCookiesOnly($client);
+
+        $crawler = $client->request(Request::METHOD_GET, '/login');
+        $form = $crawler->selectButton('Sign in')->form([
+            'login[username]' => 'full-auth-user',
+            'login[password]' => 'password',
+        ]);
+        $client->submit($form);
+
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+
+        $client->request(Request::METHOD_GET, '/login/confirm');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Confirm your password', (string) $client->getResponse()->getContent());
+    }
+
+    private function createRememberMeOnlyClient(string $username): \Symfony\Bundle\FrameworkBundle\KernelBrowser
+    {
+        $client = $this->browser()->client();
+        $this->loginWithRememberMe($client, $username);
+        $cookies = $this->extractRememberMeSessionCookies($client);
+        $this->useRememberMeSessionOnly($client, $cookies['rememberMe'], $cookies['consentSubject']);
+
+        return $client;
+    }
+}

--- a/tests/User/Functional/Controller/SettingsControllerTest.php
+++ b/tests/User/Functional/Controller/SettingsControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\User\Functional\Controller;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -69,6 +70,28 @@ final class SettingsControllerTest extends WebTestCase
         $browser->click('Resend verification email')->assertSee('Verification email sent.');
         $browser->click('Resend verification email')->assertSee('Verification email sent.');
         $browser->click('Resend verification email')->assertSee('Please wait before requesting another verification email.');
+    }
+
+    public function testRememberMeUserCanOpenSettingsOverviewAndPasswordPage(): void
+    {
+        UserFactory::new([
+            'email' => 'remember-settings@example.test',
+            'isVerified' => true,
+            'username' => 'remember-settings-user',
+        ])->create();
+
+        $client = $this->browser()->client();
+        $this->loginWithRememberMe($client, 'remember-settings-user');
+        $cookies = $this->extractRememberMeSessionCookies($client);
+        $this->useRememberMeSessionOnly($client, $cookies['rememberMe'], $cookies['consentSubject']);
+
+        $client->request(Request::METHOD_GET, '/settings');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Account Settings');
+
+        $client->request(Request::METHOD_GET, '/settings/password');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2', 'Change password');
     }
 
     public function testAuthenticatedUserCanOpenChangeEmailPage(): void

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -2087,6 +2087,22 @@
         <source>title.infection.list</source>
         <target>Listing Infections</target>
       </trans-unit>
+      <trans-unit id="cPw1Ttl" resname="title.confirm_password">
+        <source>title.confirm_password</source>
+        <target>Confirm your password</target>
+      </trans-unit>
+      <trans-unit id="cPw1Txt" resname="text.confirm_password.intro">
+        <source>text.confirm_password.intro</source>
+        <target>For security, please enter your password again before changing your email address.</target>
+      </trans-unit>
+      <trans-unit id="cPw1Lbl" resname="label.confirm_password">
+        <source>label.confirm_password</source>
+        <target>Password</target>
+      </trans-unit>
+      <trans-unit id="cPw1Sub" resname="label.confirm_password.submit">
+        <source>label.confirm_password.submit</source>
+        <target>Continue</target>
+      </trans-unit>
       <trans-unit id="Q.Y20KD" resname="title.login">
         <source>title.login</source>
         <target>Login</target>


### PR DESCRIPTION
### Summary

- Added a password confirmation (“step-up authentication”) flow
- Introduced a dedicated confirmation step before sensitive user actions
- Added handling for temporary elevated authentication state
- Integrated step-up checks into protected workflows and backend actions
- Updated security and authentication-related logic to support re-confirmation
- Added or updated tests covering confirmation flow and access restrictions

### Motivation

- Improve security for sensitive account and administrative operations
- Require users to re-confirm their identity before critical actions
- Reduce risk from stolen or unattended sessions
- Align authentication flows with common security best practices for privileged actions

### Notes for Reviewers

- Verify password confirmation and re-authentication behavior
- Check expiration/timeout handling for elevated authentication sessions
- Ensure protected actions correctly require step-up confirmation
- Review redirect and UX behavior after successful confirmation
- Confirm tests cover both successful and denied access scenarios