### PR TITLE
feat: Add page key system for identifying system pages

### DIFF
--- a/migrations/Version20260602121126.php
+++ b/migrations/Version20260602121126.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260602121126 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional unique page_key to page table for system-known pages';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE page ADD key VARCHAR(32) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_page_key ON page (key)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_page_key');
+        $this->addSql('ALTER TABLE page DROP key');
+    }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,6 +33,7 @@
                 <file name="src/Shared/Infrastructure/Pagination/CursorPaginator.php" />
                 <directory name="src/*/Application/Contracts/" />
                 <directory name="src/*/Application/DTO/" />
+                <directory name="src/*/Application/Page/" />
                 <directory name="src/*/Application/Exception/" />
                 <directory name="src/*/Domain/Entity/" />
                 <directory name="src/*/Domain/Enum/" />
@@ -57,6 +58,7 @@
         <PossiblyUnusedProperty>
             <errorLevel type="suppress">
                 <directory name="src/*/Application/DTO/" />
+                <directory name="src/*/Application/Page/DTO/" />
                 <directory name="src/*/UI/Http/DTO/" />
                 <directory name="src/Import/Infrastructure/Adapter/" />
                 <directory name="src/Statistics/" />
@@ -68,6 +70,7 @@
                 <directory name="src/*/Application/MessageHandler/" />
                 <directory name="src/*/Infrastructure/EventSubscriber/" />
                 <directory name="src/*/UI/Twig/Components" />
+                <directory name="src/*/UI/Twig" />
                 <directory name="src/*/UI/Http/Controller" />
                 <directory name="src/*/UI/Console/Command" />
                 <directory name="src/DataFixtures" />

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -9,6 +9,7 @@ use App\Content\Application\Page\PageContentSanitizer;
 use App\Content\Application\Page\PageContentValidator;
 use App\Content\Application\Page\PagePathResolver;
 use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
@@ -58,7 +59,7 @@ final class PageCrudController extends AbstractCrudController
         return $crud
             ->setEntityLabelInSingular('label.page')
             ->setEntityLabelInPlural('label.pages')
-            ->setSearchFields(['id', 'title', 'slug', 'path'])
+            ->setSearchFields(['id', 'title', 'slug', 'path', 'key'])
             ->setDefaultSort(['path' => 'ASC']);
     }
 
@@ -104,6 +105,11 @@ final class PageCrudController extends AbstractCrudController
         yield IdField::new('id')->onlyOnDetail();
         yield TextField::new('title', 'label.title');
         yield SlugField::new('slug', 'label.slug')->setTargetFieldName('title');
+        yield ChoiceField::new('key', 'label.page_key')
+            ->setChoices($this->buildPageKeyChoices())
+            ->setRequired(false)
+            ->allowMultipleChoices(false)
+            ->setFormTypeOption('placeholder', '—');
         yield AssociationField::new('parent', 'label.parent_page')->autocomplete();
         yield ChoiceField::new('status', 'label.status')
             ->setChoices([
@@ -192,6 +198,19 @@ final class PageCrudController extends AbstractCrudController
         $content = $page->getContent();
         $this->pageContentValidator->assertValid($content);
         $page->setContent($this->pageContentSanitizer->sanitize($content));
+    }
+
+    /**
+     * @return array<string, PageKey>
+     */
+    private function buildPageKeyChoices(): array
+    {
+        $choices = [];
+        foreach (PageKey::cases() as $pageKey) {
+            $choices[$pageKey->translationKey()] = $pageKey;
+        }
+
+        return $choices;
     }
 
     /**

--- a/src/Content/Application/Page/DTO/PageNavigationLink.php
+++ b/src/Content/Application/Page/DTO/PageNavigationLink.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page\DTO;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+
+final readonly class PageNavigationLink
+{
+    public function __construct(
+        public PageKey $key,
+        public Page $page,
+        public string $url,
+        public string $label,
+    ) {
+    }
+}

--- a/src/Content/Application/Page/PageNavigationProvider.php
+++ b/src/Content/Application/Page/PageNavigationProvider.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Application\Page\DTO\PageNavigationLink;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Repository\PageRepository;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class PageNavigationProvider
+{
+    /** @var array<string, Page>|null */
+    private ?array $publishedByKey = null;
+
+    public function __construct(
+        private readonly PageRepository $pageRepository,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly PageAccessChecker $pageAccessChecker,
+    ) {
+    }
+
+    public function getPageByKey(PageKey $key): ?Page
+    {
+        $page = $this->getPublishedByKey()[$key->value] ?? null;
+        if (!$page instanceof Page) {
+            return null;
+        }
+
+        if (!$this->pageAccessChecker->canView($page)) {
+            return null;
+        }
+
+        return $page;
+    }
+
+    public function getUrlByKey(PageKey $key): ?string
+    {
+        $page = $this->getPageByKey($key);
+        if (!$page instanceof Page) {
+            return null;
+        }
+
+        return $this->buildUrl($page);
+    }
+
+    /**
+     * @return list<PageNavigationLink>
+     */
+    public function getHeaderPages(): array
+    {
+        return $this->buildLinksForKeys(
+            PageKey::About,
+            PageKey::Features,
+            PageKey::Faq,
+        );
+    }
+
+    /**
+     * @return list<PageNavigationLink>
+     */
+    public function getFooterPages(): array
+    {
+        return $this->buildLinksForKeys(
+            PageKey::Imprint,
+            PageKey::Privacy,
+            PageKey::Terms,
+        );
+    }
+
+    /**
+     * @return array<string, Page>
+     */
+    private function getPublishedByKey(): array
+    {
+        if (null !== $this->publishedByKey) {
+            return $this->publishedByKey;
+        }
+
+        $this->publishedByKey = [];
+        foreach ($this->pageRepository->findAllPublishedWithKey() as $page) {
+            $key = $page->getKey();
+            if (!$key instanceof PageKey) {
+                continue;
+            }
+
+            $this->publishedByKey[$key->value] = $page;
+        }
+
+        return $this->publishedByKey;
+    }
+
+    /**
+     * @return list<PageNavigationLink>
+     */
+    private function buildLinksForKeys(PageKey ...$keys): array
+    {
+        $links = [];
+        foreach ($keys as $key) {
+            $page = $this->getPageByKey($key);
+            if (!$page instanceof Page) {
+                continue;
+            }
+
+            $url = $this->buildUrl($page);
+            if (null === $url) {
+                continue;
+            }
+
+            $links[] = new PageNavigationLink(
+                key: $key,
+                page: $page,
+                url: $url,
+                label: (string) $page->getTitle(),
+            );
+        }
+
+        return $links;
+    }
+
+    private function buildUrl(Page $page): ?string
+    {
+        $pathSegment = trim((string) $page->getPath(), '/');
+        if ('' === $pathSegment) {
+            return null;
+        }
+
+        return $this->urlGenerator->generate('app_page_show', ['path' => $pathSegment]);
+    }
+}

--- a/src/Content/Domain/Entity/Page.php
+++ b/src/Content/Domain/Entity/Page.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Content\Domain\Entity;
 
+use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Repository\PageRepository;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -18,10 +19,12 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Table(name: 'page')]
 #[ORM\UniqueConstraint(name: 'uniq_page_path', columns: ['path'])]
 #[ORM\UniqueConstraint(name: 'uniq_page_parent_slug', columns: ['parent_id', 'slug'])]
+#[ORM\UniqueConstraint(name: 'uniq_page_key', columns: ['key'])]
 #[ORM\Index(name: 'idx_page_parent_sort', columns: ['parent_id', 'sort_order'])]
 #[ORM\HasLifecycleCallbacks]
 #[UniqueEntity(fields: ['path'], message: 'page.validation.path_unique')]
 #[UniqueEntity(fields: ['parent', 'slug'], message: 'page.validation.parent_slug_unique')]
+#[UniqueEntity(fields: ['key'], message: 'page.validation.key_unique')]
 class Page implements \Stringable
 {
     public const string STATUS_DRAFT = 'draft';
@@ -61,6 +64,9 @@ class Page implements \Stringable
     #[Assert\Length(max: 500)]
     #[ORM\Column(length: 500)]
     private ?string $path = null;
+
+    #[ORM\Column(nullable: true, enumType: PageKey::class)]
+    private ?PageKey $key = null;
 
     #[Assert\Choice(choices: [self::STATUS_DRAFT, self::STATUS_PUBLISHED])]
     #[ORM\Column(length: 32)]
@@ -169,6 +175,18 @@ class Page implements \Stringable
     public function setPath(string $path): self
     {
         $this->path = $path;
+
+        return $this;
+    }
+
+    public function getKey(): ?PageKey
+    {
+        return $this->key;
+    }
+
+    public function setKey(?PageKey $key): self
+    {
+        $this->key = $key;
 
         return $this;
     }

--- a/src/Content/Domain/Enum/PageKey.php
+++ b/src/Content/Domain/Enum/PageKey.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Domain\Enum;
+
+enum PageKey: string
+{
+    case Imprint = 'imprint';
+    case Privacy = 'privacy';
+    case Terms = 'terms';
+    case About = 'about';
+    case Features = 'features';
+    case Faq = 'faq';
+
+    public function translationKey(): string
+    {
+        return 'page.key.'.$this->value;
+    }
+}

--- a/src/Content/Infrastructure/Repository/PageRepository.php
+++ b/src/Content/Infrastructure/Repository/PageRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Content\Infrastructure\Repository;
 
 use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -31,6 +32,37 @@ final class PageRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
 
         return $page;
+    }
+
+    public function findOnePublishedByKey(PageKey $key): ?Page
+    {
+        /** @var ?Page $page */
+        $page = $this->createQueryBuilder('p')
+            ->andWhere('p.key = :key')
+            ->andWhere('p.status = :status')
+            ->setParameter('key', $key)
+            ->setParameter('status', Page::STATUS_PUBLISHED)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $page;
+    }
+
+    /**
+     * @return list<Page>
+     */
+    public function findAllPublishedWithKey(): array
+    {
+        /** @var list<Page> $pages */
+        $pages = $this->createQueryBuilder('p')
+            ->andWhere('p.key IS NOT NULL')
+            ->andWhere('p.status = :status')
+            ->setParameter('status', Page::STATUS_PUBLISHED)
+            ->getQuery()
+            ->getResult();
+
+        return $pages;
     }
 
     /**

--- a/src/Content/UI/Twig/PageExtension.php
+++ b/src/Content/UI/Twig/PageExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\UI\Twig;
+
+use App\Content\Application\Page\DTO\PageNavigationLink;
+use App\Content\Application\Page\PageNavigationProvider;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class PageExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly PageNavigationProvider $pageNavigationProvider,
+    ) {
+    }
+
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('page_by_key', $this->pageByKey(...)),
+            new TwigFunction('page_url_by_key', $this->pageUrlByKey(...)),
+            new TwigFunction('page_nav_header_items', $this->pageNavHeaderItems(...)),
+            new TwigFunction('page_nav_footer_items', $this->pageNavFooterItems(...)),
+        ];
+    }
+
+    public function pageByKey(string $key): ?Page
+    {
+        $pageKey = PageKey::tryFrom($key);
+        if (!$pageKey instanceof PageKey) {
+            return null;
+        }
+
+        return $this->pageNavigationProvider->getPageByKey($pageKey);
+    }
+
+    public function pageUrlByKey(string $key): ?string
+    {
+        $pageKey = PageKey::tryFrom($key);
+        if (!$pageKey instanceof PageKey) {
+            return null;
+        }
+
+        return $this->pageNavigationProvider->getUrlByKey($pageKey);
+    }
+
+    /**
+     * @return list<PageNavigationLink>
+     */
+    public function pageNavHeaderItems(): array
+    {
+        return $this->pageNavigationProvider->getHeaderPages();
+    }
+
+    /**
+     * @return list<PageNavigationLink>
+     */
+    public function pageNavFooterItems(): array
+    {
+        return $this->pageNavigationProvider->getFooterPages();
+    }
+}

--- a/src/Shared/UI/Twig/templates/_embeds/header.html.twig
+++ b/src/Shared/UI/Twig/templates/_embeds/header.html.twig
@@ -51,6 +51,13 @@
                                     </span>
                                 </a>
                             </li>
+                            {% for item in page_nav_header_items() %}
+                                <li class="nav-item">
+                                    <a class="nav-link" href="{{ item.url }}">
+                                        <span class="nav-link-title">{{ item.label }}</span>
+                                    </a>
+                                </li>
+                            {% endfor %}
                         {% endblock %}
                     </ul>
                 </div>

--- a/src/Shared/UI/Twig/templates/_includes/footer.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/footer.html.twig
@@ -6,6 +6,11 @@
                     <li class="list-inline-item">
                         &copy; 2025 <a href="https://github.com/nplhse/collaborative-ivena-statistics" class="link-secondary">collaborative-ivena-statistics</a>
                     </li>
+                    {% for item in page_nav_footer_items() %}
+                        <li class="list-inline-item">
+                            <a href="{{ item.url }}" class="link-secondary">{{ item.label }}</a>
+                        </li>
+                    {% endfor %}
                     <li class="list-inline-item">
                         <a href="{{ path('app_cookie_preferences') }}" class="link-secondary">{{ 'link.cookie_preferences'|trans }}</a>
                     </li>

--- a/src/User/UI/Form/RegistrationFormType.php
+++ b/src/User/UI/Form/RegistrationFormType.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\User\UI\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -40,6 +42,13 @@ final class RegistrationFormType extends AbstractType
                 'constraints' => [
                     new NotBlank(),
                     new Length(min: 8, max: 4096),
+                ],
+            ])
+            ->add('acceptTerms', CheckboxType::class, [
+                'mapped' => false,
+                'label' => false,
+                'constraints' => [
+                    new IsTrue(message: 'validation.registration.accept_terms_required'),
                 ],
             ]);
     }

--- a/src/User/UI/Twig/templates/registration/register.html.twig
+++ b/src/User/UI/Twig/templates/registration/register.html.twig
@@ -10,6 +10,31 @@
                 {{ form_row(registrationForm.username) }}
                 {{ form_row(registrationForm.email) }}
                 {{ form_row(registrationForm.plainPassword) }}
+                {% set termsPageUrl = page_url_by_key('terms') %}
+                {% set acceptTerms = registrationForm.acceptTerms %}
+                <div class="mb-3">
+                    <label class="d-flex align-items-center gap-2 mb-0" for="{{ acceptTerms.vars.id }}">
+                        <input
+                            type="checkbox"
+                            id="{{ acceptTerms.vars.id }}"
+                            name="{{ acceptTerms.vars.full_name }}"
+                            class="form-check-input m-0 flex-shrink-0{{ acceptTerms.vars.valid ? '' : ' is-invalid' }}"
+                            value="1"
+                            {% if acceptTerms.vars.checked %}checked="checked"{% endif %}
+                            {% if acceptTerms.vars.required %}required="required"{% endif %}
+                        />
+                        <span class="form-check-label required mb-0">
+                            {{- 'label.registration.accept_terms_prefix'|trans -}}
+                            {%- if termsPageUrl -%}
+                                <a href="{{ termsPageUrl }}" class="link-primary">{{ 'link.terms'|trans }}</a>
+                            {%- else -%}
+                                {{- 'link.terms'|trans -}}
+                            {%- endif -%}
+                        </span>
+                    </label>
+                    {{ form_errors(acceptTerms) }}
+                </div>
+                {% do acceptTerms.setRendered %}
                 <div class="form-footer">
                     <button class="btn btn-primary w-100" type="submit">{{ 'label.register'|trans }}</button>
                 </div>

--- a/tests/Content/Integration/Domain/PageKeyUniqueTest.php
+++ b/tests/Content/Integration/Domain/PageKeyUniqueTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Domain;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Factory\PageFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageKeyUniqueTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private ValidatorInterface $validator;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->validator = self::getContainer()->get(ValidatorInterface::class);
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testSamePageKeyCannotBeAssignedTwice(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'terms-first',
+            'path' => '/legal/terms-first',
+            'key' => PageKey::Terms,
+            'status' => Page::STATUS_PUBLISHED,
+        ]);
+
+        $duplicate = new Page();
+        $duplicate
+            ->setTitle('Second terms')
+            ->setSlug('terms-second')
+            ->setPath('/legal/terms-second')
+            ->setKey(PageKey::Terms)
+            ->setStatus(Page::STATUS_PUBLISHED)
+            ->setVisibility(Page::VISIBILITY_PUBLIC)
+            ->setContent([
+                [
+                    'type' => 'richtext',
+                    'data' => ['html' => '<p>x</p>'],
+                ],
+            ]);
+
+        $this->entityManager->persist($duplicate);
+        $violations = $this->validator->validate($duplicate);
+
+        self::assertGreaterThan(0, $violations->count());
+    }
+
+    public function testPageCanExistWithKey(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'privacy-page',
+            'path' => '/legal/privacy-policy',
+            'key' => PageKey::Privacy,
+            'status' => Page::STATUS_PUBLISHED,
+        ])->_real();
+
+        self::assertSame(PageKey::Privacy, $page->getKey());
+    }
+}

--- a/tests/Content/Integration/Page/PageNavigationProviderTest.php
+++ b/tests/Content/Integration/Page/PageNavigationProviderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PageNavigationProvider;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Factory\PageFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageNavigationProviderTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private PageNavigationProvider $provider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->provider = self::getContainer()->get(PageNavigationProvider::class);
+    }
+
+    public function testGetUrlByKeyUsesPagePathNotSlug(): void
+    {
+        $parent = PageFactory::createOne([
+            'slug' => 'legal',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ])->_real();
+
+        PageFactory::createOne([
+            'parent' => $parent,
+            'slug' => 'imprint-custom',
+            'key' => PageKey::Imprint,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $url = $this->provider->getUrlByKey(PageKey::Imprint);
+
+        self::assertNotNull($url);
+        self::assertStringContainsString('/legal/imprint-custom', $url);
+        self::assertStringNotContainsString('/imprint-slug', $url);
+    }
+
+    public function testGetUrlByKeyReturnsNullForDraftPage(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'features-draft',
+            'path' => '/features-draft',
+            'key' => PageKey::Features,
+            'status' => Page::STATUS_DRAFT,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        self::assertNull($this->provider->getUrlByKey(PageKey::Features));
+    }
+
+    public function testGetUrlByKeyReturnsNullForAuthenticatedOnlyPageForGuest(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'about-auth',
+            'path' => '/about-auth',
+            'key' => PageKey::About,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        self::assertNull($this->provider->getUrlByKey(PageKey::About));
+    }
+
+    public function testGetHeaderPagesOnlyIncludesVisiblePublishedPages(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'about-public',
+            'path' => '/about-public',
+            'key' => PageKey::About,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'title' => 'About us',
+        ]);
+
+        PageFactory::createOne([
+            'slug' => 'features-draft',
+            'path' => '/features-draft',
+            'key' => PageKey::Features,
+            'status' => Page::STATUS_DRAFT,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'title' => 'Features',
+        ]);
+
+        $headerPages = $this->provider->getHeaderPages();
+
+        self::assertCount(1, $headerPages);
+        self::assertSame(PageKey::About, $headerPages[0]->key);
+        self::assertSame('About us', $headerPages[0]->label);
+    }
+
+    public function testGetFooterPagesRespectsKeyOrder(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'terms-footer',
+            'path' => '/terms-footer',
+            'key' => PageKey::Terms,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageFactory::createOne([
+            'slug' => 'imprint-footer',
+            'path' => '/imprint-footer',
+            'key' => PageKey::Imprint,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $keys = array_map(
+            static fn (\App\Content\Application\Page\DTO\PageNavigationLink $link): PageKey => $link->key,
+            $this->provider->getFooterPages(),
+        );
+
+        self::assertSame([PageKey::Imprint, PageKey::Terms], $keys);
+    }
+}

--- a/tests/Content/Integration/Repository/PageRepositoryQueryTest.php
+++ b/tests/Content/Integration/Repository/PageRepositoryQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Content\Integration\Repository;
 
 use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Factory\PageFactory;
 use App\Content\Infrastructure\Repository\PageRepository;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -69,5 +70,44 @@ final class PageRepositoryQueryTest extends KernelTestCase
 
         self::assertContains('vis-public', $slugs);
         self::assertContains('vis-auth', $slugs);
+    }
+
+    public function testFindOnePublishedByKeyReturnsPublishedPage(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'about-live',
+            'key' => PageKey::About,
+            'status' => Page::STATUS_PUBLISHED,
+        ]);
+
+        $page = $this->repo->findOnePublishedByKey(PageKey::About);
+
+        self::assertNotNull($page);
+        self::assertSame('about-live', $page->getSlug());
+        self::assertSame('/about-live', $page->getPath());
+    }
+
+    public function testFindOnePublishedByKeyReturnsNullWhenOnlyDraftExists(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'faq-draft-only',
+            'path' => '/faq-draft-only',
+            'key' => PageKey::Faq,
+            'status' => Page::STATUS_DRAFT,
+        ]);
+
+        self::assertNull($this->repo->findOnePublishedByKey(PageKey::Faq));
+    }
+
+    public function testPageCanExistWithoutKey(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'generic-page',
+            'path' => '/generic-page',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+        ]);
+
+        self::assertNull($this->repo->findOnePublishedByKey(PageKey::About));
     }
 }

--- a/tests/Content/Integration/Twig/PageExtensionTest.php
+++ b/tests/Content/Integration/Twig/PageExtensionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Twig;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Factory\PageFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageExtensionTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Environment $twig;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->twig = self::getContainer()->get(Environment::class);
+    }
+
+    public function testPageByKeyReturnsPageForPublishedKey(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'faq-page',
+            'path' => '/help/faq',
+            'key' => PageKey::Faq,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $html = $this->twig->createTemplate('{{ page_by_key("faq") ? "found" : "missing" }}')->render();
+
+        self::assertSame('found', $html);
+    }
+
+    public function testPageByKeyReturnsNullWhenPageMissing(): void
+    {
+        $html = $this->twig->createTemplate('{{ page_by_key("faq") is null ? "null" : "present" }}')->render();
+
+        self::assertSame('null', $html);
+    }
+
+    public function testPageByKeyReturnsNullForInvalidKeyString(): void
+    {
+        $html = $this->twig->createTemplate('{{ page_by_key("not-a-key") is null ? "null" : "present" }}')->render();
+
+        self::assertSame('null', $html);
+    }
+
+    public function testPageUrlByKeyReturnsUrlFromPath(): void
+    {
+        $parent = PageFactory::createOne([
+            'slug' => 'legal',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ])->_real();
+
+        PageFactory::createOne([
+            'parent' => $parent,
+            'slug' => 'privacy-notice',
+            'key' => PageKey::Privacy,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $html = $this->twig->createTemplate('{{ page_url_by_key("privacy") }}')->render();
+
+        self::assertStringContainsString('/legal/privacy-notice', $html);
+        self::assertStringNotContainsString('/privacy-slug', $html);
+    }
+
+    public function testPageNavHeaderItemsOnlyListsAvailablePages(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'about-nav',
+            'path' => '/about-nav',
+            'key' => PageKey::About,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'title' => 'About Nav',
+        ]);
+
+        $html = $this->twig->createTemplate('{% for item in page_nav_header_items() %}{{ item.label }};{% endfor %}')->render();
+
+        self::assertSame('About Nav;', $html);
+    }
+}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\User\Functional\Controller;
 
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Factory\PageFactory;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -30,11 +33,74 @@ final class RegistrationControllerTest extends WebTestCase
             ->fillField('Username', $username)
             ->fillField('Email', $email)
             ->fillField('Plain password', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
             ->click('Register')
             ->assertSuccessful()
             ->assertSeeIn('h2', 'Check your email')
             ->assertSee('Your registration was almost successful.')
             ->assertNotSee($username)
+        ;
+    }
+
+    public function testRegistrationFailsWithoutAcceptingTerms(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('register-no-terms-%s', $suffix);
+        $email = sprintf('register-no-terms-%s@example.test', $suffix);
+
+        $this->browser()
+            ->visit('/register')
+            ->fillField('Username', $username)
+            ->fillField('Email', $email)
+            ->fillField('Plain password', 'super-secret-password')
+            ->click('Register')
+            ->assertStatus(422)
+            ->assertSeeIn('h2', 'Register')
+            ->assertSee('You must accept the terms and conditions to register.')
+        ;
+    }
+
+    public function testRegistrationShowsTermsLinkWhenPublishedTermsPageExists(): void
+    {
+        $parent = PageFactory::createOne([
+            'slug' => 'legal',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ])->_real();
+
+        PageFactory::createOne([
+            'parent' => $parent,
+            'slug' => 'terms-of-service',
+            'key' => PageKey::Terms,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->browser()
+            ->visit('/register')
+            ->assertSuccessful()
+            ->assertSeeElement('label[for="registration_form_acceptTerms"] a[href="/legal/terms-of-service"]')
+            ->assertSee('terms and conditions')
+        ;
+    }
+
+    public function testRegistrationWorksWithoutTermsPageLink(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('register-no-terms-page-%s', $suffix);
+        $email = sprintf('register-no-terms-page-%s@example.test', $suffix);
+
+        $this->browser()
+            ->visit('/register')
+            ->assertSuccessful()
+            ->assertNotSee('href="/legal/terms-of-service"')
+            ->fillField('Username', $username)
+            ->fillField('Email', $email)
+            ->fillField('Plain password', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
+            ->click('Register')
+            ->assertSuccessful()
+            ->assertSeeIn('h2', 'Check your email')
         ;
     }
 
@@ -49,6 +115,7 @@ final class RegistrationControllerTest extends WebTestCase
             ->fillField('Username', $username)
             ->fillField('Email', $email)
             ->fillField('Plain password', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
             ->click('Register')
             ->assertSuccessful()
             ->assertSeeIn('h2', 'Check your email')

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3175,6 +3175,42 @@
         <source>label.content_blocks</source>
         <target>Content blocks</target>
       </trans-unit>
+      <trans-unit id="page00k10" resname="label.page_key">
+        <source>label.page_key</source>
+        <target>Page key</target>
+      </trans-unit>
+      <trans-unit id="page00k11" resname="page.key.imprint">
+        <source>page.key.imprint</source>
+        <target>Imprint</target>
+      </trans-unit>
+      <trans-unit id="page00k12" resname="page.key.privacy">
+        <source>page.key.privacy</source>
+        <target>Privacy policy</target>
+      </trans-unit>
+      <trans-unit id="page00k13" resname="page.key.terms">
+        <source>page.key.terms</source>
+        <target>Terms and conditions</target>
+      </trans-unit>
+      <trans-unit id="page00k14" resname="page.key.about">
+        <source>page.key.about</source>
+        <target>About us</target>
+      </trans-unit>
+      <trans-unit id="page00k15" resname="page.key.features">
+        <source>page.key.features</source>
+        <target>Features</target>
+      </trans-unit>
+      <trans-unit id="page00k16" resname="page.key.faq">
+        <source>page.key.faq</source>
+        <target>FAQ</target>
+      </trans-unit>
+      <trans-unit id="regterms01" resname="label.registration.accept_terms_prefix">
+        <source>label.registration.accept_terms_prefix</source>
+        <target>I accept the </target>
+      </trans-unit>
+      <trans-unit id="regterms03" resname="link.terms">
+        <source>link.terms</source>
+        <target>terms and conditions</target>
+      </trans-unit>
       <trans-unit id="page0010" resname="label.block">
         <source>label.block</source>
         <target>Block</target>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -709,6 +709,14 @@
         <source>page.validation.parent_slug_unique</source>
         <target>This slug already exists on the same level.</target>
       </trans-unit>
+      <trans-unit id="regv001" resname="validation.registration.accept_terms_required">
+        <source>validation.registration.accept_terms_required</source>
+        <target>You must accept the terms and conditions to register.</target>
+      </trans-unit>
+      <trans-unit id="pagev013" resname="page.validation.key_unique">
+        <source>page.validation.key_unique</source>
+        <target>This page key is already assigned to another page.</target>
+      </trans-unit>
       <trans-unit id="pagev003" resname="page.validation.slug_format">
         <source>page.validation.slug_format</source>
         <target>The slug may only contain lowercase letters, numbers, and hyphens.</target>


### PR DESCRIPTION
### Summary

- Added a page key system for identifying predefined system pages
- Introduced stable keys for important application/content pages
- Improved page lookup and resolution logic to avoid relying only on paths or titles
- Updated related page fixtures, templates, or routing where needed
- Added or adjusted tests for page key handling and system page resolution

### Motivation

- Make system pages easier and safer to reference internally
- Avoid fragile lookups based only on mutable page paths or titles
- Improve maintainability of content/page management
- Provide a cleaner foundation for future static/content page features

### Notes for Reviewers

- Verify that system page keys are unique and stable
- Check that existing page routing and rendering still work as expected
- Confirm fallback behavior for pages without a system key
- Ensure tests cover key-based lookup and existing path-based behavior