### PR TITLE
feat: Add admin dashboard overview

### DIFF
--- a/src/Admin/UI/Http/Controller/DashboardController.php
+++ b/src/Admin/UI/Http/Controller/DashboardController.php
@@ -34,7 +34,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AdminDashboard(routePath: '/admin', routeName: 'app_admin_dashboard')]
@@ -48,13 +48,137 @@ final class DashboardController extends AbstractDashboardController
     }
 
     #[\Override]
-    public function index(): RedirectResponse
+    public function index(): Response
     {
-        $url = $this->adminUrlGenerator
-            ->setController(UserCrudController::class)
-            ->generateUrl();
+        return $this->render('@Admin/dashboard/index.html.twig', [
+            'dashboard_sections' => $this->buildDashboardSections(),
+        ]);
+    }
 
-        return $this->redirect($url);
+    /**
+     * @return list<array{title: string, tiles: list<array{label: string, description: string|null, icon: string, url: string, badge: array{value: int, style: string}|null}>}>
+     */
+    private function buildDashboardSections(): array
+    {
+        $openFeedbackCount = $this->feedbackRepository->countOpen();
+
+        $sections = $this->dashboardSections();
+        $built = [];
+
+        foreach ($sections as $section) {
+            $tiles = [];
+
+            foreach ($section['tiles'] as $tile) {
+                $badge = null;
+                if (isset($tile['badge_key']) && 'feedback' === $tile['badge_key']) {
+                    $badge = [
+                        'value' => $openFeedbackCount,
+                        'style' => $openFeedbackCount > 0 ? 'info' : 'primary',
+                    ];
+                }
+
+                $tiles[] = [
+                    'label' => $tile['label'],
+                    'description' => $tile['description'] ?? null,
+                    'icon' => $tile['icon'],
+                    'url' => $this->adminUrlGenerator
+                        ->setController($tile['controller'])
+                        ->generateUrl(),
+                    'badge' => $badge,
+                ];
+            }
+
+            $built[] = [
+                'title' => $section['title'],
+                'tiles' => $tiles,
+            ];
+        }
+
+        return $built;
+    }
+
+    /**
+     * @return list<array{title: string, tiles: list<array{label: string, description?: string, icon: string, controller: class-string, badge_key?: string}>}>
+     */
+    private function dashboardSections(): array
+    {
+        return [
+            [
+                'title' => 'Management',
+                'tiles' => [
+                    [
+                        'label' => 'Users',
+                        'description' => 'Manage user accounts and permissions',
+                        'icon' => 'fas fa-users',
+                        'controller' => UserCrudController::class,
+                    ],
+                    [
+                        'label' => 'Feedback',
+                        'description' => 'Review and respond to user feedback',
+                        'icon' => 'fas fa-comment-dots',
+                        'controller' => FeedbackCrudController::class,
+                        'badge_key' => 'feedback',
+                    ],
+                ],
+            ],
+            [
+                'title' => 'Data',
+                'tiles' => [
+                    [
+                        'label' => 'Data',
+                        'description' => 'Reference data and allocations',
+                        'icon' => 'fas fa-layer-group',
+                        'controller' => AllocationCrudController::class,
+                    ],
+                    [
+                        'label' => 'Import Rejects',
+                        'description' => 'Review failed import records',
+                        'icon' => 'fas fa-triangle-exclamation',
+                        'controller' => ImportRejectCrudController::class,
+                    ],
+                    [
+                        'label' => 'Imports',
+                        'description' => 'View import history and status',
+                        'icon' => 'fa fa-database',
+                        'controller' => ImportCrudController::class,
+                    ],
+                ],
+            ],
+            [
+                'title' => 'Content',
+                'tiles' => [
+                    [
+                        'label' => 'Blog',
+                        'description' => 'Manage blog posts and related content',
+                        'icon' => 'fas fa-book',
+                        'controller' => PostCrudController::class,
+                    ],
+                    [
+                        'label' => 'Pages',
+                        'description' => 'Edit static pages and site content',
+                        'icon' => 'fas fa-file',
+                        'controller' => PageCrudController::class,
+                    ],
+                ],
+            ],
+            [
+                'title' => 'System',
+                'tiles' => [
+                    [
+                        'label' => 'Audit log',
+                        'description' => 'Browse system audit entries',
+                        'icon' => 'fas fa-clipboard-list',
+                        'controller' => AuditLogCrudController::class,
+                    ],
+                    [
+                        'label' => 'Cookie consents',
+                        'description' => 'View recorded cookie consent choices',
+                        'icon' => 'fas fa-cookie-bite',
+                        'controller' => CookieConsentCrudController::class,
+                    ],
+                ],
+            ],
+        ];
     }
 
     #[\Override]

--- a/src/Admin/UI/Twig/templates/dashboard/index.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/index.html.twig
@@ -1,15 +1,35 @@
-{% extends '@Admin/base.html.twig' %}
+{% extends '@EasyAdmin/page/content.html.twig' %}
 
-{% block title %}{{ 'title.dashboard'|trans({}, 'admin') }} - {{ parent() }}{% endblock %}
+{% block content_title %}{{ 'title.dashboard'|trans({}, 'admin') }}{% endblock %}
 
-{% block header_title %}
-    <h2 class="page-title">
-        {{ 'title.dashboard'|trans({}, 'admin') }}
-    </h2>
-{% endblock %}
-
-{% block header_breadcrumb %}
-    <li class="breadcrumb-item active">
-        <a href="{{ path('app_admin_dashboard') }}">{{ 'link.backend'|trans({}, 'admin') }}</a>
-    </li>
+{% block main %}
+    {% for section in dashboard_sections %}
+        <h3 class="h5 text-muted text-uppercase mb-3">{{ section.title }}</h3>
+        <div class="row mb-4">
+            {% for tile in section.tiles %}
+                <div class="col-12 col-sm-6 col-lg-4 mb-3">
+                    <a href="{{ tile.url }}" class="text-decoration-none text-body">
+                        <div class="card h-100 shadow-sm">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex align-items-start justify-content-between mb-2">
+                                    <div class="d-flex align-items-center gap-2">
+                                        {% if tile.icon %}
+                                            <i class="{{ tile.icon }} fa-lg text-secondary" aria-hidden="true"></i>
+                                        {% endif %}
+                                        <h4 class="card-title h5 mb-0">{{ tile.label }}</h4>
+                                    </div>
+                                    {% if tile.badge %}
+                                        <span class="badge rounded-pill bg-{{ tile.badge.style }}">{{ tile.badge.value }}</span>
+                                    {% endif %}
+                                </div>
+                                {% if tile.description %}
+                                    <p class="card-text text-muted small mb-0">{{ tile.description }}</p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
 {% endblock %}

--- a/tests/Admin/Functional/Controller/AdminDashboardTest.php
+++ b/tests/Admin/Functional/Controller/AdminDashboardTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class AdminDashboardTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testDashboardShowsTilesWithoutRedirectingToUserCrud(): void
+    {
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'dashboard-admin-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $browser = $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin')
+            ->assertSuccessful()
+            ->assertSee('Users')
+            ->assertSee('Pages')
+            ->assertSee('Feedback')
+            ->assertSee('Reference data and allocations')
+        ;
+
+        $path = parse_url($browser->client()->getHistory()->current()->getUri(), \PHP_URL_PATH);
+        self::assertMatchesRegularExpression('#^/admin/?$#', (string) $path);
+    }
+}


### PR DESCRIPTION
### Summary

- Added an initial **admin dashboard** overview
- Introduced backend landing page content for administrative workflows
- Added dashboard sections/cards for relevant management areas
- Integrated the dashboard into the existing admin navigation/layout
- Updated templates and routing where needed
- Added or adjusted tests for admin dashboard access and rendering

### Motivation

- Provide admins with a clearer starting point in the backend
- Improve navigation across administrative features
- Create a foundation for future admin KPIs, shortcuts, and management widgets
- Make the backend feel more complete and easier to use

### Notes for Reviewers

- Verify dashboard layout and navigation links
- Check admin access restrictions still behave correctly
- Confirm the dashboard integrates cleanly with the existing admin layout
- Ensure no regressions in other backend pages or routes