### PR TITLE
fix: Backfill allocation indication links

### DIFF
--- a/src/Allocation/Application/Indication/BackfillAllocationIndicationNormalizedResult.php
+++ b/src/Allocation/Application/Indication/BackfillAllocationIndicationNormalizedResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Indication;
+
+/**
+ * Counts from {@see BackfillAllocationIndicationNormalizedService::run()}.
+ */
+final readonly class BackfillAllocationIndicationNormalizedResult
+{
+    public function __construct(
+        public int $rawNormalizedSyncedFromTarget,
+        public int $allocationsPrimaryUpdated,
+        public int $allocationsSecondaryUpdated,
+    ) {
+    }
+}

--- a/src/Allocation/Application/Indication/BackfillAllocationIndicationNormalizedService.php
+++ b/src/Allocation/Application/Indication/BackfillAllocationIndicationNormalizedService.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Indication;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Copies normalized indication IDs from indication_raw onto allocation rows and keeps raw.normalized in sync with raw.target.
+ */
+final readonly class BackfillAllocationIndicationNormalizedService
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function run(bool $dryRun = false, bool $syncRawNormalizedFromTarget = true, bool $backfillAllocations = true): BackfillAllocationIndicationNormalizedResult
+    {
+        $rawSynced = 0;
+        $primaryUpdated = 0;
+        $secondaryUpdated = 0;
+
+        if ($syncRawNormalizedFromTarget) {
+            $rawSynced = $this->countOrUpdateRawNormalizedFromTarget($dryRun);
+        }
+
+        if ($backfillAllocations) {
+            $primaryUpdated = $this->countOrUpdateAllocationPrimary($dryRun);
+            $secondaryUpdated = $this->countOrUpdateAllocationSecondary($dryRun);
+        }
+
+        return new BackfillAllocationIndicationNormalizedResult(
+            $rawSynced,
+            $primaryUpdated,
+            $secondaryUpdated,
+        );
+    }
+
+    private function countOrUpdateRawNormalizedFromTarget(bool $dryRun): int
+    {
+        $sql = <<<'SQL'
+UPDATE indication_raw r
+SET normalized_id = r.target_id
+WHERE r.normalized_id IS NULL
+  AND r.target_id IS NOT NULL
+SQL;
+
+        if ($dryRun) {
+            return (int) $this->connection->fetchOne(
+                'SELECT COUNT(*) FROM indication_raw r WHERE r.normalized_id IS NULL AND r.target_id IS NOT NULL',
+            );
+        }
+
+        return $this->connection->executeStatement($sql);
+    }
+
+    private function countOrUpdateAllocationPrimary(bool $dryRun): int
+    {
+        $matchSql = <<<'SQL'
+SELECT COUNT(*)
+FROM allocation a
+INNER JOIN indication_raw r ON r.id = a.indication_raw_id
+WHERE a.indication_normalized_id IS NULL
+  AND COALESCE(r.normalized_id, r.target_id) IS NOT NULL
+SQL;
+
+        $updateSql = <<<'SQL'
+UPDATE allocation a
+SET indication_normalized_id = COALESCE(r.normalized_id, r.target_id)
+FROM indication_raw r
+WHERE r.id = a.indication_raw_id
+  AND a.indication_normalized_id IS NULL
+  AND COALESCE(r.normalized_id, r.target_id) IS NOT NULL
+SQL;
+
+        if ($dryRun) {
+            return (int) $this->connection->fetchOne($matchSql);
+        }
+
+        return $this->connection->executeStatement($updateSql);
+    }
+
+    private function countOrUpdateAllocationSecondary(bool $dryRun): int
+    {
+        $matchSql = <<<'SQL'
+SELECT COUNT(*)
+FROM allocation a
+INNER JOIN indication_raw r ON r.id = a.secondary_indication_raw_id
+WHERE a.secondary_indication_normalized_id IS NULL
+  AND COALESCE(r.normalized_id, r.target_id) IS NOT NULL
+SQL;
+
+        $updateSql = <<<'SQL'
+UPDATE allocation a
+SET secondary_indication_normalized_id = COALESCE(r.normalized_id, r.target_id)
+FROM indication_raw r
+WHERE r.id = a.secondary_indication_raw_id
+  AND a.secondary_indication_normalized_id IS NULL
+  AND COALESCE(r.normalized_id, r.target_id) IS NOT NULL
+SQL;
+
+        if ($dryRun) {
+            return (int) $this->connection->fetchOne($matchSql);
+        }
+
+        return $this->connection->executeStatement($updateSql);
+    }
+}

--- a/src/Allocation/Domain/Entity/IndicationRaw.php
+++ b/src/Allocation/Domain/Entity/IndicationRaw.php
@@ -154,6 +154,9 @@ class IndicationRaw implements \Stringable
     public function setTarget(?IndicationNormalized $target): static
     {
         $this->target = $target;
+        if ($target instanceof IndicationNormalized) {
+            $this->normalized = $target;
+        }
 
         return $this;
     }

--- a/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
+++ b/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Console\Command;
+
+use App\Allocation\Application\Indication\BackfillAllocationIndicationNormalizedService;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:allocation:backfill-indications',
+    description: 'Sync indication_raw.normalized from target and copy normalized IDs onto allocations (optional projection rebuild).',
+)]
+final class BackfillAllocationIndicationNormalizedCommand extends Command
+{
+    private const int GC_EVERY_N_IMPORTS = 25;
+
+    public function __construct(
+        private readonly BackfillAllocationIndicationNormalizedService $backfillService,
+        private readonly AllocationStatsProjectionRebuildInterface $projectionRebuilder,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report how many rows would change')
+            ->addOption('skip-raw-sync', null, InputOption::VALUE_NONE, 'Do not copy indication_raw.target_id to normalized_id')
+            ->addOption('skip-allocations', null, InputOption::VALUE_NONE, 'Do not update allocation indication columns')
+            ->addOption('rebuild-projection', null, InputOption::VALUE_NONE, 'Rebuild allocation_stats_projection per import after backfill');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = (bool) $input->getOption('dry-run');
+        $syncRaw = !(bool) $input->getOption('skip-raw-sync');
+        $backfillAllocations = !(bool) $input->getOption('skip-allocations');
+        $rebuildProjection = (bool) $input->getOption('rebuild-projection');
+
+        $io->title('Backfill allocation indication_normalized');
+
+        if ($dryRun) {
+            $io->note('Dry run: no rows will be written.');
+        }
+
+        $startedAt = microtime(true);
+        $result = $this->backfillService->run($dryRun, $syncRaw, $backfillAllocations);
+
+        $io->table(
+            ['Step', 'Rows'],
+            [
+                ['indication_raw.normalized_id ← target_id', (string) $result->rawNormalizedSyncedFromTarget],
+                ['allocation.indication_normalized_id', (string) $result->allocationsPrimaryUpdated],
+                ['allocation.secondary_indication_normalized_id', (string) $result->allocationsSecondaryUpdated],
+            ],
+        );
+
+        if ($dryRun) {
+            $io->success('Dry run finished. Re-run without --dry-run to apply changes.');
+
+            return Command::SUCCESS;
+        }
+
+        if ($rebuildProjection) {
+            $importIds = $this->fetchImportIdsFromAllocations();
+            if ([] === $importIds) {
+                $io->warning('No allocations found; projection rebuild skipped.');
+            } else {
+                $io->section(sprintf('Rebuilding allocation_stats_projection for %d import(s)', \count($importIds)));
+                $progress = new ProgressBar($output, \count($importIds));
+                $progress->start();
+
+                foreach ($importIds as $index => $importId) {
+                    $this->projectionRebuilder->rebuildForImport($importId);
+                    $progress->advance();
+
+                    if (0 === (($index + 1) % self::GC_EVERY_N_IMPORTS)) {
+                        gc_collect_cycles();
+                    }
+                }
+
+                $progress->finish();
+                $output->writeln('');
+            }
+        } else {
+            $io->writeln('<comment>Projection not rebuilt. Use --rebuild-projection or <info>app:seed:projection</info> so Top diagnoses reflect the backfill.</comment>');
+        }
+
+        $io->success(sprintf('Backfill finished in %.2fs.', microtime(true) - $startedAt));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function fetchImportIdsFromAllocations(): array
+    {
+        /** @var list<int|string> $rows */
+        $rows = $this->connection->fetchFirstColumn('SELECT DISTINCT import_id FROM allocation ORDER BY import_id ASC');
+
+        return array_map(static fn (int|string $value): int => (int) $value, $rows);
+    }
+}

--- a/src/Seed/UI/Console/Command/SeedProjectionCommand.php
+++ b/src/Seed/UI/Console/Command/SeedProjectionCommand.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class SeedProjectionCommand extends Command
 {
+    private const int GC_EVERY_N_IMPORTS = 25;
+
     public function __construct(
         private readonly Connection $connection,
         private readonly EntityManagerInterface $entityManager,
@@ -50,9 +52,13 @@ final class SeedProjectionCommand extends Command
             $progress = new ProgressBar($output, \count($importIds));
             $progress->start();
 
-            foreach ($importIds as $importId) {
+            foreach ($importIds as $index => $importId) {
                 $this->rebuilder->rebuildForImport($importId);
                 $progress->advance();
+
+                if (0 === (($index + 1) % self::GC_EVERY_N_IMPORTS)) {
+                    gc_collect_cycles();
+                }
             }
 
             $progress->finish();

--- a/src/Statistics/Infrastructure/Query/AllocationStatsProjectionRebuilder.php
+++ b/src/Statistics/Infrastructure/Query/AllocationStatsProjectionRebuilder.php
@@ -5,20 +5,12 @@ declare(strict_types=1);
 namespace App\Statistics\Infrastructure\Query;
 
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
-use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
-use App\Statistics\Application\Mapping\AllocationStatsHospitalLocationProjectionCode;
-use App\Statistics\Application\Mapping\AllocationStatsHospitalTierProjectionCode;
-use App\Statistics\Application\Mapping\AllocationStatsTransportTypeProjectionCode;
-use App\Statistics\Application\Mapping\AllocationStatsUrgencyProjectionCode;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Types\Types;
 use Psr\Log\LoggerInterface;
 
 /** @psalm-suppress UnusedClass */
 final readonly class AllocationStatsProjectionRebuilder implements AllocationStatsProjectionRebuildInterface
 {
-    private const int BATCH_SIZE = 250;
-
     public function __construct(
         private Connection $connection,
         private LoggerInterface $logger,
@@ -49,60 +41,10 @@ final readonly class AllocationStatsProjectionRebuilder implements AllocationSta
         try {
             $this->deleteForImport($importId);
 
-            $result = $this->connection->executeQuery(
-                <<<'SQL'
-SELECT
-  a.id,
-  a.import_id,
-  a.hospital_id,
-  a.state_id,
-  a.dispatch_area_id,
-  a.speciality_id,
-  a.department_id,
-  a.occasion_id,
-  a.assignment_id,
-  a.infection_id,
-  a.indication_normalized_id,
-  a.secondary_indication_normalized_id,
-  a.created_at,
-  a.arrival_at,
-  a.age,
-  a.gender,
-  a.urgency,
-  a.transport_type,
-  a.requires_resus,
-  a.requires_cathlab,
-  a.is_cpr,
-  a.is_ventilated,
-  a.is_shock,
-  a.is_pregnant,
-  a.is_work_accident,
-  a.is_with_physician,
-  h.tier AS hospital_tier,
-  h.location AS hospital_location
-FROM allocation a
-INNER JOIN hospital h ON h.id = a.hospital_id
-WHERE a.import_id = :importId
-ORDER BY a.id ASC
-SQL,
-                ['importId' => $importId]
+            $insertedRows = $this->connection->executeStatement(
+                $this->insertSelectSql(),
+                ['importId' => $importId],
             );
-
-            $chunk = [];
-            $insertedRows = 0;
-            foreach ($result->iterateAssociative() as $row) {
-                $chunk[] = $row;
-                if (\count($chunk) < self::BATCH_SIZE) {
-                    continue;
-                }
-                $this->insertChunk($chunk);
-                $insertedRows += \count($chunk);
-                $chunk = [];
-            }
-            if ([] !== $chunk) {
-                $this->insertChunk($chunk);
-                $insertedRows += \count($chunk);
-            }
 
             $this->connection->commit();
 
@@ -123,187 +65,108 @@ SQL,
     }
 
     /**
-     * @param list<array<string,mixed>> $chunk
+     * Rebuilds projection rows in the database without loading allocations into PHP (memory-safe for large imports).
      */
-    private function insertChunk(array $chunk): void
+    private function insertSelectSql(): string
     {
-        if ([] === $chunk) {
-            return;
-        }
-
-        $columns = [
-            'id', 'import_id', 'hospital_id', 'state_id', 'dispatch_area_id',
-            'speciality_id', 'department_id', 'occasion_id', 'assignment_id',
-            'infection_id', 'indication_normalized_id', 'secondary_indication_normalized_id',
-            'created_at', 'arrival_at',
-            'created_year', 'created_quarter', 'created_month', 'created_week',
-            'created_day', 'created_weekday', 'created_hour',
-            'transport_time_minutes',
-            'age', 'gender_code', 'urgency_code', 'transport_type_code', 'hospital_tier_code', 'hospital_location_code',
-            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_work_accident', 'is_with_physician',
-        ];
-
-        $params = [];
-        $types = [];
-        $valueTuples = [];
-        $rowIndex = 0;
-
-        foreach ($chunk as $row) {
-            $mapped = $this->mapRow($row);
-            $placeholders = [];
-
-            foreach ($columns as $col) {
-                $param = $col.'_'.$rowIndex;
-                $placeholders[] = ':'.$param;
-                $params[$param] = $mapped[$col];
-                $types[$param] = $this->doctrineTypeNameForProjectionColumn($col);
-            }
-
-            $valueTuples[] = '('.implode(', ', $placeholders).')';
-            ++$rowIndex;
-        }
-
-        $sql = sprintf(
-            'INSERT INTO allocation_stats_projection (%s) VALUES %s',
-            implode(', ', $columns),
-            implode(', ', $valueTuples)
-        );
-
-        $this->connection->executeStatement($sql, $params, $types);
-    }
-
-    /**
-     * DBAL resolves these names to {@see \Doctrine\DBAL\Types\Type} instances (Psalm-compatible $types array).
-     */
-    private function doctrineTypeNameForProjectionColumn(string $column): string
-    {
-        return match ($column) {
-            'created_at', 'arrival_at' => Types::STRING,
-            'requires_resus', 'requires_cathlab', 'is_cpr', 'is_ventilated', 'is_shock', 'is_pregnant', 'is_work_accident', 'is_with_physician' => Types::BOOLEAN,
-            default => Types::INTEGER,
-        };
-    }
-
-    /**
-     * @param array<string,mixed> $row
-     *
-     * @return array<string,mixed>
-     */
-    private function mapRow(array $row): array
-    {
-        $createdAt = $this->parseDateTimeImmutable($row['created_at'] ?? null);
-        $arrivalAt = $this->parseDateTimeImmutable($row['arrival_at'] ?? null);
-
-        if (!$createdAt instanceof \DateTimeImmutable || !$arrivalAt instanceof \DateTimeImmutable) {
-            throw new \InvalidArgumentException('allocation row missing created_at or arrival_at');
-        }
-
-        $transportMinutes = (int) round(($arrivalAt->getTimestamp() - $createdAt->getTimestamp()) / 60);
-
-        $year = (int) $createdAt->format('Y');
-        $month = (int) $createdAt->format('n');
-        $quarter = (int) ceil($month / 3);
-
-        $urgency = AllocationStatsUrgencyProjectionCode::tryFromDbValue($row['urgency'] ?? null);
-        if (!$urgency instanceof AllocationStatsUrgencyProjectionCode) {
-            throw new \InvalidArgumentException('allocation row has invalid urgency: '.var_export($row['urgency'] ?? null, true));
-        }
-
-        return [
-            'id' => (int) $row['id'],
-            'import_id' => (int) $row['import_id'],
-            'hospital_id' => (int) $row['hospital_id'],
-            'state_id' => (int) $row['state_id'],
-            'dispatch_area_id' => (int) $row['dispatch_area_id'],
-            'speciality_id' => (int) $row['speciality_id'],
-            'department_id' => (int) $row['department_id'],
-            'occasion_id' => null !== ($row['occasion_id'] ?? null) ? (int) $row['occasion_id'] : null,
-            'assignment_id' => (int) $row['assignment_id'],
-            'infection_id' => null !== ($row['infection_id'] ?? null) ? (int) $row['infection_id'] : null,
-            'indication_normalized_id' => null !== ($row['indication_normalized_id'] ?? null) ? (int) $row['indication_normalized_id'] : null,
-            'secondary_indication_normalized_id' => null !== ($row['secondary_indication_normalized_id'] ?? null) ? (int) $row['secondary_indication_normalized_id'] : null,
-            'created_at' => $createdAt->format('Y-m-d H:i:s'),
-            'arrival_at' => $arrivalAt->format('Y-m-d H:i:s'),
-            'created_year' => $year,
-            'created_quarter' => $quarter,
-            'created_month' => $month,
-            'created_week' => (int) $createdAt->format('W'),
-            'created_day' => (int) $createdAt->format('j'),
-            'created_weekday' => (int) $createdAt->format('N'),
-            'created_hour' => (int) $createdAt->format('G'),
-            'transport_time_minutes' => $transportMinutes,
-            'age' => \array_key_exists('age', $row)
-                ? (null === $row['age'] ? null : (int) $row['age'])
-                : null,
-            'gender_code' => AllocationStatsGenderProjectionCode::tryFromDbLetter(
-                isset($row['gender']) && \is_string($row['gender']) ? $row['gender'] : null
-            )?->value,
-            'urgency_code' => $urgency->value,
-            'transport_type_code' => AllocationStatsTransportTypeProjectionCode::tryFromDbLetter(
-                isset($row['transport_type']) && \is_string($row['transport_type']) ? $row['transport_type'] : null
-            )?->value,
-            'hospital_tier_code' => AllocationStatsHospitalTierProjectionCode::tryFromTierDbValue($row['hospital_tier'] ?? null)?->value,
-            'hospital_location_code' => AllocationStatsHospitalLocationProjectionCode::tryFromLocationDbValue($row['hospital_location'] ?? null)?->value,
-            'requires_resus' => $this->nullableBool($row['requires_resus'] ?? null),
-            'requires_cathlab' => $this->nullableBool($row['requires_cathlab'] ?? null),
-            'is_cpr' => $this->nullableBool($row['is_cpr'] ?? null),
-            'is_ventilated' => $this->nullableBool($row['is_ventilated'] ?? null),
-            'is_shock' => $this->nullableBool($row['is_shock'] ?? null),
-            'is_pregnant' => $this->nullableBool($row['is_pregnant'] ?? null),
-            'is_work_accident' => $this->nullableBool($row['is_work_accident'] ?? null),
-            'is_with_physician' => $this->nullableBool($row['is_with_physician'] ?? null),
-        ];
-    }
-
-    private function nullableBool(mixed $value): ?bool
-    {
-        if (null === $value) {
-            return null;
-        }
-
-        if (\is_bool($value)) {
-            return $value;
-        }
-
-        if (\is_int($value) || \is_float($value)) {
-            return 0 !== (int) $value;
-        }
-
-        if ($value instanceof \Stringable) {
-            $value = (string) $value;
-        }
-
-        if (\is_string($value)) {
-            $v = strtolower(trim($value, " \t\n\r\0\x0B"));
-
-            return match ($v) {
-                '', 'null' => null,
-                '1', 't', 'true', 'yes', 'on' => true,
-                '0', 'f', 'false', 'no', 'off' => false,
-                default => filter_var($v, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
-            };
-        }
-
-        return (bool) $value;
-    }
-
-    private function parseDateTimeImmutable(mixed $value): ?\DateTimeImmutable
-    {
-        if ($value instanceof \DateTimeImmutable) {
-            return $value;
-        }
-
-        if ($value instanceof \DateTimeInterface) {
-            return \DateTimeImmutable::createFromInterface($value);
-        }
-
-        if (\is_string($value) && '' !== $value) {
-            $dt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $value)
-                ?: \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', $value);
-
-            return $dt ?: new \DateTimeImmutable($value);
-        }
-
-        return null;
+        return <<<'SQL'
+INSERT INTO allocation_stats_projection (
+    id,
+    import_id,
+    hospital_id,
+    state_id,
+    dispatch_area_id,
+    speciality_id,
+    department_id,
+    occasion_id,
+    assignment_id,
+    infection_id,
+    indication_normalized_id,
+    secondary_indication_normalized_id,
+    created_at,
+    arrival_at,
+    created_year,
+    created_quarter,
+    created_month,
+    created_week,
+    created_day,
+    created_weekday,
+    created_hour,
+    transport_time_minutes,
+    age,
+    gender_code,
+    urgency_code,
+    transport_type_code,
+    hospital_tier_code,
+    hospital_location_code,
+    requires_resus,
+    requires_cathlab,
+    is_cpr,
+    is_ventilated,
+    is_shock,
+    is_pregnant,
+    is_work_accident,
+    is_with_physician
+)
+SELECT
+    a.id,
+    a.import_id,
+    a.hospital_id,
+    a.state_id,
+    a.dispatch_area_id,
+    a.speciality_id,
+    a.department_id,
+    a.occasion_id,
+    a.assignment_id,
+    a.infection_id,
+    a.indication_normalized_id,
+    a.secondary_indication_normalized_id,
+    a.created_at,
+    a.arrival_at,
+    EXTRACT(YEAR FROM a.created_at)::SMALLINT,
+    CEIL(EXTRACT(MONTH FROM a.created_at) / 3.0)::SMALLINT,
+    EXTRACT(MONTH FROM a.created_at)::SMALLINT,
+    TO_CHAR(a.created_at, 'IW')::SMALLINT,
+    EXTRACT(DAY FROM a.created_at)::SMALLINT,
+    EXTRACT(ISODOW FROM a.created_at)::SMALLINT,
+    EXTRACT(HOUR FROM a.created_at)::SMALLINT,
+    ROUND(EXTRACT(EPOCH FROM (a.arrival_at - a.created_at)) / 60)::INT,
+    a.age,
+    CASE UPPER(a.gender)
+        WHEN 'M' THEN 1
+        WHEN 'F' THEN 2
+        WHEN 'X' THEN 3
+        ELSE NULL
+    END,
+    a.urgency::SMALLINT,
+    CASE UPPER(a.transport_type)
+        WHEN 'G' THEN 1
+        WHEN 'A' THEN 2
+        ELSE NULL
+    END,
+    CASE h.tier
+        WHEN 'Basic' THEN 1
+        WHEN 'Extended' THEN 2
+        WHEN 'Full' THEN 3
+        ELSE NULL
+    END,
+    CASE h.location
+        WHEN 'Urban' THEN 1
+        WHEN 'Mixed' THEN 2
+        WHEN 'Rural' THEN 3
+        ELSE NULL
+    END,
+    a.requires_resus,
+    a.requires_cathlab,
+    a.is_cpr,
+    a.is_ventilated,
+    a.is_shock,
+    a.is_pregnant,
+    a.is_work_accident,
+    a.is_with_physician
+FROM allocation a
+INNER JOIN hospital h ON h.id = a.hospital_id
+WHERE a.import_id = :importId
+SQL;
     }
 }

--- a/tests/Allocation/Functional/Command/BackfillAllocationIndicationNormalizedCommandTest.php
+++ b/tests/Allocation/Functional/Command/BackfillAllocationIndicationNormalizedCommandTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Functional\Command;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\UI\Console\Command\BackfillAllocationIndicationNormalizedCommand;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class BackfillAllocationIndicationNormalizedCommandTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDryRunShowsNoteAndDoesNotPersist(): void
+    {
+        self::bootKernel();
+        $this->seedAllocationNeedingBackfill();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dry run: no rows will be written.', $display);
+        self::assertStringContainsString('Dry run finished. Re-run without --dry-run to apply changes.', $display);
+        self::assertStringNotContainsString('Backfill finished in', $display);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertGreaterThanOrEqual(
+            1,
+            (int) $connection->fetchOne(
+                'SELECT COUNT(*) FROM allocation WHERE indication_normalized_id IS NULL',
+            ),
+        );
+    }
+
+    public function testBackfillWithoutProjectionRebuildShowsHint(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedAllocationNeedingBackfill();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Backfill allocation indication_normalized', $display);
+        self::assertStringContainsString('indication_raw.normalized_id', $display);
+        self::assertStringContainsString('Projection not rebuilt.', $display);
+        self::assertStringContainsString('app:seed:projection', $display);
+        self::assertStringContainsString('Backfill finished in', $display);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $allocationNormalizedId = $connection->fetchOne(
+            'SELECT indication_normalized_id FROM allocation WHERE id = :id',
+            ['id' => $fixture['allocationId']],
+        );
+        self::assertSame($fixture['normalizedId'], (int) $allocationNormalizedId);
+    }
+
+    public function testBackfillWithProjectionRebuild(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedAllocationNeedingBackfill();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--rebuild-projection' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Rebuilding allocation_stats_projection for 1 import(s)', $display);
+        self::assertStringNotContainsString('Projection not rebuilt.', $display);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $projectionNormalizedId = $connection->fetchOne(
+            'SELECT indication_normalized_id FROM allocation_stats_projection WHERE id = :id',
+            ['id' => $fixture['allocationId']],
+        );
+        self::assertSame($fixture['normalizedId'], (int) $projectionNormalizedId);
+    }
+
+    public function testRebuildProjectionSkippedWhenNoAllocationsExist(): void
+    {
+        self::bootKernel();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--rebuild-projection' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No allocations found; projection rebuild skipped.', $tester->getDisplay());
+    }
+
+    public function testSkipRawSyncSkipsRawNormalizedCopy(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedAllocationNeedingBackfill();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--skip-raw-sync' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertNull(
+            $connection->fetchOne(
+                'SELECT normalized_id FROM indication_raw WHERE id = :id',
+                ['id' => $fixture['rawId']],
+            ),
+        );
+        self::assertSame(
+            $fixture['normalizedId'],
+            (int) $connection->fetchOne(
+                'SELECT indication_normalized_id FROM allocation WHERE id = :id',
+                ['id' => $fixture['allocationId']],
+            ),
+        );
+    }
+
+    public function testSkipAllocationsSkipsAllocationColumns(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedAllocationNeedingBackfill();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--skip-allocations' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertNull(
+            $connection->fetchOne(
+                'SELECT indication_normalized_id FROM allocation WHERE id = :id',
+                ['id' => $fixture['allocationId']],
+            ),
+        );
+        self::assertSame(
+            $fixture['normalizedId'],
+            (int) $connection->fetchOne(
+                'SELECT normalized_id FROM indication_raw WHERE id = :id',
+                ['id' => $fixture['rawId']],
+            ),
+        );
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $command = self::getContainer()->get(BackfillAllocationIndicationNormalizedCommand::class);
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * @return array{allocationId: int, rawId: int, normalizedId: int}
+     */
+    private function seedAllocationNeedingBackfill(): array
+    {
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Cmd Backfill Norm', 'code' => 99101]);
+        $raw = IndicationRawFactory::createOne([
+            'code' => 99101,
+            'name' => 'Cmd Backfill Raw',
+            'target' => $normalized,
+        ]);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->executeStatement(
+            'UPDATE indication_raw SET normalized_id = NULL WHERE id = :id',
+            ['id' => $raw->getId()],
+        );
+
+        $user = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'createdBy' => $user,
+        ]);
+        $import = ImportFactory::createOne(['hospital' => $hospital, 'createdBy' => $user]);
+
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        AssignmentFactory::createOne();
+        OccasionFactory::createOne();
+
+        $allocation = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'infection' => null,
+            'secondaryTransport' => null,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => null,
+        ]);
+
+        return [
+            'allocationId' => (int) $allocation->getId(),
+            'rawId' => (int) $raw->getId(),
+            'normalizedId' => (int) $normalized->getId(),
+        ];
+    }
+}

--- a/tests/Allocation/Functional/Controller/Indications/AssignIndicationRawControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/AssignIndicationRawControllerTest.php
@@ -74,5 +74,7 @@ final class AssignIndicationRawControllerTest extends WebTestCase
         self::assertNotNull($reloadedRaw, 'Raw entity should exist.');
         self::assertNotNull($reloadedRaw->getTarget(), 'Raw Indication should be assigned to a normalized Indication.');
         self::assertSame($normalized->getId(), $reloadedRaw->getTarget()->getId(), 'Assignment should match expected ID.');
+        self::assertNotNull($reloadedRaw->getNormalized(), 'Raw Indication should mirror normalized for import and statistics.');
+        self::assertSame($normalized->getId(), $reloadedRaw->getNormalized()->getId());
     }
 }

--- a/tests/Allocation/Integration/Application/Indication/BackfillAllocationIndicationNormalizedServiceTest.php
+++ b/tests/Allocation/Integration/Application/Indication/BackfillAllocationIndicationNormalizedServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Application\Indication;
+
+use App\Allocation\Application\Indication\BackfillAllocationIndicationNormalizedService;
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class BackfillAllocationIndicationNormalizedServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testBackfillCopiesTargetOntoRawNormalizedAndAllocation(): void
+    {
+        self::bootKernel();
+
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Backfill Norm', 'code' => 99001]);
+        $raw = IndicationRawFactory::createOne([
+            'code' => 99001,
+            'name' => 'Backfill Raw',
+            'target' => $normalized,
+        ]);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->executeStatement(
+            'UPDATE indication_raw SET normalized_id = NULL WHERE id = :id',
+            ['id' => $raw->getId()],
+        );
+
+        $user = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'createdBy' => $user,
+        ]);
+        $import = ImportFactory::createOne(['hospital' => $hospital, 'createdBy' => $user]);
+
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        AssignmentFactory::createOne();
+        OccasionFactory::createOne();
+
+        $allocation = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'createdAt' => new \DateTimeImmutable('2025-03-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-03-01 08:30:00'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'infection' => null,
+            'secondaryTransport' => null,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => null,
+        ]);
+
+        /** @var BackfillAllocationIndicationNormalizedService $service */
+        $service = self::getContainer()->get(BackfillAllocationIndicationNormalizedService::class);
+        $result = $service->run(dryRun: false);
+
+        self::assertGreaterThanOrEqual(1, $result->rawNormalizedSyncedFromTarget);
+        self::assertGreaterThanOrEqual(1, $result->allocationsPrimaryUpdated);
+
+        $rawNormalizedId = $connection->fetchOne(
+            'SELECT normalized_id FROM indication_raw WHERE id = :id',
+            ['id' => $raw->getId()],
+        );
+        self::assertSame($normalized->getId(), (int) $rawNormalizedId);
+
+        $allocationNormalizedId = $connection->fetchOne(
+            'SELECT indication_normalized_id FROM allocation WHERE id = :id',
+            ['id' => $allocation->getId()],
+        );
+        self::assertSame($normalized->getId(), (int) $allocationNormalizedId);
+    }
+
+    public function testDryRunDoesNotPersistChanges(): void
+    {
+        self::bootKernel();
+
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Dry Run Norm', 'code' => 99002]);
+        $raw = IndicationRawFactory::createOne([
+            'code' => 99002,
+            'name' => 'Dry Run Raw',
+            'target' => $normalized,
+        ]);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->executeStatement(
+            'UPDATE indication_raw SET normalized_id = NULL WHERE id = :id',
+            ['id' => $raw->getId()],
+        );
+
+        /** @var BackfillAllocationIndicationNormalizedService $service */
+        $service = self::getContainer()->get(BackfillAllocationIndicationNormalizedService::class);
+        $service->run(dryRun: true);
+
+        self::assertGreaterThanOrEqual(
+            1,
+            (int) $connection->fetchOne(
+                'SELECT COUNT(*) FROM indication_raw WHERE normalized_id IS NULL AND target_id IS NOT NULL',
+            ),
+        );
+    }
+}

--- a/tests/Seed/Functional/Command/SeedProjectionCommandTest.php
+++ b/tests/Seed/Functional/Command/SeedProjectionCommandTest.php
@@ -88,6 +88,39 @@ final class SeedProjectionCommandTest extends KernelTestCase
         self::assertStringContainsString('No allocations found. Projection table remains empty.', $tester->getDisplay());
     }
 
+    public function testCommandRunsGarbageCollectionAfterTwentyFiveImports(): void
+    {
+        self::bootKernel();
+        $connection = self::getContainer()->get(Connection::class);
+        $seed = $this->seedReferenceGraph();
+
+        for ($i = 0; $i < 25; ++$i) {
+            $import = ImportFactory::createOne([
+                'name' => 'GC Projection Import '.$i,
+                'hospital' => $seed['hospital'],
+                'createdBy' => $seed['user'],
+            ]);
+            AllocationFactory::createOne($this->allocationDefaults(
+                $seed,
+                $import,
+                20 + $i,
+                '2025-04-01 08:00:00',
+                '2025-04-01 08:30:00',
+            ));
+        }
+
+        $command = self::getContainer()->get(SeedProjectionCommand::class);
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+        self::assertSame(0, $exitCode);
+
+        $allocationCount = (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation');
+        $projectionCount = (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation_stats_projection');
+        self::assertSame($allocationCount, $projectionCount);
+        self::assertStringContainsString('Projection rebuild finished. Imports processed: 25', $tester->getDisplay());
+    }
+
     /**
      * @return array{
      *     user: object,


### PR DESCRIPTION
### Summary

- Added tooling to backfill missing allocation indication links
- Reconstructs allocation indication associations from existing imported data where possible
- Helps repair allocations with missing or incomplete indication references
- Added safeguards to keep the backfill focused and repeatable
- Added or updated tests for the backfill behavior

### Motivation

- Fix existing data inconsistencies around allocation indications
- Avoid manual correction of missing indication links
- Ensure allocations are linked correctly to their indication data for views, imports, and statistics
- Resolve the reported issue around missing allocation indication assignments

### Notes for Reviewers

- Verify that the backfill only updates allocations with missing or incomplete indication links
- Check that existing valid indication links are not overwritten unexpectedly
- Confirm the command/backfill can be run safely more than once
- Review test coverage for missing links, already-correct links, and edge cases

This closes #143 because the unexpectedly high number of "unknown" Diagnoses originated in the missing normalized indications. Also this fixes #99 because this issue was also caused by missing normalized indications.