### PR TITLE
fix(import): map Groá-Gerau dispatch area typo to Groß-Gerau

### DIFF
--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -276,6 +276,13 @@ trait AllocationRowNormalizationTrait
             return null;
         }
 
+        $knownTypos = [
+            'Groá-Gerau' => 'Groß-Gerau',
+        ];
+        if (isset($knownTypos[$value])) {
+            $value = $knownTypos[$value];
+        }
+
         return $value;
     }
 

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaTest.php
@@ -20,6 +20,7 @@ final class AllocationRowMapperDispatchAreaTest extends TestCase
      */
     public static function dispatchAreaProvider(): iterable
     {
+        yield 'issue 126 Groá-Gerau typo' => ['Groá-Gerau', 'Groß-Gerau'];
         yield 'issue 122 trailing Kreis without dash' => ['Rheingau Taunus Kreis', 'Rheingau Taunus'];
         yield 'unchanged canonical name' => ['Rheingau Taunus', 'Rheingau Taunus'];
         yield 'leading Leitstelle prefix' => ['Leitstelle Nord', 'Nord'];


### PR DESCRIPTION
## Summary

Fixes #126. Some CSV imports were rejected because `dispatchArea` contained the malformed value `Groá-Gerau` instead of the canonical reference name `Groß-Gerau` (21 affected rows).

Investigation showed this is not caused by broken UTF-8/ISO-8859-1 decoding in our import pipeline: correctly encoded `Groß-Gerau` values already import fine. The rejected string is a known bad literal in source data (`á` instead of `ß`), which passes through normalization unchanged and then fails reference lookup (`groá-gerau` ≠ `groß-gerau`).

This PR adds a single, exact alias mapping in `normalizeDispatchArea`, consistent with the approach used for dispatch area normalization in #122.

## Changes

- **`AllocationRowNormalizationTrait`**: map `Groá-Gerau` → `Groß-Gerau` after trim (applies to allocation, MCI, and legacy import mappers via the shared trait).
- **`AllocationRowMapperDispatchAreaTest`**: regression test for the new mapping.

## Why this approach

- Minimal, targeted fix — one known typo, no broad encoding refactor.
- No impact on correctly encoded `Groß-Gerau` CSV values.
- No global umlaut/character replacement that could affect other fields.

## Test plan

- [x] `vendor/bin/phpunit tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaTest.php`
- [x] `vendor/bin/phpunit tests/Import/`