### PR TITLE
fix(import): skip empty assessment rows during messenger import

### DIFF
--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -286,14 +286,25 @@ trait AllocationRowNormalizationTrait
         return $value;
     }
 
-    private static function normalizeAssessmentAirway(?string $value): ?string
+    private static function stripAssessmentPrefix(?string $value): ?string
     {
         if (null === $value) {
             return null;
         }
 
-        $value = preg_replace('/^[A-D]-/i', '', $value) ?? '';
-        $normalized = mb_strtolower(trim($value));
+        $value = trim(preg_replace('/^[A-D]-/i', '', $value) ?? '');
+
+        return '' === $value ? null : $value;
+    }
+
+    private static function normalizeAssessmentAirway(?string $value): ?string
+    {
+        $value = self::stripAssessmentPrefix($value);
+        if (null === $value) {
+            return null;
+        }
+
+        $normalized = mb_strtolower($value);
 
         return match ($normalized) {
             'frei' => 'free',
@@ -306,12 +317,12 @@ trait AllocationRowNormalizationTrait
 
     private static function normalizeAssessmentBreathing(?string $value): ?string
     {
+        $value = self::stripAssessmentPrefix($value);
         if (null === $value) {
             return null;
         }
 
-        $value = preg_replace('/^[A-D]-/i', '', $value) ?? '';
-        $normalized = mb_strtolower(trim($value));
+        $normalized = mb_strtolower($value);
 
         return match ($normalized) {
             'spontan' => 'spontaneous',
@@ -325,12 +336,12 @@ trait AllocationRowNormalizationTrait
 
     private static function normalizeAssessmentCirculation(?string $value): ?string
     {
+        $value = self::stripAssessmentPrefix($value);
         if (null === $value) {
             return null;
         }
 
-        $value = preg_replace('/^[A-D]-/i', '', $value) ?? '';
-        $normalized = mb_strtolower(trim($value));
+        $normalized = mb_strtolower($value);
 
         return match ($normalized) {
             'stabil' => 'stable',
@@ -343,12 +354,12 @@ trait AllocationRowNormalizationTrait
 
     private static function normalizeAssessmentDisability(?string $value): ?string
     {
+        $value = self::stripAssessmentPrefix($value);
         if (null === $value) {
             return null;
         }
 
-        $value = preg_replace('/^[A-D]-/i', '', $value) ?? '';
-        $normalized = mb_strtolower(trim($value));
+        $normalized = mb_strtolower($value);
 
         return match ($normalized) {
             'wach' => 'awake',

--- a/src/Import/Infrastructure/Resolver/AllocationAssessmentResolver.php
+++ b/src/Import/Infrastructure/Resolver/AllocationAssessmentResolver.php
@@ -29,61 +29,111 @@ final readonly class AllocationAssessmentResolver implements AllocationEntityRes
     #[\Override]
     public function supports(Allocation $entity, AllocationRowDTO $dto): bool
     {
-        return null !== $dto->assessmentAirway
-            || null !== $dto->assessmentBreathing
-            || null !== $dto->assessmentCirculation
-            || null !== $dto->assessmentDisability;
+        return $this->hasAnyAssessmentData($dto);
     }
 
     #[\Override]
     public function apply(Allocation $entity, AllocationRowDTO $dto): void
     {
+        $airway = $this->mapAirway($dto, $entity);
+        $breathing = $this->mapBreathing($dto, $entity);
+        $circulation = $this->mapCirculation($dto, $entity);
+        $disability = $this->mapDisability($dto, $entity);
+
+        if (in_array(null, [$airway, $breathing, $circulation, $disability], true)) {
+            return;
+        }
+
         $assessment = new Assessment();
         $assessment->setCreatedAt(new \DateTimeImmutable());
+        $assessment->setAirway($airway);
+        $assessment->setBreathing($breathing);
+        $assessment->setCirculation($circulation);
+        $assessment->setDisability($disability);
 
-        if (null !== $dto->assessmentAirway) {
-            $enum = AssessmentAirway::tryFrom($dto->assessmentAirway);
+        $entity->setAssessment($assessment);
+    }
 
-            if (null === $enum) {
-                $this->logEnumFailure('airway', $dto->assessmentAirway, $entity);
-            } else {
-                $assessment->setAirway($enum);
-            }
+    private function hasAnyAssessmentData(AllocationRowDTO $dto): bool
+    {
+        return $this->isNonEmptyAssessmentField($dto->assessmentAirway)
+            || $this->isNonEmptyAssessmentField($dto->assessmentBreathing)
+            || $this->isNonEmptyAssessmentField($dto->assessmentCirculation)
+            || $this->isNonEmptyAssessmentField($dto->assessmentDisability);
+    }
+
+    private function isNonEmptyAssessmentField(?string $value): bool
+    {
+        return null !== $value && '' !== trim($value);
+    }
+
+    private function nonEmptyAssessmentField(?string $value): ?string
+    {
+        if (!$this->isNonEmptyAssessmentField($value)) {
+            return null;
         }
 
-        if (null !== $dto->assessmentBreathing) {
-            $enum = AssessmentBreathing::tryFrom($dto->assessmentBreathing);
+        return $value;
+    }
 
-            if (null === $enum) {
-                $this->logEnumFailure('breathing', $dto->assessmentBreathing, $entity);
-            } else {
-                $assessment->setBreathing($enum);
-            }
+    private function mapAirway(AllocationRowDTO $dto, Allocation $entity): ?AssessmentAirway
+    {
+        $raw = $this->nonEmptyAssessmentField($dto->assessmentAirway);
+        if (null === $raw) {
+            return null;
         }
 
-        if (null !== $dto->assessmentCirculation) {
-            $enum = AssessmentCirculation::tryFrom($dto->assessmentCirculation);
-
-            if (null === $enum) {
-                $this->logEnumFailure('circulation', $dto->assessmentCirculation, $entity);
-            } else {
-                $assessment->setCirculation($enum);
-            }
+        $enum = AssessmentAirway::tryFrom($raw);
+        if (null === $enum) {
+            $this->logEnumFailure('airway', $raw, $entity);
         }
 
-        if (null !== $dto->assessmentDisability) {
-            $enum = AssessmentDisability::tryFrom($dto->assessmentDisability);
+        return $enum;
+    }
 
-            if (null === $enum) {
-                $this->logEnumFailure('disability', $dto->assessmentDisability, $entity);
-            } else {
-                $assessment->setDisability($enum);
-            }
+    private function mapBreathing(AllocationRowDTO $dto, Allocation $entity): ?AssessmentBreathing
+    {
+        $raw = $this->nonEmptyAssessmentField($dto->assessmentBreathing);
+        if (null === $raw) {
+            return null;
         }
 
-        if ($assessment->isValid()) {
-            $entity->setAssessment($assessment);
+        $enum = AssessmentBreathing::tryFrom($raw);
+        if (null === $enum) {
+            $this->logEnumFailure('breathing', $raw, $entity);
         }
+
+        return $enum;
+    }
+
+    private function mapCirculation(AllocationRowDTO $dto, Allocation $entity): ?AssessmentCirculation
+    {
+        $raw = $this->nonEmptyAssessmentField($dto->assessmentCirculation);
+        if (null === $raw) {
+            return null;
+        }
+
+        $enum = AssessmentCirculation::tryFrom($raw);
+        if (null === $enum) {
+            $this->logEnumFailure('circulation', $raw, $entity);
+        }
+
+        return $enum;
+    }
+
+    private function mapDisability(AllocationRowDTO $dto, Allocation $entity): ?AssessmentDisability
+    {
+        $raw = $this->nonEmptyAssessmentField($dto->assessmentDisability);
+        if (null === $raw) {
+            return null;
+        }
+
+        $enum = AssessmentDisability::tryFrom($raw);
+        if (null === $enum) {
+            $this->logEnumFailure('disability', $raw, $entity);
+        }
+
+        return $enum;
     }
 
     private function logEnumFailure(string $field, string $rawValue, Allocation $entity): void

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 namespace App\Tests\Import\Integration\MessageHandler;
 
 use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Assessment;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
@@ -134,6 +135,100 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         $firstReject = $rejectWriter->all()[0];
         self::assertArrayHasKey('messages', $firstReject);
         self::assertNotEmpty($firstReject['messages']);
+    }
+
+    public function testImportWithPlaceholderAbcdColumnsDoesNotPersistAssessmentOrAudit(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'import-abcd-empty-'.bin2hex(random_bytes(6))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Test', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Testkrankenhaus Musterstadt',
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+
+        AssignmentFactory::createOne(['name' => 'Patient']);
+        OccasionFactory::createOne(['name' => 'aus Arztpraxis']);
+        InfectionFactory::createOne(['name' => 'Noro']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication', 'code' => 123, 'hash' => '070f5e78cc3ce4b3c3378aeaa0a304a4']);
+
+        $header = [
+            'Versorgungsbereich', 'KHS-Versorgungsgebiet', 'Krankenhaus', 'Krankenhaus-Kurzname',
+            'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
+            'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
+            'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC', 'Fachgebiet', 'Fachbereich', 'Fachbereich war abgemeldet?', 'Anlass', 'Grund', 'Ansteckungsfähig',
+            'PZC und Text', 'Airway', 'Breathing', 'Circulation', 'Disability',
+        ];
+
+        $rows = [
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741', 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', '123 Test Indication', 'A-', 'B-', 'C-', 'D-'],
+        ];
+
+        $import = $this->createInMemoryImport($owner, $hospital);
+        $reader = new InMemoryRowReader($header, $rows);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $assessmentsBefore = $this->countAssessments();
+        $assessmentAuditsBefore = $this->countAuditEntriesForEntityClass(Assessment::class);
+
+        $this->handler->run($import, $reader, $rejectWriter);
+
+        self::assertSame($assessmentsBefore, $this->countAssessments());
+        self::assertSame($assessmentAuditsBefore, $this->countAuditEntriesForEntityClass(Assessment::class));
+    }
+
+    public function testImportWithValidAbcdColumnsPersistsAssessment(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'import-abcd-valid-'.bin2hex(random_bytes(6))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Test', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Testkrankenhaus Musterstadt',
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+
+        AssignmentFactory::createOne(['name' => 'Patient']);
+        OccasionFactory::createOne(['name' => 'aus Arztpraxis']);
+        InfectionFactory::createOne(['name' => 'Noro']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication', 'code' => 123, 'hash' => '070f5e78cc3ce4b3c3378aeaa0a304a4']);
+
+        $header = [
+            'Versorgungsbereich', 'KHS-Versorgungsgebiet', 'Krankenhaus', 'Krankenhaus-Kurzname',
+            'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
+            'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
+            'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC', 'Fachgebiet', 'Fachbereich', 'Fachbereich war abgemeldet?', 'Anlass', 'Grund', 'Ansteckungsfähig',
+            'PZC und Text', 'Airway', 'Breathing', 'Circulation', 'Disability',
+        ];
+
+        $rows = [
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741', 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', '123 Test Indication', 'A-Frei', 'B-Spontan', 'C-Stabil', 'D-Wach'],
+        ];
+
+        $import = $this->createInMemoryImport($owner, $hospital);
+        $reader = new InMemoryRowReader($header, $rows);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $assessmentsBefore = $this->countAssessments();
+        $importId = (int) $import->getId();
+
+        $this->handler->run($import, $reader, $rejectWriter);
+
+        self::assertSame($assessmentsBefore + 1, $this->countAssessments());
+
+        $this->em->clear();
+        $allocation = $this->em->getRepository(Allocation::class)->findOneBy(['import' => $importId]);
+        self::assertNotNull($allocation);
+        self::assertNotNull($allocation->getAssessment());
     }
 
     public function testInvokeWithUnknownImportIdDoesNotThrow(): void
@@ -365,6 +460,42 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         $this->em->flush();
 
         return ['id' => (int) $import->getId(), 'csvPath' => $csvPath];
+    }
+
+    private function countAssessments(): int
+    {
+        return (int) $this->em->createQueryBuilder()
+            ->select('COUNT(a.id)')
+            ->from(Assessment::class, 'a')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function createInMemoryImport(
+        \App\User\Domain\Entity\User $owner,
+        \App\Allocation\Domain\Entity\Hospital $hospital,
+    ): Import {
+        $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
+        $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
+
+        $import = new Import()
+            ->setName('Handler IT (in-memory assessment)')
+            ->setHospital($hospitalRef)
+            ->setCreatedBy($userRef)
+            ->setType(ImportType::ALLOCATION)
+            ->setStatus(ImportStatus::PENDING)
+            ->setFilePath('in-memory://allocations.csv')
+            ->setFileExtension('csv')
+            ->setFileMimeType('text/csv')
+            ->setFileSize(0)
+            ->setRunCount(0)
+            ->setRunTime(0)
+            ->setRowCount(0);
+
+        $this->em->persist($import);
+        $this->em->flush();
+
+        return $import;
     }
 
     private function countAllocationsForImport(int $importId): int

--- a/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
+++ b/tests/Import/Integration/Service/Mapping/AllocationImportFactoryTest.php
@@ -159,4 +159,33 @@ final class AllocationImportFactoryTest extends KernelTestCase
         $this->expectException(InvalidDateException::class);
         $this->factory->fromDto($this->makeDto(['arrivalAt' => '31.02.2025 25:61']), $this->import);
     }
+
+    public function testValidAssessmentFieldsAreMappedFromDto(): void
+    {
+        $allocation = $this->factory->fromDto($this->makeDto([
+            'assessmentAirway' => 'free',
+            'assessmentBreathing' => 'spontaneous',
+            'assessmentCirculation' => 'stable',
+            'assessmentDisability' => 'awake',
+        ]), $this->import);
+
+        $assessment = $allocation->getAssessment();
+        self::assertNotNull($assessment);
+        self::assertSame(\App\Allocation\Domain\Enum\AssessmentAirway::FREE, $assessment->getAirway());
+        self::assertSame(\App\Allocation\Domain\Enum\AssessmentBreathing::SPONTANEOUS, $assessment->getBreathing());
+        self::assertSame(\App\Allocation\Domain\Enum\AssessmentCirculation::STABLE, $assessment->getCirculation());
+        self::assertSame(\App\Allocation\Domain\Enum\AssessmentDisability::AWAKE, $assessment->getDisability());
+    }
+
+    public function testPlaceholderAssessmentFieldsDoNotCreateAssessment(): void
+    {
+        $allocation = $this->factory->fromDto($this->makeDto([
+            'assessmentAirway' => 'A-',
+            'assessmentBreathing' => 'B-',
+            'assessmentCirculation' => 'C-',
+            'assessmentDisability' => 'D-',
+        ]), $this->import);
+
+        self::assertNull($allocation->getAssessment());
+    }
 }

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperAssessmentTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperAssessmentTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use App\Import\Infrastructure\Mapping\AllocationRowMapper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationRowMapperAssessmentTest extends TestCase
+{
+    private AllocationRowMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AllocationRowMapper();
+    }
+
+    /**
+     * @param array<string, string> $row
+     */
+    #[DataProvider('placeholderAssessmentRowProvider')]
+    public function testPlaceholderAssessmentValuesMapToNull(array $row): void
+    {
+        $dto = $this->mapper->mapAssoc($row);
+
+        self::assertNull($dto->assessmentAirway);
+        self::assertNull($dto->assessmentBreathing);
+        self::assertNull($dto->assessmentCirculation);
+        self::assertNull($dto->assessmentDisability);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function placeholderAssessmentRowProvider(): iterable
+    {
+        yield 'abcd prefix only' => [[
+            'airway' => 'A-',
+            'breathing' => 'B-',
+            'circulation' => 'C-',
+            'disability' => 'D-',
+        ]];
+        yield 'empty cells' => [[
+            'airway' => '',
+            'breathing' => '',
+            'circulation' => '',
+            'disability' => '',
+        ]];
+        yield 'whitespace only' => [[
+            'airway' => '   ',
+            'breathing' => '   ',
+            'circulation' => '   ',
+            'disability' => '   ',
+        ]];
+    }
+
+    public function testValidGermanAssessmentValuesAreMapped(): void
+    {
+        $dto = $this->mapper->mapAssoc([
+            'airway' => 'A-Frei',
+            'breathing' => 'B-Spontan',
+            'circulation' => 'C-Stabil',
+            'disability' => 'D-Wach',
+        ]);
+
+        self::assertSame('free', $dto->assessmentAirway);
+        self::assertSame('spontaneous', $dto->assessmentBreathing);
+        self::assertSame('stable', $dto->assessmentCirculation);
+        self::assertSame('awake', $dto->assessmentDisability);
+    }
+}

--- a/tests/Import/Unit/Service/Resolver/AllocationAssessmentResolverTest.php
+++ b/tests/Import/Unit/Service/Resolver/AllocationAssessmentResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Resolver;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Enum\AssessmentAirway;
+use App\Allocation\Domain\Enum\AssessmentBreathing;
+use App\Allocation\Domain\Enum\AssessmentCirculation;
+use App\Allocation\Domain\Enum\AssessmentDisability;
+use App\Import\Application\DTO\AllocationRowDTO;
+use App\Import\Infrastructure\Resolver\AllocationAssessmentResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class AllocationAssessmentResolverTest extends TestCase
+{
+    private AllocationAssessmentResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new AllocationAssessmentResolver(new NullLogger());
+    }
+
+    public function testSupportsReturnsFalseForEmptyStringFields(): void
+    {
+        $dto = new AllocationRowDTO();
+        $dto->assessmentAirway = '';
+
+        self::assertFalse($this->resolver->supports(new Allocation(), $dto));
+    }
+
+    public function testApplyDoesNotAttachAssessmentWhenFieldsAreEmptyStrings(): void
+    {
+        $dto = new AllocationRowDTO();
+        $dto->assessmentAirway = '';
+        $dto->assessmentBreathing = '';
+        $dto->assessmentCirculation = '';
+        $dto->assessmentDisability = '';
+
+        $allocation = new Allocation();
+        $this->resolver->apply($allocation, $dto);
+
+        self::assertNull($allocation->getAssessment());
+    }
+
+    public function testApplyDoesNotAttachAssessmentForAbcdPrefixPlaceholders(): void
+    {
+        $dto = new AllocationRowDTO();
+        $dto->assessmentAirway = 'A-';
+        $dto->assessmentBreathing = 'B-';
+        $dto->assessmentCirculation = 'C-';
+        $dto->assessmentDisability = 'D-';
+
+        $allocation = new Allocation();
+        self::assertTrue($this->resolver->supports($allocation, $dto));
+
+        $this->resolver->apply($allocation, $dto);
+
+        self::assertNull($allocation->getAssessment());
+    }
+
+    public function testApplyAttachesAssessmentWhenAllFieldsAreValid(): void
+    {
+        $dto = new AllocationRowDTO();
+        $dto->assessmentAirway = 'free';
+        $dto->assessmentBreathing = 'spontaneous';
+        $dto->assessmentCirculation = 'stable';
+        $dto->assessmentDisability = 'awake';
+
+        $allocation = new Allocation();
+        $this->resolver->apply($allocation, $dto);
+
+        $assessment = $allocation->getAssessment();
+        self::assertNotNull($assessment);
+        self::assertSame(AssessmentAirway::FREE, $assessment->getAirway());
+        self::assertSame(AssessmentBreathing::SPONTANEOUS, $assessment->getBreathing());
+        self::assertSame(AssessmentCirculation::STABLE, $assessment->getCirculation());
+        self::assertSame(AssessmentDisability::AWAKE, $assessment->getDisability());
+    }
+}


### PR DESCRIPTION
## Summary

- Prevents empty `Assessment` entities from being created during allocation imports via Symfony Messenger (Issue #123).
- ABCD placeholder values in CSV columns (`A-`, `B-`, empty cells) are no longer treated as assessment data.
- This avoids unnecessary AuditLog `create` entries for empty assessments.

## Root cause

In the import path `ImportAllocationsMessageHandler` → `AllocationAssessmentResolver`, normalization after stripping ABCD prefixes sometimes returned empty strings (`""`) instead of `null`. `supports()` incorrectly treated these as present data. The resolver also instantiated `Assessment` objects before it was clear whether all four enums could be mapped.

## Changes

- **`AllocationRowNormalizationTrait`**: Added `stripAssessmentPrefix()` helper; empty values after normalization → `null`
- **`AllocationAssessmentResolver`**: Added `hasAnyAssessmentData()`, map-first pattern (create `Assessment` only when all four enums are valid), Psalm-safe enum mapping helper
- **Tests**: Unit tests for mapper/resolver; integration tests for messenger import with placeholder and valid ABCD data

No changes to AuditLog infrastructure.

## Test plan

- [x] `make ci` (Rector, PHP-CS-Fixer, PHPStan, Psalm)
- [x] `make lint`
- [x] `make test` (804 tests)
- [x] Placeholder ABCD values (`A-`/`B-`/`C-`/`D-`) → no `Assessment`, no audit entry
- [x] Valid ABCD data (`A-Frei`, `B-Spontan`, …) → `Assessment` is still created correctly

Closes #123