### PR TITLE
feat: Add import processing status page and live polling

### DIFF
--- a/assets/controllers/import_status_controller.js
+++ b/assets/controllers/import_status_controller.js
@@ -1,0 +1,240 @@
+import { Controller } from '@hotwired/stimulus'
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        url: String,
+        initialInterval: { type: Number, default: 1000 },
+        maxInterval: { type: Number, default: 15000 },
+        startPolling: { type: Boolean, default: true },
+        processingHint: String,
+        statusPayload: Object,
+    }
+
+    static targets = [
+        'hint',
+        'activityBlock',
+        'activitySpinner',
+        'message',
+        'progressWrapper',
+        'progressBar',
+        'detailLink',
+        'error',
+        'heroAvatar',
+        'heroIcon',
+        'stepsList',
+        'stepItem',
+    ]
+
+    connect () {
+        this._currentInterval = this.initialIntervalValue
+        this._pollTimer = null
+        this._inFlight = false
+        this._stopped = false
+
+        this._onVisibilityChange = this._handleVisibilityChange.bind(this)
+        document.addEventListener('visibilitychange', this._onVisibilityChange)
+
+        if (this.hasStatusPayloadValue) {
+            this._applyStatus(this.statusPayloadValue)
+        }
+
+        if (this.startPollingValue) {
+            this._schedulePoll(0)
+        }
+    }
+
+    disconnect () {
+        this._stopPolling()
+        document.removeEventListener('visibilitychange', this._onVisibilityChange)
+    }
+
+    _handleVisibilityChange () {
+        if (document.hidden) {
+            this._clearPollTimer()
+            return
+        }
+
+        this._currentInterval = this.initialIntervalValue
+        if (this.startPollingValue && !this._stopped) {
+            void this._fetchStatus()
+            this._schedulePoll(this._currentInterval)
+        }
+    }
+
+    _schedulePoll (delayMs) {
+        this._clearPollTimer()
+        if (this._stopped || document.hidden) {
+            return
+        }
+
+        this._pollTimer = window.setTimeout(() => {
+            void this._fetchStatus()
+        }, delayMs)
+    }
+
+    _clearPollTimer () {
+        if (null !== this._pollTimer) {
+            window.clearTimeout(this._pollTimer)
+            this._pollTimer = null
+        }
+    }
+
+    _stopPolling () {
+        this._stopped = true
+        this._clearPollTimer()
+    }
+
+    async _fetchStatus () {
+        if (this._inFlight || this._stopped) {
+            return
+        }
+
+        this._inFlight = true
+        try {
+            const response = await fetch(this.urlValue, {
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+            })
+
+            if (!response.ok) {
+                throw new Error(`Status request failed: ${response.status}`)
+            }
+
+            const data = await response.json()
+            this._applyStatus(data)
+            this._hideError()
+
+            if (data.isFinal) {
+                this._stopPolling()
+                return
+            }
+
+            this._currentInterval = Math.min(
+                Math.round(this._currentInterval * 1.5),
+                this.maxIntervalValue,
+            )
+            this._schedulePoll(this._currentInterval)
+        } catch {
+            this._showError()
+            this._currentInterval = Math.min(
+                Math.round(this._currentInterval * 1.5),
+                this.maxIntervalValue,
+            )
+            this._schedulePoll(this._currentInterval)
+        } finally {
+            this._inFlight = false
+        }
+    }
+
+    _applyStatus (data) {
+        if (!data || typeof data !== 'object') {
+            return
+        }
+
+        if (this.hasHintTarget) {
+            this.hintTarget.textContent = data.isFinal
+                ? (data.message ?? '')
+                : (this.processingHintValue ?? '')
+        }
+
+        if (this.hasActivityBlockTarget) {
+            this.activityBlockTarget.classList.toggle('d-none', Boolean(data.isFinal))
+        }
+
+        if (this.hasActivitySpinnerTarget) {
+            const showSpinner = !data.isFinal && ('pending' === data.status || 'running' === data.status)
+            this.activitySpinnerTarget.classList.toggle('d-none', !showSpinner)
+        }
+
+        if (this.hasMessageTarget && !data.isFinal) {
+            this.messageTarget.textContent = data.message ?? ''
+        }
+
+        if (this.hasProgressWrapperTarget && this.hasProgressBarTarget) {
+            if (null === data.progress || undefined === data.progress) {
+                this.progressWrapperTarget.classList.add('d-none')
+            } else {
+                this.progressWrapperTarget.classList.remove('d-none')
+                this.progressBarTarget.style.width = `${data.progress}%`
+                this.progressBarTarget.setAttribute('aria-valuenow', String(data.progress))
+            }
+        }
+
+        this._applyHero(data)
+        this._applySteps(data)
+
+        if (data.isFinal && this.hasDetailLinkTarget) {
+            if (data.detailUrl) {
+                this.detailLinkTarget.href = data.detailUrl
+            }
+            this.detailLinkTarget.classList.remove('d-none')
+        }
+    }
+
+    _applyHero (data) {
+        if (!this.hasHeroAvatarTarget) {
+            return
+        }
+
+        const tone = data.iconTone ?? 'secondary'
+        const avatar = this.heroAvatarTarget
+        avatar.className = `avatar avatar-lg bg-${tone}-lt text-${tone} flex-shrink-0 import-processing-hero`
+
+        if (this.hasHeroIconTarget) {
+            this.heroIconTargets.forEach((iconEl) => {
+                const isActive = iconEl.dataset.statusKey === data.status
+                iconEl.classList.toggle('d-none', !isActive)
+            })
+        }
+    }
+
+    _applySteps (data) {
+        if (!Array.isArray(data.steps) || data.steps.length === 0) {
+            return
+        }
+
+        const modifier = data.stepsModifier ?? 'green'
+        if (this.hasStepsListTarget) {
+            this.stepsListTarget.className = `steps steps-vertical steps-${modifier} import-processing-steps my-0`
+        }
+
+        const stepsByKey = Object.fromEntries(data.steps.map((step) => [step.key, step]))
+        const stepElements = this.hasStepItemTarget
+            ? this.stepItemTargets
+            : Array.from(this.element.querySelectorAll('[data-step-key]'))
+
+        stepElements.forEach((itemEl) => {
+            const step = stepsByKey[itemEl.dataset.stepKey]
+            if (!step) {
+                return
+            }
+
+            itemEl.classList.remove('active')
+            if (step.state === 'active') {
+                itemEl.classList.add('active')
+            }
+
+            const labelEl = itemEl.querySelector('.import-step-label')
+            const descEl = itemEl.querySelector('.import-step-description')
+            if (labelEl) {
+                labelEl.textContent = step.label ?? ''
+            }
+            if (descEl) {
+                descEl.textContent = step.description ?? ''
+            }
+        })
+    }
+
+    _showError () {
+        if (this.hasErrorTarget) {
+            this.errorTarget.classList.remove('d-none')
+        }
+    }
+
+    _hideError () {
+        if (this.hasErrorTarget) {
+            this.errorTarget.classList.add('d-none')
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -8,3 +8,51 @@
 .apexcharts-menu-item.exportCSV {
     display: none;
 }
+
+.import-processing-name {
+    font-size: 1.5rem;
+    line-height: 1.3;
+}
+
+.import-processing-hero {
+    --tblr-avatar-size: 3.5rem;
+}
+
+.import-processing-step-title {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.import-processing-step-desc {
+    font-size: 0.875rem;
+    line-height: 1.45;
+}
+
+.import-processing-steps.steps-vertical .step-item {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+}
+
+.import-processing-steps.steps-vertical .step-item:not(:first-child) {
+    margin-top: 0.75rem;
+}
+
+.import-processing-status-message {
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--tblr-body-color);
+}
+
+.import-processing-spinner-icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    animation: import-processing-spin 0.9s linear infinite;
+}
+
+@keyframes import-processing-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -45,7 +45,4 @@ return [
     'apexcharts' => [
         'version' => '5.3.6',
     ],
-    '@symfony/ux-live-component' => [
-        'path' => './vendor/symfony/ux-live-component/assets/dist/live_controller.js',
-    ],
 ];

--- a/src/Import/Domain/Entity/Import.php
+++ b/src/Import/Domain/Entity/Import.php
@@ -132,6 +132,11 @@ class Import implements \Stringable
         return $this;
     }
 
+    public function isFinalStatus(): bool
+    {
+        return $this->status?->isFinal() ?? false;
+    }
+
     public function getType(): ?ImportType
     {
         return $this->type;

--- a/src/Import/Domain/Enum/ImportStatus.php
+++ b/src/Import/Domain/Enum/ImportStatus.php
@@ -39,4 +39,12 @@ enum ImportStatus: string
             self::PARTIAL->value,
         ];
     }
+
+    public function isFinal(): bool
+    {
+        return match ($this) {
+            self::COMPLETED, self::PARTIAL, self::FAILED, self::CANCELLED => true,
+            self::PENDING, self::RUNNING => false,
+        };
+    }
 }

--- a/src/Import/UI/Http/Controller/ImportStatusController.php
+++ b/src/Import/UI/Http/Controller/ImportStatusController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Http\Controller;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Security\Voter\ImportVoter;
+use App\Import\UI\Http\Presenter\ImportStatusPresenter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class ImportStatusController extends AbstractController
+{
+    public function __construct(
+        private readonly ImportStatusPresenter $statusPresenter,
+    ) {
+    }
+
+    #[Route('/import/{id}/status', name: 'app_import_status')]
+    #[IsGranted(ImportVoter::VIEW, subject: 'import')]
+    public function __invoke(Import $import): \Symfony\Component\HttpFoundation\JsonResponse
+    {
+        return $this->json($this->statusPresenter->present($import), Response::HTTP_OK, [
+            'Cache-Control' => 'no-store',
+        ]);
+    }
+}

--- a/src/Import/UI/Http/Controller/NewImportController.php
+++ b/src/Import/UI/Http/Controller/NewImportController.php
@@ -99,6 +99,6 @@ final class NewImportController extends AbstractController
 
         $this->addFlash('success', 'flash.import.created');
 
-        return $this->redirectToRoute('app_import_show', ['id' => $importId]);
+        return $this->redirectToRoute('app_import_processing', ['id' => $importId]);
     }
 }

--- a/src/Import/UI/Http/Controller/ProcessingImportController.php
+++ b/src/Import/UI/Http/Controller/ProcessingImportController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Http\Controller;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Security\Voter\ImportVoter;
+use App\Import\UI\Http\Presenter\ImportStatusPresenter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class ProcessingImportController extends AbstractController
+{
+    public function __construct(
+        private readonly ImportStatusPresenter $statusPresenter,
+    ) {
+    }
+
+    #[Route('/import/{id}/processing', name: 'app_import_processing')]
+    #[IsGranted(ImportVoter::VIEW, subject: 'import')]
+    public function __invoke(Import $import): Response
+    {
+        $statusView = $this->statusPresenter->present($import);
+
+        return $this->render('@Import/processing.html.twig', [
+            'import' => $import,
+            'statusView' => $statusView,
+            'startPolling' => !$import->isFinalStatus(),
+        ]);
+    }
+}

--- a/src/Import/UI/Http/Presenter/ImportStatusPresenter.php
+++ b/src/Import/UI/Http/Presenter/ImportStatusPresenter.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Http\Presenter;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class ImportStatusPresenter
+{
+    /** @var array<string, array{icon: string, tone: string}> */
+    private const array VISUALS = [
+        'pending' => ['icon' => 'tabler:clock', 'tone' => 'secondary'],
+        'running' => ['icon' => 'tabler:loader-2', 'tone' => 'lime'],
+        'completed' => ['icon' => 'tabler:circle-check', 'tone' => 'green'],
+        'failed' => ['icon' => 'tabler:alert-triangle', 'tone' => 'red'],
+        'cancelled' => ['icon' => 'tabler:circle-x', 'tone' => 'orange'],
+        'partial' => ['icon' => 'tabler:circle-half', 'tone' => 'yellow'],
+    ];
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private TranslatorInterface $translator,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     id: int,
+     *     status: string,
+     *     label: string,
+     *     message: string,
+     *     progress: int|null,
+     *     isFinal: bool,
+     *     detailUrl: string,
+     *     icon: string,
+     *     iconTone: string,
+     *     stepsModifier: string,
+     *     steps: list<array{key: string, label: string, description: string, state: string}>,
+     * }
+     */
+    public function present(Import $import): array
+    {
+        $id = $import->getId();
+        if (null === $id) {
+            throw new \InvalidArgumentException('Import must be persisted.');
+        }
+
+        $status = $import->getStatus() ?? ImportStatus::PENDING;
+        $statusKey = strtolower($status->name);
+        $visuals = self::VISUALS[$statusKey] ?? self::VISUALS['pending'];
+
+        return [
+            'id' => $id,
+            'status' => $statusKey,
+            'label' => $this->translator->trans('import.status.label.'.$statusKey),
+            'message' => $this->translator->trans('import.status.message.'.$statusKey),
+            'progress' => $this->resolveProgress($import, $status),
+            'isFinal' => $import->isFinalStatus(),
+            'detailUrl' => $this->urlGenerator->generate('app_import_show', ['id' => $id]),
+            'icon' => $visuals['icon'],
+            'iconTone' => $visuals['tone'],
+            'stepsModifier' => $this->resolveStepsModifier($status),
+            'steps' => $this->buildSteps($status),
+        ];
+    }
+
+    /**
+     * @return list<array{key: string, label: string, description: string, state: string}>
+     */
+    private function buildSteps(ImportStatus $status): array
+    {
+        $uploaded = [
+            'key' => 'uploaded',
+            'label' => $this->translator->trans('import.processing.step.uploaded'),
+            'description' => $this->translator->trans('import.processing.step.uploaded_desc'),
+            'state' => 'done',
+        ];
+
+        $processingState = match ($status) {
+            ImportStatus::PENDING, ImportStatus::RUNNING => 'active',
+            default => 'done',
+        };
+
+        $processing = [
+            'key' => 'processing',
+            'label' => $this->translator->trans('import.processing.step.processing'),
+            'description' => $this->translator->trans('import.processing.step.processing_desc'),
+            'state' => $processingState,
+        ];
+
+        $resultState = $status->isFinal() ? 'active' : 'pending';
+
+        $result = [
+            'key' => 'result',
+            'label' => $this->resolveResultLabel($status),
+            'description' => $this->translator->trans('import.status.message.'.strtolower($status->name)),
+            'state' => $resultState,
+        ];
+
+        return [$uploaded, $processing, $result];
+    }
+
+    private function resolveResultLabel(ImportStatus $status): string
+    {
+        return match ($status) {
+            ImportStatus::COMPLETED => $this->translator->trans('import.processing.step.result.completed'),
+            ImportStatus::PARTIAL => $this->translator->trans('import.processing.step.result.partial'),
+            ImportStatus::FAILED => $this->translator->trans('import.processing.step.result.failed'),
+            ImportStatus::CANCELLED => $this->translator->trans('import.processing.step.result.cancelled'),
+            default => $this->translator->trans('import.processing.step.result'),
+        };
+    }
+
+    private function resolveStepsModifier(ImportStatus $status): string
+    {
+        return match ($status) {
+            ImportStatus::FAILED, ImportStatus::CANCELLED => 'red',
+            ImportStatus::PARTIAL => 'yellow',
+            default => 'green',
+        };
+    }
+
+    private function resolveProgress(Import $import, ImportStatus $status): ?int
+    {
+        if (ImportStatus::RUNNING !== $status) {
+            return null;
+        }
+
+        $rowCount = $import->getRowCount();
+        $rowsPassed = $import->getRowsPassed();
+        if (null === $rowCount || $rowCount <= 0 || null === $rowsPassed) {
+            return null;
+        }
+
+        $percentage = (int) round((float) ($rowsPassed * 100) / (float) $rowCount);
+
+        return min(100, max(0, $percentage));
+    }
+}

--- a/src/Import/UI/Twig/templates/processing.html.twig
+++ b/src/Import/UI/Twig/templates/processing.html.twig
@@ -1,0 +1,136 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.import.processing'|trans }}: {{ import.name ?? ('#' ~ import.id) }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    <div class="container-xl">
+        <twig:Breadcrumbs
+            :items="[
+                { label: 'title.import.index', path: path('app_import_index') },
+                { label: 'title.import.processing' }
+            ]"
+        />
+    </div>
+{% endblock %}
+
+{% block page_content %}
+    <div class="page-body">
+        <div class="container-xl">
+            <twig:Card>
+                <div
+                    data-controller="import-status"
+                    data-import-status-url-value="{{ path('app_import_status', {id: import.id}) }}"
+                    data-import-status-initial-interval-value="1000"
+                    data-import-status-max-interval-value="15000"
+                    data-import-status-start-polling-value="{{ startPolling ? 'true' : 'false' }}"
+                    data-import-status-processing-hint-value="{{ 'import.processing.hint'|trans }}"
+                    data-import-status-status-payload-value="{{ statusView|json_encode|e('html_attr') }}"
+                >
+                    <div class="row g-3 g-md-4 align-items-start">
+                        <div class="col-md-8" data-import-status-target="importMeta">
+                            <div class="d-flex align-items-start gap-3">
+                                <span
+                                    data-import-status-target="heroAvatar"
+                                    class="avatar avatar-lg bg-{{ statusView.iconTone }}-lt text-{{ statusView.iconTone }} flex-shrink-0 import-processing-hero"
+                                >
+                                    {% set heroIcons = {
+                                        pending: 'tabler:clock',
+                                        running: 'tabler:loader-2',
+                                        completed: 'tabler:circle-check',
+                                        failed: 'tabler:alert-triangle',
+                                        cancelled: 'tabler:circle-x',
+                                        partial: 'tabler:circle-half',
+                                    } %}
+                                    {% for key, iconName in heroIcons %}
+                                        <span
+                                            data-import-status-target="heroIcon"
+                                            data-status-key="{{ key }}"
+                                            class="{{ statusView.status == key ? '' : 'd-none' }}"
+                                        >
+                                            <twig:ux:icon name="{{ iconName }}" style="height: 1.75em;" />
+                                        </span>
+                                    {% endfor %}
+                                </span>
+                                <div class="flex-fill">
+                                    <h2 class="import-processing-name fw-bold mb-2">{{ import.name ?? ('#' ~ import.id) }}</h2>
+                                    <div class="list-inline list-inline-dots text-muted mb-2">
+                                        <span class="list-inline-item">
+                                            <twig:ux:icon name="tabler:building-hospital" width="1em" height="1em" />
+                                            {{ import.hospital.name }}
+                                        </span>
+                                        {% if import.hospital.dispatchArea or import.hospital.state %}
+                                            <span class="list-inline-item">
+                                                <twig:ux:icon name="tabler:map" width="1em" height="1em" />
+                                                {{ import.hospital.dispatchArea }}{% if import.hospital.state %}, {{ import.hospital.state }}{% endif %}
+                                            </span>
+                                        {% endif %}
+                                    </div>
+                                    <p data-import-status-target="hint" class="text-muted mb-3">
+                                        {{ import.isFinalStatus ? statusView.message : 'import.processing.hint'|trans }}
+                                    </p>
+                                    <div
+                                        data-import-status-target="activityBlock"
+                                        class="import-processing-activity mb-3{{ import.isFinalStatus ? ' d-none' : '' }}"
+                                    >
+                                        <div data-import-status-target="activitySpinner" class="import-processing-spinner mb-2">
+                                            <twig:ux:icon name="tabler:loader-2" class="icon text-lime import-processing-spinner-icon" />
+                                        </div>
+                                        <p data-import-status-target="message" class="import-processing-status-message mb-0">{{ statusView.message }}</p>
+                                    </div>
+
+                                    <div
+                                        data-import-status-target="progressWrapper"
+                                        class="mb-3 {{ statusView.progress is null ? 'd-none' : '' }}"
+                                    >
+                                        <div class="progress">
+                                            <div
+                                                data-import-status-target="progressBar"
+                                                class="progress-bar"
+                                                role="progressbar"
+                                                style="width: {{ statusView.progress ?? 0 }}%"
+                                                aria-valuenow="{{ statusView.progress ?? 0 }}"
+                                                aria-valuemin="0"
+                                                aria-valuemax="100"
+                                            ></div>
+                                        </div>
+                                    </div>
+
+                                    <div data-import-status-target="error" class="alert alert-warning d-none mb-3" role="alert">
+                                        {{ 'import.processing.error'|trans }}
+                                    </div>
+
+                                    <a
+                                        data-import-status-target="detailLink"
+                                        href="{{ statusView.detailUrl }}"
+                                        class="btn btn-primary {{ startPolling ? 'd-none' : '' }}"
+                                    >
+                                        <twig:ux:icon name="tabler:eye" class="w-3 h-3" />&nbsp;
+                                        {{ 'import.processing.view_detail'|trans }}
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="col-md-4 ps-md-3 pt-3 pt-md-0">
+                            <ul
+                                data-import-status-target="stepsList"
+                                class="steps steps-vertical steps-{{ statusView.stepsModifier }} import-processing-steps my-0"
+                            >
+                                {% for step in statusView.steps %}
+                                    <li
+                                        class="step-item{{ step.state == 'active' ? ' active' : '' }}"
+                                        data-import-status-target="stepItem"
+                                        data-step-key="{{ step.key }}"
+                                    >
+                                        <div class="import-processing-step-title import-step-label mb-1">{{ step.label }}</div>
+                                        <div class="text-secondary import-processing-step-desc import-step-description">{{ step.description }}</div>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </twig:Card>
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Import/Functional/Controller/ImportStatusControllerTest.php
+++ b/tests/Import/Functional/Controller/ImportStatusControllerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ImportStatusControllerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testStatusEndpointReturnsExpectedJsonShape(): void
+    {
+        $client = self::createClient();
+        [$owner, $importId] = $this->createImportForOwner(ImportStatus::PENDING);
+
+        $client->loginUser($owner);
+        $client->request(Request::METHOD_GET, \sprintf('/import/%d/status', $importId));
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($client->getResponse()->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame($importId, $data['id']);
+        self::assertSame('pending', $data['status']);
+        self::assertIsString($data['label']);
+        self::assertIsString($data['message']);
+        self::assertArrayHasKey('progress', $data);
+        self::assertFalse($data['isFinal']);
+        self::assertStringContainsString(\sprintf('/import/%d', $importId), (string) $data['detailUrl']);
+        self::assertSame('tabler:clock', $data['icon']);
+        self::assertSame('secondary', $data['iconTone']);
+        self::assertSame('green', $data['stepsModifier']);
+        self::assertIsArray($data['steps']);
+        self::assertCount(3, $data['steps']);
+        self::assertSame('active', $data['steps'][1]['state']);
+    }
+
+    public function testStatusEndpointReturnsCompletedStepStates(): void
+    {
+        $client = self::createClient();
+        [$owner, $importId] = $this->createImportForOwner(ImportStatus::COMPLETED);
+
+        $client->loginUser($owner);
+        $client->request(Request::METHOD_GET, \sprintf('/import/%d/status', $importId));
+
+        self::assertResponseIsSuccessful();
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($client->getResponse()->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertTrue($data['isFinal']);
+        self::assertSame('done', $data['steps'][0]['state']);
+        self::assertSame('done', $data['steps'][1]['state']);
+        self::assertSame('active', $data['steps'][2]['state']);
+        self::assertSame('Finished', $data['steps'][2]['label']);
+    }
+
+    #[DataProvider('isFinalStatusProvider')]
+    public function testStatusEndpointReportsIsFinalCorrectly(ImportStatus $status, bool $expectedIsFinal): void
+    {
+        $client = self::createClient();
+        [$owner, $importId] = $this->createImportForOwner($status);
+
+        $client->loginUser($owner);
+        $client->request(Request::METHOD_GET, \sprintf('/import/%d/status', $importId));
+
+        self::assertResponseIsSuccessful();
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($client->getResponse()->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(strtolower($status->name), $data['status']);
+        self::assertSame($expectedIsFinal, $data['isFinal']);
+    }
+
+    public function testForeignImportStatusIsForbidden(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne([
+            'username' => 'owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $intruder = UserFactory::createOne([
+            'username' => 'intruder-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $createdBy = UserFactory::createOne(['username' => 'creator-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Protected Import',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::PENDING,
+            'filePath' => '/tmp/protected.csv',
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => 12,
+            'rowCount' => 5,
+            'runCount' => 0,
+            'runTime' => 0,
+            'createdBy' => $createdBy,
+        ]);
+
+        $client->loginUser($intruder->_real());
+        $client->request(Request::METHOD_GET, \sprintf('/import/%d/status', $import->getId()));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    /**
+     * @return array<string, array{status: ImportStatus, expectedIsFinal: bool}>
+     */
+    public static function isFinalStatusProvider(): array
+    {
+        return [
+            'PENDING' => ['status' => ImportStatus::PENDING, 'expectedIsFinal' => false],
+            'RUNNING' => ['status' => ImportStatus::RUNNING, 'expectedIsFinal' => false],
+            'COMPLETED' => ['status' => ImportStatus::COMPLETED, 'expectedIsFinal' => true],
+            'PARTIAL' => ['status' => ImportStatus::PARTIAL, 'expectedIsFinal' => true],
+            'FAILED' => ['status' => ImportStatus::FAILED, 'expectedIsFinal' => true],
+            'CANCELLED' => ['status' => ImportStatus::CANCELLED, 'expectedIsFinal' => true],
+        ];
+    }
+
+    /**
+     * @return array{0:User,1:int}
+     */
+    private function createImportForOwner(ImportStatus $status): array
+    {
+        $owner = UserFactory::createOne([
+            'username' => 'owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $createdBy = UserFactory::createOne(['username' => 'creator-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Status Test Import',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => $status,
+            'filePath' => '/tmp/status-test.csv',
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => 100,
+            'rowCount' => 10,
+            'runCount' => 0,
+            'runTime' => 0,
+            'createdBy' => $createdBy,
+        ]);
+
+        return [$owner->_real(), (int) $import->getId()];
+    }
+}

--- a/tests/Import/Functional/Controller/NewImportControllerTest.php
+++ b/tests/Import/Functional/Controller/NewImportControllerTest.php
@@ -44,7 +44,7 @@ final class NewImportControllerTest extends WebTestCase
             ->assertSeeElement('input[type="file"][name="import_create[file]"]');
     }
 
-    public function testSubmitWithCsvRedirectsToShowAndPersists(): void
+    public function testSubmitWithCsvRedirectsToProcessingAndPersists(): void
     {
         [$owner, $hospitalId] = $this->createOwnerWithHospital();
 
@@ -65,6 +65,8 @@ final class NewImportControllerTest extends WebTestCase
             ->assertSuccessful()
             ->assertSee('Test Allocations')
             ->assertSee('New Import has been created successfully!')
+            ->assertSee('Your file is being processed in the background')
+            ->assertSeeElement('ul.steps.steps-vertical')
             ->use(function (): void {
                 /** @var EntityManagerInterface $em */
                 $em = self::getContainer()->get(EntityManagerInterface::class);

--- a/tests/Import/Functional/Controller/NewImportControllerTest.php
+++ b/tests/Import/Functional/Controller/NewImportControllerTest.php
@@ -65,8 +65,11 @@ final class NewImportControllerTest extends WebTestCase
             ->assertSuccessful()
             ->assertSee('Test Allocations')
             ->assertSee('New Import has been created successfully!')
-            ->assertSee('Your file is being processed in the background')
             ->assertSeeElement('ul.steps.steps-vertical')
+            ->assertSeeElement('[data-controller="import-status"]')
+            ->assertSee('File uploaded')
+            ->assertSee('View import details')
+            ->assertSeeElement('[data-import-status-target="detailLink"]:not(.d-none)')
             ->use(function (): void {
                 /** @var EntityManagerInterface $em */
                 $em = self::getContainer()->get(EntityManagerInterface::class);
@@ -74,6 +77,7 @@ final class NewImportControllerTest extends WebTestCase
                 /** @var Import|null $import */
                 $import = $em->getRepository(Import::class)->findOneBy(['name' => 'Test Allocations']);
                 self::assertNotNull($import, 'Import has been persisted.');
+                self::assertTrue($import->isFinalStatus(), 'Import is processed synchronously in the test environment.');
 
                 self::assertNotEmpty($import->getFileMimeType());
                 self::assertTrue(

--- a/tests/Import/Functional/Controller/ProcessingImportControllerTest.php
+++ b/tests/Import/Functional/Controller/ProcessingImportControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ProcessingImportControllerTest extends WebTestCase
+{
+    use HasBrowser;
+    use Factories;
+    use ResetDatabase;
+
+    public function testProcessingPageShowsStepsForPendingImport(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner(ImportStatus::PENDING);
+
+        $this->browser()
+            ->actingAs($owner)
+            ->visit(\sprintf('/import/%d/processing', $importId))
+            ->assertSuccessful()
+            ->assertSeeElement('[data-import-status-target="importMeta"]')
+            ->assertSee('Processing Test Import')
+            ->assertSee('Your file is being processed in the background')
+            ->assertSee('St. Test Hospital')
+            ->assertSeeElement('.import-processing-hero')
+            ->assertSeeElement('ul.steps.steps-vertical')
+            ->assertSee('Processing data')
+            ->assertSeeElement('[data-controller="import-status"]')
+            ->assertSeeElement('[data-import-status-start-polling-value="true"]')
+            ->assertSeeElement('[data-step-key="processing"].step-item.active')
+            ->assertSeeElement('[data-import-status-target="detailLink"].d-none');
+    }
+
+    public function testProcessingPageShowsDetailButtonForCompletedImport(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner(ImportStatus::COMPLETED);
+
+        $this->browser()
+            ->actingAs($owner)
+            ->visit(\sprintf('/import/%d/processing', $importId))
+            ->assertSuccessful()
+            ->assertSee('Processing Test Import')
+            ->assertSee('Finished')
+            ->assertSee('The import finished successfully.')
+            ->assertSeeElement('[data-import-status-start-polling-value="false"]')
+            ->assertSeeElement('[data-step-key="result"].step-item.active')
+            ->assertSeeElement('ul.steps-green')
+            ->assertSeeElement('[data-import-status-target="detailLink"]:not(.d-none)')
+            ->assertSee('View import details');
+    }
+
+    public function testForeignImportProcessingIsNotAccessible(): void
+    {
+        $owner = UserFactory::createOne([
+            'username' => 'owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $intruder = UserFactory::createOne([
+            'username' => 'intruder-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $createdBy = UserFactory::createOne(['username' => 'creator-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Protected Import',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::PENDING,
+            'filePath' => '/tmp/protected.csv',
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => 12,
+            'rowCount' => 5,
+            'runCount' => 0,
+            'runTime' => 0,
+            'createdBy' => $createdBy,
+        ]);
+
+        $this->browser()
+            ->actingAs($intruder)
+            ->visit(\sprintf('/import/%d/processing', $import->getId()))
+            ->assertStatus(403);
+    }
+
+    /**
+     * @return array{0:User,1:int}
+     */
+    private function createImportForOwner(ImportStatus $status): array
+    {
+        $owner = UserFactory::createOne([
+            'username' => 'owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $createdBy = UserFactory::createOne(['username' => 'creator-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'Hessen']);
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Dispatch Area']);
+
+        $hospital = HospitalFactory::createOne([
+            'name' => 'St. Test Hospital',
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Processing Test Import',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => $status,
+            'filePath' => '/tmp/processing-test.csv',
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => 100,
+            'rowCount' => 10,
+            'runCount' => 0,
+            'runTime' => 0,
+            'createdBy' => $createdBy,
+        ]);
+
+        return [$owner->_real(), (int) $import->getId()];
+    }
+}

--- a/tests/Import/Unit/Enum/ImportStatusTest.php
+++ b/tests/Import/Unit/Enum/ImportStatusTest.php
@@ -30,6 +30,27 @@ final class ImportStatusTest extends TestCase
         self::assertNull(ImportStatus::tryFrom('Unknown'));
     }
 
+    #[DataProvider('isFinalProvider')]
+    public function testIsFinal(ImportStatus $case, bool $expected): void
+    {
+        self::assertSame($expected, $case->isFinal());
+    }
+
+    /**
+     * @return array<string, array{case: ImportStatus, expected: bool}>
+     */
+    public static function isFinalProvider(): array
+    {
+        return [
+            'PENDING' => ['case' => ImportStatus::PENDING, 'expected' => false],
+            'RUNNING' => ['case' => ImportStatus::RUNNING, 'expected' => false],
+            'COMPLETED' => ['case' => ImportStatus::COMPLETED, 'expected' => true],
+            'FAILED' => ['case' => ImportStatus::FAILED, 'expected' => true],
+            'CANCELLED' => ['case' => ImportStatus::CANCELLED, 'expected' => true],
+            'PARTIAL' => ['case' => ImportStatus::PARTIAL, 'expected' => true],
+        ];
+    }
+
     /**
      * @return array<string, array{case: ImportStatus, value: string}>
      */

--- a/tests/Import/Unit/UI/Http/Presenter/ImportStatusPresenterTest.php
+++ b/tests/Import/Unit/UI/Http/Presenter/ImportStatusPresenterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\UI\Http\Presenter;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\UI\Http\Presenter\ImportStatusPresenter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ImportStatusPresenterTest extends TestCase
+{
+    #[DataProvider('stepStateProvider')]
+    public function testBuildsExpectedStepStates(ImportStatus $status, string $activeStepKey, string $stepsModifier): void
+    {
+        $import = new Import()
+            ->setStatus($status)
+            ->setRowCount(100);
+
+        $importReflection = new \ReflectionProperty(Import::class, 'id');
+        $importReflection->setValue($import, 42);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/import/42');
+
+        $presenter = new ImportStatusPresenter($translator, $urlGenerator);
+        $view = $presenter->present($import);
+
+        self::assertSame($stepsModifier, $view['stepsModifier']);
+        self::assertCount(3, $view['steps']);
+        self::assertSame('done', $view['steps'][0]['state']);
+
+        $activeSteps = array_filter($view['steps'], static fn (array $step): bool => 'active' === $step['state']);
+        self::assertCount(1, $activeSteps);
+        self::assertSame($activeStepKey, array_values($activeSteps)[0]['key']);
+    }
+
+    /**
+     * @return array<string, array{status: ImportStatus, activeStepKey: string, stepsModifier: string}>
+     */
+    public static function stepStateProvider(): array
+    {
+        return [
+            'PENDING' => ['status' => ImportStatus::PENDING, 'activeStepKey' => 'processing', 'stepsModifier' => 'green'],
+            'RUNNING' => ['status' => ImportStatus::RUNNING, 'activeStepKey' => 'processing', 'stepsModifier' => 'green'],
+            'COMPLETED' => ['status' => ImportStatus::COMPLETED, 'activeStepKey' => 'result', 'stepsModifier' => 'green'],
+            'PARTIAL' => ['status' => ImportStatus::PARTIAL, 'activeStepKey' => 'result', 'stepsModifier' => 'yellow'],
+            'FAILED' => ['status' => ImportStatus::FAILED, 'activeStepKey' => 'result', 'stepsModifier' => 'red'],
+        ];
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -2071,6 +2071,106 @@
         <source>title.import.show</source>
         <target>Showing Import detail</target>
       </trans-unit>
+      <trans-unit id="impProcTitle" resname="title.import.processing">
+        <source>title.import.processing</source>
+        <target>Processing import</target>
+      </trans-unit>
+      <trans-unit id="impProcHint" resname="import.processing.hint">
+        <source>import.processing.hint</source>
+        <target>Your file is being processed in the background. This page updates automatically.</target>
+      </trans-unit>
+      <trans-unit id="impProcDetail" resname="import.processing.view_detail">
+        <source>import.processing.view_detail</source>
+        <target>View import details</target>
+      </trans-unit>
+      <trans-unit id="impProcErr" resname="import.processing.error">
+        <source>import.processing.error</source>
+        <target>Could not refresh status. Retrying…</target>
+      </trans-unit>
+      <trans-unit id="impStLblPend" resname="import.status.label.pending">
+        <source>import.status.label.pending</source>
+        <target>Pending</target>
+      </trans-unit>
+      <trans-unit id="impStLblRun" resname="import.status.label.running">
+        <source>import.status.label.running</source>
+        <target>Running</target>
+      </trans-unit>
+      <trans-unit id="impStLblComp" resname="import.status.label.completed">
+        <source>import.status.label.completed</source>
+        <target>Completed</target>
+      </trans-unit>
+      <trans-unit id="impStLblFail" resname="import.status.label.failed">
+        <source>import.status.label.failed</source>
+        <target>Failed</target>
+      </trans-unit>
+      <trans-unit id="impStLblCanc" resname="import.status.label.cancelled">
+        <source>import.status.label.cancelled</source>
+        <target>Cancelled</target>
+      </trans-unit>
+      <trans-unit id="impStLblPart" resname="import.status.label.partial">
+        <source>import.status.label.partial</source>
+        <target>Partial</target>
+      </trans-unit>
+      <trans-unit id="impStMsgPend" resname="import.status.message.pending">
+        <source>import.status.message.pending</source>
+        <target>The import is queued and will start shortly.</target>
+      </trans-unit>
+      <trans-unit id="impStMsgRun" resname="import.status.message.running">
+        <source>import.status.message.running</source>
+        <target>Rows are being processed.</target>
+      </trans-unit>
+      <trans-unit id="impStMsgComp" resname="import.status.message.completed">
+        <source>import.status.message.completed</source>
+        <target>The import finished successfully.</target>
+      </trans-unit>
+      <trans-unit id="impStMsgFail" resname="import.status.message.failed">
+        <source>import.status.message.failed</source>
+        <target>The import failed.</target>
+      </trans-unit>
+      <trans-unit id="impStMsgCanc" resname="import.status.message.cancelled">
+        <source>import.status.message.cancelled</source>
+        <target>The import was cancelled.</target>
+      </trans-unit>
+      <trans-unit id="impStMsgPart" resname="import.status.message.partial">
+        <source>import.status.message.partial</source>
+        <target>The import finished with some rejected rows.</target>
+      </trans-unit>
+      <trans-unit id="impStpUp" resname="import.processing.step.uploaded">
+        <source>import.processing.step.uploaded</source>
+        <target>File uploaded</target>
+      </trans-unit>
+      <trans-unit id="impStpUpD" resname="import.processing.step.uploaded_desc">
+        <source>import.processing.step.uploaded_desc</source>
+        <target>Your CSV file has been received and queued.</target>
+      </trans-unit>
+      <trans-unit id="impStpPr" resname="import.processing.step.processing">
+        <source>import.processing.step.processing</source>
+        <target>Processing data</target>
+      </trans-unit>
+      <trans-unit id="impStpPrD" resname="import.processing.step.processing_desc">
+        <source>import.processing.step.processing_desc</source>
+        <target>Rows are being validated and imported.</target>
+      </trans-unit>
+      <trans-unit id="impStpRs" resname="import.processing.step.result">
+        <source>import.processing.step.result</source>
+        <target>Result</target>
+      </trans-unit>
+      <trans-unit id="impStpRsC" resname="import.processing.step.result.completed">
+        <source>import.processing.step.result.completed</source>
+        <target>Finished</target>
+      </trans-unit>
+      <trans-unit id="impStpRsP" resname="import.processing.step.result.partial">
+        <source>import.processing.step.result.partial</source>
+        <target>Import completed with rejections</target>
+      </trans-unit>
+      <trans-unit id="impStpRsF" resname="import.processing.step.result.failed">
+        <source>import.processing.step.result.failed</source>
+        <target>Import failed</target>
+      </trans-unit>
+      <trans-unit id="impStpRsX" resname="import.processing.step.result.cancelled">
+        <source>import.processing.step.result.cancelled</source>
+        <target>Import cancelled</target>
+      </trans-unit>
       <trans-unit id="njXB7xf" resname="title.indication.assign">
         <source>title.indication.assign</source>
         <target>Assign Indications</target>


### PR DESCRIPTION
### Summary

- Added final status detection for imports via `ImportStatus::isFinal()` and `Import::isFinalStatus()`
- Introduced a centralized status presenter for labels, messages, progress, steps, and visual metadata
- Added a dedicated import processing page shown after upload
- Added a JSON status endpoint for frontend polling
- Implemented adaptive polling with backoff in the processing UI
- Updated the upload flow to redirect to the processing page instead of the import detail view
- Fixed a broken importmap entry for `ux-live-component` assets

### Motivation

- Improve user feedback while imports are being processed
- Avoid sending users directly to a detail page before processing has finished
- Stop polling automatically once an import reaches a final state
- Centralize status presentation logic so UI and API responses stay consistent
- Resolve Issue #97 by making import processing state visible and understandable

### Notes for Reviewers

- Verify upload flow redirects to the new processing page
- Check status endpoint responses for pending, running, successful, failed, and final states
- Confirm adaptive polling stops correctly once an import reaches a final status
- Review status labels, progress steps, and messages for clarity
- Ensure asset-map compilation works after removing the invalid importmap entry
- This PR closes #97