### PR TITLE
security: Remove redundant admin security checks

### DIFF
--- a/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
+++ b/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
@@ -18,10 +18,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Allocation>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class AllocationCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Assignment/AssignmentCrudController.php
+++ b/src/Admin/UI/Http/Controller/Assignment/AssignmentCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Assignment>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class AssignmentCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Blog/PostCategoryCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCategoryCrudController.php
@@ -13,11 +13,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * @extends AbstractCrudController<PostCategory>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class PostCategoryCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Blog/PostCommentCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCommentCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<PostComment>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class PostCommentCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
@@ -18,11 +18,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * @extends AbstractCrudController<Post>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class PostCrudController extends AbstractCrudController
 {
     public function __construct(

--- a/src/Admin/UI/Http/Controller/Blog/PostTagCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostTagCrudController.php
@@ -13,11 +13,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * @extends AbstractCrudController<PostTag>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class PostTagCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/DashboardController.php
+++ b/src/Admin/UI/Http/Controller/DashboardController.php
@@ -35,8 +35,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AdminDashboard(routePath: '/admin', routeName: 'app_admin_dashboard')]
+#[IsGranted('ROLE_ADMIN')]
 final class DashboardController extends AbstractDashboardController
 {
     public function __construct(

--- a/src/Admin/UI/Http/Controller/Department/DepartmentCrudController.php
+++ b/src/Admin/UI/Http/Controller/Department/DepartmentCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Department>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class DepartmentCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/DispatchArea/DispatchAreaCrudController.php
+++ b/src/Admin/UI/Http/Controller/DispatchArea/DispatchAreaCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<DispatchArea>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class DispatchAreaCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -21,10 +21,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Hospital>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class HospitalCrudController extends AbstractCrudController
 {
     public function __construct(

--- a/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
@@ -22,10 +22,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\ChoiceFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Import>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class ImportCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/ImportReject/ImportRejectCrudController.php
+++ b/src/Admin/UI/Http/Controller/ImportReject/ImportRejectCrudController.php
@@ -25,10 +25,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<ImportReject>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class ImportRejectCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/IndicationNormalized/IndicationNormalizedCrudController.php
+++ b/src/Admin/UI/Http/Controller/IndicationNormalized/IndicationNormalizedCrudController.php
@@ -14,10 +14,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<IndicationNormalized>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class IndicationNormalizedCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/IndicationRaw/IndicationRawCrudController.php
+++ b/src/Admin/UI/Http/Controller/IndicationRaw/IndicationRawCrudController.php
@@ -14,10 +14,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<IndicationRaw>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class IndicationRawCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Infection/InfectionCrudController.php
+++ b/src/Admin/UI/Http/Controller/Infection/InfectionCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Infection>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class InfectionCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/MciCase/MciCaseCrudController.php
+++ b/src/Admin/UI/Http/Controller/MciCase/MciCaseCrudController.php
@@ -19,10 +19,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<MciCase>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class MciCaseCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Occasion/OccasionCrudController.php
+++ b/src/Admin/UI/Http/Controller/Occasion/OccasionCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Occasion>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class OccasionCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/SecondaryTransport/SecondaryTransportCrudController.php
+++ b/src/Admin/UI/Http/Controller/SecondaryTransport/SecondaryTransportCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<SecondaryTransport>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class SecondaryTransportCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Speciality/SpecialityCrudController.php
+++ b/src/Admin/UI/Http/Controller/Speciality/SpecialityCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<Speciality>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class SpecialityCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/src/Admin/UI/Http/Controller/State/StateCrudController.php
+++ b/src/Admin/UI/Http/Controller/State/StateCrudController.php
@@ -13,10 +13,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * @extends AbstractCrudController<State>
  */
+#[IsGranted('ROLE_ADMIN')]
 final class StateCrudController extends AbstractCrudController
 {
     #[\Override]

--- a/tests/Shared/Functional/Security/AdminAccessControlTest.php
+++ b/tests/Shared/Functional/Security/AdminAccessControlTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Functional\Security;
+
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class AdminAccessControlTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+    use ResetDatabase;
+
+    public function testAdminRedirectsGuestsToLogin(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testAdminIsForbiddenForUserWithoutAdminRole(): void
+    {
+        $client = self::createClient();
+        $this->loginAsRoleUser($client);
+        $client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminIsAccessibleForAdminUser(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']])->_real();
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
### Summary

- Removed redundant admin security checks/configuration
- Simplified access-control handling for admin routes
- Reduced duplication between controller-level and configuration-level security rules
- Kept existing admin access restrictions intact
- Added or updated tests where needed to verify access behavior

### Motivation

- Avoid duplicated security declarations that are harder to maintain
- Keep admin access rules centralized and easier to reason about
- Reduce risk of inconsistent authorization behavior over time
- Improve clarity of the security configuration without changing intended access

### Notes for Reviewers

- Verify admin routes remain protected as before
- Check that removed security checks were truly redundant
- Confirm non-admin users are still denied access
- Ensure no admin controller or route became unintentionally public
- Review related tests for admin access coverage