### PR TITLE
bug: Fix dispatch area normalization for trailing “Kreis”

### DIFF
--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -225,6 +225,7 @@ trait AllocationRowNormalizationTrait
             '/^Kreis\s+/u',
             '/\s*\(.+$/u',
             '/\s*-\s*Kreis$/u',
+            '/\s*Kreis$/u',
         ], ['', ''], $value);
 
         if (null === $value) {

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationRowMapperDispatchAreaTest extends TestCase
+{
+    #[DataProvider('dispatchAreaProvider')]
+    public function testNormalizeDispatchArea(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, TraitHelper::normalizeDispatchArea($input));
+    }
+
+    /**
+     * @return iterable<string, array{0: string|null, 1: string|null}>
+     */
+    public static function dispatchAreaProvider(): iterable
+    {
+        yield 'issue 122 trailing Kreis without dash' => ['Rheingau Taunus Kreis', 'Rheingau Taunus'];
+        yield 'unchanged canonical name' => ['Rheingau Taunus', 'Rheingau Taunus'];
+        yield 'leading Leitstelle prefix' => ['Leitstelle Nord', 'Nord'];
+        yield 'leading Kreis prefix' => ['Kreis Offenbach', 'Offenbach'];
+        yield 'parenthetical suffix' => ['Frankfurt (Main)', 'Frankfurt'];
+        yield 'trailing dash Kreis suffix' => ['Main-Taunus - Kreis', 'Main-Taunus'];
+        yield 'null' => [null, null];
+        yield 'empty string' => ['', null];
+        yield 'whitespace only' => ['   ', null];
+    }
+}

--- a/tests/Import/Unit/Service/Mapping/TraitHelper.php
+++ b/tests/Import/Unit/Service/Mapping/TraitHelper.php
@@ -16,6 +16,7 @@ final class TraitHelper
         normalizeUrgencyFromPZC as private traitNormalizeUrgencyFromPZC;
         combineDateAndTime as private traitCombineDateAndTime;
         getStringOrNull as private traitGetStringOrNull;
+        normalizeDispatchArea as private traitNormalizeDispatchArea;
     }
 
     public static function normalizeGender(?string $value): string
@@ -54,5 +55,10 @@ final class TraitHelper
     public static function getStringOrNull(array $row, string $key): ?string
     {
         return self::traitGetStringOrNull($row, $key);
+    }
+
+    public static function normalizeDispatchArea(?string $value): ?string
+    {
+        return self::traitNormalizeDispatchArea($value);
     }
 }


### PR DESCRIPTION
### Summary

- Fixed dispatch area handling for names ending with trailing `Kreis`
- Improved normalization/matching logic for dispatch area names
- Prevented mismatches caused by inconsistent area naming
- Added or updated tests for the affected edge case
- This fixes Issue #122.

### Motivation

- Ensure dispatch areas are resolved reliably during imports and lookups
- Avoid duplicate or missing matches caused by minor naming differences
- Improve data consistency for area-based allocation processing

### Notes for Reviewers

- Verify normalization behavior for dispatch areas with and without trailing `Kreis`
- Check that existing dispatch area mappings still work as expected
- Confirm tests cover the corrected edge case