### PR TITLE
Fix Uberspace u8 deploy failure at `cachetool:clear:opcache`

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -15,7 +15,7 @@ set('env', [
 set('messenger_systemd_service', 'messenger.service');
 set('messenger_restart_on_deploy', true);
 
-set('cachetool_args', '--web --web-path={{release_or_current_path}}/public --web-url={{web_url}}');
+set('cachetool_args', '--web --web-path={{deploy_path}}/current/public --web-url={{web_url}}');
 
 desc('Point Uberspace u8 DocumentRoot symlinks at current/public');
 task('deploy:uberspace:webroot', function () {
@@ -92,10 +92,21 @@ task('messenger:restart', function () {
     run('systemctl --user restart '.escapeshellarg($service));
 });
 
+desc('Reset OPcache after deploy');
+task('deploy:cache:opcache', function () {
+    if (test('command -v uberspace >/dev/null 2>&1')) {
+        run('uberspace web php reload');
+
+        return;
+    }
+
+    invoke('cachetool:clear:opcache');
+});
+
 // Attach tasks from recipes& contrib to default workflow
 before('deploy:symlink', 'messenger:stop');
 after('deploy:symlink', 'deploy:uberspace:webroot');
-after('deploy:uberspace:webroot', 'cachetool:clear:opcache');
+after('deploy:uberspace:webroot', 'deploy:cache:opcache');
 
 before('deploy:publish', 'database:migrate');
 after('deploy:publish', 'messenger:restart');

--- a/deploy.php
+++ b/deploy.php
@@ -17,6 +17,29 @@ set('messenger_restart_on_deploy', true);
 
 set('cachetool_args', '--web --web-path={{release_or_current_path}}/public --web-url={{web_url}}');
 
+desc('Point Uberspace u8 DocumentRoot symlinks at current/public');
+task('deploy:uberspace:webroot', function () {
+    if (!test('command -v uberspace >/dev/null 2>&1')) {
+        return;
+    }
+
+    $deployPath = get('deploy_path');
+    $domain = parse_url(get('web_url'), PHP_URL_HOST) ?: '';
+    $linkNames = array_values(array_unique(array_filter(['html', $domain])));
+
+    foreach ($linkNames as $linkName) {
+        $linkPath = $deployPath.'/'.$linkName;
+        $before = trim(run('if [ -L '.escapeshellarg($linkPath).' ]; then readlink '.escapeshellarg($linkPath).'; elif [ -e '.escapeshellarg($linkPath).' ]; then echo directory; else echo missing; fi'));
+        if ($before === 'current/public') {
+            continue;
+        }
+
+        run('cd '.escapeshellarg($deployPath).' && rm -f html/nocontent.html 2>/dev/null || true');
+        run('cd '.escapeshellarg($deployPath).' && if [ -d '.escapeshellarg($linkName).' ] && [ ! -L '.escapeshellarg($linkName).' ]; then rm -rf '.escapeshellarg($linkName).'; fi');
+        run('cd '.escapeshellarg($deployPath).' && ln -sfn current/public '.escapeshellarg($linkName));
+    }
+});
+
 add('shared_files', [
     '.env.local',
 ]);
@@ -71,7 +94,8 @@ task('messenger:restart', function () {
 
 // Attach tasks from recipes& contrib to default workflow
 before('deploy:symlink', 'messenger:stop');
-after('deploy:symlink', 'cachetool:clear:opcache');
+after('deploy:symlink', 'deploy:uberspace:webroot');
+after('deploy:uberspace:webroot', 'cachetool:clear:opcache');
 
 before('deploy:publish', 'database:migrate');
 after('deploy:publish', 'messenger:restart');


### PR DESCRIPTION
### Problem
Production deploys on Uberspace u8 failed at the final step with:

`file_get_contents() call failed with url: [https://coishub.uber.space/cachetool-….php](https://coishub.uber.space/cachetool-%E2%80%A6.php) opcache:reset exit code 1file_get_contents() call failed with url: [https://coishub.uber.space/cachetool-….php](https://coishub.uber.space/cachetool-%E2%80%A6.php) opcache:reset exit code 1`


Deployer runs CacheTool in **web mode** after `deploy:symlink`: it drops a temporary PHP file into `public/` and triggers OPcache reset via HTTP. That step started failing even though the site itself was reachable (homepage returned HTTP 200).

### Root cause

Two factors combined:

1. **Deploy path vs. DocumentRoot (since May 2025)**  
   The project moved from `deploy_path: ~/html` to `~/www` (Uberspace u8 best practice). Deployments live under `/var/www/virtual/$USER/`, while Apache serves from `html` and optional domain folders. CacheTool only works if those DocumentRoot symlinks resolve to `current/public`.

2. **PHP realpath cache right after symlink switch**  
   Even with correct symlinks (`html → current/public`, domain → `html`), freshly created files in `public/` can return **HTTP 404** when requested immediately after `deploy:symlink`. Apache/PHP-FPM may still resolve paths via a stale realpath cache. Existing files such as `index.php` keep working; new temporary files (CacheTool stubs, deploy probes) do not.

This matches a known limitation of CacheTool’s web adapter with symlink-based Deployer releases on shared hosting.

### Debugging (short)

Runtime checks on the server:

| Check | Result |
|-------|--------|
| `readlink html` | `current/public` ✓ |
| `readlink coishub.uber.space` | `html` ✓ |
| Manual test file in `current/public` | HTTP 200 ✓ |
| Same test during deploy (right after symlink) | HTTP 404 ✗ |

Git history showed CacheTool was added together with the `deploy_path` change and `web_url`; no later regression in `deploy.php`. `APP_URL` changes were unrelated (mail only).

### Solution

1. **`deploy:uberspace:webroot`** — After each symlink switch, ensure `html` and the domain folder symlink to `current/public` (idempotent; skips if already correct).

2. **`deploy:cache:opcache`** — On Uberspace hosts, call `uberspace web php reload` instead of CacheTool web mode. This reloads PHP-FPM and clears OPcache without relying on HTTP access to temporary files. Non-Uberspace hosts still use `cachetool:clear:opcache`.

3. **`cachetool_args`** — For fallback hosts, point `--web-path` at `{{deploy_path}}/current/public` instead of the concrete release path.

### Verification

Deploy completes successfully; no CacheTool error; PHP reload runs on Uberspace.