### PR TITLE
Bug: Fix issue 125 obstetrics department mappings

### DIFF
--- a/src/Import/Infrastructure/Resolver/Strategy/SpecialityDepartmentReferenceStrategy.php
+++ b/src/Import/Infrastructure/Resolver/Strategy/SpecialityDepartmentReferenceStrategy.php
@@ -13,6 +13,13 @@ use Doctrine\ORM\EntityManagerInterface;
 
 final class SpecialityDepartmentReferenceStrategy
 {
+    /** @var array<string,string> normalized import value => normalized canonical department name */
+    private const array DEPARTMENT_ALIASES = [
+        'perinatalzentrum level 1' => 'geburtshilfe',
+        'perinataler schwerpunkt' => 'geburtshilfe',
+        'geburtsklinik' => 'geburtshilfe',
+    ];
+
     /** @var array<string,int> */
     private array $specialityIdByKey = [];
 
@@ -80,7 +87,7 @@ final class SpecialityDepartmentReferenceStrategy
             $entity->setSpeciality($specialityRef);
         }
 
-        $departmentKey = $this->key((string) $departmentName);
+        $departmentKey = $this->resolveDepartmentKey((string) $departmentName);
         if ('' !== $departmentKey) {
             $departmentId = $this->departmentIdByKey[$departmentKey] ?? null;
             if (null === $departmentId) {
@@ -93,6 +100,16 @@ final class SpecialityDepartmentReferenceStrategy
         }
 
         $entity->setDepartmentWasClosed($departmentWasClosedPolicy($departmentWasClosed));
+    }
+
+    private function resolveDepartmentKey(string $departmentName): string
+    {
+        $key = $this->key($departmentName);
+        if ('' === $key) {
+            return '';
+        }
+
+        return self::DEPARTMENT_ALIASES[$key] ?? $key;
     }
 
     private function key(string $name): string

--- a/tests/Import/Unit/Service/Resolver/SpecialityDepartmentReferenceStrategyTest.php
+++ b/tests/Import/Unit/Service/Resolver/SpecialityDepartmentReferenceStrategyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Resolver;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Import\Application\Exception\ReferenceNotFoundException;
+use App\Import\Infrastructure\Resolver\Strategy\SpecialityDepartmentReferenceStrategy;
+use App\User\Domain\Factory\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class SpecialityDepartmentReferenceStrategyTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private SpecialityDepartmentReferenceStrategy $strategy;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        UserFactory::createOne();
+        DepartmentFactory::createOne(['name' => 'Geburtshilfe']);
+
+        $this->strategy = self::getContainer()->get(SpecialityDepartmentReferenceStrategy::class);
+        $this->strategy->warm();
+    }
+
+    #[DataProvider('obstetricsDepartmentAliasProvider')]
+    public function testResolvesObstetricsDepartmentAliasesToGeburtshilfe(string $importValue): void
+    {
+        $allocation = new Allocation();
+
+        $this->strategy->apply(
+            $allocation,
+            null,
+            $importValue,
+            false,
+            static fn (?bool $v): bool => $v ?? false,
+        );
+
+        self::assertSame('Geburtshilfe', $allocation->getDepartment()?->getName());
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function obstetricsDepartmentAliasProvider(): iterable
+    {
+        yield 'issue 125 Perinatalzentrum Level 1' => ['Perinatalzentrum Level 1'];
+        yield 'issue 125 Perinataler Schwerpunkt' => ['Perinataler Schwerpunkt'];
+        yield 'issue 125 Geburtsklinik' => ['Geburtsklinik'];
+    }
+
+    public function testUnknownDepartmentStillThrowsReferenceNotFoundException(): void
+    {
+        $allocation = new Allocation();
+
+        $this->expectException(ReferenceNotFoundException::class);
+
+        $this->strategy->apply(
+            $allocation,
+            null,
+            'Unbekanntes Department',
+            false,
+            static fn (?bool $v): bool => $v ?? false,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes import rejections caused by `REF_NOT_FOUND` for obstetrics/perinatal department values (Closes #125).

Import rows with the following `fachbereich` values were previously rejected because they did not exactly match canonical department references:

| Import value | Affected cases |
|---|---:|
| Perinatalzentrum Level 1 | 412 |
| Perinataler Schwerpunkt | 74 |
| Geburtsklinik | 23 |

These values are now mapped to the canonical department name **`Geburtshilfe`** during reference lookup.

## Changes

- **`SpecialityDepartmentReferenceStrategy`**: alias map + `resolveDepartmentKey()` for the three values
- **`SpecialityDepartmentReferenceStrategyTest`**: regression test with a data provider for all three issue values; unknown departments still throw `ReferenceNotFoundException`

## Why `Geburtshilfe`?

Among the existing seeded departments, `Geburtshilfe` is the semantically best fit for perinatal centers, perinatal focus units, and maternity clinics. No new seed entries or schema changes are required.

## Test plan

- [x] `make test` — 808 tests passing (including new regression tests)
- [x] `make ci` — Rector, PHP-CS-Fixer, PHPStan, Psalm all clean
- [x] Re-run an import containing the affected `fachbereich` values and verify that no `REF_NOT_FOUND` rejections occur for these departments