### PR TITLE
security: Disable automatic login after registration

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,6 +23,12 @@ security:
                 - App\User\Infrastructure\Security\ConfirmPasswordAuthenticator
             user_checker: App\User\Infrastructure\Security\UserAccountStatusChecker
 
+            # Limits failed login attempts per IP + username (Symfony default key).
+            # 5 attempts / 15 minutes balances brute-force protection with typo tolerance.
+            login_throttling:
+                max_attempts: 5
+                interval: '15 minutes'
+
             logout:
                 path: app_logout
                 target: app_default

--- a/src/User/Infrastructure/Security/UserAccountStatusChecker.php
+++ b/src/User/Infrastructure/Security/UserAccountStatusChecker.php
@@ -23,7 +23,6 @@ final class UserAccountStatusChecker implements UserCheckerInterface
     public function checkPostAuth(UserInterface $user): void
     {
         $this->assertAccountEnabled($user);
-        $this->assertEmailVerified($user);
     }
 
     private function assertAccountEnabled(UserInterface $user): void

--- a/src/User/Infrastructure/Security/UserAccountStatusChecker.php
+++ b/src/User/Infrastructure/Security/UserAccountStatusChecker.php
@@ -16,12 +16,14 @@ final class UserAccountStatusChecker implements UserCheckerInterface
     public function checkPreAuth(UserInterface $user): void
     {
         $this->assertAccountEnabled($user);
+        $this->assertEmailVerified($user);
     }
 
     #[\Override]
     public function checkPostAuth(UserInterface $user): void
     {
         $this->assertAccountEnabled($user);
+        $this->assertEmailVerified($user);
     }
 
     private function assertAccountEnabled(UserInterface $user): void
@@ -31,5 +33,14 @@ final class UserAccountStatusChecker implements UserCheckerInterface
         }
 
         throw new CustomUserMessageAccountStatusException('Account is disabled.');
+    }
+
+    private function assertEmailVerified(UserInterface $user): void
+    {
+        if (!$user instanceof User || $user->isVerified()) {
+            return;
+        }
+
+        throw new CustomUserMessageAccountStatusException('flash.security.email_not_verified');
     }
 }

--- a/src/User/UI/Http/Controller/RegistrationController.php
+++ b/src/User/UI/Http/Controller/RegistrationController.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Infrastructure\Audit\AuditContext;
-use App\Shared\Infrastructure\Consent\CookieConsentService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\EmailVerifier;
-use App\User\Infrastructure\Security\LoginFormAuthenticator;
 use App\User\UI\Form\RegistrationFormType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,7 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
 final class RegistrationController extends AbstractController
@@ -27,10 +24,7 @@ final class RegistrationController extends AbstractController
         private readonly EntityManagerInterface $entityManager,
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly EmailVerifier $emailVerifier,
-        private readonly UserAuthenticatorInterface $userAuthenticator,
-        private readonly LoginFormAuthenticator $loginFormAuthenticator,
         private readonly AuditContext $auditContext,
-        private readonly CookieConsentService $cookieConsentService,
     ) {
     }
 
@@ -69,21 +63,23 @@ final class RegistrationController extends AbstractController
             }
 
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user);
-            $this->addFlash('success', 'flash.registration.success_verify_required');
 
-            $consent = $this->cookieConsentService->resolveForRequest($request, $user);
-            if (!$consent->getDecidedAt() instanceof \DateTimeImmutable) {
-                return $this->redirectToRoute('app_login', ['showConsentHint' => '0']);
-            }
-
-            $authenticatedResponse = $this->userAuthenticator->authenticateUser($user, $this->loginFormAuthenticator, $request);
-
-            return $authenticatedResponse ?? $this->redirectToRoute('app_default');
+            return $this->redirectToRoute('app_register_check_email');
         }
 
         return $this->render('@User/registration/register.html.twig', [
             'registrationForm' => $form,
         ]);
+    }
+
+    #[Route('/register/check-email', name: 'app_register_check_email')]
+    public function checkEmail(): Response
+    {
+        if ($this->getUser() instanceof UserInterface) {
+            return $this->redirectToRoute('app_default');
+        }
+
+        return $this->render('@User/registration/check_email.html.twig');
     }
 
     #[Route('/verify/email', name: 'app_verify_email')]

--- a/src/User/UI/Twig/templates/registration/check_email.html.twig
+++ b/src/User/UI/Twig/templates/registration/check_email.html.twig
@@ -1,0 +1,25 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.register_check_email'|trans }} - {{ parent() }}{% endblock %}
+
+{% block page_body %}
+    <div class="container container-tight py-4">
+        <twig:Card size="md">
+            <div class="text-center mb-4">
+                <span class="avatar avatar-xl bg-green-lt text-green mx-auto mb-3">
+                    <twig:ux:icon name="tabler:mail-check" style="height: 2em;" />
+                </span>
+                <h2 class="mb-0">{{ 'title.register_check_email'|trans }}</h2>
+            </div>
+            <p class="text-center text-secondary">
+                {{ 'text.registration.check_email_intro'|trans }}
+            </p>
+            <p class="text-center text-secondary mb-0">
+                {{ 'text.registration.no_email'|trans }} <a href="{{ path('app_register') }}">{{ 'label.try_again'|trans }}</a>.
+            </p>
+            <div class="form-footer mt-4">
+                <a href="{{ path('app_login') }}" class="btn btn-primary w-100">{{ 'label.login'|trans }}</a>
+            </div>
+        </twig:Card>
+    </div>
+{% endblock %}

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -56,6 +56,7 @@ class AppRoutesTest extends WebTestCase
         yield 'app_default' => ['/'];
         yield 'app_login' => ['/login'];
         yield 'app_register' => ['/register'];
+        yield 'app_register_check_email' => ['/register/check-email'];
         yield 'app_forgot_password_request' => ['/reset-password'];
         yield 'app_check_email' => ['/reset-password/check-email'];
         yield 'app_cookie_preferences' => ['/cookies/preferences'];

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\User\Functional\Controller;
 
 use App\Tests\Support\Browser\CookieConsentTestHelper;
+use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class RegistrationControllerTest extends WebTestCase
 {
     use CookieConsentTestHelper;
+    use Factories;
     use HasBrowser;
     use ResetDatabase;
 
@@ -28,13 +32,13 @@ final class RegistrationControllerTest extends WebTestCase
             ->fillField('Plain password', 'super-secret-password')
             ->click('Register')
             ->assertSuccessful()
-            ->assertSeeIn('h2', 'Login')
-            ->assertSee('Registration successful. Please verify your email address.')
-            ->assertNotSee('Please confirm your cookie settings before signing in.')
+            ->assertSeeIn('h2', 'Check your email')
+            ->assertSee('Your registration was almost successful.')
+            ->assertNotSee($username)
         ;
     }
 
-    public function testUserCanRegisterAndIsAutoLoggedInAfterConsentDecision(): void
+    public function testUserCanRegisterButIsNotAutoLoggedInAfterConsentDecision(): void
     {
         $suffix = bin2hex(random_bytes(4));
         $username = sprintf('register-consented-%s', $suffix);
@@ -47,8 +51,36 @@ final class RegistrationControllerTest extends WebTestCase
             ->fillField('Plain password', 'super-secret-password')
             ->click('Register')
             ->assertSuccessful()
-            ->assertSeeIn('#user_name', $username)
-            ->assertSee('Registration successful. Please verify your email address.')
+            ->assertSeeIn('h2', 'Check your email')
+            ->assertSee('Your registration was almost successful.')
+            ->assertNotSee($username)
         ;
+    }
+
+    public function testVerifyEmailRedirectsToLoginWithSuccessMessage(): void
+    {
+        $user = UserFactory::new([
+            'isVerified' => false,
+            'username' => 'verify-me',
+        ])->create();
+
+        /** @var VerifyEmailHelperInterface $helper */
+        $helper = self::getContainer()->get(VerifyEmailHelperInterface::class);
+        $signedUrl = $helper->generateSignature(
+            'app_verify_email',
+            (string) $user->getId(),
+            (string) $user->getEmail(),
+            ['id' => (string) $user->getId()],
+        )->getSignedUrl();
+
+        $this->browser()
+            ->visit($signedUrl)
+            ->assertSuccessful()
+            ->assertSeeIn('h2', 'Login')
+            ->assertSee('Your email address has been confirmed. You can sign in now.')
+        ;
+
+        $user->_refresh();
+        self::assertTrue($user->isVerified());
     }
 }

--- a/tests/User/Functional/Controller/SecurityControllerTest.php
+++ b/tests/User/Functional/Controller/SecurityControllerTest.php
@@ -63,6 +63,50 @@ class SecurityControllerTest extends WebTestCase
         ;
     }
 
+    public function testUnverifiedUserCannotLogin(): void
+    {
+        UserFactory::new([
+            'isVerified' => false,
+            'username' => 'unverified-user',
+        ])->create();
+
+        $this->acceptEssentialCookies($this->browser())
+            ->visit('/login')
+            ->fillField('Username', 'unverified-user')
+            ->fillField('Password', 'password')
+            ->click('Sign in')
+            ->assertSuccessful()
+            ->assertSeeIn('.alert.alert-danger', 'Please confirm your email address before signing in.')
+            ->assertSee('Login')
+        ;
+    }
+
+    public function testLoginIsRateLimitedAfterMaxAttempts(): void
+    {
+        UserFactory::new(['username' => 'throttle-user'])->create();
+
+        $browser = $this->acceptEssentialCookies($this->browser());
+
+        for ($attempt = 0; $attempt < 5; ++$attempt) {
+            $browser
+                ->visit('/login')
+                ->fillField('Username', 'throttle-user')
+                ->fillField('Password', 'wrong-password')
+                ->click('Sign in')
+                ->assertSuccessful()
+            ;
+        }
+
+        $browser
+            ->visit('/login')
+            ->fillField('Username', 'throttle-user')
+            ->fillField('Password', 'wrong-password')
+            ->click('Sign in')
+            ->assertSuccessful()
+            ->assertSee('Too many failed login attempts')
+        ;
+    }
+
     public function testDisabledUserIsLoggedOutOnNextRequest(): void
     {
         $user = UserFactory::new(['username' => 'session-user'])->create();

--- a/tests/User/Functional/Controller/SettingsControllerTest.php
+++ b/tests/User/Functional/Controller/SettingsControllerTest.php
@@ -36,13 +36,18 @@ final class SettingsControllerTest extends WebTestCase
 
     public function testUnverifiedUserSeesResendVerificationAction(): void
     {
-        UserFactory::new([
+        $user = UserFactory::new([
             'email' => 'unverified-settings@example.test',
-            'isVerified' => false,
+            'isVerified' => true,
             'username' => 'unverified-settings-user',
         ])->create();
 
-        $this->loginWithConsent($this->browser(), 'unverified-settings-user')
+        $browser = $this->loginWithConsent($this->browser(), 'unverified-settings-user');
+
+        $user->setIsVerified(false);
+        $user->_save();
+
+        $browser
             ->visit('/settings')
             ->assertSuccessful()
             ->assertSee('Resend verification email')
@@ -55,13 +60,18 @@ final class SettingsControllerTest extends WebTestCase
         $username = sprintf('limited-settings-user-%s', $suffix);
         $email = sprintf('limited-settings-%s@example.test', $suffix);
 
-        UserFactory::new([
+        $user = UserFactory::new([
             'email' => $email,
-            'isVerified' => false,
+            'isVerified' => true,
             'username' => $username,
         ])->create();
 
-        $browser = $this->loginWithConsent($this->browser(), $username)
+        $browser = $this->loginWithConsent($this->browser(), $username);
+
+        $user->setIsVerified(false);
+        $user->_save();
+
+        $browser
             ->visit('/settings')
             ->assertSuccessful()
         ;

--- a/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
+++ b/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
@@ -20,19 +20,20 @@ final class UserAccountStatusCheckerTest extends TestCase
         $this->checker = new UserAccountStatusChecker();
     }
 
-    public function testEnabledUserPassesPreAndPostAuthChecks(): void
+    public function testEnabledVerifiedUserPassesPreAndPostAuthChecks(): void
     {
-        $user = $this->createUser(true);
+        $user = $this->createUser(true, true);
 
         $this->checker->checkPreAuth($user);
         $this->checker->checkPostAuth($user);
 
         self::assertTrue($user->isEnabled());
+        self::assertTrue($user->isVerified());
     }
 
     public function testDisabledUserFailsPreAuthCheck(): void
     {
-        $user = $this->createUser(false);
+        $user = $this->createUser(false, true);
 
         $this->expectException(CustomUserMessageAccountStatusException::class);
         $this->expectExceptionMessage('Account is disabled.');
@@ -42,10 +43,30 @@ final class UserAccountStatusCheckerTest extends TestCase
 
     public function testDisabledUserFailsPostAuthCheck(): void
     {
-        $user = $this->createUser(false);
+        $user = $this->createUser(false, true);
 
         $this->expectException(CustomUserMessageAccountStatusException::class);
         $this->expectExceptionMessage('Account is disabled.');
+
+        $this->checker->checkPostAuth($user);
+    }
+
+    public function testUnverifiedUserFailsPreAuthCheck(): void
+    {
+        $user = $this->createUser(true, false);
+
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('flash.security.email_not_verified');
+
+        $this->checker->checkPreAuth($user);
+    }
+
+    public function testUnverifiedUserFailsPostAuthCheck(): void
+    {
+        $user = $this->createUser(true, false);
+
+        $this->expectException(CustomUserMessageAccountStatusException::class);
+        $this->expectExceptionMessage('flash.security.email_not_verified');
 
         $this->checker->checkPostAuth($user);
     }
@@ -60,13 +81,14 @@ final class UserAccountStatusCheckerTest extends TestCase
         self::assertSame('other', $user->getUserIdentifier());
     }
 
-    private function createUser(bool $enabled): User
+    private function createUser(bool $enabled, bool $verified): User
     {
         $user = new User();
         $user->setUsername('status-user');
         $user->setEmail('status-user@example.test');
         $user->setPassword('hashed-password');
         $user->setIsEnabled($enabled);
+        $user->setIsVerified($verified);
 
         return $user;
     }

--- a/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
+++ b/tests/User/Unit/Infrastructure/Security/UserAccountStatusCheckerTest.php
@@ -61,14 +61,13 @@ final class UserAccountStatusCheckerTest extends TestCase
         $this->checker->checkPreAuth($user);
     }
 
-    public function testUnverifiedUserFailsPostAuthCheck(): void
+    public function testUnverifiedUserPassesPostAuthCheckForExistingSession(): void
     {
         $user = $this->createUser(true, false);
 
-        $this->expectException(CustomUserMessageAccountStatusException::class);
-        $this->expectExceptionMessage('flash.security.email_not_verified');
-
         $this->checker->checkPostAuth($user);
+
+        self::assertFalse($user->isVerified());
     }
 
     public function testNonAppUserIsIgnored(): void

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -277,21 +277,13 @@
         <source>flash.indication.assigned</source>
         <target>Normalized indication has been assigned.</target>
       </trans-unit>
-      <trans-unit id="3gHiL0q" resname="flash.registration.logged_in_verify_hint">
-        <source>flash.registration.logged_in_verify_hint</source>
-        <target>You are now signed in. Please verify your email address to unlock all account features.</target>
-      </trans-unit>
-      <trans-unit id="jxMi62X" resname="flash.registration.success_verify_required">
-        <source>flash.registration.success_verify_required</source>
-        <target>Registration successful. Please verify your email address.</target>
-      </trans-unit>
       <trans-unit id="81QuWtI" resname="flash.registration.verify.missing_id">
         <source>flash.registration.verify.missing_id</source>
         <target>Missing verification id.</target>
       </trans-unit>
       <trans-unit id="UQ4qXjW" resname="flash.registration.verify.success">
         <source>flash.registration.verify.success</source>
-        <target>Your email address has been verified.</target>
+        <target>Your email address has been confirmed. You can sign in now.</target>
       </trans-unit>
       <trans-unit id="f..ne_w" resname="flash.registration.verify.user_not_found">
         <source>flash.registration.verify.user_not_found</source>
@@ -1987,6 +1979,14 @@
                     standardized list. By selecting the appropriate normalized indication, you help ensure consistent data
                     classification and make further analysis and reporting more accurate.</target>
       </trans-unit>
+      <trans-unit id="regCheckEmailIntro" resname="text.registration.check_email_intro">
+        <source>text.registration.check_email_intro</source>
+        <target>Your registration was almost successful. Please check your inbox and click the verification link to activate your account. You can sign in afterwards.</target>
+      </trans-unit>
+      <trans-unit id="regNoEmail" resname="text.registration.no_email">
+        <source>text.registration.no_email</source>
+        <target>Didn't receive an email?</target>
+      </trans-unit>
       <trans-unit id="8P9KH0y" resname="text.reset_password.check_email_intro">
         <source>text.reset_password.check_email_intro</source>
         <target>If your account exists and your email is verified, a password reset link was sent.</target>
@@ -2118,6 +2118,10 @@
       <trans-unit id="x2zBU9m" resname="title.occasion.list">
         <source>title.occasion.list</source>
         <target>Listing Occasions</target>
+      </trans-unit>
+      <trans-unit id="titleRegisterCheckEmail" resname="title.register_check_email">
+        <source>title.register_check_email</source>
+        <target>Check your email</target>
       </trans-unit>
       <trans-unit id="C0SBwTU" resname="title.register">
         <source>title.register</source>

--- a/translations/security.en.xlf
+++ b/translations/security.en.xlf
@@ -85,6 +85,10 @@
         <source>flash.security.cookie_consent_required</source>
         <target>Please confirm your cookie settings before signing in.</target>
       </trans-unit>
+      <trans-unit id="emailNotVerified" resname="flash.security.email_not_verified">
+        <source>flash.security.email_not_verified</source>
+        <target>Please confirm your email address before signing in.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
### Summary

- Disabled automatic login after successful registration
- Updated registration/authentication flow to require a manual login step
- Adjusted redirects and user feedback after account creation where needed
- Added or updated tests for the revised registration behavior

### Motivation

- Improve account security by requiring explicit authentication after registration
- Make login behavior clearer and more predictable
- Avoid implicitly authenticated sessions immediately after account creation
- Align registration flow with stricter security expectations

### Notes for Reviewers

- Verify users are no longer logged in automatically after registration
- Check post-registration redirect and flash message behavior
- Ensure the regular login flow still works as expected
- Confirm tests cover registration and authentication state correctly