### PR TITLE
Bug: Fix two digit year created at in import pipeline

### DIFF
--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -48,9 +48,48 @@ trait AllocationRowNormalizationTrait
             return null;
         }
 
+        $date = self::normalizeImportDatePart($date);
+        if (null === $date) {
+            return null;
+        }
+
         $time = substr($time, 0, 5);
 
         return sprintf('%s %s', $date, $time);
+    }
+
+    protected static function normalizeImportDatePart(?string $date): ?string
+    {
+        if (null === $date) {
+            return null;
+        }
+
+        $date = trim($date);
+        if ('' === $date) {
+            return null;
+        }
+
+        $parts = explode('.', $date);
+        if (3 !== \count($parts)) {
+            return $date;
+        }
+
+        $format = match (\strlen($parts[2])) {
+            2 => '!d.m.y',
+            4 => '!d.m.Y',
+            default => null,
+        };
+
+        if (null === $format) {
+            return $date;
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat($format, $date);
+        if (!$parsed instanceof \DateTimeImmutable) {
+            return $date;
+        }
+
+        return $parsed->format('d.m.Y');
     }
 
     protected static function normalizeAge(?string $value): ?int

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperDateTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperDateTest.php
@@ -23,9 +23,30 @@ final class AllocationRowMapperDateTest extends TestCase
         yield 'ok HH:MM' => ['01.01.2025', '12:34', '01.01.2025 12:34'];
         yield 'four-digit year issue 124 example' => ['16.04.2022', '19:36', '16.04.2022 19:36'];
         yield 'two-digit year normalized to four-digit' => ['16.04.22', '19:36', '16.04.2022 19:36'];
+        yield 'empty date string' => ['', '12:34', null];
         yield 'trim seconds' => ['01.01.2025', '12:34:56', '01.01.2025 12:34'];
         yield 'missing time' => ['01.01.2025', null, null];
         yield 'missing date' => [null, '12:34', null];
         yield 'both missing' => [null, null, null];
+    }
+
+    #[DataProvider('normalizeImportDatePartProvider')]
+    public function testNormalizeImportDatePart(?string $date, ?string $expected): void
+    {
+        self::assertSame($expected, TraitHelper::normalizeImportDatePart($date));
+    }
+
+    /**
+     * @return iterable<array{0: string|null, 1: string|null}>
+     */
+    public static function normalizeImportDatePartProvider(): iterable
+    {
+        yield 'null' => [null, null];
+        yield 'empty string' => ['', null];
+        yield 'whitespace only' => ['   ', null];
+        yield 'non dotted format passthrough' => ['2022-04-16', '2022-04-16'];
+        yield 'single digit year segment passthrough' => ['16.04.2', '16.04.2'];
+        yield 'three digit year segment passthrough' => ['16.04.202', '16.04.202'];
+        yield 'unparseable dotted date passthrough' => ['16.04.xx', '16.04.xx'];
     }
 }

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperDateTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperDateTest.php
@@ -21,6 +21,8 @@ final class AllocationRowMapperDateTest extends TestCase
     public static function dateTimeCombineProvider(): iterable
     {
         yield 'ok HH:MM' => ['01.01.2025', '12:34', '01.01.2025 12:34'];
+        yield 'four-digit year issue 124 example' => ['16.04.2022', '19:36', '16.04.2022 19:36'];
+        yield 'two-digit year normalized to four-digit' => ['16.04.22', '19:36', '16.04.2022 19:36'];
         yield 'trim seconds' => ['01.01.2025', '12:34:56', '01.01.2025 12:34'];
         yield 'missing time' => ['01.01.2025', null, null];
         yield 'missing date' => [null, '12:34', null];

--- a/tests/Import/Unit/Service/Mapping/TraitHelper.php
+++ b/tests/Import/Unit/Service/Mapping/TraitHelper.php
@@ -15,6 +15,7 @@ final class TraitHelper
         normalizeAge as private traitNormalizeAge;
         normalizeUrgencyFromPZC as private traitNormalizeUrgencyFromPZC;
         combineDateAndTime as private traitCombineDateAndTime;
+        normalizeImportDatePart as private traitNormalizeImportDatePart;
         getStringOrNull as private traitGetStringOrNull;
         normalizeDispatchArea as private traitNormalizeDispatchArea;
     }
@@ -47,6 +48,11 @@ final class TraitHelper
     public static function combineDateAndTime(?string $date, ?string $time): ?string
     {
         return self::traitCombineDateAndTime($date, $time);
+    }
+
+    public static function normalizeImportDatePart(?string $date): ?string
+    {
+        return self::traitNormalizeImportDatePart($date);
     }
 
     /**


### PR DESCRIPTION
## Problem

Some import rows were rejected because `createdAt` used a **two-digit year**.

**Example from CSV data:**
- `datum_erstellungsdatum`: `16.04.22`
- `uhrzeit_erstellungsdatum`: `19:36`
- combined: `16.04.22 19:36`

The system expected the internal format `d.m.Y H:i` (e.g. `16.04.2022 19:36`). This fixes Issue #124.

### Root cause

In the import pipeline, `combineDateAndTime()` only concatenated date and time **without** normalizing the year. The resulting string `16.04.22 19:36` later failed in `DateParsingStrategy`, because `new DateTimeImmutable(...)` cannot parse this German format with a two-digit year → `InvalidDateException` → import reject.

## Solution

Date normalization is handled centrally in `AllocationRowNormalizationTrait`:

- new helper method `normalizeImportDatePart()`
- format detection based on year length:
  - `d.m.y` for two-digit years (e.g. `16.04.22` → `16.04.2022`)
  - `d.m.Y` for four-digit years (unchanged)
- called from `combineDateAndTime()` before combining with the time value

Both mappers benefit automatically:
- `AllocationRowMapper`
- `MciCaseRowMapper`

## Result

Both formats are accepted:

| Input | Normalized |
|-------|------------|
| `16.04.2022 19:36` | `16.04.2022 19:36` |
| `16.04.22 19:36` | `16.04.2022 19:36` |

No changes to DTO constraints, validators, or factory logic were required.

## Tests

Extended `AllocationRowMapperDateTest` with regression cases for issue #124, including an explicit test for normalizing `16.04.22` + `19:36` → `16.04.2022 19:36`.