### PR TITLE
Fix “My Hospitals” scope access handling

### DIFF
--- a/src/Statistics/Application/Analysis/AllocationsComparisonOverTimeAnalysisDefinition.php
+++ b/src/Statistics/Application/Analysis/AllocationsComparisonOverTimeAnalysisDefinition.php
@@ -18,6 +18,7 @@ use App\Statistics\Application\DTO\WidgetPayload\SimpleChartWidgetPayload;
 use App\Statistics\Application\DTO\WidgetPayload\TableWidgetPayload;
 use App\Statistics\Application\DTO\WidgetPayload\WidgetPayloadNormalizer;
 use App\Statistics\Application\StatisticsContextFactory;
+use App\Statistics\Application\StatisticsHospitalScopeLabelResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class AllocationsComparisonOverTimeAnalysisDefinition implements AnalysisDefinitionInterface
@@ -29,6 +30,7 @@ final readonly class AllocationsComparisonOverTimeAnalysisDefinition implements 
         private TranslatorInterface $translator,
         private StateRepository $stateRepository,
         private DispatchAreaRepository $dispatchAreaRepository,
+        private StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
     ) {
     }
 
@@ -69,7 +71,7 @@ final readonly class AllocationsComparisonOverTimeAnalysisDefinition implements 
         $primarySeries = $this->allocationsByMonthQuery->fetch($context, StatisticsAnalysisDimension::Total);
         $primaryLabel = sprintf(
             '%s (%s)',
-            $this->scopeLabel($context->filter),
+            $this->scopeLabel($context->filter, $context->user),
             $this->periodLabel($context->filter),
         );
         $comparisonContext = $this->statisticsContextFactory->create(
@@ -79,7 +81,7 @@ final readonly class AllocationsComparisonOverTimeAnalysisDefinition implements 
         $comparisonFilter = $context->comparisonFilter ?? $context->filter;
         $comparisonLabel = sprintf(
             '%s (%s)',
-            $this->scopeLabel($comparisonFilter),
+            $this->scopeLabel($comparisonFilter, $context->user),
             $this->periodLabel($comparisonFilter),
         );
         $comparisonSeries = $this->allocationsByMonthQuery->fetch($comparisonContext, StatisticsAnalysisDimension::Total);
@@ -212,11 +214,11 @@ final readonly class AllocationsComparisonOverTimeAnalysisDefinition implements 
         };
     }
 
-    private function scopeLabel(StatisticsFilter $filter): string
+    private function scopeLabel(StatisticsFilter $filter, ?\App\User\Domain\Entity\User $user): string
     {
         return match ($filter->scope) {
             \App\Statistics\Application\DTO\StatisticsFilterScope::Public => $this->translator->trans('stats.filter.scope.public'),
-            \App\Statistics\Application\DTO\StatisticsFilterScope::MyHospitals => $this->translator->trans('stats.filter.scope.my_hospitals'),
+            \App\Statistics\Application\DTO\StatisticsFilterScope::MyHospitals => $this->hospitalScopeLabelResolver->groupLabel($user),
             \App\Statistics\Application\DTO\StatisticsFilterScope::Hospital => null !== $filter->hospitalId
                 ? sprintf('Hospital %d', $filter->hospitalId)
                 : $this->translator->trans('stats.filter.hospital.choose'),

--- a/src/Statistics/Application/ComparisonScopeResolver.php
+++ b/src/Statistics/Application/ComparisonScopeResolver.php
@@ -82,7 +82,7 @@ final readonly class ComparisonScopeResolver
      */
     private function accessibleHospitalIds(?User $user): array
     {
-        if (!$user instanceof User) {
+        if (!$user instanceof User || !$this->hospitalAccess->canUseMyHospitalsScope($user)) {
             return [];
         }
 

--- a/src/Statistics/Application/Contract/HospitalAccessInterface.php
+++ b/src/Statistics/Application/Contract/HospitalAccessInterface.php
@@ -8,6 +8,12 @@ use App\User\Domain\Entity\User;
 
 interface HospitalAccessInterface
 {
+    public function isAdminHospitalScopeUser(User $user): bool;
+
+    public function canUseMyHospitalsScope(User $user): bool;
+
+    public function canSelectHospitalScope(User $user, int $hospitalId): bool;
+
     public function countAccessibleHospitals(User $user): int;
 
     /**

--- a/src/Statistics/Application/StatisticsFilterFactory.php
+++ b/src/Statistics/Application/StatisticsFilterFactory.php
@@ -57,8 +57,13 @@ final readonly class StatisticsFilterFactory
             $hospitalId = null;
         }
 
-        if (StatisticsFilterScope::Hospital === $scope && $user instanceof User && null !== $hospitalId && !$this->userMayUseHospital($user, $hospitalId)) {
-            $scope = StatisticsFilterScope::MyHospitals;
+        if (StatisticsFilterScope::Hospital === $scope && $user instanceof User && null !== $hospitalId && !$this->hospitalAccess->canSelectHospitalScope($user, $hospitalId)) {
+            if ($this->hospitalAccess->canUseMyHospitalsScope($user)) {
+                $scope = StatisticsFilterScope::MyHospitals;
+            } else {
+                $scope = StatisticsFilterScope::Public;
+                $requiresPublicRedirect = true;
+            }
             $hospitalId = null;
         }
 
@@ -75,7 +80,9 @@ final readonly class StatisticsFilterFactory
         if (StatisticsFilterScope::HospitalCohort !== $scope) {
             $cohortType = null;
         } elseif (!$cohortType instanceof HospitalCohortType) {
-            $scope = StatisticsFilterScope::MyHospitals;
+            $scope = $user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)
+                ? StatisticsFilterScope::MyHospitals
+                : StatisticsFilterScope::Public;
         } else {
             $cohort = $this->hospitalCohortResolver->resolve($cohortType);
             if (!$this->hospitalCohortEligibilityChecker->hasMinimumParticipants($cohort)) {
@@ -116,8 +123,22 @@ final readonly class StatisticsFilterFactory
             $referenceMonth = null;
         }
 
-        if ($user instanceof User && StatisticsFilterScope::MyHospitals === $scope && !$this->userHasAnyAccessibleHospital($user) && !$explicitMyHospitalsInUrl) {
+        if (StatisticsFilterScope::MyHospitals === $scope && (!$user instanceof User || !$this->hospitalAccess->canUseMyHospitalsScope($user))) {
             $scope = StatisticsFilterScope::Public;
+            if ($explicitMyHospitalsInUrl) {
+                $requiresPublicRedirect = true;
+            }
+        }
+
+        if (StatisticsFilterScope::Hospital === $scope && $user instanceof User && null !== $hospitalId && !$this->hospitalAccess->canSelectHospitalScope($user, $hospitalId)) {
+            $scope = StatisticsFilterScope::Public;
+            $hospitalId = null;
+            $requiresPublicRedirect = true;
+        }
+
+        if (!$user instanceof User && StatisticsFilterScope::Hospital === $scope) {
+            $scope = StatisticsFilterScope::Public;
+            $hospitalId = null;
         }
 
         return new StatisticsFilter(
@@ -198,7 +219,7 @@ final readonly class StatisticsFilterFactory
 
     private function parseScope(string $raw): StatisticsFilterScope
     {
-        return StatisticsFilterScope::tryFrom($raw) ?? StatisticsFilterScope::MyHospitals;
+        return StatisticsFilterScope::tryFrom($raw) ?? StatisticsFilterScope::Public;
     }
 
     private function parsePeriod(string $raw): StatisticsFilterPeriod
@@ -224,17 +245,5 @@ final readonly class StatisticsFilterFactory
         $int = (int) $value;
 
         return $int > 0 ? $int : null;
-    }
-
-    private function userHasAnyAccessibleHospital(User $user): bool
-    {
-        return $this->hospitalAccess->countAccessibleHospitals($user) > 0;
-    }
-
-    private function userMayUseHospital(User $user, int $hospitalId): bool
-    {
-        $allowedIds = $this->hospitalAccess->accessibleHospitalIds($user);
-
-        return array_any($allowedIds, static fn (int $id): bool => $id === $hospitalId);
     }
 }

--- a/src/Statistics/Application/StatisticsHospitalScopeLabelResolver.php
+++ b/src/Statistics/Application/StatisticsHospitalScopeLabelResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application;
+
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\User\Domain\Entity\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class StatisticsHospitalScopeLabelResolver
+{
+    public function __construct(
+        private HospitalAccessInterface $hospitalAccess,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function groupLabel(?User $user, ?string $locale = null): string
+    {
+        if ($user instanceof User && $this->hospitalAccess->isAdminHospitalScopeUser($user)) {
+            return $this->translator->trans('stats.filter.scope.hospitals', [], null, $locale);
+        }
+
+        return $this->translator->trans('stats.filter.scope.my_hospitals', [], null, $locale);
+    }
+}

--- a/src/Statistics/Application/StatisticsScopeResolver.php
+++ b/src/Statistics/Application/StatisticsScopeResolver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application;
 
-use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Statistics\Application\Cohort\HospitalCohortResolver;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\Application\DTO\StatisticsScopeCriteria;
@@ -21,7 +21,7 @@ final class StatisticsScopeResolver
     private ?StatisticsScopeCriteria $resolvedCriteria = null;
 
     public function __construct(
-        private readonly HospitalRepository $hospitalRepository,
+        private readonly HospitalAccessInterface $hospitalAccess,
         private readonly HospitalCohortResolver $hospitalCohortResolver,
         private readonly GetDistinctHospitalIdsByStateQuery $distinctHospitalIdsByStateQuery,
         private readonly GetDistinctHospitalIdsByDispatchAreaQuery $distinctHospitalIdsByDispatchAreaQuery,
@@ -104,17 +104,10 @@ final class StatisticsScopeResolver
      */
     private function resolveMyHospitalIds(?User $user): array
     {
-        if (!$user instanceof User) {
+        if (!$user instanceof User || !$this->hospitalAccess->canUseMyHospitalsScope($user)) {
             return [];
         }
 
-        /** @var list<int|string> $rawIds */
-        $rawIds = $this->hospitalRepository
-            ->getQueryBuilderForAccessibleHospitals($user)
-            ->select('h.id')
-            ->getQuery()
-            ->getSingleColumnResult();
-
-        return array_map(static fn (int|string $id): int => (int) $id, $rawIds);
+        return $this->hospitalAccess->accessibleHospitalIds($user);
     }
 }

--- a/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
+++ b/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
@@ -7,12 +7,39 @@ namespace App\Statistics\Infrastructure\Adapter;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
 
 final readonly class DoctrineHospitalAccess implements HospitalAccessInterface
 {
     public function __construct(
         private HospitalRepository $hospitalRepository,
     ) {
+    }
+
+    #[\Override]
+    public function isAdminHospitalScopeUser(User $user): bool
+    {
+        return \in_array(UserRole::ADMIN, $user->getRoles(), true);
+    }
+
+    #[\Override]
+    public function canUseMyHospitalsScope(User $user): bool
+    {
+        if ($this->isAdminHospitalScopeUser($user)) {
+            return true;
+        }
+
+        if (!\in_array(UserRole::PARTICIPANT, $user->getRoles(), true)) {
+            return false;
+        }
+
+        return $this->countAccessibleHospitals($user) > 0;
+    }
+
+    #[\Override]
+    public function canSelectHospitalScope(User $user, int $hospitalId): bool
+    {
+        return \in_array($hospitalId, $this->accessibleHospitalIds($user), true);
     }
 
     #[\Override]

--- a/src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php
@@ -4,21 +4,32 @@ declare(strict_types=1);
 
 namespace App\Statistics\UI\Http\Controller;
 
+use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\Statistics\Application\DTO\StatisticsFilterInput;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
+use App\User\Domain\Entity\User;
 use Symfony\Component\HttpFoundation\InputBag;
 
-final class StatisticsFilterInputFactory
+final readonly class StatisticsFilterInputFactory
 {
+    public function __construct(
+        private HospitalAccessInterface $hospitalAccess,
+    ) {
+    }
+
     /**
      * @param InputBag<string> $query
      */
-    public function fromQuery(InputBag $query): StatisticsFilterInput
+    public function fromQuery(InputBag $query, ?User $user): StatisticsFilterInput
     {
+        $defaultScope = $user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)
+            ? StatisticsFilterScope::MyHospitals->value
+            : StatisticsFilterScope::Public->value;
+
         return new StatisticsFilterInput(
-            $query->getString('scope', StatisticsFilterScope::MyHospitals->value),
+            $query->getString('scope', $defaultScope),
             $query->getString('hospital'),
             $query->getString('cohort'),
             $query->getString('state'),

--- a/src/Statistics/UI/Http/Controller/StatisticsFilterValueResolver.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsFilterValueResolver.php
@@ -35,7 +35,7 @@ final readonly class StatisticsFilterValueResolver implements ValueResolverInter
         $domainUser = $user instanceof User ? $user : null;
 
         yield $this->statisticsFilterFactory->createFromInput(
-            $this->statisticsFilterInputFactory->fromQuery($request->query),
+            $this->statisticsFilterInputFactory->fromQuery($request->query, $domainUser),
             $domainUser,
         );
     }

--- a/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
@@ -10,9 +10,11 @@ use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Statistics\Application\Cohort\HospitalCohortEligibilityChecker;
 use App\Statistics\Application\Cohort\HospitalCohortResolver;
 use App\Statistics\Application\Cohort\HospitalCohortType;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\StatisticsHospitalScopeLabelResolver;
 use App\Statistics\Infrastructure\Query\Overview\GetEligibleDispatchAreaIdsQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery;
 use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
@@ -25,9 +27,11 @@ final readonly class StatisticsPageViewModelFactory
 {
     public function __construct(
         private HospitalRepository $hospitalRepository,
+        private HospitalAccessInterface $hospitalAccess,
         private HospitalCohortResolver $hospitalCohortResolver,
         private HospitalCohortEligibilityChecker $hospitalCohortEligibilityChecker,
         private TranslatorInterface $translator,
+        private StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
         private StatisticsNavigationUrlBuilder $statisticsNavigationUrlBuilder,
         private GetEligibleStateIdsQuery $eligibleStateIdsQuery,
         private GetEligibleDispatchAreaIdsQuery $eligibleDispatchAreaIdsQuery,
@@ -60,7 +64,7 @@ final readonly class StatisticsPageViewModelFactory
 
         $accessibleHospitals = [];
         $hospitalUrls = [];
-        if ($user instanceof User) {
+        if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
             $accessibleHospitals = $this->hospitalRepository->findAccessibleHospitalSummaries($user);
             foreach ($accessibleHospitals as $row) {
                 $hospitalUrls[(string) $row['id']] = $this->statisticsNavigationUrlBuilder->build(
@@ -148,7 +152,6 @@ final readonly class StatisticsPageViewModelFactory
             $eligibleDispatchRows,
             $cohortScopeChoices,
             $user,
-            $accessibleHospitals,
             $locale,
         );
 
@@ -165,7 +168,9 @@ final readonly class StatisticsPageViewModelFactory
             $accessibleHospitals,
         );
 
-        $myHospitalsDual = $user instanceof User && \count($accessibleHospitals) > 1
+        $myHospitalsDual = $user instanceof User
+            && $this->hospitalAccess->canUseMyHospitalsScope($user)
+            && \count($accessibleHospitals) > 1
             && (StatisticsFilterScope::MyHospitals === $filter->scope || StatisticsFilterScope::Hospital === $filter->scope);
         $stateDual = StatisticsFilterScope::State === $filter->scope && [] !== $eligibleStateRows;
         $dispatchDual = StatisticsFilterScope::DispatchArea === $filter->scope && [] !== $eligibleDispatchRows;
@@ -188,6 +193,7 @@ final readonly class StatisticsPageViewModelFactory
 
         [$scopePrimaryDropdownLabel, $scopeSecondaryDropdownLabel] = $this->scopeDropdownLabels(
             $filter,
+            $user,
             $accessibleHospitals,
             $locale,
             $showScopeSecondaryPicker,
@@ -216,6 +222,7 @@ final readonly class StatisticsPageViewModelFactory
             $user instanceof User,
             $this->statisticsHeadingScope(
                 $filter,
+                $user,
                 $hospitalDropdownSelectedName,
                 $locale,
                 $showUnscopedHint,
@@ -278,7 +285,6 @@ final readonly class StatisticsPageViewModelFactory
      * @param list<array{id: int, name: string}>                                 $eligibleStateRows
      * @param list<array{id: int, name: string}>                                 $eligibleDispatchRows
      * @param list<array{key: string, label: string, url: string, active: bool}> $cohortScopeChoices
-     * @param list<array{id: int, name: string}>                                 $accessibleHospitals
      *
      * @return list<array{key: string, label: string, url: string, active: bool}>
      */
@@ -291,7 +297,6 @@ final readonly class StatisticsPageViewModelFactory
         array $eligibleDispatchRows,
         array $cohortScopeChoices,
         ?User $user,
-        array $accessibleHospitals,
         string $locale,
     ): array {
         $menu = [];
@@ -332,10 +337,10 @@ final readonly class StatisticsPageViewModelFactory
             ];
         }
 
-        if ($user instanceof User && [] !== $accessibleHospitals) {
+        if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
             $menu[] = [
                 'key' => 'my_hospitals_group',
-                'label' => $this->translator->trans('stats.filter.scope.my_hospitals', [], null, $locale),
+                'label' => $this->hospitalScopeLabelResolver->groupLabel($user, $locale),
                 'url' => $scopeUrls['my_hospitals'],
                 'active' => StatisticsFilterScope::MyHospitals === $filter->scope
                     || StatisticsFilterScope::Hospital === $filter->scope,
@@ -407,6 +412,7 @@ final readonly class StatisticsPageViewModelFactory
         }
 
         if ($user instanceof User
+            && $this->hospitalAccess->canUseMyHospitalsScope($user)
             && \count($accessibleHospitals) > 1
             && (StatisticsFilterScope::MyHospitals === $filter->scope || StatisticsFilterScope::Hospital === $filter->scope)
         ) {
@@ -436,6 +442,7 @@ final readonly class StatisticsPageViewModelFactory
      */
     private function scopeDropdownLabels(
         StatisticsFilter $filter,
+        ?User $user,
         array $accessibleHospitals,
         string $locale,
         bool $showScopeSecondaryPicker,
@@ -446,6 +453,7 @@ final readonly class StatisticsPageViewModelFactory
             return [
                 $this->statisticsHeadingScope(
                     $filter,
+                    $user,
                     $hospitalDropdownSelectedName,
                     $locale,
                     $showUnscopedHint,
@@ -457,13 +465,15 @@ final readonly class StatisticsPageViewModelFactory
             ];
         }
 
+        $hospitalGroupLabel = $this->hospitalScopeLabelResolver->groupLabel($user, $locale);
+
         $primary = match ($filter->scope) {
             StatisticsFilterScope::Public => $this->translator->trans('stats.filter.scope.public', [], null, $locale),
             StatisticsFilterScope::State => $this->translator->trans('stats.filter.scope.state', [], null, $locale),
             StatisticsFilterScope::DispatchArea => $this->translator->trans('stats.filter.scope.dispatch_area', [], null, $locale),
             StatisticsFilterScope::HospitalCohort => $this->translator->trans('stats.filter.scope.hospital_cohort', [], null, $locale),
             StatisticsFilterScope::MyHospitals,
-            StatisticsFilterScope::Hospital => $this->translator->trans('stats.filter.scope.my_hospitals', [], null, $locale),
+            StatisticsFilterScope::Hospital => $hospitalGroupLabel,
         };
 
         $secondary = match ($filter->scope) {
@@ -527,6 +537,7 @@ final readonly class StatisticsPageViewModelFactory
 
     private function statisticsHeadingScope(
         StatisticsFilter $filter,
+        ?User $user,
         ?string $hospitalDisplayName,
         string $locale,
         bool $loggedInUserHasNoAccessibleHospitals,
@@ -534,17 +545,19 @@ final readonly class StatisticsPageViewModelFactory
         ?string $stateDisplayName,
         ?string $dispatchDisplayName,
     ): string {
+        $hospitalGroupLabel = $this->hospitalScopeLabelResolver->groupLabel($user, $locale);
+
         if (StatisticsFilterScope::MyHospitals === $filter->scope && $loggedInUserHasNoAccessibleHospitals) {
             return $this->translator->trans('stats.filter.scope.public', [], null, $locale);
         }
 
         if (1 === $accessibleHospitalCount && StatisticsFilterScope::Hospital === $filter->scope) {
-            return $this->translator->trans('stats.filter.scope.my_hospitals', [], null, $locale);
+            return $hospitalGroupLabel;
         }
 
         return match ($filter->scope) {
             StatisticsFilterScope::Public => $this->translator->trans('stats.filter.scope.public', [], null, $locale),
-            StatisticsFilterScope::MyHospitals => $this->translator->trans('stats.filter.scope.my_hospitals', [], null, $locale),
+            StatisticsFilterScope::MyHospitals => $hospitalGroupLabel,
             StatisticsFilterScope::Hospital => (null !== $hospitalDisplayName && '' !== $hospitalDisplayName)
                 ? $this->translator->trans('stats.filter.hospital.named_line', ['name' => $hospitalDisplayName], null, $locale)
                 : $this->translator->trans('stats.filter.hospital.choose', [], null, $locale),

--- a/tests/Statistics/Unit/Application/Analysis/AllocationsComparisonOverTimeAnalysisDefinitionTest.php
+++ b/tests/Statistics/Unit/Application/Analysis/AllocationsComparisonOverTimeAnalysisDefinitionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application\Analysis;
+
+use App\Statistics\Application\Analysis\AllocationsComparisonOverTimeAnalysisDefinition;
+use App\Statistics\Application\DTO\StatisticsAnalysisDimension;
+use App\Statistics\Application\DTO\StatisticsChartMeasure;
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\DTO\StatisticWidgetType;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class AllocationsComparisonOverTimeAnalysisDefinitionTest extends KernelTestCase
+{
+    public function testBuildUsesHospitalsLabelForAdminMyHospitalsScope(): void
+    {
+        self::bootKernel();
+        $definition = self::getContainer()->get(AllocationsComparisonOverTimeAnalysisDefinition::class);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $primary = new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All);
+        $comparison = new StatisticsFilter(StatisticsFilterScope::Public, null, null, StatisticsFilterPeriod::All);
+        $context = new StatisticsContext($admin, $primary, comparisonFilter: $comparison);
+
+        self::assertTrue($definition->supports($context));
+
+        $widget = $definition->build(
+            $context,
+            'table',
+            'line',
+            StatisticsAnalysisDimension::Total,
+            StatisticsChartMeasure::Absolute,
+        );
+
+        self::assertSame(StatisticWidgetType::Table, $widget->type);
+        $headers = $widget->payload['headerTranslationKeys'] ?? null;
+        self::assertIsArray($headers);
+        self::assertStringContainsString('Hospitals', (string) $headers[1]);
+    }
+}

--- a/tests/Statistics/Unit/Application/ComparisonScopeResolverTest.php
+++ b/tests/Statistics/Unit/Application/ComparisonScopeResolverTest.php
@@ -8,6 +8,7 @@ use App\Statistics\Application\ComparisonScopeResolver;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -111,5 +112,20 @@ final class ComparisonScopeResolverTest extends KernelTestCase
 
         self::assertSame(StatisticsFilterScope::Public, $comparisonFilter->scope);
         self::assertNull($comparisonFilter->stateId);
+    }
+
+    public function testPrimaryMyHospitalsWithoutAccessStillResolvesComparisonFilter(): void
+    {
+        self::bootKernel();
+        $resolver = self::getContainer()->get(ComparisonScopeResolver::class);
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+
+        $comparisonFilter = $resolver->resolve(
+            new Request(query: ['comparison_scope' => 'public']),
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertSame(StatisticsFilterScope::Public, $comparisonFilter->scope);
     }
 }

--- a/tests/Statistics/Unit/Application/StatisticsFilterFactoryAccessTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsFilterFactoryAccessTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\Application\DTO\StatisticsFilterInput;
+use App\Statistics\Application\StatisticsFilterFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class StatisticsFilterFactoryAccessTest extends KernelTestCase
+{
+    private StatisticsFilterFactory $factory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->factory = self::getContainer()->get(StatisticsFilterFactory::class);
+    }
+
+    public function testInvalidCohortFallsBackToPublicForAnonymousUser(): void
+    {
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital_cohort',
+                '',
+                'unknown_cohort',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            null,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+    }
+
+    public function testExplicitMyHospitalsWithoutAccessRedirectsToPublic(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'my_hospitals',
+                '',
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+        self::assertTrue($filter->requiresPublicRedirect);
+    }
+
+    public function testParticipantWithHospitalCanUseHospitalScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $user]);
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital',
+                (string) $hospital->getId(),
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('hospital', $filter->scope->value);
+        self::assertSame($hospital->getId(), $filter->hospitalId);
+    }
+}

--- a/tests/Statistics/Unit/Application/StatisticsFilterFactoryAccessTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsFilterFactoryAccessTest.php
@@ -91,4 +91,172 @@ final class StatisticsFilterFactoryAccessTest extends KernelTestCase
         self::assertSame('hospital', $filter->scope->value);
         self::assertSame($hospital->getId(), $filter->hospitalId);
     }
+
+    public function testAnonymousMyHospitalsScopeBecomesPublic(): void
+    {
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'my_hospitals',
+                '',
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                false,
+            ),
+            null,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+    }
+
+    public function testAnonymousHospitalScopeBecomesPublic(): void
+    {
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital',
+                '99',
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            null,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+        self::assertNull($filter->hospitalId);
+    }
+
+    public function testHospitalScopeWithoutIdFallsBackToMyHospitalsForParticipant(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $user]);
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital',
+                '',
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('my_hospitals', $filter->scope->value);
+    }
+
+    public function testUnauthorizedHospitalFallsBackToMyHospitalsWhenParticipantHasOwnedHospitals(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $otherOwner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $user]);
+        $foreign = HospitalFactory::createOne(['owner' => $otherOwner]);
+        self::assertNotNull($foreign->getId());
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital',
+                (string) $foreign->getId(),
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('my_hospitals', $filter->scope->value);
+        self::assertNull($filter->hospitalId);
+    }
+
+    public function testUnauthorizedHospitalRedirectsToPublicWithoutMyHospitalsAccess(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+        $otherOwner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $foreign = HospitalFactory::createOne(['owner' => $otherOwner]);
+        self::assertNotNull($foreign->getId());
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital',
+                (string) $foreign->getId(),
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+        self::assertTrue($filter->requiresPublicRedirect);
+    }
+
+    public function testInvalidCohortFallsBackToMyHospitalsForParticipant(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $user]);
+
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'hospital_cohort',
+                '',
+                'unknown_cohort',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            $user,
+        );
+
+        self::assertSame('my_hospitals', $filter->scope->value);
+    }
+
+    public function testUnknownScopeTokenFallsBackToPublic(): void
+    {
+        $filter = $this->factory->createFromInput(
+            new StatisticsFilterInput(
+                'not_a_real_scope',
+                '',
+                '',
+                '',
+                '',
+                'all',
+                null,
+                null,
+                true,
+            ),
+            null,
+        );
+
+        self::assertSame('public', $filter->scope->value);
+    }
 }

--- a/tests/Statistics/Unit/Application/StatisticsFilterFactoryTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsFilterFactoryTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Unit\Application;
 
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Statistics\Application\DTO\StatisticsFilterInput;
 use App\Statistics\Application\StatisticsFilterFactory;
+use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class StatisticsFilterFactoryTest extends KernelTestCase
@@ -30,7 +34,7 @@ final class StatisticsFilterFactoryTest extends KernelTestCase
             null,
         );
 
-        self::assertSame('my_hospitals', $filter->scope->value);
+        self::assertSame('public', $filter->scope->value);
         self::assertNull($filter->cohortType);
         self::assertNull($filter->notice);
     }
@@ -55,7 +59,7 @@ final class StatisticsFilterFactoryTest extends KernelTestCase
             null,
         );
 
-        self::assertSame('my_hospitals', $filter->scope->value);
+        self::assertSame('public', $filter->scope->value);
         self::assertNull($filter->cohortType);
         self::assertNull($filter->notice);
     }
@@ -64,10 +68,16 @@ final class StatisticsFilterFactoryTest extends KernelTestCase
     {
         self::bootKernel();
         $factory = self::getContainer()->get(StatisticsFilterFactory::class);
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $user]);
+        $hospitalId = $hospital->getId();
+        self::assertNotNull($hospitalId);
 
         $filter = $factory->createFromInput(
             new StatisticsFilterInput(
-                'hospital:12',
+                'hospital:'.$hospitalId,
                 '',
                 '',
                 '',
@@ -77,11 +87,11 @@ final class StatisticsFilterFactoryTest extends KernelTestCase
                 null,
                 true,
             ),
-            null,
+            $user,
         );
 
         self::assertSame('hospital', $filter->scope->value);
-        self::assertSame(12, $filter->hospitalId);
+        self::assertSame($hospitalId, $filter->hospitalId);
     }
 
     public function testInvalidStateScopeFallsBackToPublic(): void

--- a/tests/Statistics/Unit/Application/StatisticsFilterInputFactoryTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsFilterInputFactoryTest.php
@@ -11,6 +11,7 @@ use App\Statistics\UI\Http\Controller\StatisticsFilterInputFactory;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
 
 final class StatisticsFilterInputFactoryTest extends KernelTestCase
 {
@@ -26,7 +27,7 @@ final class StatisticsFilterInputFactoryTest extends KernelTestCase
     public function testDefaultScopeIsPublicForUserWithoutHospitalAccess(): void
     {
         $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
-        $input = $this->factory->fromQuery(new InputBag([]), $user);
+        $input = $this->factory->fromQuery($this->queryBag([]), $user);
 
         self::assertSame('public', $input->scope);
         self::assertFalse($input->hasScopeQueryParameter);
@@ -39,8 +40,18 @@ final class StatisticsFilterInputFactoryTest extends KernelTestCase
         DispatchAreaFactory::createOne();
         HospitalFactory::createOne(['owner' => $user]);
 
-        $input = $this->factory->fromQuery(new InputBag([]), $user);
+        $input = $this->factory->fromQuery($this->queryBag([]), $user);
 
         self::assertSame('my_hospitals', $input->scope);
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     *
+     * @return InputBag<string>
+     */
+    private function queryBag(array $parameters): InputBag
+    {
+        return (new Request($parameters))->query;
     }
 }

--- a/tests/Statistics/Unit/Application/StatisticsFilterInputFactoryTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsFilterInputFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\UI\Http\Controller\StatisticsFilterInputFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+
+final class StatisticsFilterInputFactoryTest extends KernelTestCase
+{
+    private StatisticsFilterInputFactory $factory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->factory = self::getContainer()->get(StatisticsFilterInputFactory::class);
+    }
+
+    public function testDefaultScopeIsPublicForUserWithoutHospitalAccess(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+        $input = $this->factory->fromQuery(new InputBag([]), $user);
+
+        self::assertSame('public', $input->scope);
+        self::assertFalse($input->hasScopeQueryParameter);
+    }
+
+    public function testDefaultScopeIsMyHospitalsForParticipantWithOwnedHospital(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $user]);
+
+        $input = $this->factory->fromQuery(new InputBag([]), $user);
+
+        self::assertSame('my_hospitals', $input->scope);
+    }
+}

--- a/tests/Statistics/Unit/Application/StatisticsHospitalScopeLabelResolverTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsHospitalScopeLabelResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application;
+
+use App\Statistics\Application\StatisticsHospitalScopeLabelResolver;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class StatisticsHospitalScopeLabelResolverTest extends KernelTestCase
+{
+    public function testAdminSeesHospitalsLabel(): void
+    {
+        self::bootKernel();
+        $resolver = self::getContainer()->get(StatisticsHospitalScopeLabelResolver::class);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+
+        self::assertSame('Hospitals', $resolver->groupLabel($admin));
+    }
+
+    public function testParticipantSeesMyHospitalsLabel(): void
+    {
+        self::bootKernel();
+        $resolver = self::getContainer()->get(StatisticsHospitalScopeLabelResolver::class);
+        $participant = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        self::assertSame('My hospitals', $resolver->groupLabel($participant));
+    }
+}

--- a/tests/Statistics/Unit/Application/StatisticsScopeResolverTest.php
+++ b/tests/Statistics/Unit/Application/StatisticsScopeResolverTest.php
@@ -10,6 +10,7 @@ use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\Application\StatisticsScopeResolver;
+use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class StatisticsScopeResolverTest extends KernelTestCase
@@ -77,5 +78,19 @@ final class StatisticsScopeResolverTest extends KernelTestCase
         self::assertSame(HospitalCohortType::UrbanBasic, $criteria->cohortType);
         self::assertNotEmpty($criteria->locationCodes);
         self::assertNotEmpty($criteria->tierCodes);
+    }
+
+    public function testMyHospitalsScopeWithoutAccessFallsBackToPublicCriteria(): void
+    {
+        self::bootKernel();
+        $resolver = self::getContainer()->get(StatisticsScopeResolver::class);
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+
+        $criteria = $resolver->resolveCriteria(new StatisticsContext(
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        ));
+
+        self::assertNull($criteria->hospitalIds);
     }
 }

--- a/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
+++ b/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
@@ -95,6 +95,21 @@ final class StatisticsPageViewModelFactoryAccessTest extends KernelTestCase
         self::assertGreaterThanOrEqual(3, \count($model->scopeSecondaryMenu));
     }
 
+    public function testShowsUnscopedHintForParticipantWithoutLinkedHospitalsOnMyHospitalsScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertTrue($model->showUnscopedHint);
+        self::assertSame('Public', $model->headingScope);
+    }
+
     /**
      * @param list<array{key: string, label: string, url: string, active: bool}> $menu
      */

--- a/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
+++ b/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\UI\Http\Controller\StatisticsPageViewModelFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class StatisticsPageViewModelFactoryAccessTest extends KernelTestCase
+{
+    private StatisticsPageViewModelFactory $factory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->factory = self::getContainer()->get(StatisticsPageViewModelFactory::class);
+    }
+
+    public function testUserWithoutParticipantHasNoMyHospitalsMenuEntry(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'public', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::Public, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertFalse($this->hasMenuKey($model->scopePrimaryMenu, 'my_hospitals_group'));
+    }
+
+    public function testParticipantSeesMyHospitalsLabel(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $user]);
+        HospitalFactory::createOne(['owner' => $user]);
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertTrue($this->hasMenuKey($model->scopePrimaryMenu, 'my_hospitals_group'));
+        self::assertSame('My hospitals', $this->menuLabel($model->scopePrimaryMenu, 'my_hospitals_group'));
+    }
+
+    public function testAdminSeesHospitalsLabel(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createMany(2);
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertTrue($this->hasMenuKey($model->scopePrimaryMenu, 'my_hospitals_group'));
+        self::assertSame('Hospitals', $this->menuLabel($model->scopePrimaryMenu, 'my_hospitals_group'));
+    }
+
+    public function testDualRoleUserSeesHospitalsLabelAndAllHospitalsInSecondary(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createMany(3);
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertSame('Hospitals', $this->menuLabel($model->scopePrimaryMenu, 'my_hospitals_group'));
+        self::assertTrue($model->showScopeSecondaryPicker);
+        self::assertGreaterThanOrEqual(3, \count($model->scopeSecondaryMenu));
+    }
+
+    /**
+     * @param list<array{key: string, label: string, url: string, active: bool}> $menu
+     */
+    private function hasMenuKey(array $menu, string $key): bool
+    {
+        return array_any($menu, fn ($item): bool => $item['key'] === $key);
+    }
+
+    /**
+     * @param list<array{key: string, label: string, url: string, active: bool}> $menu
+     */
+    private function menuLabel(array $menu, string $key): string
+    {
+        foreach ($menu as $item) {
+            if ($item['key'] === $key) {
+                return $item['label'];
+            }
+        }
+
+        throw new \RuntimeException(sprintf('Menu key "%s" not found.', $key));
+    }
+}

--- a/tests/Statistics/Unit/Infrastructure/Adapter/DoctrineHospitalAccessTest.php
+++ b/tests/Statistics/Unit/Infrastructure/Adapter/DoctrineHospitalAccessTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Infrastructure\Adapter;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DoctrineHospitalAccessTest extends KernelTestCase
+{
+    private HospitalAccessInterface $access;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->access = self::getContainer()->get(HospitalAccessInterface::class);
+    }
+
+    public function testUserWithoutParticipantCannotUseMyHospitalsScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+
+        self::assertFalse($this->access->canUseMyHospitalsScope($user));
+        self::assertFalse($this->access->isAdminHospitalScopeUser($user));
+    }
+
+    public function testParticipantWithoutOwnedHospitalsCannotUseScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        self::assertFalse($this->access->canUseMyHospitalsScope($user));
+    }
+
+    public function testParticipantWithOwnedHospitalsCanUseScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $owned = HospitalFactory::createOne(['owner' => $user]);
+        HospitalFactory::createOne();
+
+        self::assertTrue($this->access->canUseMyHospitalsScope($user));
+        self::assertTrue($this->access->canSelectHospitalScope($user, $owned->getId() ?? 0));
+        self::assertSame([$owned->getId()], $this->access->accessibleHospitalIds($user));
+    }
+
+    public function testAdminCanAlwaysUseScopeAndSeesAllHospitals(): void
+    {
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $owned = HospitalFactory::createOne(['owner' => $owner]);
+        $other = HospitalFactory::createOne();
+
+        self::assertTrue($this->access->isAdminHospitalScopeUser($admin));
+        self::assertTrue($this->access->canUseMyHospitalsScope($admin));
+        self::assertContains($owned->getId(), $this->access->accessibleHospitalIds($admin));
+        self::assertContains($other->getId(), $this->access->accessibleHospitalIds($admin));
+    }
+
+    public function testAdminAndParticipantUsesAdminVariant(): void
+    {
+        $dual = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_PARTICIPANT']]);
+        $otherOwner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne(['owner' => $dual]);
+        $foreign = HospitalFactory::createOne(['owner' => $otherOwner]);
+
+        self::assertTrue($this->access->isAdminHospitalScopeUser($dual));
+        self::assertTrue($this->access->canUseMyHospitalsScope($dual));
+        self::assertContains($foreign->getId(), $this->access->accessibleHospitalIds($dual));
+    }
+}

--- a/tests/Statistics/Unit/Infrastructure/Adapter/DoctrineHospitalAccessTest.php
+++ b/tests/Statistics/Unit/Infrastructure/Adapter/DoctrineHospitalAccessTest.php
@@ -40,13 +40,15 @@ final class DoctrineHospitalAccessTest extends KernelTestCase
     public function testParticipantWithOwnedHospitalsCanUseScope(): void
     {
         $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $otherOwner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
         StateFactory::createOne();
         DispatchAreaFactory::createOne();
         $owned = HospitalFactory::createOne(['owner' => $user]);
-        HospitalFactory::createOne();
+        HospitalFactory::createOne(['owner' => $otherOwner]);
 
         self::assertTrue($this->access->canUseMyHospitalsScope($user));
-        self::assertTrue($this->access->canSelectHospitalScope($user, $owned->getId() ?? 0));
+        self::assertNotNull($owned->getId());
+        self::assertTrue($this->access->canSelectHospitalScope($user, $owned->getId()));
         self::assertSame([$owned->getId()], $this->access->accessibleHospitalIds($user));
     }
 
@@ -56,8 +58,9 @@ final class DoctrineHospitalAccessTest extends KernelTestCase
         $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
         StateFactory::createOne();
         DispatchAreaFactory::createOne();
+        $foreignOwner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
         $owned = HospitalFactory::createOne(['owner' => $owner]);
-        $other = HospitalFactory::createOne();
+        $other = HospitalFactory::createOne(['owner' => $foreignOwner]);
 
         self::assertTrue($this->access->isAdminHospitalScopeUser($admin));
         self::assertTrue($this->access->canUseMyHospitalsScope($admin));

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -2187,6 +2187,10 @@
         <source>stats.filter.scope.my_hospitals</source>
         <target>My hospitals</target>
       </trans-unit>
+      <trans-unit id="statsFlt03a" resname="stats.filter.scope.hospitals">
+        <source>stats.filter.scope.hospitals</source>
+        <target>Hospitals</target>
+      </trans-unit>
       <trans-unit id="statsFlt03b" resname="stats.filter.scope.hospital_cohort">
         <source>stats.filter.scope.hospital_cohort</source>
         <target>Hospital cohort</target>


### PR DESCRIPTION
### Summary

- Fixed access handling for the **My Hospitals** scope
- Ensured hospital-based scope checks correctly respect the current user’s assigned hospitals
- Adjusted related query/filter logic where scope restrictions are applied
- Improved consistency between hospital access rules and scoped statistics/data views
- Added or updated tests for the corrected access behavior

### Motivation

- Prevent users from seeing data outside their assigned hospital scope
- Ensure “My Hospitals” behaves consistently across affected views and queries
- Strengthen access control around hospital-scoped data
- Improve reliability of statistics and data filtering for restricted users

### Notes for Reviewers

- Verify that users only see data for hospitals assigned to them
- Check behavior for users with no assigned hospitals
- Confirm admins/global users still retain expected broader access
- Review affected filters and statistics queries for correct scope application
- Ensure related tests cover the fixed access scenarios