### PR TITLE
feat: Improve legacy import requeue cleanup and assessment mapping

### DIFF
--- a/docs/import/batch-requeue.md
+++ b/docs/import/batch-requeue.md
@@ -77,8 +77,8 @@ When an import is processed again (`runCount > 0`), `ImportAllocationsMessageHan
 
 - `allocation_stats_projection` rows for that import
 - `import_reject` rows and the reject CSV file on disk
-- `assessment` records linked to previous allocations
 - `allocation` and `mci_case` rows for that import
+- `assessment` records that were linked to those allocations (IDs collected before allocations are removed)
 
 The `import` record and source CSV file are kept; only import-scoped result data is removed. Shared reference data (specialities, departments, indication catalog entries, etc.) is not deleted.
 

--- a/src/Import/Application/Service/ImportPreviousRunCleanupService.php
+++ b/src/Import/Application/Service/ImportPreviousRunCleanupService.php
@@ -9,7 +9,6 @@ use App\Allocation\Infrastructure\Repository\MciCaseRepository;
 use App\Import\Domain\Entity\Import;
 use App\Import\Infrastructure\Repository\ImportRejectRepository;
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -84,10 +83,11 @@ SQL,
             return 0;
         }
 
+        $placeholders = implode(', ', array_fill(0, \count($assessmentIds), '?'));
+
         return $this->connection->executeStatement(
-            'DELETE FROM assessment WHERE id IN (:ids)',
-            ['ids' => $assessmentIds],
-            ['ids' => ArrayParameterType::INTEGER],
+            'DELETE FROM assessment WHERE id IN ('.$placeholders.')',
+            $assessmentIds,
         );
     }
 

--- a/src/Import/Application/Service/ImportPreviousRunCleanupService.php
+++ b/src/Import/Application/Service/ImportPreviousRunCleanupService.php
@@ -9,6 +9,7 @@ use App\Allocation\Infrastructure\Repository\MciCaseRepository;
 use App\Import\Domain\Entity\Import;
 use App\Import\Infrastructure\Repository\ImportRejectRepository;
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -34,13 +35,17 @@ final readonly class ImportPreviousRunCleanupService
     {
         $importId = (int) $import->getId();
 
-        $counts = $this->em->wrapInTransaction(fn (): array => [
-            'projection' => $this->statsProjectionRebuilder->deleteForImport($importId),
-            'rejects' => $this->importRejectRepository->deleteByImport($import),
-            'assessments' => $this->deleteAssessmentsForImport($importId),
-            'allocations' => $this->allocationRepository->deleteByImport($import),
-            'mci_cases' => $this->mciCaseRepository->deleteByImport($import),
-        ]);
+        $counts = $this->em->wrapInTransaction(function () use ($import, $importId): array {
+            $assessmentIds = $this->collectAssessmentIdsForImport($importId);
+
+            return [
+                'projection' => $this->statsProjectionRebuilder->deleteForImport($importId),
+                'rejects' => $this->importRejectRepository->deleteByImport($import),
+                'allocations' => $this->allocationRepository->deleteByImport($import),
+                'assessments' => $this->deleteAssessmentsByIds($assessmentIds),
+                'mci_cases' => $this->mciCaseRepository->deleteByImport($import),
+            ];
+        });
 
         $this->logCleanup(
             $importId,
@@ -56,19 +61,33 @@ final readonly class ImportPreviousRunCleanupService
         $this->em->flush();
     }
 
-    private function deleteAssessmentsForImport(int $importId): int
+    /** @return list<int> */
+    private function collectAssessmentIdsForImport(int $importId): array
     {
-        return $this->connection->executeStatement(
+        $ids = $this->connection->fetchFirstColumn(
             <<<'SQL'
-DELETE FROM assessment
-WHERE id IN (
-    SELECT assessment_id
-    FROM allocation
-    WHERE import_id = :importId
-      AND assessment_id IS NOT NULL
-)
+SELECT DISTINCT assessment_id
+FROM allocation
+WHERE import_id = :importId
+  AND assessment_id IS NOT NULL
 SQL,
             ['importId' => $importId],
+        );
+
+        return array_map(static fn (mixed $id): int => (int) $id, $ids);
+    }
+
+    /** @param list<int> $assessmentIds */
+    private function deleteAssessmentsByIds(array $assessmentIds): int
+    {
+        if ([] === $assessmentIds) {
+            return 0;
+        }
+
+        return $this->connection->executeStatement(
+            'DELETE FROM assessment WHERE id IN (:ids)',
+            ['ids' => $assessmentIds],
+            ['ids' => ArrayParameterType::INTEGER],
         );
     }
 

--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -310,7 +310,7 @@ trait AllocationRowNormalizationTrait
             'frei' => 'free',
             'gefährdet', 'gefaehrdet' => 'risk',
             'intubiert' => 'intubated',
-            'krit. atemweg', 'kritischer atemweg', 'krit atemweg' => 'critical',
+            'krit. atemweg', 'kritischer atemweg', 'krit atemweg', 'kritisch', 'krit.', 'krit' => 'critical',
             default => $value,
         };
     }
@@ -326,8 +326,8 @@ trait AllocationRowNormalizationTrait
 
         return match ($normalized) {
             'spontan' => 'spontaneous',
-            'resp. insuff.', 'resp insuff.', 'resp. insuff', 'resp insuff', 'respiratorische insuffizienz' => 'insufficient',
-            'cpap' => 'cpap',
+            'resp. insuff.', 'resp insuff.', 'resp. insuff', 'resp insuff', 'respiratorische insuffizienz', 'kritisch', 'krit.', 'krit' => 'insufficient',
+            'cpap', 'flow-cpap', 'flow cpap' => 'cpap',
             'niv' => 'niv',
             'invasiv' => 'invasive',
             default => $value,
@@ -345,9 +345,9 @@ trait AllocationRowNormalizationTrait
 
         return match ($normalized) {
             'stabil' => 'stable',
-            'stabil unter med.', 'stabil u. med.', 'stabil unter med' => 'medication',
-            'instabil' => 'unstable',
-            'laufende rea', 'rea laufend' => 'cpr',
+            'stabil unter med.', 'stabil u. med.', 'stabil unter med', 'katecholamin', 'katecholamine' => 'medication',
+            'instabil', 'kritisch', 'krit.', 'krit' => 'unstable',
+            'laufende rea', 'rea laufend', 'laufende reanimation' => 'cpr',
             default => $value,
         };
     }
@@ -361,13 +361,29 @@ trait AllocationRowNormalizationTrait
 
         $normalized = mb_strtolower($value);
 
+        $gcs = self::normalizeAssessmentGcsDisability($normalized);
+        if (null !== $gcs) {
+            return $gcs;
+        }
+
         return match ($normalized) {
             'wach' => 'awake',
-            'gcs < 15', 'gcs<15' => 'gcs_below_15',
-            'gcs < 9', 'gcs<9' => 'gcs_below_9',
             'sediert' => 'sedated',
             'narkotisiert' => 'anesthetized',
             default => $value,
         };
+    }
+
+    private static function normalizeAssessmentGcsDisability(string $normalized): ?string
+    {
+        if (preg_match('/^gcs\s*<\s*15$/', $normalized)) {
+            return 'gcs_below_15';
+        }
+
+        if (preg_match('/^gcs\s*<\s*9$/', $normalized)) {
+            return 'gcs_below_9';
+        }
+
+        return null;
     }
 }

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
@@ -320,6 +320,27 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         self::assertNotSame(ImportStatus::FAILED, $fresh->getStatus());
     }
 
+    public function testReimportWithAssessmentSucceedsAfterCleanup(): void
+    {
+        ['id' => $id, 'csvPath' => $csvPath] = $this->arrangeSingleRowSuccessfulCsvImport(withAssessment: true);
+
+        try {
+            $this->handler->__invoke(new ImportAllocationsMessage($id));
+
+            self::assertSame(1, $this->countAllocationsForImport($id));
+            self::assertGreaterThan(0, $this->countAssessmentsForImport($id));
+
+            $this->handler->__invoke(new ImportAllocationsMessage($id));
+
+            self::assertSame(1, $this->countAllocationsForImport($id));
+            self::assertGreaterThan(0, $this->countAssessmentsForImport($id));
+        } finally {
+            if (is_file($csvPath)) {
+                @unlink($csvPath);
+            }
+        }
+    }
+
     public function testReimportDeletesPreviousAllocationsBeforeImportingAgain(): void
     {
         ['id' => $id, 'csvPath' => $csvPath] = $this->arrangeSingleRowSuccessfulCsvImport();
@@ -377,7 +398,7 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
     /**
      * @return array{id: int, csvPath: string}
      */
-    private function arrangeSingleRowSuccessfulCsvImport(): array
+    private function arrangeSingleRowSuccessfulCsvImport(bool $withAssessment = false): array
     {
         $suffix = bin2hex(random_bytes(5));
 
@@ -420,12 +441,19 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
             'PZC und Text',
         ];
 
+        if ($withAssessment) {
+            $header = array_merge($header, ['Airway', 'Breathing', 'Circulation', 'Disability']);
+        }
+
         $pzcCol = '456741';
         $pzTextCol = '456 Evt Indication '.$suffix;
 
-        $rows = [
-            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', $pzcCol, 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', $pzTextCol],
-        ];
+        $row = ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', $pzcCol, 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', $pzTextCol];
+        if ($withAssessment) {
+            $row = array_merge($row, ['A-Frei', 'B-Spontan', 'C-Stabil', 'D-Wach']);
+        }
+
+        $rows = [$row];
 
         $csvPath = sys_get_temp_dir().'/ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv';
         $fh = fopen($csvPath, 'wb');
@@ -467,6 +495,18 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         return (int) $this->em->createQueryBuilder()
             ->select('COUNT(a.id)')
             ->from(Assessment::class, 'a')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function countAssessmentsForImport(int $importId): int
+    {
+        return (int) $this->em->createQueryBuilder()
+            ->select('COUNT(DISTINCT ass.id)')
+            ->from(Allocation::class, 'a')
+            ->join('a.assessment', 'ass')
+            ->where('a.import = :importId')
+            ->setParameter('importId', $importId)
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperAssessmentTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperAssessmentTest.php
@@ -70,4 +70,60 @@ final class AllocationRowMapperAssessmentTest extends TestCase
         self::assertSame('stable', $dto->assessmentCirculation);
         self::assertSame('awake', $dto->assessmentDisability);
     }
+
+    /**
+     * @param array<string, string> $row
+     */
+    #[DataProvider('frequentLogCombinationProvider')]
+    public function testFrequentLogCombinationValuesAreMapped(
+        array $row,
+        string $dtoProperty,
+        string $expected,
+    ): void {
+        $dto = $this->mapper->mapAssoc($row);
+
+        self::assertSame($expected, $dto->{$dtoProperty});
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>, string, string}>
+     */
+    public static function frequentLogCombinationProvider(): iterable
+    {
+        yield 'disability GCS <15' => [
+            ['disability' => 'D-GCS <15'],
+            'assessmentDisability',
+            'gcs_below_15',
+        ];
+        yield 'circulation Kritisch' => [
+            ['circulation' => 'C-Kritisch'],
+            'assessmentCirculation',
+            'unstable',
+        ];
+        yield 'breathing Kritisch' => [
+            ['breathing' => 'B-Kritisch'],
+            'assessmentBreathing',
+            'insufficient',
+        ];
+        yield 'circulation Katecholamin' => [
+            ['circulation' => 'C-Katecholamin'],
+            'assessmentCirculation',
+            'medication',
+        ];
+        yield 'breathing Flow-CPAP' => [
+            ['breathing' => 'B-Flow-CPAP'],
+            'assessmentBreathing',
+            'cpap',
+        ];
+        yield 'airway Kritisch' => [
+            ['airway' => 'A-Kritisch'],
+            'assessmentAirway',
+            'critical',
+        ];
+        yield 'circulation Laufende Reanimation' => [
+            ['circulation' => 'C-Laufende Reanimation'],
+            'assessmentCirculation',
+            'cpr',
+        ];
+    }
 }

--- a/tests/Import/Unit/Service/Resolver/AllocationAssessmentResolverTest.php
+++ b/tests/Import/Unit/Service/Resolver/AllocationAssessmentResolverTest.php
@@ -79,4 +79,23 @@ final class AllocationAssessmentResolverTest extends TestCase
         self::assertSame(AssessmentCirculation::STABLE, $assessment->getCirculation());
         self::assertSame(AssessmentDisability::AWAKE, $assessment->getDisability());
     }
+
+    public function testApplyAttachesAssessmentForPreviouslyUnmappedNormalizedValues(): void
+    {
+        $dto = new AllocationRowDTO();
+        $dto->assessmentAirway = 'critical';
+        $dto->assessmentBreathing = 'insufficient';
+        $dto->assessmentCirculation = 'unstable';
+        $dto->assessmentDisability = 'gcs_below_15';
+
+        $allocation = new Allocation();
+        $this->resolver->apply($allocation, $dto);
+
+        $assessment = $allocation->getAssessment();
+        self::assertNotNull($assessment);
+        self::assertSame(AssessmentAirway::CRITICAL_AIRWAY, $assessment->getAirway());
+        self::assertSame(AssessmentBreathing::INSUFFICIENT, $assessment->getBreathing());
+        self::assertSame(AssessmentCirculation::UNSTABLE, $assessment->getCirculation());
+        self::assertSame(AssessmentDisability::GCS_BELOW_15, $assessment->getDisability());
+    }
 }


### PR DESCRIPTION
### Summary

- Improved cleanup behavior during legacy import requeue/reimport flows
- Extended `ImportPreviousRunCleanupService` to delete assessments linked through allocations
- Added tests for assessment cleanup during repeated imports
- Clarified assessment cleanup behavior in batch requeue documentation
- Added tests and mappings for normalized assessment values
- Covered frequent log combinations such as circulation, breathing, and disability
- Added normalization support for additional critical values and GCS thresholds
- Replaced deprecated DBAL array parameter usage in cleanup queries with individual placeholders

### Motivation

- Make legacy import requeue behavior safer and more complete
- Prevent stale assessment data from remaining after an import is processed again
- Improve reliability of assessment normalization during legacy import handling
- Keep cleanup SQL compatible with updated DBAL behavior
- Document cleanup expectations more clearly for future maintenance

### Notes for Reviewers

- Verify cleanup behavior for assessments linked indirectly through allocations
- Check that repeated imports no longer leave stale assessments behind
- Review normalized assessment mappings for correctness and clinical/logging edge cases
- Confirm DBAL query changes behave correctly with empty and non-empty ID lists
- Review batch requeue documentation for accuracy and clarity