### PR TITLE
feat: Add generic statistics analysis explorer

### DIFF
--- a/assets/controllers/analysis-chart_controller.js
+++ b/assets/controllers/analysis-chart_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import { loadApexCharts } from '../lib/load-apexcharts.js';
+import { buildAnalysisChartOptions } from '../lib/build-analysis-chart-options.js';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
@@ -28,6 +29,11 @@ export default class extends Controller {
             return;
         }
 
+        const options = buildAnalysisChartOptions(this.specValue);
+        if (!options) {
+            return;
+        }
+
         const ApexCharts = await loadApexCharts();
 
         if (generation !== this._renderGeneration || !this.hasChartTarget) {
@@ -37,208 +43,6 @@ export default class extends Controller {
         if (this.instance) {
             this.instance.destroy();
             this.instance = null;
-        }
-
-        const data = this.specValue;
-        const labels = data.labels || [];
-        const chartType = data.chartType === 'line' ? 'line' : 'bar';
-
-        const isLine = chartType === 'line';
-
-        const coerceNumbers = (arr) => {
-            if (!Array.isArray(arr)) {
-                return [];
-            }
-            return arr.map((v) => {
-                const n = typeof v === 'number' ? v : Number(v);
-                return Number.isFinite(n) ? n : 0;
-            });
-        };
-
-        /** @type {{ name: string, data: number[] }[]} */
-        let series;
-        if (Array.isArray(data.series) && data.series.length > 0) {
-            series = data.series.map((s) => ({
-                name: s.name || '',
-                data: coerceNumbers(s.data),
-            }));
-        } else {
-            const counts = Array.isArray(data.counts) ? data.counts : [];
-            series = [
-                {
-                    name: 'Allocations',
-                    data: coerceNumbers(counts),
-                },
-            ];
-        }
-
-        const multi = series.length > 1;
-        const percentScale = data.percentScale === true;
-        const barGrouped = data.barGrouped === true && !percentScale;
-
-        const formatPercentValue = (val) => {
-            const n = typeof val === 'number' ? val : Number(val);
-            if (!Number.isFinite(n)) {
-                return '—';
-            }
-            const rounded = Math.round(n * 100) / 100;
-            const str =
-                rounded % 1 === 0
-                    ? String(rounded)
-                    : rounded.toLocaleString(undefined, {
-                          minimumFractionDigits: 0,
-                          maximumFractionDigits: 2,
-                      });
-            return `${str}%`;
-        };
-
-        const stackedBars =
-            !isLine && multi && chartType === 'bar' && (percentScale || !barGrouped);
-
-        let maxVal = 0;
-        if (stackedBars) {
-            const n = labels.length;
-            for (let i = 0; i < n; i++) {
-                let sum = 0;
-                for (const s of series) {
-                    sum += s.data[i] ?? 0;
-                }
-                if (sum > maxVal) {
-                    maxVal = sum;
-                }
-            }
-        } else {
-            for (const s of series) {
-                for (const v of s.data) {
-                    if (v > maxVal) {
-                        maxVal = v;
-                    }
-                }
-            }
-        }
-
-        const barPlotOptions =
-            chartType === 'bar'
-                ? {
-                      bar: {
-                          columnWidth: percentScale && stackedBars ? '65%' : '55%',
-                          ...(stackedBars
-                              ? percentScale
-                                  ? {
-                                        borderRadius: 0,
-                                        borderRadiusApplication: 'end',
-                                    }
-                                  : {
-                                        borderRadius: 2,
-                                        borderRadiusApplication: 'end',
-                                        borderRadiusWhenStacked: 'last',
-                                    }
-                              : {
-                                    borderRadius: 4,
-                                    borderRadiusApplication: 'end',
-                                }),
-                      },
-                  }
-                : {};
-
-        const options = {
-            chart: {
-                type: chartType,
-                height: 320,
-                toolbar: { show: false },
-                fontFamily: 'inherit',
-                zoom: { enabled: false },
-                stacked: stackedBars,
-            },
-            series,
-            xaxis: {
-                categories: labels,
-                labels: {
-                    rotate: labels.length > 8 ? -45 : 0,
-                    trim: true,
-                },
-                axisBorder: { show: false },
-                axisTicks: { show: false },
-            },
-            yaxis: {
-                min: 0,
-                max:
-                    maxVal === 0
-                        ? undefined
-                        : percentScale
-                          ? maxVal <= 100
-                              ? 100
-                              : Math.ceil(maxVal * 1.05)
-                          : Math.ceil(maxVal * 1.1),
-                show: percentScale,
-                labels: {
-                    formatter: percentScale ? formatPercentValue : undefined,
-                },
-            },
-            plotOptions: barPlotOptions,
-            stroke: isLine
-                ? {
-                      curve: 'smooth',
-                      width: 3,
-                      lineCap: 'round',
-                  }
-                : percentScale && stackedBars
-                  ? {
-                        show: true,
-                        width: 1,
-                        colors: ['#fff'],
-                  }
-                  : {},
-            ...(multi
-                ? {
-                      colors: [
-                          '#206bc4',
-                          '#d63939',
-                          '#74b816',
-                          '#fab005',
-                          '#ae3ec9',
-                          '#15aabf',
-                          '#fd7e14',
-                          '#7048e8',
-                      ].slice(0, series.length),
-                  }
-                : isLine && !multi
-                  ? {
-                        colors: ['#206bc4'],
-                    }
-                  : {}),
-            dataLabels: { enabled: false },
-            grid: {
-                strokeDashArray: 4,
-                borderColor: 'rgba(0,0,0,0.04)',
-            },
-            tooltip: {
-                shared: true,
-                intersect: false,
-                ...(percentScale
-                    ? {
-                          y: {
-                              formatter: formatPercentValue,
-                          },
-                      }
-                    : {}),
-            },
-            legend: {
-                show: multi,
-                position: 'bottom',
-                fontSize: '12px',
-                markers: { width: 8, height: 8, radius: 2 },
-                ...(multi && series.length > 6
-                    ? {
-                          height: 96,
-                          offsetY: 4,
-                      }
-                    : {}),
-            },
-        };
-
-        if (generation !== this._renderGeneration || !this.hasChartTarget) {
-            return;
         }
 
         this.instance = new ApexCharts(this.chartTarget, options);

--- a/assets/controllers/generic-analysis-chart_controller.js
+++ b/assets/controllers/generic-analysis-chart_controller.js
@@ -1,0 +1,107 @@
+import { Controller } from '@hotwired/stimulus';
+import { loadApexCharts } from '../lib/load-apexcharts.js';
+import { buildAnalysisChartOptions } from '../lib/build-analysis-chart-options.js';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        specs: Object,
+        defaultType: String,
+    };
+
+    static targets = ['chart', 'typeButton'];
+
+    connect() {
+        this.instance = null;
+        this._renderGeneration = (this._renderGeneration ?? 0) + 1;
+        this.currentType = this.defaultTypeValue || '';
+        void this.render(this._renderGeneration);
+    }
+
+    disconnect() {
+        this._renderGeneration = (this._renderGeneration ?? 0) + 1;
+        if (this.instance) {
+            this.instance.destroy();
+            this.instance = null;
+        }
+    }
+
+    selectType(event) {
+        const button = event.currentTarget;
+        if (!(button instanceof HTMLButtonElement)) {
+            return;
+        }
+        const type = button.dataset.chartType;
+        if (!type || type === this.currentType) {
+            return;
+        }
+        this.currentType = type;
+        this.updateActiveButtons();
+        this._renderGeneration = (this._renderGeneration ?? 0) + 1;
+        void this.render(this._renderGeneration);
+    }
+
+    scrollToTable() {
+        const table = document.querySelector('[data-testid="stats-generic-analysis-table"]');
+        if (table) {
+            table.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    updateActiveButtons() {
+        if (!this.hasTypeButtonTarget) {
+            return;
+        }
+        for (const button of this.typeButtonTargets) {
+            const isActive = button.dataset.chartType === this.currentType;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        }
+    }
+
+    async render(generation) {
+        if (!this.hasChartTarget) {
+            return;
+        }
+
+        const spec = this.currentSpec();
+        const options = buildAnalysisChartOptions(spec);
+        if (!options) {
+            if (this.instance) {
+                this.instance.destroy();
+                this.instance = null;
+            }
+            return;
+        }
+
+        const ApexCharts = await loadApexCharts();
+
+        if (generation !== this._renderGeneration || !this.hasChartTarget) {
+            return;
+        }
+
+        if (this.instance) {
+            this.instance.destroy();
+            this.instance = null;
+        }
+
+        this.instance = new ApexCharts(this.chartTarget, options);
+        this.instance.render().catch((err) => console.error('[generic-analysis-chart]', err));
+    }
+
+    currentSpec() {
+        const specs = this.specsValue;
+        if (!specs || typeof specs !== 'object') {
+            return null;
+        }
+        const type = this.currentType || this.defaultTypeValue;
+        if (type && specs[type]) {
+            return specs[type];
+        }
+        const keys = Object.keys(specs);
+        if (keys.length === 0) {
+            return null;
+        }
+        return specs[keys[0]];
+    }
+}

--- a/assets/lib/build-analysis-chart-options.js
+++ b/assets/lib/build-analysis-chart-options.js
@@ -1,0 +1,213 @@
+/**
+ * Builds ApexCharts options from the analysis chart spec payload.
+ *
+ * @param {Record<string, unknown>} data
+ * @returns {import('apexcharts').ApexOptions | null}
+ */
+export function buildAnalysisChartOptions(data) {
+    if (!data || typeof data !== 'object') {
+        return null;
+    }
+
+    const labels = Array.isArray(data.labels) ? data.labels : [];
+    if (labels.length === 0) {
+        return null;
+    }
+
+    const chartType = data.chartType === 'line' ? 'line' : 'bar';
+    const isLine = chartType === 'line';
+    const horizontal = data.horizontal === true;
+
+    const coerceNumbers = (arr) => {
+        if (!Array.isArray(arr)) {
+            return [];
+        }
+        return arr.map((v) => {
+            const n = typeof v === 'number' ? v : Number(v);
+            return Number.isFinite(n) ? n : 0;
+        });
+    };
+
+    /** @type {{ name: string, data: number[] }[]} */
+    let series;
+    if (Array.isArray(data.series) && data.series.length > 0) {
+        series = data.series.map((s) => ({
+            name: (s && typeof s.name === 'string' ? s.name : '') || '',
+            data: coerceNumbers(s && s.data),
+        }));
+    } else {
+        const counts = Array.isArray(data.counts) ? data.counts : [];
+        series = [
+            {
+                name: 'Allocations',
+                data: coerceNumbers(counts),
+            },
+        ];
+    }
+
+    const multi = series.length > 1;
+    const percentScale = data.percentScale === true;
+    const barGrouped = data.barGrouped === true && !percentScale;
+
+    const formatPercentValue = (val) => {
+        const n = typeof val === 'number' ? val : Number(val);
+        if (!Number.isFinite(n)) {
+            return '—';
+        }
+        const rounded = Math.round(n * 100) / 100;
+        const str =
+            rounded % 1 === 0
+                ? String(rounded)
+                : rounded.toLocaleString(undefined, {
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 2,
+                  });
+        return `${str}%`;
+    };
+
+    const stackedBars =
+        !isLine && multi && chartType === 'bar' && (percentScale || !barGrouped);
+
+    let maxVal = 0;
+    if (stackedBars) {
+        const n = labels.length;
+        for (let i = 0; i < n; i++) {
+            let sum = 0;
+            for (const s of series) {
+                sum += s.data[i] ?? 0;
+            }
+            if (sum > maxVal) {
+                maxVal = sum;
+            }
+        }
+    } else {
+        for (const s of series) {
+            for (const v of s.data) {
+                if (v > maxVal) {
+                    maxVal = v;
+                }
+            }
+        }
+    }
+
+    const barPlotOptions =
+        chartType === 'bar'
+            ? {
+                  bar: {
+                      horizontal,
+                      columnWidth: percentScale && stackedBars ? '65%' : '55%',
+                      ...(stackedBars
+                          ? percentScale
+                              ? {
+                                    borderRadius: 0,
+                                    borderRadiusApplication: 'end',
+                                }
+                              : {
+                                    borderRadius: 2,
+                                    borderRadiusApplication: 'end',
+                                    borderRadiusWhenStacked: 'last',
+                                }
+                          : {
+                                borderRadius: 4,
+                                borderRadiusApplication: 'end',
+                            }),
+                  },
+              }
+            : {};
+
+    return {
+        chart: {
+            type: chartType,
+            height: 320,
+            toolbar: { show: false },
+            fontFamily: 'inherit',
+            zoom: { enabled: false },
+            stacked: stackedBars,
+        },
+        series,
+        xaxis: {
+            categories: labels,
+            labels: {
+                rotate: !horizontal && labels.length > 8 ? -45 : 0,
+                trim: true,
+            },
+            axisBorder: { show: false },
+            axisTicks: { show: false },
+        },
+        yaxis: {
+            min: 0,
+            max:
+                maxVal === 0
+                    ? undefined
+                    : percentScale
+                      ? maxVal <= 100
+                          ? 100
+                          : Math.ceil(maxVal * 1.05)
+                      : Math.ceil(maxVal * 1.1),
+            show: percentScale,
+            labels: {
+                formatter: percentScale ? formatPercentValue : undefined,
+            },
+        },
+        plotOptions: barPlotOptions,
+        stroke: isLine
+            ? {
+                  curve: 'smooth',
+                  width: 3,
+                  lineCap: 'round',
+              }
+            : percentScale && stackedBars
+              ? {
+                    show: true,
+                    width: 1,
+                    colors: ['#fff'],
+                }
+              : {},
+        ...(multi
+            ? {
+                  colors: [
+                      '#206bc4',
+                      '#d63939',
+                      '#74b816',
+                      '#fab005',
+                      '#ae3ec9',
+                      '#15aabf',
+                      '#fd7e14',
+                      '#7048e8',
+                  ].slice(0, series.length),
+              }
+            : isLine && !multi
+              ? {
+                    colors: ['#206bc4'],
+                }
+              : {}),
+        dataLabels: { enabled: false },
+        grid: {
+            strokeDashArray: 4,
+            borderColor: 'rgba(0,0,0,0.04)',
+        },
+        tooltip: {
+            shared: true,
+            intersect: false,
+            ...(percentScale
+                ? {
+                      y: {
+                          formatter: formatPercentValue,
+                      },
+                  }
+                : {}),
+        },
+        legend: {
+            show: multi,
+            position: 'bottom',
+            fontSize: '12px',
+            markers: { width: 8, height: 8, radius: 2 },
+            ...(multi && series.length > 6
+                ? {
+                      height: 96,
+                      offsetY: 4,
+                  }
+                : {}),
+        },
+    };
+}

--- a/src/Allocation/Application/Contracts/HospitalLookupInterface.php
+++ b/src/Allocation/Application/Contracts/HospitalLookupInterface.php
@@ -9,4 +9,11 @@ use App\Allocation\Domain\Entity\Hospital;
 interface HospitalLookupInterface
 {
     public function findById(int $id): ?Hospital;
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string> hospital id => display name
+     */
+    public function findNamesByIds(array $ids): array;
 }

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -36,6 +36,33 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
         return $entity instanceof Hospital ? $entity : null;
     }
 
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    public function findNamesByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        /** @var list<array{id: int|string, name: string}> $rows */
+        $rows = $this->createQueryBuilder('h')
+            ->select('h.id', 'h.name')
+            ->andWhere('h.id IN (:ids)')
+            ->setParameter('ids', array_values(array_unique($ids)))
+            ->getQuery()
+            ->getArrayResult();
+
+        $names = [];
+        foreach ($rows as $row) {
+            $names[(int) $row['id']] = $row['name'];
+        }
+
+        return $names;
+    }
+
     public function countParticipating(): int
     {
         return $this->createQueryBuilder('h')

--- a/src/Shared/UI/Twig/templates/_includes/subnav_stats.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/subnav_stats.html.twig
@@ -21,6 +21,14 @@
                             </span>
                         </a>
                     </li>
+                    <li class="nav-item {{ route == 'app_stats_generic_analysis' ? 'active' : '' }}">
+                        <a class="nav-link" href="{{ path('app_stats_generic_analysis', {presetKey: 'allocations_by_month'}) }}">
+                            <span class="nav-link-title">
+                                <twig:ux:icon name="tabler:chart-dots-3" style="height: 1.2em;" />
+                                {{ 'link.stats.analysis_explorer'|trans }}
+                            </span>
+                        </a>
+                    </li>
                     <li class="nav-item {{ route == 'app_stats_reports' ? 'active' : '' }}">
                         <a class="nav-link" href="{{ path('app_stats_reports') }}">
                             <span class="nav-link-title">

--- a/src/Statistics/Application/Mapping/AllocationStatsGenderProjectionCode.php
+++ b/src/Statistics/Application/Mapping/AllocationStatsGenderProjectionCode.php
@@ -31,4 +31,16 @@ enum AllocationStatsGenderProjectionCode: int
             default => null,
         };
     }
+
+    /**
+     * Translation key aligned with {@see \App\Allocation\Domain\Enum\AllocationGender::label()}.
+     */
+    public function labelTranslationKey(): string
+    {
+        return match ($this) {
+            self::Male => 'label.gender.male',
+            self::Female => 'label.gender.female',
+            self::Other => 'label.gender.other',
+        };
+    }
 }

--- a/src/Statistics/Application/Mapping/AllocationStatsUrgencyProjectionCode.php
+++ b/src/Statistics/Application/Mapping/AllocationStatsUrgencyProjectionCode.php
@@ -28,4 +28,16 @@ enum AllocationStatsUrgencyProjectionCode: int
 
         return self::tryFrom($int);
     }
+
+    /**
+     * Translation key aligned with overview/analysis charts (U1–U3).
+     */
+    public function labelTranslationKey(): string
+    {
+        return match ($this) {
+            self::Emergency => 'stats.overview.hospital_summary.urgency_u1',
+            self::Inpatient => 'stats.overview.hospital_summary.urgency_u2',
+            self::Outpatient => 'stats.overview.hospital_summary.urgency_u3',
+        };
+    }
 }

--- a/src/Statistics/GenericAnalysis/Application/AnalysisPresetRegistry.php
+++ b/src/Statistics/GenericAnalysis/Application/AnalysisPresetRegistry.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisPreset;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisPresetException;
+
+final class AnalysisPresetRegistry
+{
+    /** @var array<string, AnalysisPreset> */
+    private array $presets = [];
+
+    public function __construct()
+    {
+        $this->registerDefaults();
+    }
+
+    public function get(string $key): AnalysisPreset
+    {
+        return $this->presets[$key] ?? throw UnknownAnalysisPresetException::forKey($key);
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->presets[$key]);
+    }
+
+    /**
+     * @return list<AnalysisPreset>
+     */
+    public function all(): array
+    {
+        return array_values($this->presets);
+    }
+
+    /**
+     * @return list<AnalysisPreset>
+     */
+    public function selectable(): array
+    {
+        return array_values(array_filter(
+            $this->presets,
+            static fn (AnalysisPreset $preset): bool => 'custom' !== $preset->key,
+        ));
+    }
+
+    private function register(AnalysisPreset $preset): void
+    {
+        $this->presets[$preset->key] = $preset;
+    }
+
+    private function registerDefaults(): void
+    {
+        $this->register(new AnalysisPreset(
+            key: 'allocations_by_month',
+            title: 'Allocations by month',
+            primaryDimensionKey: 'month',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'allocations_by_weekday',
+            title: 'Allocations by weekday',
+            primaryDimensionKey: 'weekday',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'allocations_by_hour',
+            title: 'Allocations by hour',
+            primaryDimensionKey: 'hour',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'urgency_by_month',
+            title: 'Urgency by month',
+            primaryDimensionKey: 'month',
+            seriesDimensionKey: 'urgency',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'gender_distribution',
+            title: 'Gender distribution',
+            primaryDimensionKey: 'gender',
+            includeNullBuckets: false,
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'resus_by_hour',
+            title: 'Resuscitation by hour',
+            primaryDimensionKey: 'hour',
+            seriesDimensionKey: 'resus',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'age_group_distribution',
+            title: 'Age group distribution',
+            primaryDimensionKey: 'age_group',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'allocations_by_hospital_cohort',
+            title: 'Allocations by hospital cohort',
+            primaryDimensionKey: 'hospital_cohort',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'urgency_by_hospital_cohort',
+            title: 'Urgency by hospital cohort',
+            primaryDimensionKey: 'hospital_cohort',
+            seriesDimensionKey: 'urgency',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'custom',
+            title: 'Custom analysis',
+            primaryDimensionKey: 'month',
+        ));
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/Contract/GenericAnalysisEntityLabelResolverInterface.php
+++ b/src/Statistics/GenericAnalysis/Application/Contract/GenericAnalysisEntityLabelResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\Contract;
+
+interface GenericAnalysisEntityLabelResolverInterface
+{
+    public function supports(string $dimensionKey): bool;
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    public function resolve(string $dimensionKey, array $ids): array;
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/EnrichedAnalysisRow.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/EnrichedAnalysisRow.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class EnrichedAnalysisRow
+{
+    public function __construct(
+        public string $bucketKey,
+        public string $bucketLabel,
+        public int $value,
+        public float $percentOfTotal,
+        public float $percentOfBucket,
+        public ?string $seriesKey = null,
+        public ?string $seriesLabel = null,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisChartRecommendation.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisChartRecommendation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+
+final readonly class GenericAnalysisChartRecommendation
+{
+    /**
+     * @param list<GenericAnalysisChartType> $allowedChartTypes
+     * @param list<string>                   $warnings
+     */
+    public function __construct(
+        public bool $hasChart,
+        public GenericAnalysisChartType $defaultChartType,
+        public array $allowedChartTypes,
+        public array $warnings = [],
+        public ?string $reason = null,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisGroupedSeriesCell.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisGroupedSeriesCell.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class GenericAnalysisGroupedSeriesCell
+{
+    public function __construct(
+        public int $value,
+        public float $percentOfTotal,
+        public float $percentOfBucket,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisGroupedTableRow.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisGroupedTableRow.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class GenericAnalysisGroupedTableRow
+{
+    /**
+     * @param array<string, GenericAnalysisGroupedSeriesCell|null> $cellsBySeriesKey
+     */
+    public function __construct(
+        public string $bucketKey,
+        public string $bucketLabel,
+        public array $cellsBySeriesKey,
+        public int $bucketTotal,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisReducedChartData.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisReducedChartData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class GenericAnalysisReducedChartData
+{
+    /**
+     * @param list<string>                                    $labels
+     * @param list<int>|null                                  $counts
+     * @param list<array{name: string, data: list<int>}>|null $series
+     */
+    public function __construct(
+        public array $labels,
+        public ?array $counts = null,
+        public ?array $series = null,
+        public bool $limitedPrimaryBuckets = false,
+        public bool $limitedSeries = false,
+    ) {
+    }
+
+    public function wasLimited(): bool
+    {
+        return $this->limitedPrimaryBuckets || $this->limitedSeries;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisTableFooterSeriesCell.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisTableFooterSeriesCell.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class GenericAnalysisTableFooterSeriesCell
+{
+    public function __construct(
+        public int $value,
+        public float $percentOfGrandTotal,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisTableFooterTotals.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/GenericAnalysisTableFooterTotals.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class GenericAnalysisTableFooterTotals
+{
+    /**
+     * @param array<string, GenericAnalysisTableFooterSeriesCell> $seriesCellsByKey
+     */
+    public function __construct(
+        public int $totalValue,
+        public float $percentOfGrandTotal,
+        public array $seriesCellsByKey = [],
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/NormalizedAnalysisResult.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/NormalizedAnalysisResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+final readonly class NormalizedAnalysisResult
+{
+    /**
+     * @param list<EnrichedAnalysisRow> $rows
+     * @param array<string, mixed>      $chartData
+     */
+    public function __construct(
+        public string $title,
+        public string $primaryDimensionLabel,
+        public ?string $seriesDimensionLabel,
+        public int $grandTotal,
+        public array $rows,
+        public array $chartData,
+        public string $recommendedChartType = 'bar',
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/DTO/ResolvedGenericAnalysisConfig.php
+++ b/src/Statistics/GenericAnalysis/Application/DTO/ResolvedGenericAnalysisConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application\DTO;
+
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+
+final readonly class ResolvedGenericAnalysisConfig
+{
+    public function __construct(
+        public AnalysisQuery $query,
+        public string $displayTitle,
+        public bool $isCustom,
+        public string $routePresetKey,
+        public ?string $referencePresetKey,
+        public string $primaryDimensionKey,
+        public ?string $seriesDimensionKey,
+        public bool $includeNullBuckets,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartDataReducer.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartDataReducer.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisReducedChartData;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class GenericAnalysisChartDataReducer
+{
+    public const int TOP_LIMIT = 5;
+
+    public function __construct(
+        private DimensionRegistry $dimensionRegistry,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function reduce(AnalysisQuery $query, NormalizedAnalysisResult $result): GenericAnalysisReducedChartData
+    {
+        $primary = $this->dimensionRegistry->get($query->primaryDimensionKey);
+
+        $labels = $this->extractLabels($result);
+        $counts = $this->extractCounts($result, $labels);
+        $series = $this->extractSeries($result);
+
+        $limitedSeries = false;
+        $limitedBuckets = false;
+
+        if (\count($series) > self::TOP_LIMIT) {
+            $series = $this->limitSeries($series, $labels);
+            $limitedSeries = true;
+        }
+
+        if ($this->shouldLimitPrimaryBuckets($primary, \count($labels))) {
+            [$labels, $counts, $series] = $this->limitPrimaryBuckets($labels, $counts, $series);
+            $limitedBuckets = true;
+        }
+
+        return new GenericAnalysisReducedChartData(
+            labels: $labels,
+            counts: [] !== $series ? null : $counts,
+            series: [] !== $series ? $series : null,
+            limitedPrimaryBuckets: $limitedBuckets,
+            limitedSeries: $limitedSeries,
+        );
+    }
+
+    private function shouldLimitPrimaryBuckets(AnalysisDimension $primary, int $labelCount): bool
+    {
+        if ($labelCount <= self::TOP_LIMIT) {
+            return false;
+        }
+
+        return AnalysisDimensionType::Temporal !== $primary->type;
+    }
+
+    /**
+     * @param list<array{name: string, data: list<int>}> $series
+     * @param list<string>                               $labels
+     *
+     * @return list<array{name: string, data: list<int>}>
+     */
+    private function limitSeries(array $series, array $labels): array
+    {
+        $labelCount = \count($labels);
+        $totals = [];
+        foreach ($series as $index => $item) {
+            $totals[$index] = array_sum($item['data']);
+        }
+
+        arsort($totals);
+        $topIndices = array_slice(array_keys($totals), 0, self::TOP_LIMIT);
+
+        $restData = array_fill(0, $labelCount, 0);
+        foreach ($series as $index => $item) {
+            if (\in_array($index, $topIndices, true)) {
+                continue;
+            }
+            foreach ($item['data'] as $labelIndex => $value) {
+                $restData[$labelIndex] += $value;
+            }
+        }
+
+        $limited = [];
+        foreach ($topIndices as $index) {
+            $limited[] = $series[$index];
+        }
+
+        if (array_sum($restData) > 0) {
+            $limited[] = [
+                'name' => $this->remainderSeriesLabel(),
+                'data' => $restData,
+            ];
+        }
+
+        return $limited;
+    }
+
+    /**
+     * @param list<string>                               $labels
+     * @param list<int>                                  $counts
+     * @param list<array{name: string, data: list<int>}> $series
+     *
+     * @return array{0: list<string>, 1: list<int>, 2: list<array{name: string, data: list<int>}>}
+     */
+    private function limitPrimaryBuckets(array $labels, array $counts, array $series): array
+    {
+        $bucketTotals = [];
+
+        if ([] !== $series) {
+            foreach ($labels as $labelIndex => $label) {
+                $sum = 0;
+                foreach ($series as $item) {
+                    $sum += $item['data'][$labelIndex] ?? 0;
+                }
+                $bucketTotals[$label] = $sum;
+            }
+        } else {
+            foreach ($labels as $labelIndex => $label) {
+                $bucketTotals[$label] = $counts[$labelIndex] ?? 0;
+            }
+        }
+
+        arsort($bucketTotals);
+        $topLabels = array_slice(array_keys($bucketTotals), 0, self::TOP_LIMIT);
+
+        $restTotal = 0;
+        foreach ($bucketTotals as $label => $total) {
+            if (!\in_array($label, $topLabels, true)) {
+                $restTotal += $total;
+            }
+        }
+
+        $newLabels = $topLabels;
+        if ($restTotal > 0) {
+            $newLabels[] = $this->remainderBucketLabel();
+        }
+
+        $newCounts = [];
+        if ([] === $series) {
+            foreach ($topLabels as $label) {
+                $newCounts[] = $bucketTotals[$label];
+            }
+            if ($restTotal > 0) {
+                $newCounts[] = $restTotal;
+            }
+
+            return [$newLabels, $newCounts, $series];
+        }
+
+        $newSeries = [];
+        foreach ($series as $item) {
+            $newData = [];
+            foreach ($topLabels as $label) {
+                $labelIndex = array_search($label, $labels, true);
+                $newData[] = false !== $labelIndex ? ($item['data'][$labelIndex] ?? 0) : 0;
+            }
+            if ($restTotal > 0) {
+                $restForSeries = 0;
+                foreach (array_keys($bucketTotals) as $label) {
+                    if (\in_array($label, $topLabels, true)) {
+                        continue;
+                    }
+                    $labelIndex = array_search($label, $labels, true);
+                    if (false !== $labelIndex) {
+                        $restForSeries += $item['data'][$labelIndex] ?? 0;
+                    }
+                }
+                $newData[] = $restForSeries;
+            }
+            $newSeries[] = [
+                'name' => $item['name'],
+                'data' => $newData,
+            ];
+        }
+
+        return [$newLabels, $newCounts, $newSeries];
+    }
+
+    private function remainderBucketLabel(): string
+    {
+        return $this->translator->trans('stats.generic_analysis.chart.remainder_bucket');
+    }
+
+    private function remainderSeriesLabel(): string
+    {
+        return $this->translator->trans('stats.generic_analysis.chart.remainder_series');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractLabels(NormalizedAnalysisResult $result): array
+    {
+        $labels = $result->chartData['labels'] ?? null;
+        if (!\is_array($labels)) {
+            return [];
+        }
+
+        return array_values(array_filter($labels, \is_string(...)));
+    }
+
+    /**
+     * @param list<string> $labels
+     *
+     * @return list<int>
+     */
+    private function extractCounts(NormalizedAnalysisResult $result, array $labels): array
+    {
+        $values = $result->chartData['values'] ?? null;
+        if (\is_array($values)) {
+            return array_values(array_map(static fn (mixed $v): int => (int) $v, $values));
+        }
+
+        $counts = array_fill(0, \count($labels), 0);
+        foreach ($result->rows as $row) {
+            if (null !== $row->seriesKey) {
+                continue;
+            }
+            $index = array_search($row->bucketLabel, $labels, true);
+            if (false !== $index) {
+                $counts[$index] = $row->value;
+            }
+        }
+
+        return array_values($counts);
+    }
+
+    /**
+     * @return list<array{name: string, data: list<int>}>
+     */
+    private function extractSeries(NormalizedAnalysisResult $result): array
+    {
+        $raw = $result->chartData['series'] ?? null;
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        $series = [];
+        foreach ($raw as $item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+            $name = $item['name'] ?? '';
+            $data = $item['data'] ?? [];
+            if (!\is_string($name) || !\is_array($data)) {
+                continue;
+            }
+            $series[] = [
+                'name' => $name,
+                'data' => array_values(array_map(static fn (mixed $v): int => (int) $v, $data)),
+            ];
+        }
+
+        return $series;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartRecommendationService.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartRecommendationService.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisChartRecommendation;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class GenericAnalysisChartRecommendationService
+{
+    private const int MANY_BUCKETS_THRESHOLD = 24;
+    private const int MANY_SERIES_WARNING_THRESHOLD = 8;
+
+    public function __construct(
+        private DimensionRegistry $dimensionRegistry,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function recommend(AnalysisQuery $query, NormalizedAnalysisResult $result): GenericAnalysisChartRecommendation
+    {
+        $primary = $this->dimensionRegistry->get($query->primaryDimensionKey);
+        $series = null !== $query->seriesDimensionKey
+            ? $this->dimensionRegistry->get($query->seriesDimensionKey)
+            : null;
+
+        $labels = $this->extractLabels($result);
+        $seriesCount = $this->countDistinctSeries($result);
+        $warnings = [];
+
+        if (0 === $result->grandTotal || [] === $labels) {
+            return new GenericAnalysisChartRecommendation(
+                hasChart: false,
+                defaultChartType: GenericAnalysisChartType::Bar,
+                allowedChartTypes: [],
+                warnings: [],
+                reason: 'empty_data',
+            );
+        }
+
+        if (AnalysisDimensionType::Numeric === $primary->type) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.numeric_dimension');
+
+            return new GenericAnalysisChartRecommendation(
+                hasChart: false,
+                defaultChartType: GenericAnalysisChartType::Table,
+                allowedChartTypes: [GenericAnalysisChartType::Table],
+                warnings: $warnings,
+                reason: 'numeric_primary',
+            );
+        }
+
+        if ('histogram' === $primary->recommendedChartType) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.histogram_not_supported');
+
+            return new GenericAnalysisChartRecommendation(
+                hasChart: false,
+                defaultChartType: GenericAnalysisChartType::Table,
+                allowedChartTypes: [GenericAnalysisChartType::Table],
+                warnings: $warnings,
+                reason: 'histogram_primary',
+            );
+        }
+
+        if ('hour' === $primary->key && $series instanceof AnalysisDimension && 'weekday' === $series->key) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.heatmap_not_implemented');
+
+            return new GenericAnalysisChartRecommendation(
+                hasChart: false,
+                defaultChartType: GenericAnalysisChartType::Heatmap,
+                allowedChartTypes: [GenericAnalysisChartType::Heatmap, GenericAnalysisChartType::Table],
+                warnings: $warnings,
+                reason: 'hour_weekday_heatmap',
+            );
+        }
+
+        if ($seriesCount > self::MANY_SERIES_WARNING_THRESHOLD) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.many_series');
+        }
+
+        $manyBuckets = \count($labels) > self::MANY_BUCKETS_THRESHOLD;
+
+        if ($series instanceof AnalysisDimension) {
+            return $this->recommendWithSeries($primary, $manyBuckets, $warnings);
+        }
+
+        return $this->recommendWithoutSeries($primary, $manyBuckets, $warnings);
+    }
+
+    /**
+     * @param list<string> $warnings
+     */
+    private function recommendWithSeries(
+        AnalysisDimension $primary,
+        bool $manyBuckets,
+        array $warnings,
+    ): GenericAnalysisChartRecommendation {
+        if (AnalysisDimensionType::Temporal === $primary->type) {
+            $allowed = [
+                GenericAnalysisChartType::StackedBar,
+                GenericAnalysisChartType::GroupedBar,
+                GenericAnalysisChartType::Line,
+                GenericAnalysisChartType::PercentStackedBar,
+                GenericAnalysisChartType::Table,
+            ];
+
+            if ($manyBuckets) {
+                $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.many_buckets');
+            }
+
+            return new GenericAnalysisChartRecommendation(
+                hasChart: true,
+                defaultChartType: GenericAnalysisChartType::StackedBar,
+                allowedChartTypes: $allowed,
+                warnings: $warnings,
+                reason: 'temporal_with_series',
+            );
+        }
+
+        $allowed = [
+            GenericAnalysisChartType::StackedBar,
+            GenericAnalysisChartType::GroupedBar,
+            GenericAnalysisChartType::Bar,
+            GenericAnalysisChartType::Table,
+        ];
+        if ($manyBuckets) {
+            $allowed[] = GenericAnalysisChartType::HorizontalBar;
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.many_buckets');
+        }
+
+        return new GenericAnalysisChartRecommendation(
+            hasChart: true,
+            defaultChartType: GenericAnalysisChartType::StackedBar,
+            allowedChartTypes: $allowed,
+            warnings: $warnings,
+            reason: 'categorical_with_series',
+        );
+    }
+
+    /**
+     * @param list<string> $warnings
+     */
+    private function recommendWithoutSeries(
+        AnalysisDimension $primary,
+        bool $manyBuckets,
+        array $warnings,
+    ): GenericAnalysisChartRecommendation {
+        if ('pie' === $primary->recommendedChartType) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.pie_deferred');
+        }
+
+        if (AnalysisDimensionType::Temporal === $primary->type) {
+            $allowed = [GenericAnalysisChartType::Bar, GenericAnalysisChartType::Line, GenericAnalysisChartType::Table];
+            if ($manyBuckets) {
+                $allowed[] = GenericAnalysisChartType::HorizontalBar;
+                $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.many_buckets');
+            }
+
+            return new GenericAnalysisChartRecommendation(
+                hasChart: true,
+                defaultChartType: $manyBuckets ? GenericAnalysisChartType::HorizontalBar : GenericAnalysisChartType::Bar,
+                allowedChartTypes: $allowed,
+                warnings: $warnings,
+                reason: 'temporal_no_series',
+            );
+        }
+
+        $allowed = [GenericAnalysisChartType::Bar, GenericAnalysisChartType::Table];
+        if ($manyBuckets) {
+            $allowed[] = GenericAnalysisChartType::HorizontalBar;
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.many_buckets');
+        } else {
+            $allowed[] = GenericAnalysisChartType::HorizontalBar;
+        }
+
+        return new GenericAnalysisChartRecommendation(
+            hasChart: true,
+            defaultChartType: $manyBuckets ? GenericAnalysisChartType::HorizontalBar : GenericAnalysisChartType::Bar,
+            allowedChartTypes: $allowed,
+            warnings: $warnings,
+            reason: 'categorical_no_series',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractLabels(NormalizedAnalysisResult $result): array
+    {
+        $labels = $result->chartData['labels'] ?? null;
+        if (!\is_array($labels)) {
+            return [];
+        }
+
+        return array_values(array_filter($labels, static fn (mixed $label): bool => \is_string($label) && '' !== $label));
+    }
+
+    private function countDistinctSeries(NormalizedAnalysisResult $result): int
+    {
+        $keys = [];
+        foreach ($result->rows as $row) {
+            if (null !== $row->seriesKey) {
+                $keys[$row->seriesKey] = true;
+            }
+        }
+
+        if ([] !== $keys) {
+            return \count($keys);
+        }
+
+        $series = $result->chartData['series'] ?? null;
+        if (!\is_array($series)) {
+            return 0;
+        }
+
+        return \count($series);
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartSpecBuilder.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartSpecBuilder.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisReducedChartData;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+
+final readonly class GenericAnalysisChartSpecBuilder
+{
+    public function __construct(
+        private GenericAnalysisChartDataReducer $chartDataReducer,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function buildSpec(
+        GenericAnalysisChartType $chartType,
+        AnalysisQuery $query,
+        NormalizedAnalysisResult $result,
+    ): ?array {
+        if (!$chartType->supportsApexChart()) {
+            return null;
+        }
+
+        $data = $this->chartDataReducer->reduce($query, $result);
+        if ([] === $data->labels) {
+            return null;
+        }
+
+        return match ($chartType) {
+            GenericAnalysisChartType::Line => $this->buildLineSpec($data),
+            GenericAnalysisChartType::GroupedBar => $this->buildGroupedBarSpec($data),
+            GenericAnalysisChartType::PercentStackedBar => $this->buildPercentStackedBarSpec($data),
+            GenericAnalysisChartType::HorizontalBar => $this->buildHorizontalBarSpec($data),
+            GenericAnalysisChartType::StackedBar => $this->buildStackedBarSpec($data),
+            GenericAnalysisChartType::Bar => $this->buildBarSpec($data),
+            default => null,
+        };
+    }
+
+    /**
+     * @param list<GenericAnalysisChartType> $allowedTypes
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function buildSpecsForTypes(
+        array $allowedTypes,
+        AnalysisQuery $query,
+        NormalizedAnalysisResult $result,
+    ): array {
+        $specs = [];
+        foreach ($allowedTypes as $type) {
+            if (!$type->supportsApexChart()) {
+                continue;
+            }
+            $spec = $this->buildSpec($type, $query, $result);
+            if (null !== $spec) {
+                $specs[$type->value] = $spec;
+            }
+        }
+
+        return $specs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildBarSpec(GenericAnalysisReducedChartData $data): array
+    {
+        if (null !== $data->series && [] !== $data->series) {
+            return [
+                'chartType' => 'bar',
+                'labels' => $data->labels,
+                'series' => $data->series,
+            ];
+        }
+
+        return [
+            'chartType' => 'bar',
+            'labels' => $data->labels,
+            'counts' => $data->counts ?? [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildStackedBarSpec(GenericAnalysisReducedChartData $data): array
+    {
+        if (null === $data->series || [] === $data->series) {
+            return $this->buildBarSpec($data);
+        }
+
+        return [
+            'chartType' => 'bar',
+            'labels' => $data->labels,
+            'series' => $data->series,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildGroupedBarSpec(GenericAnalysisReducedChartData $data): array
+    {
+        if (null === $data->series || [] === $data->series) {
+            return $this->buildBarSpec($data);
+        }
+
+        return [
+            'chartType' => 'bar',
+            'labels' => $data->labels,
+            'series' => $data->series,
+            'barGrouped' => true,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildLineSpec(GenericAnalysisReducedChartData $data): array
+    {
+        if (null !== $data->series && [] !== $data->series) {
+            return [
+                'chartType' => 'line',
+                'labels' => $data->labels,
+                'series' => $data->series,
+            ];
+        }
+
+        return [
+            'chartType' => 'line',
+            'labels' => $data->labels,
+            'counts' => $data->counts ?? [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildHorizontalBarSpec(GenericAnalysisReducedChartData $data): array
+    {
+        $spec = $this->buildBarSpec($data);
+        $spec['horizontal'] = true;
+
+        return $spec;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildPercentStackedBarSpec(GenericAnalysisReducedChartData $data): array
+    {
+        $percentSeries = $this->buildPercentSeriesFromCounts($data);
+        if ([] === $percentSeries) {
+            return $this->buildBarSpec($data);
+        }
+
+        return [
+            'chartType' => 'bar',
+            'labels' => $data->labels,
+            'series' => $percentSeries,
+            'percentScale' => true,
+        ];
+    }
+
+    /**
+     * @return list<array{name: string, data: list<float>}>
+     */
+    private function buildPercentSeriesFromCounts(GenericAnalysisReducedChartData $data): array
+    {
+        if (null === $data->series || [] === $data->series) {
+            return [];
+        }
+
+        $labelCount = \count($data->labels);
+        $seriesOutput = [];
+
+        foreach ($data->series as $item) {
+            $seriesOutput[] = [
+                'name' => $item['name'],
+                'data' => array_fill(0, $labelCount, 0.0),
+            ];
+        }
+
+        for ($labelIndex = 0; $labelIndex < $labelCount; ++$labelIndex) {
+            $bucketTotal = 0;
+            foreach ($data->series as $item) {
+                $bucketTotal += $item['data'][$labelIndex] ?? 0;
+            }
+
+            foreach ($data->series as $seriesIndex => $item) {
+                $value = $item['data'][$labelIndex] ?? 0;
+                $percent = $bucketTotal > 0
+                    ? round(((float) $value / (float) $bucketTotal) * 100.0, 2)
+                    : 0.0;
+                $seriesOutput[$seriesIndex]['data'][$labelIndex] = $percent;
+            }
+        }
+
+        /** @var list<array{name: string, data: list<float>}> $result */
+        $result = [];
+        foreach ($seriesOutput as $item) {
+            $result[] = [
+                'name' => $item['name'],
+                'data' => array_values($item['data']),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisConfigResolver.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisConfigResolver.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\DTO\ResolvedGenericAnalysisConfig;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisPreset;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisPresetException;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class GenericAnalysisConfigResolver
+{
+    public function __construct(
+        private AnalysisPresetRegistry $presetRegistry,
+        private DimensionRegistry $dimensionRegistry,
+        private GenericAnalysisDimensionPolicy $dimensionPolicy,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function resolve(
+        string $presetKey,
+        Request $request,
+        StatisticsScopeCriteria $scopeCriteria,
+        StatisticsPeriodBounds $periodBounds,
+        StatisticsFilter $filter,
+        ?User $user,
+    ): ResolvedGenericAnalysisConfig {
+        $routePreset = $this->presetRegistry->get($presetKey);
+
+        $overridePrimary = $this->queryString($request, GenericAnalysisQueryKeys::PRIMARY);
+        $overrideSeries = $this->querySeries($request);
+        $overrideIncludeNull = $this->queryIncludeNull($request);
+        $referencePresetKey = $this->queryString($request, GenericAnalysisQueryKeys::REF_PRESET);
+
+        $hasExplicitOverrides = $request->query->has(GenericAnalysisQueryKeys::PRIMARY)
+            || $request->query->has(GenericAnalysisQueryKeys::SERIES)
+            || $request->query->has(GenericAnalysisQueryKeys::INCLUDE_NULL);
+
+        $isCustomRoute = GenericAnalysisQueryKeys::PRESET_CUSTOM === $presetKey;
+
+        if ($isCustomRoute || ($hasExplicitOverrides && $this->differsFromPreset(
+            $routePreset,
+            $overridePrimary,
+            $overrideSeries,
+            $overrideIncludeNull,
+        ))) {
+            return $this->resolveCustom(
+                $routePreset,
+                $referencePresetKey,
+                $overridePrimary,
+                $overrideSeries,
+                $overrideIncludeNull,
+                $scopeCriteria,
+                $periodBounds,
+                $isCustomRoute,
+                $filter,
+                $user,
+            );
+        }
+
+        $this->assertDimensionKey($routePreset->primaryDimensionKey, $filter, $user);
+        if (null !== $routePreset->seriesDimensionKey) {
+            $this->assertDimensionKey($routePreset->seriesDimensionKey, $filter, $user);
+        }
+
+        return new ResolvedGenericAnalysisConfig(
+            query: $routePreset->toQuery($scopeCriteria, $periodBounds),
+            displayTitle: $routePreset->title,
+            isCustom: false,
+            routePresetKey: $routePreset->key,
+            referencePresetKey: null,
+            primaryDimensionKey: $routePreset->primaryDimensionKey,
+            seriesDimensionKey: $routePreset->seriesDimensionKey,
+            includeNullBuckets: $routePreset->includeNullBuckets,
+        );
+    }
+
+    public function findMatchingSelectablePreset(
+        string $primaryDimensionKey,
+        ?string $seriesDimensionKey,
+        bool $includeNullBuckets,
+    ): ?AnalysisPreset {
+        foreach ($this->presetRegistry->selectable() as $preset) {
+            if ($this->presetMatches($preset, $primaryDimensionKey, $seriesDimensionKey, $includeNullBuckets)) {
+                return $preset;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveCustom(
+        AnalysisPreset $routePreset,
+        ?string $referencePresetKey,
+        ?string $overridePrimary,
+        ?string $overrideSeries,
+        ?bool $overrideIncludeNull,
+        StatisticsScopeCriteria $scopeCriteria,
+        StatisticsPeriodBounds $periodBounds,
+        bool $isCustomRoute,
+        StatisticsFilter $filter,
+        ?User $user,
+    ): ResolvedGenericAnalysisConfig {
+        $basePreset = $this->resolveBasePreset($routePreset, $referencePresetKey);
+
+        $primaryKey = $overridePrimary ?? $basePreset->primaryDimensionKey;
+        $seriesKey = $overrideSeries ?? $basePreset->seriesDimensionKey;
+        $includeNull = $overrideIncludeNull ?? $basePreset->includeNullBuckets;
+
+        $this->assertDimensionKey($primaryKey, $filter, $user);
+        if (null !== $seriesKey && '' !== $seriesKey) {
+            $this->assertDimensionKey($seriesKey, $filter, $user);
+        } else {
+            $seriesKey = null;
+        }
+
+        $referenceKey = $this->normalizeReferencePresetKey($referencePresetKey, $routePreset, $isCustomRoute);
+
+        $query = new AnalysisQuery(
+            primaryDimensionKey: $primaryKey,
+            scopeCriteria: $scopeCriteria,
+            periodBounds: $periodBounds,
+            seriesDimensionKey: $seriesKey,
+            includeNullBuckets: $includeNull,
+        );
+
+        return new ResolvedGenericAnalysisConfig(
+            query: $query,
+            displayTitle: $this->translator->trans('stats.generic_analysis.custom_title'),
+            isCustom: true,
+            routePresetKey: GenericAnalysisQueryKeys::PRESET_CUSTOM,
+            referencePresetKey: $referenceKey,
+            primaryDimensionKey: $primaryKey,
+            seriesDimensionKey: $seriesKey,
+            includeNullBuckets: $includeNull,
+        );
+    }
+
+    private function resolveBasePreset(
+        AnalysisPreset $routePreset,
+        ?string $referencePresetKey,
+    ): AnalysisPreset {
+        if (null !== $referencePresetKey && GenericAnalysisQueryKeys::PRESET_CUSTOM !== $referencePresetKey) {
+            try {
+                return $this->presetRegistry->get($referencePresetKey);
+            } catch (UnknownAnalysisPresetException) {
+            }
+        }
+
+        return $routePreset;
+    }
+
+    private function normalizeReferencePresetKey(
+        ?string $referencePresetKey,
+        AnalysisPreset $routePreset,
+        bool $isCustomRoute,
+    ): ?string {
+        if (null !== $referencePresetKey && GenericAnalysisQueryKeys::PRESET_CUSTOM !== $referencePresetKey && $this->presetRegistry->has($referencePresetKey)) {
+            return $referencePresetKey;
+        }
+
+        if ($isCustomRoute) {
+            return null;
+        }
+
+        if (GenericAnalysisQueryKeys::PRESET_CUSTOM !== $routePreset->key) {
+            return $routePreset->key;
+        }
+
+        return null;
+    }
+
+    private function differsFromPreset(
+        AnalysisPreset $preset,
+        ?string $overridePrimary,
+        ?string $overrideSeries,
+        ?bool $overrideIncludeNull,
+    ): bool {
+        if (GenericAnalysisQueryKeys::PRESET_CUSTOM === $preset->key) {
+            return true;
+        }
+
+        if (null !== $overridePrimary && $overridePrimary !== $preset->primaryDimensionKey) {
+            return true;
+        }
+
+        if (null !== $overrideSeries && $overrideSeries !== ($preset->seriesDimensionKey ?? '')) {
+            return true;
+        }
+
+        return null !== $overrideIncludeNull && $overrideIncludeNull !== $preset->includeNullBuckets;
+    }
+
+    private function presetMatches(
+        AnalysisPreset $preset,
+        string $primaryDimensionKey,
+        ?string $seriesDimensionKey,
+        bool $includeNullBuckets,
+    ): bool {
+        return $preset->primaryDimensionKey === $primaryDimensionKey
+            && $preset->seriesDimensionKey === $seriesDimensionKey
+            && $preset->includeNullBuckets === $includeNullBuckets;
+    }
+
+    private function assertDimensionKey(string $key, StatisticsFilter $filter, ?User $user): void
+    {
+        if (!$this->dimensionRegistry->has($key)) {
+            throw UnknownAnalysisDimensionException::forKey($key);
+        }
+
+        if (!$this->dimensionPolicy->isAllowed($key, $filter, $user)) {
+            throw UnknownAnalysisDimensionException::notAllowedForScope($key);
+        }
+    }
+
+    private function queryString(Request $request, string $key): ?string
+    {
+        $value = $request->query->get($key);
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function querySeries(Request $request): ?string
+    {
+        if (!$request->query->has(GenericAnalysisQueryKeys::SERIES)) {
+            return null;
+        }
+
+        $value = $request->query->get(GenericAnalysisQueryKeys::SERIES);
+        if (!\is_string($value) || '' === $value) {
+            return '';
+        }
+
+        return $value;
+    }
+
+    private function queryIncludeNull(Request $request): ?bool
+    {
+        if (!$request->query->has(GenericAnalysisQueryKeys::INCLUDE_NULL)) {
+            return null;
+        }
+
+        return '1' === (string) $request->query->get(GenericAnalysisQueryKeys::INCLUDE_NULL);
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisDimensionPolicy.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisDimensionPolicy.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\User\Domain\Entity\User;
+
+final readonly class GenericAnalysisDimensionPolicy
+{
+    public function __construct(
+        private HospitalAccessInterface $hospitalAccess,
+    ) {
+    }
+
+    public function isAllowed(string $dimensionKey, StatisticsFilter $filter, ?User $user): bool
+    {
+        return match ($dimensionKey) {
+            'hospital' => $this->allowsHospital($filter, $user),
+            'state' => $this->allowsState($filter, $user),
+            'dispatchArea' => $this->allowsDispatchArea($filter, $user),
+            'hospital_cohort' => true,
+            default => true,
+        };
+    }
+
+    private function isAdmin(?User $user): bool
+    {
+        return $user instanceof User && $this->hospitalAccess->isAdminHospitalScopeUser($user);
+    }
+
+    private function allowsHospital(StatisticsFilter $filter, ?User $user): bool
+    {
+        if ($this->isAdmin($user)) {
+            return true;
+        }
+
+        return match ($filter->scope) {
+            StatisticsFilterScope::MyHospitals,
+            StatisticsFilterScope::Hospital,
+            StatisticsFilterScope::State,
+            StatisticsFilterScope::DispatchArea,
+            StatisticsFilterScope::HospitalCohort => true,
+            default => false,
+        };
+    }
+
+    private function allowsState(StatisticsFilter $filter, ?User $user): bool
+    {
+        if ($this->isAdmin($user)) {
+            return true;
+        }
+
+        return StatisticsFilterScope::State === $filter->scope;
+    }
+
+    private function allowsDispatchArea(StatisticsFilter $filter, ?User $user): bool
+    {
+        if ($this->isAdmin($user)) {
+            return true;
+        }
+
+        return StatisticsFilterScope::DispatchArea === $filter->scope;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisEntityLabelResolver.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisEntityLabelResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Allocation\Application\Contracts\HospitalLookupInterface;
+use App\Allocation\Infrastructure\Repository\AssignmentRepository;
+use App\Allocation\Infrastructure\Repository\DepartmentRepository;
+use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
+use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
+use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\StateRepository;
+use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
+
+final readonly class GenericAnalysisEntityLabelResolver implements GenericAnalysisEntityLabelResolverInterface
+{
+    /** @var list<string> */
+    private const array ENTITY_DIMENSION_KEYS = [
+        'hospital',
+        'state',
+        'dispatchArea',
+        'department',
+        'assignment',
+        'indication',
+        'infection',
+    ];
+
+    public function __construct(
+        private HospitalLookupInterface $hospitalLookup,
+        private StateRepository $stateRepository,
+        private DispatchAreaRepository $dispatchAreaRepository,
+        private DepartmentRepository $departmentRepository,
+        private AssignmentRepository $assignmentRepository,
+        private IndicationNormalizedRepository $indicationNormalizedRepository,
+        private InfectionRepository $infectionRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function supports(string $dimensionKey): bool
+    {
+        return \in_array($dimensionKey, self::ENTITY_DIMENSION_KEYS, true);
+    }
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function resolve(string $dimensionKey, array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        $uniqueIds = array_values(array_unique($ids));
+
+        return match ($dimensionKey) {
+            'hospital' => $this->hospitalLookup->findNamesByIds($uniqueIds),
+            'state' => $this->loadIdNameMap($this->stateRepository, 's', $uniqueIds),
+            'dispatchArea' => $this->loadIdNameMap($this->dispatchAreaRepository, 'da', $uniqueIds),
+            'department' => $this->loadIdNameMap($this->departmentRepository, 'd', $uniqueIds),
+            'assignment' => $this->loadIdNameMap($this->assignmentRepository, 'a', $uniqueIds),
+            'indication' => $this->loadIdNameMap($this->indicationNormalizedRepository, 'i', $uniqueIds),
+            'infection' => $this->loadIdNameMap($this->infectionRepository, 'i', $uniqueIds),
+            default => [],
+        };
+    }
+
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    private function loadIdNameMap(object $repository, string $alias, array $ids): array
+    {
+        /** @var list<array{id: int|string, name: ?string}> $rows */
+        $rows = $repository->createQueryBuilder($alias)
+            ->select(sprintf('%s.id', $alias), sprintf('%s.name', $alias))
+            ->andWhere(sprintf('%s.id IN (:ids)', $alias))
+            ->setParameter('ids', $ids)
+            ->getQuery()
+            ->getArrayResult();
+
+        $names = [];
+        foreach ($rows as $row) {
+            $id = (int) $row['id'];
+            $name = $row['name'];
+            $names[$id] = (null !== $name && '' !== $name) ? $name : (string) $id;
+        }
+
+        return $names;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisService.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisPreset;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisQuery;
+
+final readonly class GenericAnalysisService
+{
+    public function __construct(
+        private GenericAllocationAnalysisQuery $analysisQuery,
+        private RelativeDistributionCalculator $relativeDistributionCalculator,
+        private ResultNormalizer $resultNormalizer,
+    ) {
+    }
+
+    public function runPreset(AnalysisPreset $preset, AnalysisQuery $query): NormalizedAnalysisResult
+    {
+        return $this->run($preset->title, $query);
+    }
+
+    public function run(string $title, AnalysisQuery $query): NormalizedAnalysisResult
+    {
+        $raw = $this->analysisQuery->execute($query);
+        $enriched = $this->relativeDistributionCalculator->enrich($raw);
+
+        return $this->resultNormalizer->normalize($raw, $title, $enriched);
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisTableLayout.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisTableLayout.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+enum GenericAnalysisTableLayout: string
+{
+    case Stacked = 'stacked';
+    case Grouped = 'grouped';
+
+    public static function fromRequestValue(?string $value): self
+    {
+        if (self::Grouped->value === $value) {
+            return self::Grouped;
+        }
+
+        return self::Stacked;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/RelativeDistributionCalculator.php
+++ b/src/Statistics/GenericAnalysis/Application/RelativeDistributionCalculator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResultRow;
+
+/**
+ * Adds relative distribution fields to absolute aggregation rows.
+ */
+final class RelativeDistributionCalculator
+{
+    /**
+     * @return list<array{row: AnalysisResultRow, percent_of_total: float, percent_of_bucket: float}>
+     */
+    public function enrich(AnalysisResult $result): array
+    {
+        $grandTotal = $result->grandTotal;
+        $bucketTotals = $this->bucketTotals($result->rows);
+
+        $enriched = [];
+        foreach ($result->rows as $row) {
+            $bucketKey = $this->key($row->bucket);
+            $bucketTotal = $bucketTotals[$bucketKey] ?? 0;
+
+            $enriched[] = [
+                'row' => $row,
+                'percent_of_total' => $this->percent($row->value, $grandTotal),
+                'percent_of_bucket' => $this->percent($row->value, $bucketTotal),
+            ];
+        }
+
+        return $enriched;
+    }
+
+    /**
+     * @param list<AnalysisResultRow> $rows
+     *
+     * @return array<string, int>
+     */
+    private function bucketTotals(array $rows): array
+    {
+        $totals = [];
+        foreach ($rows as $row) {
+            $key = $this->key($row->bucket);
+            $totals[$key] = ($totals[$key] ?? 0) + $row->value;
+        }
+
+        return $totals;
+    }
+
+    private function percent(int $value, int $denominator): float
+    {
+        if ($denominator <= 0) {
+            return 0.0;
+        }
+
+        return round(100 * $value / $denominator, 2);
+    }
+
+    private function key(int|string|float|null $bucket): string
+    {
+        if (null === $bucket) {
+            return '__null__';
+        }
+
+        return (string) $bucket;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/ResultNormalizer.php
+++ b/src/Statistics/GenericAnalysis/Application/ResultNormalizer.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Application;
+
+use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResultRow;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ResultNormalizer
+{
+    private const int MAX_FIXED_BUCKET_FILL = 60;
+
+    /** @var array<string, array<int, string>> */
+    private array $entityLabelsByDimension = [];
+
+    public function __construct(
+        private readonly DimensionRegistry $dimensionRegistry,
+        private readonly TranslatorInterface $translator,
+        private readonly GenericAnalysisEntityLabelResolverInterface $entityLabelResolver,
+    ) {
+    }
+
+    /**
+     * @param list<array{row: AnalysisResultRow, percent_of_total: float, percent_of_bucket: float}> $enrichedRows
+     */
+    public function normalize(
+        AnalysisResult $result,
+        string $title,
+        array $enrichedRows,
+    ): NormalizedAnalysisResult {
+        $primary = $this->dimensionRegistry->get($result->primaryDimensionKey);
+        $series = null !== $result->seriesDimensionKey
+            ? $this->dimensionRegistry->get($result->seriesDimensionKey)
+            : null;
+
+        $this->entityLabelsByDimension = $this->resolveEntityLabels($result, $primary, $series);
+
+        $indexed = [];
+        foreach ($enrichedRows as $item) {
+            $row = $item['row'];
+            $bucketKey = $this->bucketKey($row->bucket);
+            $seriesKey = null !== $row->series ? $this->bucketKey($row->series) : null;
+            $indexed[$this->compositeKey($bucketKey, $seriesKey)] = $item;
+        }
+
+        $bucketKeys = $this->orderedBucketKeys($primary, $indexed, $result->includeNullBuckets);
+        $seriesKeys = $series instanceof AnalysisDimension
+            ? $this->orderedSeriesKeys($series, $indexed, $result->includeNullBuckets)
+            : [null];
+
+        $normalizedRows = [];
+        foreach ($bucketKeys as $bucketKey) {
+            foreach ($seriesKeys as $seriesKey) {
+                $item = $indexed[$this->compositeKey($bucketKey, $seriesKey)] ?? null;
+                $value = null !== $item ? $item['row']->value : 0;
+                $normalizedRows[] = new EnrichedAnalysisRow(
+                    bucketKey: $this->bucketKey($bucketKey),
+                    bucketLabel: $this->labelFor($primary, $this->bucketKey($bucketKey)),
+                    value: $value,
+                    percentOfTotal: $item['percent_of_total'] ?? 0.0,
+                    percentOfBucket: $item['percent_of_bucket'] ?? 0.0,
+                    seriesKey: null !== $seriesKey ? $this->bucketKey($seriesKey) : null,
+                    seriesLabel: $series instanceof AnalysisDimension && null !== $seriesKey
+                        ? $this->labelFor($series, $this->bucketKey($seriesKey))
+                        : null,
+                );
+            }
+        }
+
+        return new NormalizedAnalysisResult(
+            title: $title,
+            primaryDimensionLabel: $primary->label,
+            seriesDimensionLabel: $series?->label,
+            grandTotal: $result->grandTotal,
+            rows: $normalizedRows,
+            chartData: $this->buildChartData($primary, $normalizedRows, $series instanceof AnalysisDimension),
+            recommendedChartType: $primary->recommendedChartType,
+        );
+    }
+
+    /**
+     * @param array<string, array{row: AnalysisResultRow, percent_of_total: float, percent_of_bucket: float}> $indexed
+     *
+     * @return list<string>
+     */
+    private function orderedBucketKeys(AnalysisDimension $dimension, array $indexed, bool $includeNullBuckets): array
+    {
+        $fromData = [];
+        foreach (array_keys($indexed) as $key) {
+            $bucketKey = explode('|', $key, 2)[0];
+            if ($this->isExcludedNullBucketKey($dimension, $bucketKey, $includeNullBuckets)) {
+                continue;
+            }
+            $fromData[$bucketKey] = true;
+        }
+
+        if ([] !== $dimension->fixedBuckets && \count($dimension->fixedBuckets) <= self::MAX_FIXED_BUCKET_FILL) {
+            $keys = $this->normalizeKeyList($dimension->fixedBuckets);
+            $keys = $this->filterNullBucketKeys($dimension, $keys, $includeNullBuckets);
+
+            foreach (array_keys($fromData) as $extra) {
+                if (!\in_array($extra, $keys, true)) {
+                    $keys[] = $extra;
+                }
+            }
+
+            return $this->orderKeys($keys, $dimension);
+        }
+
+        return $this->orderKeys(array_keys($fromData), $dimension);
+    }
+
+    /**
+     * @param array<string, array{row: AnalysisResultRow, percent_of_total: float, percent_of_bucket: float}> $indexed
+     *
+     * @return list<string|null>
+     */
+    private function orderedSeriesKeys(AnalysisDimension $dimension, array $indexed, bool $includeNullBuckets): array
+    {
+        $fromData = [];
+        foreach (array_keys($indexed) as $key) {
+            $parts = explode('|', $key, 2);
+            $seriesKey = $parts[1] ?? '';
+            if ($this->isExcludedNullBucketKey($dimension, $seriesKey, $includeNullBuckets)) {
+                continue;
+            }
+            $fromData[$seriesKey] = true;
+        }
+
+        if ([] !== $dimension->fixedBuckets && \count($dimension->fixedBuckets) <= self::MAX_FIXED_BUCKET_FILL) {
+            $keys = $this->filterNullBucketKeys(
+                $dimension,
+                $this->normalizeKeyList($dimension->fixedBuckets),
+                $includeNullBuckets,
+            );
+        } else {
+            $keys = array_keys($fromData);
+        }
+
+        $sorted = $this->sortKeys($keys, $dimension);
+
+        return array_map(
+            static fn (string $key): ?string => '' === $key ? null : $key,
+            $sorted,
+        );
+    }
+
+    /**
+     * @param list<string> $keys
+     *
+     * @return list<string>
+     */
+    private function filterNullBucketKeys(AnalysisDimension $dimension, array $keys, bool $includeNullBuckets): array
+    {
+        if ($includeNullBuckets) {
+            return $keys;
+        }
+
+        return array_values(array_filter(
+            $keys,
+            fn (string $key): bool => !$this->isExcludedNullBucketKey($dimension, $key, false),
+        ));
+    }
+
+    private function isExcludedNullBucketKey(
+        AnalysisDimension $dimension,
+        string $bucketKey,
+        bool $includeNullBuckets,
+    ): bool {
+        if ($includeNullBuckets) {
+            return false;
+        }
+
+        return '__null__' === $bucketKey
+            || \in_array($bucketKey, $dimension->nullBucketKeys, true);
+    }
+
+    /**
+     * @param list<int|string|float|bool|null> $rawKeys
+     *
+     * @return list<string>
+     */
+    private function normalizeKeyList(array $rawKeys): array
+    {
+        return array_map($this->bucketKey(...), $rawKeys);
+    }
+
+    /**
+     * @param list<string> $keys
+     *
+     * @return list<string>
+     */
+    private function orderKeys(array $keys, AnalysisDimension $dimension): array
+    {
+        $sorted = $this->sortKeys($keys, $dimension);
+
+        return $dimension->sortAscending ? $sorted : array_reverse($sorted);
+    }
+
+    /**
+     * @param list<string> $keys
+     *
+     * @return list<string>
+     */
+    private function sortKeys(array $keys, AnalysisDimension $dimension): array
+    {
+        $keys = array_values(array_unique($keys));
+        $fixedBucketKeys = $this->normalizeKeyList($dimension->fixedBuckets);
+
+        usort($keys, static function (string $a, string $b) use ($fixedBucketKeys): int {
+            if ([] !== $fixedBucketKeys) {
+                $posA = array_search($a, $fixedBucketKeys, true);
+                $posB = array_search($b, $fixedBucketKeys, true);
+                if (false !== $posA && false !== $posB) {
+                    return $posA <=> $posB;
+                }
+            }
+
+            if (is_numeric($a) && is_numeric($b)) {
+                return (float) $a <=> (float) $b;
+            }
+
+            return strcmp($a, $b);
+        });
+
+        return $keys;
+    }
+
+    /**
+     * @param list<EnrichedAnalysisRow> $rows
+     *
+     * @return array<string, mixed>
+     */
+    private function buildChartData(
+        AnalysisDimension $primary,
+        array $rows,
+        bool $hasSeries,
+    ): array {
+        if (!$hasSeries) {
+            return [
+                'type' => $primary->recommendedChartType,
+                'labels' => array_map(static fn (EnrichedAnalysisRow $r): string => $r->bucketLabel, $rows),
+                'values' => array_map(static fn (EnrichedAnalysisRow $r): int => $r->value, $rows),
+            ];
+        }
+
+        $labels = [];
+        $seriesMap = [];
+        foreach ($rows as $row) {
+            if (!\in_array($row->bucketLabel, $labels, true)) {
+                $labels[] = $row->bucketLabel;
+            }
+            $seriesName = $row->seriesLabel ?? '—';
+            $seriesMap[$seriesName] ??= [];
+            $seriesMap[$seriesName][$row->bucketLabel] = $row->value;
+        }
+
+        $series = [];
+        foreach ($seriesMap as $name => $byLabel) {
+            $data = [];
+            foreach ($labels as $label) {
+                $data[] = $byLabel[$label] ?? 0;
+            }
+            $series[] = ['name' => $name, 'data' => $data];
+        }
+
+        return [
+            'type' => $primary->recommendedChartType,
+            'labels' => $labels,
+            'series' => $series,
+        ];
+    }
+
+    private function compositeKey(int|string|float|bool|null $bucketKey, int|string|float|bool|null $seriesKey): string
+    {
+        return $this->bucketKey($bucketKey).'|'.(null === $seriesKey ? '' : $this->bucketKey($seriesKey));
+    }
+
+    private function bucketKey(int|string|float|bool|null $bucket): string
+    {
+        if (null === $bucket) {
+            return '__null__';
+        }
+
+        if (\is_bool($bucket)) {
+            return $bucket ? '1' : '0';
+        }
+
+        return (string) $bucket;
+    }
+
+    private function labelFor(AnalysisDimension $dimension, string $bucketKey): string
+    {
+        if ('__null__' === $bucketKey) {
+            return 'Unknown';
+        }
+
+        $lookupKey = is_numeric($bucketKey) ? (int) $bucketKey : $bucketKey;
+        if (isset($dimension->valueLabelTranslationKeys[$lookupKey])) {
+            return $this->translator->trans($dimension->valueLabelTranslationKeys[$lookupKey]);
+        }
+        if (isset($dimension->valueLabelTranslationKeys[$bucketKey])) {
+            return $this->translator->trans($dimension->valueLabelTranslationKeys[$bucketKey]);
+        }
+        if (isset($dimension->valueLabels[$lookupKey])) {
+            return $dimension->valueLabels[$lookupKey];
+        }
+        if (isset($dimension->valueLabels[$bucketKey])) {
+            return $dimension->valueLabels[$bucketKey];
+        }
+
+        if (AnalysisDimensionType::Boolean === $dimension->type) {
+            return match ($bucketKey) {
+                '1', 'true' => 'Yes',
+                '0', 'false' => 'No',
+                default => $bucketKey,
+            };
+        }
+
+        if (is_numeric($bucketKey) && isset($this->entityLabelsByDimension[$dimension->key])) {
+            $entityId = (int) $bucketKey;
+
+            return $this->entityLabelsByDimension[$dimension->key][$entityId] ?? $bucketKey;
+        }
+
+        if ('month' === $dimension->key && is_numeric($bucketKey)) {
+            $month = max(1, min(12, (int) $bucketKey));
+            $formatted = \IntlDateFormatter::formatObject(
+                new \DateTimeImmutable(sprintf('2024-%02d-01', $month)),
+                'MMM',
+                'en',
+            );
+
+            return false !== $formatted && '' !== $formatted ? $formatted : (string) $month;
+        }
+
+        return $bucketKey;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private function resolveEntityLabels(
+        AnalysisResult $result,
+        AnalysisDimension $primary,
+        ?AnalysisDimension $series,
+    ): array {
+        /** @var array<string, list<int>> $idsByDimension */
+        $idsByDimension = [];
+
+        foreach ($result->rows as $row) {
+            $this->collectEntityId($idsByDimension, $primary->key, $row->bucket);
+            if ($series instanceof AnalysisDimension) {
+                $this->collectEntityId($idsByDimension, $series->key, $row->series);
+            }
+        }
+
+        $labels = [];
+        foreach ($idsByDimension as $dimensionKey => $ids) {
+            $labels[$dimensionKey] = $this->entityLabelResolver->resolve($dimensionKey, $ids);
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @param array<string, list<int>> $idsByDimension
+     */
+    private function collectEntityId(array &$idsByDimension, string $dimensionKey, mixed $value): void
+    {
+        if (!$this->entityLabelResolver->supports($dimensionKey) || !is_numeric($value)) {
+            return;
+        }
+
+        $idsByDimension[$dimensionKey] ??= [];
+        $idsByDimension[$dimensionKey][] = (int) $value;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisComparison.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisComparison.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+/**
+ * Placeholder for future period-over-period or scope comparisons.
+ */
+final readonly class AnalysisComparison
+{
+    public function __construct(
+        public ?string $mode = null,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisDimension.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisDimension.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+
+/**
+ * Whitelisted dimension metadata (column/expression comes only from the registry).
+ */
+final readonly class AnalysisDimension
+{
+    /**
+     * @param list<int|string>          $fixedBuckets
+     * @param array<int|string, string> $valueLabels
+     * @param array<int|string, string> $valueLabelTranslationKeys
+     * @param list<string>              $nullBucketKeys            Bucket keys representing missing source data (e.g. age_group "unknown")
+     */
+    public function __construct(
+        public string $key,
+        public string $column,
+        public string $label,
+        public AnalysisDimensionType $type,
+        public string $recommendedChartType = 'bar',
+        public ?string $sqlExpression = null,
+        /** @var list<int|string> */
+        public array $fixedBuckets = [],
+        /** @var array<int|string, string> */
+        public array $valueLabels = [],
+        /** @var array<int|string, string> */
+        public array $valueLabelTranslationKeys = [],
+        public bool $sortAscending = true,
+        public array $nullBucketKeys = [],
+        public ?string $requiresNonNullSourceColumn = null,
+    ) {
+    }
+
+    public function selectExpression(): string
+    {
+        return $this->sqlExpression ?? $this->column;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisFilter.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisFilterOperator;
+
+final readonly class AnalysisFilter
+{
+    /**
+     * @param int|string|bool|list<int|string|bool> $value
+     */
+    public function __construct(
+        public string $dimensionKey,
+        public AnalysisFilterOperator $operator,
+        public int|string|bool|array $value,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisMetric.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisMetric.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisMetricType;
+
+final readonly class AnalysisMetric
+{
+    public function __construct(
+        public AnalysisMetricType $type = AnalysisMetricType::Count,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisPreset.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisPreset.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+
+final readonly class AnalysisPreset
+{
+    public function __construct(
+        public string $key,
+        public string $title,
+        public string $primaryDimensionKey,
+        public ?string $seriesDimensionKey = null,
+        public bool $includeNullBuckets = false,
+    ) {
+    }
+
+    public function toQuery(
+        StatisticsScopeCriteria $scopeCriteria,
+        StatisticsPeriodBounds $periodBounds,
+    ): AnalysisQuery {
+        return new AnalysisQuery(
+            primaryDimensionKey: $this->primaryDimensionKey,
+            scopeCriteria: $scopeCriteria,
+            periodBounds: $periodBounds,
+            seriesDimensionKey: $this->seriesDimensionKey,
+            includeNullBuckets: $this->includeNullBuckets,
+        );
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisQuery.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+
+final readonly class AnalysisQuery
+{
+    /**
+     * @param list<AnalysisFilter> $filters
+     */
+    public function __construct(
+        public string $primaryDimensionKey,
+        public StatisticsScopeCriteria $scopeCriteria,
+        public StatisticsPeriodBounds $periodBounds,
+        public ?string $seriesDimensionKey = null,
+        public AnalysisMetric $metric = new AnalysisMetric(),
+        public array $filters = [],
+        public bool $includeNullBuckets = false,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisResult.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+final readonly class AnalysisResult
+{
+    /**
+     * @param list<AnalysisResultRow> $rows
+     */
+    public function __construct(
+        public array $rows,
+        public int $grandTotal,
+        public string $primaryDimensionKey,
+        public ?string $seriesDimensionKey = null,
+        public bool $includeNullBuckets = false,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisResultRow.php
+++ b/src/Statistics/GenericAnalysis/Domain/DTO/AnalysisResultRow.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\DTO;
+
+final readonly class AnalysisResultRow
+{
+    public function __construct(
+        public int|string|float|null $bucket,
+        public int $value,
+        public int|string|float|null $series = null,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisDimensionType.php
+++ b/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisDimensionType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Enum;
+
+enum AnalysisDimensionType: string
+{
+    case Temporal = 'temporal';
+    case Categorical = 'categorical';
+    case Boolean = 'boolean';
+    case Numeric = 'numeric';
+}

--- a/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisFilterOperator.php
+++ b/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisFilterOperator.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Enum;
+
+enum AnalysisFilterOperator: string
+{
+    case Equals = 'equals';
+    case In = 'in';
+}

--- a/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisMetricType.php
+++ b/src/Statistics/GenericAnalysis/Domain/Enum/AnalysisMetricType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Enum;
+
+enum AnalysisMetricType: string
+{
+    case Count = 'count';
+}

--- a/src/Statistics/GenericAnalysis/Domain/Enum/GenericAnalysisChartType.php
+++ b/src/Statistics/GenericAnalysis/Domain/Enum/GenericAnalysisChartType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Enum;
+
+enum GenericAnalysisChartType: string
+{
+    case Bar = 'bar';
+    case Line = 'line';
+    case StackedBar = 'stacked_bar';
+    case GroupedBar = 'grouped_bar';
+    case HorizontalBar = 'horizontal_bar';
+    case PercentStackedBar = 'percent_stacked_bar';
+    case Pie = 'pie';
+    case Heatmap = 'heatmap';
+    case Table = 'table';
+
+    public function supportsApexChart(): bool
+    {
+        return match ($this) {
+            self::Table, self::Heatmap, self::Pie => false,
+            default => true,
+        };
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/Exception/UnknownAnalysisDimensionException.php
+++ b/src/Statistics/GenericAnalysis/Domain/Exception/UnknownAnalysisDimensionException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Exception;
+
+final class UnknownAnalysisDimensionException extends \InvalidArgumentException
+{
+    public static function forKey(string $key): self
+    {
+        return new self(sprintf('Unknown analysis dimension: "%s".', $key));
+    }
+
+    public static function notAllowedForScope(string $key): self
+    {
+        return new self(sprintf('Analysis dimension "%s" is not allowed for the current scope.', $key));
+    }
+}

--- a/src/Statistics/GenericAnalysis/Domain/Exception/UnknownAnalysisPresetException.php
+++ b/src/Statistics/GenericAnalysis/Domain/Exception/UnknownAnalysisPresetException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Domain\Exception;
+
+final class UnknownAnalysisPresetException extends \InvalidArgumentException
+{
+    public static function forKey(string $key): self
+    {
+        return new self(sprintf('Unknown analysis preset: "%s".', $key));
+    }
+}

--- a/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAllocationAnalysisQuery.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAllocationAnalysisQuery.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Infrastructure\Query;
+
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResultRow;
+use Doctrine\DBAL\Connection;
+
+/**
+ * Executes generic analysis aggregations against allocation_stats_projection.
+ */
+final readonly class GenericAllocationAnalysisQuery
+{
+    public function __construct(
+        private Connection $connection,
+        private GenericAllocationAnalysisSqlBuilder $sqlBuilder,
+    ) {
+    }
+
+    public function execute(AnalysisQuery $query): AnalysisResult
+    {
+        if ($this->hasEmptyHospitalScope($query)) {
+            return new AnalysisResult(
+                rows: [],
+                grandTotal: 0,
+                primaryDimensionKey: $query->primaryDimensionKey,
+                seriesDimensionKey: $query->seriesDimensionKey,
+                includeNullBuckets: $query->includeNullBuckets,
+            );
+        }
+
+        [$sql, $params, $types] = $this->sqlBuilder->build($query);
+
+        /** @var list<array{bucket: mixed, value: int|string, series?: mixed}> $raw */
+        $raw = $this->connection->executeQuery($sql, $params, $types)->fetchAllAssociative();
+
+        $rows = [];
+        $grandTotal = 0;
+
+        foreach ($raw as $row) {
+            $value = (int) $row['value'];
+            $grandTotal += $value;
+            $rows[] = new AnalysisResultRow(
+                bucket: $this->normalizeBucketValue($row['bucket']),
+                value: $value,
+                series: \array_key_exists('series', $row) ? $this->normalizeBucketValue($row['series']) : null,
+            );
+        }
+
+        return new AnalysisResult(
+            rows: $rows,
+            grandTotal: $grandTotal,
+            primaryDimensionKey: $query->primaryDimensionKey,
+            seriesDimensionKey: $query->seriesDimensionKey,
+            includeNullBuckets: $query->includeNullBuckets,
+        );
+    }
+
+    private function hasEmptyHospitalScope(AnalysisQuery $query): bool
+    {
+        $hospitalIds = $query->scopeCriteria->hospitalIds;
+
+        return \is_array($hospitalIds) && [] === $hospitalIds;
+    }
+
+    private function normalizeBucketValue(mixed $value): int|string|float|null
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 1 : 0;
+        }
+
+        if (is_numeric($value) && !\is_string($value)) {
+            return (float) $value;
+        }
+
+        if (\is_string($value) && is_numeric($value)) {
+            return str_contains($value, '.') ? (float) $value : (int) $value;
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAllocationAnalysisSqlBuilder.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAllocationAnalysisSqlBuilder.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Infrastructure\Query;
+
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisFilter;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisFilterOperator;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Doctrine\DBAL\ArrayParameterType;
+
+/**
+ * Builds parameterized SQL for generic allocation_stats_projection aggregations.
+ *
+ * @phpstan-type SqlBuildResult array{0: string, 1: array<string, mixed>, 2: array<string, mixed>}
+ */
+final readonly class GenericAllocationAnalysisSqlBuilder
+{
+    public function __construct(
+        private DimensionRegistry $dimensionRegistry,
+        private GenericAnalysisScopeSqlFilter $scopeSqlFilter,
+    ) {
+    }
+
+    /**
+     * @return SqlBuildResult
+     */
+    public function build(AnalysisQuery $query): array
+    {
+        $primary = $this->dimensionRegistry->get($query->primaryDimensionKey);
+        $series = null !== $query->seriesDimensionKey
+            ? $this->dimensionRegistry->get($query->seriesDimensionKey)
+            : null;
+
+        $bucketExpr = $primary->selectExpression();
+        $seriesExpr = $series?->selectExpression();
+
+        $selectParts = [
+            sprintf('%s AS bucket', $bucketExpr),
+        ];
+        $groupParts = ['bucket'];
+
+        if (null !== $seriesExpr) {
+            $selectParts[] = sprintf('%s AS series', $seriesExpr);
+            $groupParts[] = 'series';
+        }
+
+        $selectParts[] = 'COUNT(*)::INT AS value';
+
+        [$conditions, $params] = $this->scopeSqlFilter->applyScopeAndPeriod(
+            $query->scopeCriteria,
+            $query->periodBounds,
+        );
+
+        $types = $this->scopeSqlFilter->parameterTypes($params);
+
+        if (!$query->includeNullBuckets) {
+            $this->appendExcludeNullConditions($conditions, $params, $types, $primary);
+            if ($series instanceof AnalysisDimension) {
+                $this->appendExcludeNullConditions($conditions, $params, $types, $series);
+            }
+        }
+
+        foreach ($query->filters as $filter) {
+            [$filterSql, $filterParams, $filterTypes] = $this->buildFilter($filter);
+            $conditions[] = $filterSql;
+            $params = array_merge($params, $filterParams);
+            $types = array_merge($types, $filterTypes);
+        }
+
+        $table = $this->scopeSqlFilter->tableName();
+        $sql = sprintf(
+            "SELECT\n    %s\nFROM %s\nWHERE %s\nGROUP BY %s\nORDER BY %s",
+            implode(",\n    ", $selectParts),
+            $table,
+            implode(' AND ', $conditions),
+            implode(', ', $groupParts),
+            implode(', ', $groupParts),
+        );
+
+        return [$sql, $params, $types];
+    }
+
+    /**
+     * @param list<string>         $conditions
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $types
+     */
+    private function appendExcludeNullConditions(
+        array &$conditions,
+        array &$params,
+        array &$types,
+        AnalysisDimension $dimension,
+    ): void {
+        $expr = $dimension->selectExpression();
+        $conditions[] = sprintf('%s IS NOT NULL', $expr);
+
+        if (null !== $dimension->requiresNonNullSourceColumn) {
+            $conditions[] = sprintf('%s IS NOT NULL', $dimension->requiresNonNullSourceColumn);
+        }
+
+        if ([] !== $dimension->nullBucketKeys) {
+            $param = 'exclude_null_bucket_'.$dimension->key;
+            $conditions[] = sprintf('%s NOT IN (:%s)', $expr, $param);
+            $params[$param] = $dimension->nullBucketKeys;
+            $types[$param] = ArrayParameterType::STRING;
+        }
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, mixed>, 2: array<string, mixed>}
+     */
+    private function buildFilter(AnalysisFilter $filter): array
+    {
+        if (!$this->dimensionRegistry->has($filter->dimensionKey)) {
+            throw UnknownAnalysisDimensionException::forKey($filter->dimensionKey);
+        }
+
+        $dimension = $this->dimensionRegistry->get($filter->dimensionKey);
+        $expr = $dimension->selectExpression();
+        $paramBase = 'filter_'.(preg_replace('/[^a-z0-9_]/', '_', $filter->dimensionKey) ?? $filter->dimensionKey);
+
+        return match ($filter->operator) {
+            AnalysisFilterOperator::Equals => [
+                sprintf('%s = :%s', $expr, $paramBase),
+                [$paramBase => $filter->value],
+                [],
+            ],
+            AnalysisFilterOperator::In => [
+                sprintf('%s IN (:%s)', $expr, $paramBase),
+                [$paramBase => \is_array($filter->value) ? $filter->value : [$filter->value]],
+                [$paramBase => ArrayParameterType::INTEGER],
+            ],
+        };
+    }
+}

--- a/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAnalysisScopeSqlFilter.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAnalysisScopeSqlFilter.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Infrastructure\Query;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use Doctrine\DBAL\ArrayParameterType;
+
+/**
+ * @phpstan-type WhereBuildResult array{0: list<string>, 1: array<string, mixed>}
+ */
+final class GenericAnalysisScopeSqlFilter
+{
+    private const string TABLE = 'allocation_stats_projection';
+
+    /**
+     * @return WhereBuildResult
+     */
+    public function applyScopeAndPeriod(
+        StatisticsScopeCriteria $scope,
+        StatisticsPeriodBounds $period,
+    ): array {
+        $conditions = ['1 = 1'];
+        $params = [];
+
+        if ($period->from instanceof \DateTimeImmutable) {
+            $conditions[] = 'created_at >= :period_from';
+            $params['period_from'] = $period->from->format('Y-m-d H:i:s');
+        }
+
+        if ($period->toExclusive instanceof \DateTimeImmutable) {
+            $conditions[] = 'created_at < :period_to_exclusive';
+            $params['period_to_exclusive'] = $period->toExclusive->format('Y-m-d H:i:s');
+        }
+
+        if (\is_array($scope->hospitalIds)) {
+            $conditions[] = 'hospital_id IN (:scope_hospital_ids)';
+            $params['scope_hospital_ids'] = $scope->hospitalIds;
+        }
+
+        if (null !== $scope->locationCodes) {
+            $conditions[] = 'hospital_location_code IN (:scope_location_codes)';
+            $params['scope_location_codes'] = $scope->locationCodes;
+        }
+
+        if (null !== $scope->tierCodes) {
+            $conditions[] = 'hospital_tier_code IN (:scope_tier_codes)';
+            $params['scope_tier_codes'] = $scope->tierCodes;
+        }
+
+        return [$conditions, $params];
+    }
+
+    public function tableName(): string
+    {
+        return self::TABLE;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    public function parameterTypes(array $params): array
+    {
+        $types = [];
+
+        if (isset($params['scope_hospital_ids'])) {
+            $types['scope_hospital_ids'] = ArrayParameterType::INTEGER;
+        }
+        if (isset($params['scope_location_codes'])) {
+            $types['scope_location_codes'] = ArrayParameterType::INTEGER;
+        }
+        if (isset($params['scope_tier_codes'])) {
+            $types['scope_tier_codes'] = ArrayParameterType::INTEGER;
+        }
+
+        return $types;
+    }
+}

--- a/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
+++ b/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\Registry;
+
+use App\Statistics\Application\Cohort\HospitalCohortType;
+use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsHospitalLocationProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsHospitalTierProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsUrgencyProjectionCode;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+
+final class DimensionRegistry
+{
+    /** @var array<string, AnalysisDimension> */
+    private array $dimensions = [];
+
+    public function __construct()
+    {
+        $this->registerDefaults();
+    }
+
+    public function get(string $key): AnalysisDimension
+    {
+        return $this->dimensions[$key] ?? throw UnknownAnalysisDimensionException::forKey($key);
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->dimensions[$key]);
+    }
+
+    /**
+     * @return list<AnalysisDimension>
+     */
+    public function all(): array
+    {
+        return array_values($this->dimensions);
+    }
+
+    private function register(AnalysisDimension $dimension): void
+    {
+        $this->dimensions[$dimension->key] = $dimension;
+    }
+
+    private function registerDefaults(): void
+    {
+        $ageBucketSql = <<<'SQL'
+CASE
+    WHEN age IS NULL THEN 'unknown'
+    WHEN age <= 18 THEN '0_18'
+    WHEN age <= 29 THEN '19_29'
+    WHEN age <= 39 THEN '30_39'
+    WHEN age <= 49 THEN '40_49'
+    WHEN age <= 59 THEN '50_59'
+    WHEN age <= 69 THEN '60_69'
+    WHEN age <= 79 THEN '70_79'
+    WHEN age <= 89 THEN '80_89'
+    WHEN age <= 99 THEN '90_99'
+    ELSE '100p'
+END
+SQL;
+
+        $this->register($this->temporalDimension('year', 'created_year', 'Year', range(2000, 2100), 'line'));
+        $this->register($this->temporalDimension('quarter', 'created_quarter', 'Quarter', [1, 2, 3, 4]));
+        $this->register($this->temporalDimension('month', 'created_month', 'Month', range(1, 12)));
+        $this->register($this->temporalDimension('week', 'created_week', 'Calendar week', range(1, 53)));
+        $this->register(new AnalysisDimension(
+            key: 'weekday',
+            column: 'created_weekday',
+            label: 'Weekday',
+            type: AnalysisDimensionType::Temporal,
+            recommendedChartType: 'bar',
+            fixedBuckets: [1, 2, 3, 4, 5, 6, 7],
+            valueLabels: [
+                1 => 'Monday',
+                2 => 'Tuesday',
+                3 => 'Wednesday',
+                4 => 'Thursday',
+                5 => 'Friday',
+                6 => 'Saturday',
+                7 => 'Sunday',
+            ],
+        ));
+        $this->register($this->temporalDimension('hour', 'created_hour', 'Hour', range(0, 23)));
+
+        $this->register(new AnalysisDimension(
+            key: 'gender',
+            column: 'gender_code',
+            label: 'Gender',
+            type: AnalysisDimensionType::Categorical,
+            recommendedChartType: 'pie',
+            valueLabelTranslationKeys: [
+                AllocationStatsGenderProjectionCode::Male->value => AllocationStatsGenderProjectionCode::Male->labelTranslationKey(),
+                AllocationStatsGenderProjectionCode::Female->value => AllocationStatsGenderProjectionCode::Female->labelTranslationKey(),
+                AllocationStatsGenderProjectionCode::Other->value => AllocationStatsGenderProjectionCode::Other->labelTranslationKey(),
+            ],
+        ));
+
+        $this->register(new AnalysisDimension(
+            key: 'age',
+            column: 'age',
+            label: 'Age (years)',
+            type: AnalysisDimensionType::Numeric,
+            recommendedChartType: 'histogram',
+        ));
+
+        $this->register(new AnalysisDimension(
+            key: 'age_group',
+            column: 'age',
+            label: 'Age group',
+            type: AnalysisDimensionType::Categorical,
+            recommendedChartType: 'bar',
+            sqlExpression: $ageBucketSql,
+            fixedBuckets: ['0_18', '19_29', '30_39', '40_49', '50_59', '60_69', '70_79', '80_89', '90_99', '100p', 'unknown'],
+            valueLabels: [
+                '0_18' => '0–18',
+                '19_29' => '19–29',
+                '30_39' => '30–39',
+                '40_49' => '40–49',
+                '50_59' => '50–59',
+                '60_69' => '60–69',
+                '70_79' => '70–79',
+                '80_89' => '80–89',
+                '90_99' => '90–99',
+                '100p' => '100+',
+                'unknown' => 'Unknown',
+            ],
+            nullBucketKeys: ['unknown'],
+            requiresNonNullSourceColumn: 'age',
+        ));
+
+        $this->register(new AnalysisDimension(
+            key: 'urgency',
+            column: 'urgency_code',
+            label: 'Urgency',
+            type: AnalysisDimensionType::Categorical,
+            valueLabelTranslationKeys: [
+                AllocationStatsUrgencyProjectionCode::Emergency->value => AllocationStatsUrgencyProjectionCode::Emergency->labelTranslationKey(),
+                AllocationStatsUrgencyProjectionCode::Inpatient->value => AllocationStatsUrgencyProjectionCode::Inpatient->labelTranslationKey(),
+                AllocationStatsUrgencyProjectionCode::Outpatient->value => AllocationStatsUrgencyProjectionCode::Outpatient->labelTranslationKey(),
+            ],
+        ));
+
+        $categorical = static fn (string $key, string $column, string $label): AnalysisDimension => new AnalysisDimension(
+            key: $key,
+            column: $column,
+            label: $label,
+            type: AnalysisDimensionType::Categorical,
+        );
+
+        $this->register($this->hospitalCohortDimension());
+
+        $this->register($categorical('department', 'department_id', 'Department'));
+        $this->register($categorical('assignment', 'assignment_id', 'Assignment type'));
+        $this->register($categorical('indication', 'indication_normalized_id', 'Indication'));
+        $this->register($categorical('infection', 'infection_id', 'Infection'));
+        $this->register($categorical('hospital', 'hospital_id', 'Hospital'));
+        $this->register($categorical('dispatchArea', 'dispatch_area_id', 'Dispatch area'));
+        $this->register($categorical('state', 'state_id', 'State'));
+
+        $boolean = static fn (string $key, string $column, string $label): AnalysisDimension => new AnalysisDimension(
+            key: $key,
+            column: $column,
+            label: $label,
+            type: AnalysisDimensionType::Boolean,
+            fixedBuckets: [1, 0],
+            valueLabels: [
+                1 => 'Yes',
+                0 => 'No',
+            ],
+        );
+
+        $this->register($boolean('resus', 'requires_resus', 'Resuscitation required'));
+        $this->register($boolean('cathlab', 'requires_cathlab', 'Cath lab required'));
+        $this->register($boolean('cpr', 'is_cpr', 'CPR'));
+        $this->register($boolean('ventilation', 'is_ventilated', 'Ventilation'));
+        $this->register($boolean('shock', 'is_shock', 'Shock'));
+        $this->register($boolean('workAccident', 'is_work_accident', 'Work accident'));
+        $this->register($boolean('pregnancy', 'is_pregnant', 'Pregnancy'));
+    }
+
+    /**
+     * @param list<int|string> $fixedBuckets
+     */
+    private function temporalDimension(
+        string $key,
+        string $column,
+        string $label,
+        array $fixedBuckets,
+        string $chart = 'bar',
+    ): AnalysisDimension {
+        return new AnalysisDimension(
+            key: $key,
+            column: $column,
+            label: $label,
+            type: AnalysisDimensionType::Temporal,
+            recommendedChartType: $chart,
+            fixedBuckets: $fixedBuckets,
+        );
+    }
+
+    private function hospitalCohortDimension(): AnalysisDimension
+    {
+        $urban = AllocationStatsHospitalLocationProjectionCode::Urban->value;
+        $rural = AllocationStatsHospitalLocationProjectionCode::Rural->value;
+        $basic = AllocationStatsHospitalTierProjectionCode::Basic->value;
+        $extended = AllocationStatsHospitalTierProjectionCode::Extended->value;
+        $full = AllocationStatsHospitalTierProjectionCode::Full->value;
+
+        $cohortSql = sprintf(
+            <<<'SQL'
+CASE
+    WHEN hospital_location_code = %1$d AND hospital_tier_code = %2$d THEN '%5$s'
+    WHEN hospital_location_code = %1$d AND hospital_tier_code IN (%3$d, %4$d) THEN '%6$s'
+    WHEN hospital_location_code = %7$d AND hospital_tier_code = %2$d THEN '%8$s'
+    WHEN hospital_location_code = %7$d AND hospital_tier_code = %4$d THEN '%9$s'
+    ELSE NULL
+END
+SQL,
+            $urban,
+            $basic,
+            $extended,
+            $full,
+            HospitalCohortType::UrbanBasic->value,
+            HospitalCohortType::UrbanAdvanced->value,
+            $rural,
+            HospitalCohortType::RuralBasic->value,
+            HospitalCohortType::RuralMaximum->value,
+        );
+
+        /** @var array<string, string> $cohortLabelKeys */
+        $cohortLabelKeys = [];
+        /** @var list<string> $cohortBuckets */
+        $cohortBuckets = [];
+        foreach (HospitalCohortType::cases() as $cohortType) {
+            $cohortBuckets[] = $cohortType->value;
+            $cohortLabelKeys[$cohortType->value] = $cohortType->labelTranslationKey();
+        }
+
+        return new AnalysisDimension(
+            key: 'hospital_cohort',
+            column: 'hospital_location_code',
+            label: 'Hospital cohort',
+            type: AnalysisDimensionType::Categorical,
+            recommendedChartType: 'bar',
+            sqlExpression: $cohortSql,
+            fixedBuckets: $cohortBuckets,
+            valueLabelTranslationKeys: $cohortLabelKeys,
+        );
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModel.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModel.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+final readonly class GenericAnalysisChartViewModel
+{
+    /**
+     * @param list<string>                              $allowedChartTypes Chart type values (GenericAnalysisChartType::value)
+     * @param list<string>                              $warnings
+     * @param array<string, array<string, mixed>>       $specsByChartType
+     * @param list<array{value: string, label: string}> $chartTypeOptions
+     */
+    public function __construct(
+        public string $title,
+        public ?string $subtitle,
+        public bool $hasChart,
+        public string $defaultChartType,
+        public array $allowedChartTypes,
+        /** @var array<string, mixed>|null */
+        public ?array $initialSpec,
+        public array $specsByChartType,
+        public ?string $xAxisLabel,
+        public ?string $yAxisLabel,
+        public bool $isRelative,
+        public string $valueLabel,
+        public array $warnings,
+        public string $emptyStateMessage,
+        public array $chartTypeOptions,
+        public bool $showChartTypeSelector,
+        public bool $exportPlanned,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModelFactory.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModelFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartDataReducer;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartRecommendationService;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartSpecBuilder;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class GenericAnalysisChartViewModelFactory
+{
+    public function __construct(
+        private GenericAnalysisChartRecommendationService $recommendationService,
+        private GenericAnalysisChartSpecBuilder $specBuilder,
+        private GenericAnalysisChartDataReducer $chartDataReducer,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function create(AnalysisQuery $query, NormalizedAnalysisResult $result): GenericAnalysisChartViewModel
+    {
+        $recommendation = $this->recommendationService->recommend($query, $result);
+
+        $allowedTypes = array_values(array_filter(
+            $recommendation->allowedChartTypes,
+            static fn (GenericAnalysisChartType $type): bool => $type->supportsApexChart(),
+        ));
+
+        $reducedChartData = $this->chartDataReducer->reduce($query, $result);
+        $warnings = $recommendation->warnings;
+        if ($reducedChartData->wasLimited()) {
+            $warnings[] = $this->translator->trans('stats.generic_analysis.chart.warning.top_limited', [
+                'limit' => GenericAnalysisChartDataReducer::TOP_LIMIT,
+            ]);
+        }
+
+        $specsByChartType = $recommendation->hasChart
+            ? $this->specBuilder->buildSpecsForTypes($allowedTypes, $query, $result)
+            : [];
+
+        $defaultType = $recommendation->defaultChartType->value;
+        if ($recommendation->hasChart && !isset($specsByChartType[$defaultType]) && [] !== $specsByChartType) {
+            $defaultType = array_key_first($specsByChartType);
+        }
+
+        $initialSpec = $specsByChartType[$defaultType] ?? null;
+
+        $chartTypeOptions = [];
+        foreach ($recommendation->allowedChartTypes as $type) {
+            if (GenericAnalysisChartType::Table === $type || !$type->supportsApexChart()) {
+                continue;
+            }
+            if (!isset($specsByChartType[$type->value])) {
+                continue;
+            }
+            $chartTypeOptions[] = [
+                'value' => $type->value,
+                'label' => $this->chartTypeLabel($type),
+            ];
+        }
+
+        $subtitle = null;
+        if (null !== $result->seriesDimensionLabel) {
+            $subtitle = $this->translator->trans('stats.generic_analysis.chart.subtitle_with_series', [
+                'primary' => $result->primaryDimensionLabel,
+                'series' => $result->seriesDimensionLabel,
+            ]);
+        }
+
+        return new GenericAnalysisChartViewModel(
+            title: $result->title,
+            subtitle: $subtitle,
+            hasChart: $recommendation->hasChart && null !== $initialSpec,
+            defaultChartType: $defaultType,
+            allowedChartTypes: array_values(array_map(
+                static fn (GenericAnalysisChartType $type): string => $type->value,
+                array_filter(
+                    $recommendation->allowedChartTypes,
+                    static fn (GenericAnalysisChartType $type): bool => $type->supportsApexChart(),
+                ),
+            )),
+            initialSpec: $initialSpec,
+            specsByChartType: $specsByChartType,
+            xAxisLabel: $result->primaryDimensionLabel,
+            yAxisLabel: $this->translator->trans('stats.generic_analysis.chart.y_axis_allocations'),
+            isRelative: false,
+            valueLabel: $this->translator->trans('stats.generic_analysis.chart.value_allocations'),
+            warnings: $warnings,
+            emptyStateMessage: $this->translator->trans('stats.generic_analysis.chart.empty'),
+            chartTypeOptions: $chartTypeOptions,
+            showChartTypeSelector: \count($chartTypeOptions) > 1,
+            exportPlanned: true,
+        );
+    }
+
+    private function chartTypeLabel(GenericAnalysisChartType $type): string
+    {
+        return $this->translator->trans(match ($type) {
+            GenericAnalysisChartType::Bar => 'stats.generic_analysis.chart.type.bar',
+            GenericAnalysisChartType::Line => 'stats.generic_analysis.chart.type.line',
+            GenericAnalysisChartType::StackedBar => 'stats.generic_analysis.chart.type.stacked_bar',
+            GenericAnalysisChartType::GroupedBar => 'stats.generic_analysis.chart.type.grouped_bar',
+            GenericAnalysisChartType::HorizontalBar => 'stats.generic_analysis.chart.type.horizontal_bar',
+            GenericAnalysisChartType::PercentStackedBar => 'stats.generic_analysis.chart.type.percent_stacked_bar',
+            GenericAnalysisChartType::Pie => 'stats.generic_analysis.chart.type.pie',
+            GenericAnalysisChartType::Heatmap => 'stats.generic_analysis.chart.type.heatmap',
+            GenericAnalysisChartType::Table => 'stats.generic_analysis.chart.type.table',
+        });
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisController.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisController.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\StatisticsContextFactory;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Application\StatisticsScopeResolver;
+use App\Statistics\GenericAnalysis\Application\AnalysisPresetRegistry;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisConfigResolver;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisService;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisPresetException;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Statistics\UI\Http\Controller\OverviewPeriodViewModelFactory;
+use App\Statistics\UI\Http\Controller\StatisticsFilterValueResolver;
+use App\Statistics\UI\Http\Controller\StatisticsPageViewModelFactory;
+use App\Statistics\UI\Http\Controller\StatisticsPublicScopeRedirector;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+final class GenericAnalysisController extends AbstractController
+{
+    public function __construct(
+        private readonly AnalysisPresetRegistry $presetRegistry,
+        private readonly GenericAnalysisService $genericAnalysisService,
+        private readonly GenericAnalysisConfigResolver $configResolver,
+        private readonly GenericAnalysisPageViewModelFactory $genericAnalysisPageViewModelFactory,
+        private readonly StatisticsContextFactory $statisticsContextFactory,
+        private readonly StatisticsScopeResolver $statisticsScopeResolver,
+        private readonly StatisticsPublicScopeRedirector $publicScopeRedirector,
+        private readonly StatisticsPageViewModelFactory $statisticsPageViewModelFactory,
+        private readonly OverviewPeriodViewModelFactory $overviewPeriodViewModelFactory,
+        private readonly GenericAnalysisTableViewModelFactory $tableViewModelFactory,
+    ) {
+    }
+
+    #[Route(
+        '/statistics/generic-analysis/{presetKey}',
+        name: 'app_stats_generic_analysis',
+        methods: ['GET'],
+    )]
+    public function __invoke(
+        string $presetKey,
+        Request $request,
+        #[CurrentUser] ?User $user,
+        #[ValueResolver(StatisticsFilterValueResolver::class)] StatisticsFilter $filter,
+    ): Response {
+        $publicRedirect = $this->publicScopeRedirector->maybeRedirectPayload($request, $filter);
+        if (null !== $publicRedirect) {
+            if (null !== $publicRedirect['notice']) {
+                $this->addFlash('error', $publicRedirect['notice']->value);
+            }
+
+            return $this->redirectToRoute('app_stats_generic_analysis', array_merge(
+                ['presetKey' => $presetKey],
+                $publicRedirect['query'],
+            ));
+        }
+
+        try {
+            $this->presetRegistry->get($presetKey);
+        } catch (UnknownAnalysisPresetException $e) {
+            throw new NotFoundHttpException($e->getMessage(), $e);
+        }
+
+        $matchingPresetRedirect = $this->maybeMatchingPresetRedirect($request);
+        if (null !== $matchingPresetRedirect) {
+            return $this->redirect($matchingPresetRedirect);
+        }
+
+        $context = $this->statisticsContextFactory->create($user, $filter);
+        $scopeCriteria = $this->statisticsScopeResolver->resolveCriteria($context);
+        $periodBounds = StatisticsPeriodResolver::resolve($filter);
+
+        try {
+            $config = $this->configResolver->resolve($presetKey, $request, $scopeCriteria, $periodBounds, $filter, $user);
+        } catch (UnknownAnalysisDimensionException $e) {
+            throw new BadRequestHttpException($e->getMessage(), $e);
+        }
+
+        $result = $this->genericAnalysisService->run($config->displayTitle, $config->query);
+
+        $pageViewModel = $this->statisticsPageViewModelFactory->create(
+            $request,
+            'app_stats_generic_analysis',
+            $user,
+            $filter,
+        );
+        $overviewPeriodViewModel = $this->overviewPeriodViewModelFactory->create(
+            $request,
+            'app_stats_generic_analysis',
+            $filter,
+        );
+
+        if ($pageViewModel->showUnscopedHint) {
+            $this->addFlash('info', 'stats.overview.hospital_summary.unscoped_hint');
+        }
+
+        return $this->render('@Statistics/generic_analysis/show.html.twig', [
+            'presetKey' => $presetKey,
+            'analysisResult' => $result,
+            'genericAnalysisTable' => $this->tableViewModelFactory->create($request, $presetKey, $result),
+            'chartJson' => json_encode($result->chartData, \JSON_THROW_ON_ERROR),
+            'genericAnalysisPage' => $this->genericAnalysisPageViewModelFactory->create(
+                $request,
+                $presetKey,
+                $config,
+                $filter,
+                $user,
+            ),
+            'statisticsFilter' => $pageViewModel->filter,
+            'statsScopeUrls' => $pageViewModel->scopeUrls,
+            'statsHospitalUrls' => $pageViewModel->hospitalUrls,
+            'cohortScopeChoices' => $pageViewModel->cohortScopeChoices,
+            'statsCohortDropdownSelectedName' => $pageViewModel->cohortDropdownSelectedName,
+            'statsScopePrimaryMenu' => $pageViewModel->scopePrimaryMenu,
+            'statsScopeSecondaryMenu' => $pageViewModel->scopeSecondaryMenu,
+            'statsShowScopeSecondaryPicker' => $pageViewModel->showScopeSecondaryPicker,
+            'statsScopePrimaryDropdownLabel' => $pageViewModel->scopePrimaryDropdownLabel,
+            'statsScopeSecondaryDropdownLabel' => $pageViewModel->scopeSecondaryDropdownLabel,
+            'statsPeriodUrls' => $pageViewModel->periodUrls,
+            'accessibleHospitals' => $pageViewModel->accessibleHospitals,
+            'statsHospitalDropdownSelectedName' => $pageViewModel->hospitalDropdownSelectedName,
+            'isLoggedIn' => $pageViewModel->isLoggedIn,
+            'statisticsHeadingScope' => $pageViewModel->headingScope,
+            'statisticsHeadingPeriod' => $overviewPeriodViewModel->headingLabel,
+            'overviewPeriodViewModel' => $overviewPeriodViewModel,
+            'statsUseOverviewPeriodControls' => true,
+        ]);
+    }
+
+    private function maybeMatchingPresetRedirect(Request $request): ?string
+    {
+        if (!$request->query->has(GenericAnalysisQueryKeys::PRIMARY)) {
+            return null;
+        }
+
+        $primary = $request->query->get(GenericAnalysisQueryKeys::PRIMARY);
+        if (!\is_string($primary) || '' === $primary) {
+            return null;
+        }
+
+        $series = null;
+        if ($request->query->has(GenericAnalysisQueryKeys::SERIES)) {
+            $rawSeries = $request->query->get(GenericAnalysisQueryKeys::SERIES);
+            $series = \is_string($rawSeries) && '' !== $rawSeries ? $rawSeries : null;
+        }
+
+        $includeNull = $request->query->has(GenericAnalysisQueryKeys::INCLUDE_NULL)
+            && '1' === (string) $request->query->get(GenericAnalysisQueryKeys::INCLUDE_NULL);
+
+        $matching = $this->configResolver->findMatchingSelectablePreset($primary, $series, $includeNull);
+        if (!$matching instanceof \App\Statistics\GenericAnalysis\Domain\DTO\AnalysisPreset) {
+            return null;
+        }
+
+        return $this->genericAnalysisPageViewModelFactory->buildPresetRedirectUrl($request, $matching->key);
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisController.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisController.php
@@ -41,6 +41,7 @@ final class GenericAnalysisController extends AbstractController
         private readonly StatisticsPageViewModelFactory $statisticsPageViewModelFactory,
         private readonly OverviewPeriodViewModelFactory $overviewPeriodViewModelFactory,
         private readonly GenericAnalysisTableViewModelFactory $tableViewModelFactory,
+        private readonly GenericAnalysisChartViewModelFactory $chartViewModelFactory,
     ) {
     }
 
@@ -110,7 +111,7 @@ final class GenericAnalysisController extends AbstractController
             'presetKey' => $presetKey,
             'analysisResult' => $result,
             'genericAnalysisTable' => $this->tableViewModelFactory->create($request, $presetKey, $result),
-            'chartJson' => json_encode($result->chartData, \JSON_THROW_ON_ERROR),
+            'genericAnalysisChart' => $this->chartViewModelFactory->create($config->query, $result),
             'genericAnalysisPage' => $this->genericAnalysisPageViewModelFactory->create(
                 $request,
                 $presetKey,

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisPageViewModel.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisPageViewModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+final readonly class GenericAnalysisPageViewModel
+{
+    /**
+     * @param list<array{key: string, title: string, url: string, active: bool}>                         $presetMenu
+     * @param list<array{type: string, label: string, options: list<array{key: string, label: string}>}> $dimensionGroups
+     * @param list<array{key: string, value: string}>                                                    $preservedQueryFields
+     */
+    public function __construct(
+        public array $presetMenu,
+        public string $selectedPresetLabel,
+        public array $dimensionGroups,
+        public bool $showRestrictedDimensionsHint,
+        public string $customFormAction,
+        public array $preservedQueryFields,
+        public string $formPrimary,
+        public string $formSeries,
+        public bool $formIncludeNull,
+        public ?string $formReferencePreset,
+        public bool $isCustom,
+        public ?string $referencePresetTitle,
+        public ?string $resetToPresetUrl,
+    ) {
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisPageViewModelFactory.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisPageViewModelFactory.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\GenericAnalysis\Application\AnalysisPresetRegistry;
+use App\Statistics\GenericAnalysis\Application\DTO\ResolvedGenericAnalysisConfig;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisDimensionPolicy;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
+use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class GenericAnalysisPageViewModelFactory
+{
+    private const string ROUTE = 'app_stats_generic_analysis';
+
+    /** @var list<string> */
+    private const array PRESERVED_QUERY_KEYS = [
+        StatisticsQueryKeys::SCOPE,
+        StatisticsQueryKeys::HOSPITAL,
+        StatisticsQueryKeys::COHORT,
+        StatisticsQueryKeys::STATE,
+        StatisticsQueryKeys::DISPATCH_AREA,
+        StatisticsQueryKeys::PERIOD,
+        StatisticsQueryKeys::YEAR,
+        StatisticsQueryKeys::MONTH,
+        StatisticsQueryKeys::QUARTER,
+        GenericAnalysisQueryKeys::LAYOUT,
+    ];
+
+    public function __construct(
+        private AnalysisPresetRegistry $presetRegistry,
+        private DimensionRegistry $dimensionRegistry,
+        private GenericAnalysisDimensionPolicy $dimensionPolicy,
+        private StatisticsNavigationUrlBuilder $navigationUrlBuilder,
+        private UrlGeneratorInterface $router,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function create(
+        Request $request,
+        string $routePresetKey,
+        ResolvedGenericAnalysisConfig $config,
+        StatisticsFilter $filter,
+        ?User $user,
+    ): GenericAnalysisPageViewModel {
+        $presetMenu = [];
+        foreach ($this->presetRegistry->selectable() as $preset) {
+            $presetMenu[] = [
+                'key' => $preset->key,
+                'title' => $preset->title,
+                'url' => $this->navigationUrlBuilder->build(
+                    $request,
+                    self::ROUTE,
+                    ['presetKey' => $preset->key],
+                    GenericAnalysisQueryKeys::REMOVE_CUSTOM,
+                ),
+                'active' => !$config->isCustom && $preset->key === $routePresetKey,
+            ];
+        }
+
+        $selectedPresetLabel = $config->isCustom
+            ? $this->translator->trans('stats.generic_analysis.custom_title')
+            : $this->presetRegistry->get($routePresetKey)->title;
+
+        $referencePresetTitle = null;
+        if (null !== $config->referencePresetKey && $this->presetRegistry->has($config->referencePresetKey)) {
+            $referencePresetTitle = $this->presetRegistry->get($config->referencePresetKey)->title;
+        }
+
+        $resetToPresetUrl = null;
+        if ($config->isCustom && null !== $config->referencePresetKey) {
+            $resetToPresetUrl = $this->navigationUrlBuilder->build(
+                $request,
+                self::ROUTE,
+                ['presetKey' => $config->referencePresetKey],
+                GenericAnalysisQueryKeys::REMOVE_CUSTOM,
+            );
+        }
+
+        [$dimensionGroups, $showRestrictedDimensionsHint] = $this->buildDimensionGroups(
+            $request->getLocale(),
+            $filter,
+            $user,
+        );
+
+        return new GenericAnalysisPageViewModel(
+            presetMenu: $presetMenu,
+            selectedPresetLabel: $selectedPresetLabel,
+            dimensionGroups: $dimensionGroups,
+            showRestrictedDimensionsHint: $showRestrictedDimensionsHint,
+            customFormAction: $this->router->generate(self::ROUTE, ['presetKey' => GenericAnalysisQueryKeys::PRESET_CUSTOM]),
+            preservedQueryFields: $this->buildPreservedQueryFields($request),
+            formPrimary: $config->primaryDimensionKey,
+            formSeries: $config->seriesDimensionKey ?? '',
+            formIncludeNull: $config->includeNullBuckets,
+            formReferencePreset: $config->referencePresetKey ?? ($config->isCustom ? null : $routePresetKey),
+            isCustom: $config->isCustom,
+            referencePresetTitle: $referencePresetTitle,
+            resetToPresetUrl: $resetToPresetUrl,
+        );
+    }
+
+    public function buildPresetRedirectUrl(Request $request, string $presetKey): string
+    {
+        return $this->navigationUrlBuilder->build(
+            $request,
+            self::ROUTE,
+            ['presetKey' => $presetKey],
+            GenericAnalysisQueryKeys::REMOVE_CUSTOM,
+        );
+    }
+
+    /**
+     * @return array{0: list<array{type: string, label: string, options: list<array{key: string, label: string}>}>, 1: bool}
+     */
+    private function buildDimensionGroups(string $locale, StatisticsFilter $filter, ?User $user): array
+    {
+        $grouped = [];
+        $hadRestricted = false;
+        foreach ($this->dimensionRegistry->all() as $dimension) {
+            if (!$this->dimensionPolicy->isAllowed($dimension->key, $filter, $user)) {
+                $hadRestricted = true;
+
+                continue;
+            }
+
+            $typeKey = $dimension->type->value;
+            $grouped[$typeKey]['type'] = $typeKey;
+            $grouped[$typeKey]['label'] = $this->dimensionTypeLabel($dimension->type, $locale);
+            $grouped[$typeKey]['options'][] = [
+                'key' => $dimension->key,
+                'label' => $dimension->label,
+            ];
+        }
+
+        $order = [
+            AnalysisDimensionType::Temporal->value,
+            AnalysisDimensionType::Categorical->value,
+            AnalysisDimensionType::Boolean->value,
+            AnalysisDimensionType::Numeric->value,
+        ];
+
+        $groups = [];
+        foreach ($order as $type) {
+            if (isset($grouped[$type])) {
+                $groups[] = $grouped[$type];
+            }
+        }
+
+        return [$groups, $hadRestricted];
+    }
+
+    private function dimensionTypeLabel(AnalysisDimensionType $type, string $locale): string
+    {
+        return match ($type) {
+            AnalysisDimensionType::Temporal => $this->translator->trans('stats.generic_analysis.dimension_type.temporal', locale: $locale),
+            AnalysisDimensionType::Categorical => $this->translator->trans('stats.generic_analysis.dimension_type.categorical', locale: $locale),
+            AnalysisDimensionType::Boolean => $this->translator->trans('stats.generic_analysis.dimension_type.boolean', locale: $locale),
+            AnalysisDimensionType::Numeric => $this->translator->trans('stats.generic_analysis.dimension_type.numeric', locale: $locale),
+        };
+    }
+
+    /**
+     * @return list<array{key: string, value: string}>
+     */
+    private function buildPreservedQueryFields(Request $request): array
+    {
+        $fields = [];
+        foreach (self::PRESERVED_QUERY_KEYS as $key) {
+            if (!$request->query->has($key)) {
+                continue;
+            }
+            $fields[] = ['key' => $key, 'value' => $request->query->getString($key)];
+        }
+
+        return $fields;
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModel.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisGroupedTableRow;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisTableFooterTotals;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisTableLayout;
+
+final readonly class GenericAnalysisTableViewModel
+{
+    /**
+     * @param list<EnrichedAnalysisRow>               $stackedRows
+     * @param list<array{key: string, label: string}> $seriesColumns
+     * @param list<GenericAnalysisGroupedTableRow>    $groupedRows
+     */
+    public function __construct(
+        public GenericAnalysisTableLayout $layout,
+        public bool $supportsGroupedLayout,
+        public string $stackedLayoutUrl,
+        public string $groupedLayoutUrl,
+        public string $primaryDimensionLabel,
+        public ?string $seriesDimensionLabel,
+        public int $grandTotal,
+        public array $stackedRows,
+        public array $seriesColumns,
+        public array $groupedRows,
+        public int $groupedTableMinWidthPx,
+        public GenericAnalysisTableFooterTotals $footerTotals,
+    ) {
+    }
+
+    public function isGrouped(): bool
+    {
+        return GenericAnalysisTableLayout::Grouped === $this->layout && $this->supportsGroupedLayout;
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModelFactory.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModelFactory.php
@@ -171,6 +171,7 @@ final readonly class GenericAnalysisTableViewModelFactory
         $seriesKeys = array_map(static fn (array $col): string => $col['key'], $seriesColumns);
 
         foreach ($rows as $row) {
+            // PHP casts numeric string array keys to int; keep bucket keys as strings for DTOs.
             $bucketKey = $row->bucketKey;
             if (!isset($byBucket[$bucketKey])) {
                 $cells = [];
@@ -202,13 +203,33 @@ final readonly class GenericAnalysisTableViewModelFactory
             }
 
             $grouped[] = new GenericAnalysisGroupedTableRow(
-                bucketKey: $bucketKey,
+                bucketKey: $this->stringifyArrayKey($bucketKey),
                 bucketLabel: $bucket['bucketLabel'],
-                cellsBySeriesKey: $bucket['cells'],
+                cellsBySeriesKey: $this->normalizeCellsBySeriesKey($bucket['cells']),
                 bucketTotal: $bucketTotal,
             );
         }
 
         return $grouped;
+    }
+
+    /**
+     * @param array<int|string, GenericAnalysisGroupedSeriesCell|null> $cells
+     *
+     * @return array<string, GenericAnalysisGroupedSeriesCell|null>
+     */
+    private function normalizeCellsBySeriesKey(array $cells): array
+    {
+        $normalized = [];
+        foreach ($cells as $seriesKey => $cell) {
+            $normalized[(string) $seriesKey] = $cell;
+        }
+
+        return $normalized;
+    }
+
+    private function stringifyArrayKey(int|string $key): string
+    {
+        return (string) $key;
     }
 }

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModelFactory.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisTableViewModelFactory.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Controller;
+
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisGroupedSeriesCell;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisGroupedTableRow;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisTableFooterSeriesCell;
+use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisTableFooterTotals;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisTableLayout;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class GenericAnalysisTableViewModelFactory
+{
+    private const int GROUPED_COLUMN_MIN_WIDTH_PX = 112;
+    private const int GROUPED_TABLE_BASE_WIDTH_PX = 200;
+
+    public function __construct(
+        private StatisticsNavigationUrlBuilder $navigationUrlBuilder,
+    ) {
+    }
+
+    public function create(
+        Request $request,
+        string $presetKey,
+        NormalizedAnalysisResult $result,
+    ): GenericAnalysisTableViewModel {
+        $supportsGrouped = null !== $result->seriesDimensionLabel;
+        $requestedLayout = GenericAnalysisTableLayout::fromRequestValue(
+            $request->query->getString(GenericAnalysisQueryKeys::LAYOUT),
+        );
+        $layout = $supportsGrouped && GenericAnalysisTableLayout::Grouped === $requestedLayout
+            ? GenericAnalysisTableLayout::Grouped
+            : GenericAnalysisTableLayout::Stacked;
+
+        $seriesColumns = $this->extractSeriesColumns($result->rows);
+        $groupedRows = $this->buildGroupedRows($result->rows, $seriesColumns);
+
+        $seriesColumnCount = \count($seriesColumns);
+        $footerTotals = $this->buildFooterTotals(
+            $result->rows,
+            $groupedRows,
+            $seriesColumns,
+            $result->grandTotal,
+        );
+
+        return new GenericAnalysisTableViewModel(
+            layout: $layout,
+            supportsGroupedLayout: $supportsGrouped,
+            stackedLayoutUrl: $this->layoutUrl($request, $presetKey, GenericAnalysisTableLayout::Stacked),
+            groupedLayoutUrl: $this->layoutUrl($request, $presetKey, GenericAnalysisTableLayout::Grouped),
+            primaryDimensionLabel: $result->primaryDimensionLabel,
+            seriesDimensionLabel: $result->seriesDimensionLabel,
+            grandTotal: $result->grandTotal,
+            stackedRows: $result->rows,
+            seriesColumns: $seriesColumns,
+            groupedRows: $groupedRows,
+            groupedTableMinWidthPx: self::GROUPED_TABLE_BASE_WIDTH_PX
+                + ($seriesColumnCount * self::GROUPED_COLUMN_MIN_WIDTH_PX),
+            footerTotals: $footerTotals,
+        );
+    }
+
+    /**
+     * @param list<EnrichedAnalysisRow>               $stackedRows
+     * @param list<GenericAnalysisGroupedTableRow>    $groupedRows
+     * @param list<array{key: string, label: string}> $seriesColumns
+     */
+    private function buildFooterTotals(
+        array $stackedRows,
+        array $groupedRows,
+        array $seriesColumns,
+        int $grandTotal,
+    ): GenericAnalysisTableFooterTotals {
+        $totalValue = 0;
+        foreach ($stackedRows as $row) {
+            $totalValue += $row->value;
+        }
+
+        $seriesCells = [];
+        foreach ($seriesColumns as $seriesColumn) {
+            $seriesSum = 0;
+            foreach ($groupedRows as $groupedRow) {
+                $cell = $groupedRow->cellsBySeriesKey[$seriesColumn['key']] ?? null;
+                if (null !== $cell) {
+                    $seriesSum += $cell->value;
+                }
+            }
+            $seriesCells[$seriesColumn['key']] = new GenericAnalysisTableFooterSeriesCell(
+                value: $seriesSum,
+                percentOfGrandTotal: $this->percentOfGrandTotal($seriesSum, $grandTotal),
+            );
+        }
+
+        return new GenericAnalysisTableFooterTotals(
+            totalValue: $totalValue,
+            percentOfGrandTotal: $this->percentOfGrandTotal($totalValue, $grandTotal),
+            seriesCellsByKey: $seriesCells,
+        );
+    }
+
+    private function percentOfGrandTotal(int $value, int $grandTotal): float
+    {
+        if ($grandTotal <= 0) {
+            return 0.0;
+        }
+
+        return ((float) $value / (float) $grandTotal) * 100.0;
+    }
+
+    private function layoutUrl(
+        Request $request,
+        string $presetKey,
+        GenericAnalysisTableLayout $layout,
+    ): string {
+        return $this->navigationUrlBuilder->build(
+            $request,
+            'app_stats_generic_analysis',
+            [
+                'presetKey' => $presetKey,
+                GenericAnalysisQueryKeys::LAYOUT => $layout->value,
+            ],
+        );
+    }
+
+    /**
+     * @param list<EnrichedAnalysisRow> $rows
+     *
+     * @return list<array{key: string, label: string}>
+     */
+    private function extractSeriesColumns(array $rows): array
+    {
+        $columns = [];
+        $seen = [];
+        foreach ($rows as $row) {
+            if (null === $row->seriesKey || null === $row->seriesLabel) {
+                continue;
+            }
+            if (isset($seen[$row->seriesKey])) {
+                continue;
+            }
+            $seen[$row->seriesKey] = true;
+            $columns[] = [
+                'key' => $row->seriesKey,
+                'label' => $row->seriesLabel,
+            ];
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param list<EnrichedAnalysisRow>               $rows
+     * @param list<array{key: string, label: string}> $seriesColumns
+     *
+     * @return list<GenericAnalysisGroupedTableRow>
+     */
+    private function buildGroupedRows(array $rows, array $seriesColumns): array
+    {
+        if ([] === $seriesColumns) {
+            return [];
+        }
+
+        /** @var array<string, array{bucketLabel: string, cells: array<string, GenericAnalysisGroupedSeriesCell|null>}> $byBucket */
+        $byBucket = [];
+        $seriesKeys = array_map(static fn (array $col): string => $col['key'], $seriesColumns);
+
+        foreach ($rows as $row) {
+            $bucketKey = $row->bucketKey;
+            if (!isset($byBucket[$bucketKey])) {
+                $cells = [];
+                foreach ($seriesKeys as $seriesKey) {
+                    $cells[$seriesKey] = null;
+                }
+                $byBucket[$bucketKey] = [
+                    'bucketLabel' => $row->bucketLabel,
+                    'cells' => $cells,
+                ];
+            }
+
+            if (null !== $row->seriesKey) {
+                $byBucket[$bucketKey]['cells'][$row->seriesKey] = new GenericAnalysisGroupedSeriesCell(
+                    value: $row->value,
+                    percentOfTotal: $row->percentOfTotal,
+                    percentOfBucket: $row->percentOfBucket,
+                );
+            }
+        }
+
+        $grouped = [];
+        foreach ($byBucket as $bucketKey => $bucket) {
+            $bucketTotal = 0;
+            foreach ($bucket['cells'] as $cell) {
+                if (null !== $cell) {
+                    $bucketTotal += $cell->value;
+                }
+            }
+
+            $grouped[] = new GenericAnalysisGroupedTableRow(
+                bucketKey: $bucketKey,
+                bucketLabel: $bucket['bucketLabel'],
+                cellsBySeriesKey: $bucket['cells'],
+                bucketTotal: $bucketTotal,
+            );
+        }
+
+        return $grouped;
+    }
+}

--- a/src/Statistics/GenericAnalysis/UI/Http/Navigation/GenericAnalysisQueryKeys.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Navigation/GenericAnalysisQueryKeys.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\GenericAnalysis\UI\Http\Navigation;
+
+final class GenericAnalysisQueryKeys
+{
+    public const string PRIMARY = 'ga_primary';
+
+    public const string SERIES = 'ga_series';
+
+    public const string INCLUDE_NULL = 'ga_include_null';
+
+    public const string REF_PRESET = 'ga_ref';
+
+    public const string LAYOUT = 'ga_layout';
+
+    public const string PRESET_CUSTOM = 'custom';
+
+    /** @var list<string> */
+    public const array REMOVE_CUSTOM = [
+        self::PRIMARY,
+        self::SERIES,
+        self::INCLUDE_NULL,
+        self::REF_PRESET,
+    ];
+}

--- a/src/Statistics/UI/Http/Navigation/StatisticsNavigationUrlBuilder.php
+++ b/src/Statistics/UI/Http/Navigation/StatisticsNavigationUrlBuilder.php
@@ -24,7 +24,12 @@ final readonly class StatisticsNavigationUrlBuilder
      */
     public function build(Request $request, string $routeName, array $replace = [], array $removeKeys = []): string
     {
-        $params = $request->query->all();
+        $routeParams = $request->attributes->get('_route_params', []);
+        if (!\is_array($routeParams)) {
+            $routeParams = [];
+        }
+
+        $params = array_merge($routeParams, $request->query->all());
         foreach ($removeKeys as $key) {
             unset($params[$key]);
         }

--- a/src/Statistics/UI/Twig/templates/generic_analysis/_analysis_config.html.twig
+++ b/src/Statistics/UI/Twig/templates/generic_analysis/_analysis_config.html.twig
@@ -1,0 +1,94 @@
+{% set page = genericAnalysisPage %}
+
+<div class="card mb-4" data-testid="stats-generic-analysis-config">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
+        <h3 class="card-title mb-0">{{ 'stats.generic_analysis.config_card_title'|trans }}</h3>
+        <div class="dropdown" data-testid="stats-generic-analysis-preset-select">
+            <button type="button"
+                    class="btn dropdown-toggle"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false"
+                    aria-label="{{ 'stats.generic_analysis.preset_label'|trans }}">
+                {{ page.selectedPresetLabel }}
+            </button>
+            <div class="dropdown-menu dropdown-menu-end">
+                {% for item in page.presetMenu %}
+                    <a class="dropdown-item{% if item.active %} active{% endif %}"
+                       href="{{ item.url }}"
+                       data-testid="stats-generic-analysis-preset-{{ item.key }}">
+                        {{ item.title }}
+                    </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    <div class="card-body">
+        {% if page.showRestrictedDimensionsHint %}
+            <p class="text-secondary small mb-3">{{ 'stats.generic_analysis.restricted_dimensions_hint'|trans }}</p>
+        {% endif %}
+        {% if page.isCustom and page.referencePresetTitle %}
+            <p class="text-secondary small mb-3">
+                {{ 'stats.generic_analysis.based_on_preset'|trans({'%preset%': page.referencePresetTitle}) }}
+            </p>
+        {% endif %}
+
+        <form method="get" action="{{ page.customFormAction }}" class="row g-3 align-items-end">
+            {% for field in page.preservedQueryFields %}
+                <input type="hidden" name="{{ field.key }}" value="{{ field.value }}">
+            {% endfor %}
+            {% if page.formReferencePreset %}
+                <input type="hidden" name="ga_ref" value="{{ page.formReferencePreset }}">
+            {% endif %}
+
+            <div class="col-12 col-md-6 col-xl-4">
+                <label class="form-label" for="ga_primary">{{ 'stats.generic_analysis.primary_dimension'|trans }}</label>
+                <select class="form-select" id="ga_primary" name="ga_primary" required data-testid="stats-generic-analysis-primary">
+                    {% for group in page.dimensionGroups %}
+                        <optgroup label="{{ group.label }}">
+                            {% for option in group.options %}
+                                <option value="{{ option.key }}"{% if option.key == page.formPrimary %} selected{% endif %}>
+                                    {{ option.label }}
+                                </option>
+                            {% endfor %}
+                        </optgroup>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="col-12 col-md-6 col-xl-4">
+                <label class="form-label" for="ga_series">{{ 'stats.generic_analysis.series_dimension'|trans }}</label>
+                <select class="form-select" id="ga_series" name="ga_series" data-testid="stats-generic-analysis-series">
+                    <option value="">{{ 'stats.generic_analysis.series_none'|trans }}</option>
+                    {% for group in page.dimensionGroups %}
+                        <optgroup label="{{ group.label }}">
+                            {% for option in group.options %}
+                                <option value="{{ option.key }}"{% if option.key == page.formSeries %} selected{% endif %}>
+                                    {{ option.label }}
+                                </option>
+                            {% endfor %}
+                        </optgroup>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="col-12 col-xl-4">
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" id="ga_include_null" name="ga_include_null" value="1"
+                           {% if page.formIncludeNull %}checked{% endif %}
+                           data-testid="stats-generic-analysis-include-null">
+                    <label class="form-check-label" for="ga_include_null">
+                        {{ 'stats.generic_analysis.include_null_buckets'|trans }}
+                    </label>
+                </div>
+                <button type="submit" class="btn btn-primary w-100 w-xl-auto" data-testid="stats-generic-analysis-apply">
+                    {{ 'stats.generic_analysis.apply'|trans }}
+                </button>
+            </div>
+        </form>
+        {% if page.resetToPresetUrl %}
+            <p class="small text-secondary mt-3 mb-0">
+                <a href="{{ page.resetToPresetUrl }}">{{ 'stats.generic_analysis.reset_to_preset'|trans }}</a>
+            </p>
+        {% endif %}
+    </div>
+</div>

--- a/src/Statistics/UI/Twig/templates/generic_analysis/_chart_card.html.twig
+++ b/src/Statistics/UI/Twig/templates/generic_analysis/_chart_card.html.twig
@@ -1,0 +1,59 @@
+{# @var genericAnalysisChart \App\Statistics\GenericAnalysis\UI\Http\Controller\GenericAnalysisChartViewModel #}
+<div class="card mb-4"
+     data-testid="stats-generic-analysis-chart-card"
+     {% if genericAnalysisChart.hasChart %}
+     data-controller="generic-analysis-chart"
+     data-generic-analysis-chart-specs-value="{{ genericAnalysisChart.specsByChartType|json_encode|e('html_attr') }}"
+     data-generic-analysis-chart-default-type-value="{{ genericAnalysisChart.defaultChartType }}"
+     {% endif %}>
+    <div class="card-header">
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 w-100">
+            <div>
+                <h3 class="card-title mb-0">{{ genericAnalysisChart.title }}</h3>
+                {% if genericAnalysisChart.subtitle %}
+                    <div class="text-secondary small mt-1">{{ genericAnalysisChart.subtitle }}</div>
+                {% endif %}
+            </div>
+            {% if genericAnalysisChart.showChartTypeSelector %}
+                <div class="btn-group btn-group-sm flex-shrink-0"
+                     role="group"
+                     aria-label="{{ 'stats.generic_analysis.chart.type_selector_label'|trans }}"
+                     data-testid="stats-generic-analysis-chart-type">
+                    {% for option in genericAnalysisChart.chartTypeOptions %}
+                        <button type="button"
+                                class="btn btn-outline-secondary{% if option.value == genericAnalysisChart.defaultChartType %} active{% endif %}"
+                                data-generic-analysis-chart-target="typeButton"
+                                data-chart-type="{{ option.value }}"
+                                data-action="generic-analysis-chart#selectType"
+                                aria-pressed="{{ option.value == genericAnalysisChart.defaultChartType ? 'true' : 'false' }}"
+                                data-testid="stats-generic-analysis-chart-type-{{ option.value }}">
+                            {{ option.label }}
+                        </button>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+    <div class="card-body">
+        {% for warning in genericAnalysisChart.warnings %}
+            <div class="alert alert-warning py-2 mb-3" role="status" data-testid="stats-generic-analysis-chart-warning">
+                {{ warning }}
+            </div>
+        {% endfor %}
+
+        {% if genericAnalysisChart.hasChart %}
+            <div class="chart-lg" data-generic-analysis-chart-target="chart" data-testid="stats-generic-analysis-chart"></div>
+        {% else %}
+            <div class="text-center text-secondary py-5" data-testid="stats-generic-analysis-chart-empty">
+                <p class="mb-0">{{ genericAnalysisChart.emptyStateMessage }}</p>
+            </div>
+        {% endif %}
+
+        {# Export (PNG/CSV) planned — see stats.generic_analysis.chart.export_planned #}
+        {% if genericAnalysisChart.exportPlanned %}
+            <p class="text-secondary small mt-3 mb-0 d-none" data-testid="stats-generic-analysis-chart-export-todo" aria-hidden="true">
+                {{ 'stats.generic_analysis.chart.export_planned'|trans }}
+            </p>
+        {% endif %}
+    </div>
+</div>

--- a/src/Statistics/UI/Twig/templates/generic_analysis/_results_table.html.twig
+++ b/src/Statistics/UI/Twig/templates/generic_analysis/_results_table.html.twig
@@ -1,0 +1,176 @@
+{% set table = genericAnalysisTable %}
+{% set footer = table.footerTotals %}
+
+<div class="card" data-testid="stats-generic-analysis-table">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
+        <div>
+            <h3 class="card-title mb-0">{{ 'stats.generic_analysis.results_table_title'|trans }}</h3>
+            <div class="text-secondary small mt-1" data-testid="stats-generic-analysis-results-count">
+                {{ 'stats.generic_analysis.results_count'|trans({
+                    count: table.grandTotal|number_format(0, ',', '.'),
+                }) }}
+            </div>
+        </div>
+        {% if table.supportsGroupedLayout %}
+            <div class="btn-group btn-group-sm" role="group" aria-label="{{ 'stats.generic_analysis.table_layout_label'|trans }}"
+                 data-testid="stats-generic-analysis-table-layout-toggle">
+                <a href="{{ table.stackedLayoutUrl }}"
+                   class="btn{% if not table.isGrouped %} btn-primary{% endif %}"
+                   data-testid="stats-generic-analysis-layout-stacked">
+                    {{ 'stats.generic_analysis.table_layout_stacked'|trans }}
+                </a>
+                <a href="{{ table.groupedLayoutUrl }}"
+                   class="btn{% if table.isGrouped %} btn-primary{% endif %}"
+                   data-testid="stats-generic-analysis-layout-grouped">
+                    {{ 'stats.generic_analysis.table_layout_grouped'|trans }}
+                </a>
+            </div>
+        {% endif %}
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive stats-ga-table-scroll{% if table.isGrouped %} stats-ga-table-scroll--grouped{% endif %}">
+            {% if table.isGrouped %}
+                <table class="table table-vcenter card-table table-striped mb-0 stats-ga-table-grouped"
+                       style="min-width: {{ table.groupedTableMinWidthPx }}px;"
+                       data-testid="stats-generic-analysis-table-grouped">
+                    <thead>
+                        <tr>
+                            <th class="stats-ga-table-sticky-col">{{ table.primaryDimensionLabel }}</th>
+                            {% for series in table.seriesColumns %}
+                                <th class="text-end text-nowrap">{{ series.label }}</th>
+                            {% endfor %}
+                            <th class="text-end text-nowrap">{{ 'stats.generic_analysis.table.bucket_total'|trans }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table.groupedRows %}
+                            <tr>
+                                <th scope="row" class="stats-ga-table-sticky-col text-nowrap">{{ row.bucketLabel }}</th>
+                                {% for series in table.seriesColumns %}
+                                    {% set cell = row.cellsBySeriesKey[series.key] ?? null %}
+                                    <td class="text-end text-nowrap">
+                                        {% if cell %}
+                                            <div class="fw-medium">{{ cell.value|number_format(0, ',', '.') }}</div>
+                                            <div class="small text-secondary"
+                                                 title="{{ 'stats.generic_analysis.table.percent_total_tooltip'|trans({
+                                                     percent: cell.percentOfTotal|number_format(1, ',', '.'),
+                                                 }) }}">
+                                                {{ cell.percentOfBucket|number_format(1, ',', '.') }}%
+                                            </div>
+                                        {% else %}
+                                            <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
+                                {% endfor %}
+                                <td class="text-end text-nowrap fw-medium">
+                                    {{ row.bucketTotal|number_format(0, ',', '.') }}
+                                </td>
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td colspan="{{ table.seriesColumns|length + 2 }}" class="text-muted p-3">
+                                    {{ 'stats.generic_analysis.no_data'|trans }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                    {% if table.groupedRows is not empty %}
+                        <tfoot>
+                            <tr class="fw-semibold border-top" data-testid="stats-generic-analysis-table-footer">
+                                <th scope="row" class="stats-ga-table-sticky-col text-nowrap">
+                                    {{ 'stats.generic_analysis.table.footer_total'|trans }}
+                                </th>
+                                {% for series in table.seriesColumns %}
+                                    {% set footerCell = footer.seriesCellsByKey[series.key] ?? null %}
+                                    <td class="text-end text-nowrap">
+                                        {% if footerCell %}
+                                            <div>{{ footerCell.value|number_format(0, ',', '.') }}</div>
+                                        {% else %}
+                                            <span class="text-muted">—</span>
+                                        {% endif %}
+                                    </td>
+                                {% endfor %}
+                                <td class="text-end text-nowrap fw-medium">
+                                    {{ footer.totalValue|number_format(0, ',', '.') }}
+                                </td>
+                            </tr>
+                        </tfoot>
+                    {% endif %}
+                </table>
+            {% else %}
+                <table class="table table-vcenter card-table table-striped mb-0"
+                       data-testid="stats-generic-analysis-table-stacked">
+                    <thead>
+                        <tr>
+                            <th>{{ table.primaryDimensionLabel }}</th>
+                            {% if table.seriesDimensionLabel %}
+                                <th>{{ table.seriesDimensionLabel }}</th>
+                            {% endif %}
+                            <th class="text-end">{{ 'stats.generic_analysis.table.count'|trans }}</th>
+                            <th class="text-end">{{ 'stats.generic_analysis.table.percent_total'|trans }}</th>
+                            {% if table.seriesDimensionLabel %}
+                                <th class="text-end">{{ 'stats.generic_analysis.table.percent_bucket'|trans }}</th>
+                            {% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table.stackedRows %}
+                            <tr>
+                                <td>{{ row.bucketLabel }}</td>
+                                {% if table.seriesDimensionLabel %}
+                                    <td>{{ row.seriesLabel ?? '—' }}</td>
+                                {% endif %}
+                                <td class="text-end">{{ row.value|number_format(0, ',', '.') }}</td>
+                                <td class="text-end">{{ row.percentOfTotal|number_format(2, ',', '.') }}%</td>
+                                {% if table.seriesDimensionLabel %}
+                                    <td class="text-end">{{ row.percentOfBucket|number_format(2, ',', '.') }}%</td>
+                                {% endif %}
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td colspan="{{ table.seriesDimensionLabel ? 5 : 3 }}" class="text-muted p-3">
+                                    {{ 'stats.generic_analysis.no_data'|trans }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                    {% if table.stackedRows is not empty %}
+                        <tfoot>
+                            <tr class="fw-semibold border-top" data-testid="stats-generic-analysis-table-footer">
+                                <td>{{ 'stats.generic_analysis.table.footer_total'|trans }}</td>
+                                {% if table.seriesDimensionLabel %}
+                                    <td></td>
+                                {% endif %}
+                                <td class="text-end">{{ footer.totalValue|number_format(0, ',', '.') }}</td>
+                                <td class="text-end">{{ footer.percentOfGrandTotal|number_format(2, ',', '.') }}%</td>
+                                {% if table.seriesDimensionLabel %}
+                                    <td class="text-end text-muted">—</td>
+                                {% endif %}
+                            </tr>
+                        </tfoot>
+                    {% endif %}
+                </table>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<style>
+    .stats-ga-table-scroll {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        max-width: 100%;
+    }
+
+    .stats-ga-table-scroll--grouped .stats-ga-table-sticky-col {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+        background-color: var(--tblr-card-bg, #fff);
+        box-shadow: 1px 0 0 var(--tblr-border-color, rgba(0, 0, 0, 0.1));
+    }
+
+    .stats-ga-table-scroll--grouped thead .stats-ga-table-sticky-col {
+        z-index: 2;
+    }
+</style>

--- a/src/Statistics/UI/Twig/templates/generic_analysis/show.html.twig
+++ b/src/Statistics/UI/Twig/templates/generic_analysis/show.html.twig
@@ -38,16 +38,9 @@
         <div class="col-12 min-w-0">
             {{ include('@Statistics/generic_analysis/_analysis_config.html.twig') }}
 
-            {{ include('@Statistics/generic_analysis/_results_table.html.twig') }}
+            {{ include('@Statistics/generic_analysis/_chart_card.html.twig') }}
 
-            <div class="card mt-4">
-                <div class="card-header">
-                    <h3 class="card-title">{{ 'stats.generic_analysis.chart_json_title'|trans }}</h3>
-                </div>
-                <div class="card-body">
-                    <pre class="bg-light p-3 small mb-0" style="max-height: 16rem; overflow: auto;">{{ chartJson }}</pre>
-                </div>
-            </div>
+            {{ include('@Statistics/generic_analysis/_results_table.html.twig') }}
 
             {% if overviewPeriodViewModel is defined %}
                 {{ include('@Statistics/dashboard/_overview_period_navigation.html.twig') }}

--- a/src/Statistics/UI/Twig/templates/generic_analysis/show.html.twig
+++ b/src/Statistics/UI/Twig/templates/generic_analysis/show.html.twig
@@ -1,0 +1,57 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ analysisResult.title }} – {{ parent() }}{% endblock %}
+
+{% block header %}
+    {% embed '@Shared/_embeds/header.html.twig' %}
+        {% block header_after %}
+            {{ include('@Shared/_includes/subnav_stats.html.twig') }}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
+{% block page_header %}
+    <div class="container-xl">
+        <twig:Breadcrumbs :items="[
+            { label: 'link.statistics', path: path('app_stats_dashboard') },
+            { label: analysisResult.title }
+        ]" />
+
+        <div class="page-header d-print-none">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <div class="page-pretitle" data-testid="stats-heading-subtitle">
+                        {{ 'stats.generic_analysis.page_pretitle'|trans }}
+                    </div>
+                    <h2 class="page-title" data-testid="stats-heading-title">
+                        {{ analysisResult.title }}
+                    </h2>
+                </div>
+                {{ include('@Statistics/_header_controls.html.twig') }}
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block page_content %}
+    <div class="row g-4">
+        <div class="col-12 min-w-0">
+            {{ include('@Statistics/generic_analysis/_analysis_config.html.twig') }}
+
+            {{ include('@Statistics/generic_analysis/_results_table.html.twig') }}
+
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h3 class="card-title">{{ 'stats.generic_analysis.chart_json_title'|trans }}</h3>
+                </div>
+                <div class="card-body">
+                    <pre class="bg-light p-3 small mb-0" style="max-height: 16rem; overflow: auto;">{{ chartJson }}</pre>
+                </div>
+            </div>
+
+            {% if overviewPeriodViewModel is defined %}
+                {{ include('@Statistics/dashboard/_overview_period_navigation.html.twig') }}
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
+++ b/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
@@ -12,9 +12,13 @@ use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class HospitalRepositoryQueryTest extends KernelTestCase
 {
+    use Factories;
+    use ResetDatabase;
     private HospitalRepository $repo;
 
     #[\Override]
@@ -63,5 +67,23 @@ final class HospitalRepositoryQueryTest extends KernelTestCase
         self::assertContains($owned1->getId(), $ids);
         self::assertContains($owned2->getId(), $ids);
         self::assertNotContains($foreign->getId(), $ids);
+    }
+
+    public function testFindNamesByIdsReturnsIdToNameMap(): void
+    {
+        UserFactory::createOne();
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['name' => 'Lookup Hospital']);
+
+        self::assertSame(
+            [(int) $hospital->getId() => 'Lookup Hospital'],
+            $this->repo->findNamesByIds([(int) $hospital->getId()]),
+        );
+    }
+
+    public function testFindNamesByIdsWithEmptyListReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->repo->findNamesByIds([]));
     }
 }

--- a/tests/Statistics/Functional/Controller/GenericAnalysisControllerTest.php
+++ b/tests/Statistics/Functional/Controller/GenericAnalysisControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class GenericAnalysisControllerTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+    use ResetDatabase;
+
+    public function testAllocationsByMonthShowsChartAndTable(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $this->seedProjectionWithAllocation();
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/statistics/generic-analysis/allocations_by_month?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-config"]');
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-chart-card"]');
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-chart"]');
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-table"]');
+
+        $specsRaw = $crawler->filter('[data-controller="generic-analysis-chart"]')->attr('data-generic-analysis-chart-specs-value');
+        self::assertNotNull($specsRaw);
+        $this->assertStringContainsString('"bar"', $specsRaw);
+    }
+
+    public function testUrgencyByMonthShowsChartTypeSelector(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $this->seedProjectionWithAllocation();
+        $client->request(
+            Request::METHOD_GET,
+            '/statistics/generic-analysis/urgency_by_month?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-chart-type"]');
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-chart-type-stacked_bar"]');
+        $this->assertSelectorExists('[data-testid="stats-generic-analysis-chart-type-line"]');
+    }
+
+    public function testUnknownPresetReturnsNotFound(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $client->request(
+            Request::METHOD_GET,
+            '/statistics/generic-analysis/unknown_preset?scope=public&period=all',
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testCustomQueryMatchingPresetRedirectsToCanonicalUrl(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $client->request(
+            Request::METHOD_GET,
+            '/statistics/generic-analysis/custom?scope=public&period=all&'
+            .GenericAnalysisQueryKeys::PRIMARY.'=month&'
+            .GenericAnalysisQueryKeys::SERIES.'=urgency',
+        );
+
+        $this->assertResponseRedirects(
+            '/statistics/generic-analysis/urgency_by_month?scope=public&period=all',
+        );
+    }
+
+    private function seedProjectionWithAllocation(): void
+    {
+        $user = UserFactory::createOne(['username' => 'generic-analysis-test']);
+        $state = StateFactory::createOne(['name' => 'GA State', 'createdBy' => $user]);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'GA Dispatch']);
+        $hospital = HospitalFactory::createOne(['name' => 'GA Hospital']);
+        $import = ImportFactory::createOne(['name' => 'GA Import', 'hospital' => $hospital, 'createdBy' => $user]);
+        SpecialityFactory::createOne(['name' => 'GA Speciality']);
+        DepartmentFactory::createOne(['name' => 'GA Department']);
+        AssignmentFactory::createOne(['name' => 'GA Assignment']);
+        OccasionFactory::createOne(['name' => 'GA Occasion']);
+        InfectionFactory::createOne(['name' => 'GA Infection']);
+        $raw = IndicationRawFactory::createOne(['name' => 'GA Raw']);
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'GA Normalized']);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('today'),
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => $normalized,
+        ]);
+
+        $this->rebuildProjection([(int) $import->getId()]);
+    }
+
+    /**
+     * @param list<int> $importIds
+     */
+    private function rebuildProjection(array $importIds): void
+    {
+        $container = self::getContainer();
+        $container->get(Connection::class)->executeStatement('TRUNCATE TABLE allocation_stats_projection');
+        $rebuilder = $container->get(AllocationStatsProjectionRebuildInterface::class);
+        foreach ($importIds as $importId) {
+            $rebuilder->rebuildForImport($importId);
+        }
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/AnalysisPresetRegistryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/AnalysisPresetRegistryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\GenericAnalysis\Application\AnalysisPresetRegistry;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisPresetException;
+use PHPUnit\Framework\TestCase;
+
+final class AnalysisPresetRegistryTest extends TestCase
+{
+    private AnalysisPresetRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = new AnalysisPresetRegistry();
+    }
+
+    public function testResolvesAllocationsByMonthPreset(): void
+    {
+        $preset = $this->registry->get('allocations_by_month');
+
+        self::assertSame('month', $preset->primaryDimensionKey);
+        self::assertNull($preset->seriesDimensionKey);
+    }
+
+    public function testHospitalCohortPresets(): void
+    {
+        $byCohort = $this->registry->get('allocations_by_hospital_cohort');
+        $urgencyByCohort = $this->registry->get('urgency_by_hospital_cohort');
+
+        self::assertSame('hospital_cohort', $byCohort->primaryDimensionKey);
+        self::assertSame('hospital_cohort', $urgencyByCohort->primaryDimensionKey);
+        self::assertSame('urgency', $urgencyByCohort->seriesDimensionKey);
+    }
+
+    public function testUnknownPresetThrows(): void
+    {
+        $this->expectException(UnknownAnalysisPresetException::class);
+
+        $this->registry->get('nonexistent');
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/DimensionRegistryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/DimensionRegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class DimensionRegistryTest extends TestCase
+{
+    private DimensionRegistry $registry;
+
+    protected function setUp(): void
+    {
+        $this->registry = new DimensionRegistry();
+    }
+
+    public function testResolvesTemporalMonthWithFixedBuckets(): void
+    {
+        $month = $this->registry->get('month');
+
+        self::assertSame('created_month', $month->column);
+        self::assertSame(AnalysisDimensionType::Temporal, $month->type);
+        self::assertSame(range(1, 12), $month->fixedBuckets);
+    }
+
+    public function testAgeGroupUsesSqlExpressionNotRawUserColumn(): void
+    {
+        $ageGroup = $this->registry->get('age_group');
+
+        self::assertNotNull($ageGroup->sqlExpression);
+        self::assertStringContainsString('CASE', $ageGroup->sqlExpression);
+        self::assertSame('age', $ageGroup->column);
+    }
+
+    public function testHospitalCohortUsesCaseExpression(): void
+    {
+        $cohort = $this->registry->get('hospital_cohort');
+
+        self::assertNotNull($cohort->sqlExpression);
+        self::assertStringContainsString('urban_basic', $cohort->sqlExpression);
+        self::assertStringContainsString('rural_maximum', $cohort->sqlExpression);
+        self::assertCount(4, $cohort->fixedBuckets);
+    }
+
+    public function testUnknownDimensionThrows(): void
+    {
+        $this->expectException(UnknownAnalysisDimensionException::class);
+
+        $this->registry->get('evil_column');
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisQueryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisQueryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisSqlBuilder;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAnalysisScopeSqlFilter;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+final class GenericAllocationAnalysisQueryTest extends TestCase
+{
+    public function testEmptyHospitalScopeReturnsEmptyResultWithoutQuerying(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('executeQuery');
+
+        $query = new GenericAllocationAnalysisQuery(
+            $connection,
+            new GenericAllocationAnalysisSqlBuilder(
+                new DimensionRegistry(),
+                new GenericAnalysisScopeSqlFilter(),
+            ),
+        );
+
+        $result = $query->execute(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: new StatisticsScopeCriteria([]),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertSame([], $result->rows);
+        self::assertSame(0, $result->grandTotal);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisQueryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisQueryTest.php
@@ -38,4 +38,60 @@ final class GenericAllocationAnalysisQueryTest extends TestCase
         self::assertSame([], $result->rows);
         self::assertSame(0, $result->grandTotal);
     }
+
+    public function testExecuteMapsRowsAndGrandTotal(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result->method('fetchAllAssociative')->willReturn([
+            ['bucket' => '1', 'value' => '3', 'series' => '2'],
+            ['bucket' => '2', 'value' => 7],
+        ]);
+        $connection->expects(self::once())->method('executeQuery')->willReturn($result);
+
+        $query = new GenericAllocationAnalysisQuery($connection, $this->createSqlBuilder());
+
+        $analysisResult = $query->execute(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: 'urgency',
+        ));
+
+        self::assertSame(10, $analysisResult->grandTotal);
+        self::assertCount(2, $analysisResult->rows);
+        self::assertSame(1, $analysisResult->rows[0]->bucket);
+        self::assertSame(3, $analysisResult->rows[0]->value);
+        self::assertSame(2, $analysisResult->rows[0]->series);
+        self::assertSame(7, $analysisResult->rows[1]->value);
+        self::assertNull($analysisResult->rows[1]->series);
+    }
+
+    public function testExecuteNormalizesNumericStringBuckets(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result->method('fetchAllAssociative')->willReturn([
+            ['bucket' => '12.5', 'value' => 1],
+        ]);
+        $connection->method('executeQuery')->willReturn($result);
+
+        $analysisResult = new GenericAllocationAnalysisQuery($connection, $this->createSqlBuilder())->execute(
+            new AnalysisQuery(
+                primaryDimensionKey: 'month',
+                scopeCriteria: StatisticsScopeCriteria::public(),
+                periodBounds: new StatisticsPeriodBounds(null),
+            ),
+        );
+
+        self::assertSame(12.5, $analysisResult->rows[0]->bucket);
+    }
+
+    private function createSqlBuilder(): GenericAllocationAnalysisSqlBuilder
+    {
+        return new GenericAllocationAnalysisSqlBuilder(
+            new DimensionRegistry(),
+            new GenericAnalysisScopeSqlFilter(),
+        );
+    }
 }

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\Cohort\HospitalCohortType;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\Application\Mapping\AllocationStatsHospitalLocationProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsHospitalTierProjectionCode;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisSqlBuilder;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAnalysisScopeSqlFilter;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class GenericAllocationAnalysisSqlBuilderTest extends TestCase
+{
+    private GenericAllocationAnalysisSqlBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new GenericAllocationAnalysisSqlBuilder(
+            new DimensionRegistry(),
+            new GenericAnalysisScopeSqlFilter(),
+        );
+    }
+
+    public function testBuildsParameterizedCountByMonth(): void
+    {
+        $from = new \DateTimeImmutable('2024-01-01 00:00:00');
+        $to = new \DateTimeImmutable('2025-01-01 00:00:00');
+
+        [$sql, $params] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: new StatisticsScopeCriteria([10, 20]),
+            periodBounds: new StatisticsPeriodBounds($from, $to),
+        ));
+
+        self::assertStringContainsString('created_month AS bucket', $sql);
+        self::assertStringContainsString('COUNT(*)::INT AS value', $sql);
+        self::assertStringContainsString('FROM allocation_stats_projection', $sql);
+        self::assertStringContainsString('hospital_id IN (:scope_hospital_ids)', $sql);
+        self::assertStringContainsString('created_at >= :period_from', $sql);
+        self::assertStringContainsString('created_at < :period_to_exclusive', $sql);
+        self::assertStringNotContainsString(';', $sql);
+        self::assertSame([10, 20], $params['scope_hospital_ids']);
+    }
+
+    public function testRejectsUnknownDimensionKey(): void
+    {
+        $this->expectException(UnknownAnalysisDimensionException::class);
+
+        $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'evil_column',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+    }
+
+    public function testSeriesDimensionAddsGroupBy(): void
+    {
+        [$sql] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: 'urgency',
+        ));
+
+        self::assertStringContainsString('urgency_code AS series', $sql);
+        self::assertStringContainsString('GROUP BY bucket, series', $sql);
+    }
+
+    public function testHospitalCohortDimensionUsesCaseExpression(): void
+    {
+        [$sql] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'hospital_cohort',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertStringContainsString('CASE', $sql);
+        self::assertStringContainsString("'urban_basic'", $sql);
+        self::assertStringContainsString("'rural_basic'", $sql);
+        self::assertStringContainsString('hospital_location_code', $sql);
+        self::assertStringContainsString('hospital_tier_code', $sql);
+    }
+
+    public function testCohortScopeCriteriaAddsLocationAndTierFilters(): void
+    {
+        [$sql, $params] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: new StatisticsScopeCriteria(
+                [1, 2, 3],
+                [AllocationStatsHospitalLocationProjectionCode::Rural->value],
+                [AllocationStatsHospitalTierProjectionCode::Basic->value],
+                HospitalCohortType::RuralBasic,
+            ),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertStringContainsString('hospital_id IN (:scope_hospital_ids)', $sql);
+        self::assertStringContainsString('hospital_location_code IN (:scope_location_codes)', $sql);
+        self::assertStringContainsString('hospital_tier_code IN (:scope_tier_codes)', $sql);
+        self::assertSame([1, 2, 3], $params['scope_hospital_ids']);
+        self::assertSame(
+            [AllocationStatsHospitalLocationProjectionCode::Rural->value],
+            $params['scope_location_codes'],
+        );
+        self::assertSame(
+            [AllocationStatsHospitalTierProjectionCode::Basic->value],
+            $params['scope_tier_codes'],
+        );
+    }
+
+    public function testExcludesAgeGroupUnknownWhenNullBucketsDisabled(): void
+    {
+        [$sql, $params] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: 'age_group',
+            includeNullBuckets: false,
+        ));
+
+        self::assertStringContainsString('age IS NOT NULL', $sql);
+        self::assertStringContainsString('NOT IN (:exclude_null_bucket_age_group)', $sql);
+        self::assertSame(['unknown'], $params['exclude_null_bucket_age_group']);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartDataReducer;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisChartDataReducerTest extends TestCase
+{
+    private GenericAnalysisChartDataReducer $reducer;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'stats.generic_analysis.chart.remainder_bucket',
+                'stats.generic_analysis.chart.remainder_series' => 'Other',
+                default => $id,
+            },
+        );
+
+        $this->reducer = new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator);
+    }
+
+    public function testLimitsCategoricalPrimaryBucketsToTopFivePlusOther(): void
+    {
+        $query = $this->query('hospital');
+        $labels = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7'];
+        $values = [50, 40, 30, 20, 10, 5, 1];
+        $result = $this->normalizedResult($labels, $values);
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertTrue($reduced->limitedPrimaryBuckets);
+        self::assertCount(6, $reduced->labels);
+        self::assertSame('Other', $reduced->labels[5]);
+        self::assertSame(6, $reduced->counts[5]);
+    }
+
+    public function testDoesNotLimitTemporalPrimaryBuckets(): void
+    {
+        $query = $this->query('month');
+        $labels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        $values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        $result = $this->normalizedResult($labels, $values);
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertFalse($reduced->limitedPrimaryBuckets);
+        self::assertCount(12, $reduced->labels);
+    }
+
+    public function testLimitsSeriesToTopFivePlusOther(): void
+    {
+        $query = $this->query('month', 'urgency');
+        $series = [];
+        for ($i = 1; $i <= 7; ++$i) {
+            $series[] = ['name' => 'U'.$i, 'data' => [$i * 10, 0]];
+        }
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 280,
+            rows: [],
+            chartData: [
+                'labels' => ['Jan', 'Feb'],
+                'series' => $series,
+            ],
+        );
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertTrue($reduced->limitedSeries);
+        self::assertNotNull($reduced->series);
+        self::assertCount(6, $reduced->series);
+        self::assertSame('Other', $reduced->series[5]['name']);
+        self::assertSame(30, $reduced->series[5]['data'][0]);
+        self::assertSame(0, $reduced->series[5]['data'][1]);
+    }
+
+    private function query(string $primary, ?string $series = null): AnalysisQuery
+    {
+        return new AnalysisQuery(
+            primaryDimensionKey: $primary,
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: $series,
+        );
+    }
+
+    /**
+     * @param list<string> $labels
+     * @param list<int>    $values
+     */
+    private function normalizedResult(array $labels, array $values): NormalizedAnalysisResult
+    {
+        return new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Dim',
+            seriesDimensionLabel: null,
+            grandTotal: array_sum($values),
+            rows: [],
+            chartData: [
+                'labels' => $labels,
+                'values' => $values,
+            ],
+        );
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
@@ -88,6 +88,68 @@ final class GenericAnalysisChartDataReducerTest extends TestCase
         self::assertSame(0, $reduced->series[5]['data'][1]);
     }
 
+    public function testLimitsCategoricalBucketsWithSeries(): void
+    {
+        $query = $this->query('hospital', 'urgency');
+        $labels = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+        $series = [
+            ['name' => 'U1', 'data' => [10, 1, 1, 1, 1, 1]],
+            ['name' => 'U2', 'data' => [1, 1, 1, 1, 1, 50]],
+        ];
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Hospital',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 70,
+            rows: [],
+            chartData: ['labels' => $labels, 'series' => $series],
+        );
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertTrue($reduced->limitedPrimaryBuckets);
+        self::assertNotNull($reduced->series);
+        self::assertCount(6, $reduced->labels);
+        self::assertSame('Other', $reduced->labels[5]);
+    }
+
+    public function testExtractsCountsFromRowsWhenValuesMissing(): void
+    {
+        $query = $this->query('gender');
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Gender',
+            seriesDimensionLabel: null,
+            grandTotal: 8,
+            rows: [
+                new \App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow('1', 'Male', 5, 62.5, 100.0),
+                new \App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow('2', 'Female', 3, 37.5, 100.0),
+            ],
+            chartData: ['labels' => ['Male', 'Female']],
+        );
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertSame([5, 3], $reduced->counts);
+    }
+
+    public function testReturnsEmptyLabelsWhenChartDataInvalid(): void
+    {
+        $query = $this->query('month');
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 0,
+            rows: [],
+            chartData: ['labels' => null],
+        );
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertSame([], $reduced->labels);
+    }
+
     private function query(string $primary, ?string $series = null): AnalysisQuery
     {
         return new AnalysisQuery(

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartRecommendationServiceTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartRecommendationServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartRecommendationService;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisChartRecommendationServiceTest extends TestCase
+{
+    private GenericAnalysisChartRecommendationService $service;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
+
+        $this->service = new GenericAnalysisChartRecommendationService(
+            new DimensionRegistry(),
+            $translator,
+        );
+    }
+
+    public function testEmptyDataHasNoChart(): void
+    {
+        $query = $this->query('month');
+        $result = $this->normalizedResult(grandTotal: 0, chartData: ['labels' => [], 'values' => []]);
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertFalse($recommendation->hasChart);
+        self::assertSame('empty_data', $recommendation->reason);
+        self::assertSame([], $recommendation->allowedChartTypes);
+    }
+
+    public function testAllocationsByMonthRecommendsBarAndLine(): void
+    {
+        $query = $this->query('month');
+        $result = $this->normalizedResult(
+            chartData: [
+                'type' => 'bar',
+                'labels' => ['Jan', 'Feb'],
+                'values' => [10, 5],
+            ],
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertTrue($recommendation->hasChart);
+        self::assertSame(GenericAnalysisChartType::Bar, $recommendation->defaultChartType);
+        self::assertContains(GenericAnalysisChartType::Bar, $recommendation->allowedChartTypes);
+        self::assertContains(GenericAnalysisChartType::Line, $recommendation->allowedChartTypes);
+        self::assertSame('temporal_no_series', $recommendation->reason);
+    }
+
+    public function testUrgencyByMonthRecommendsStackedBar(): void
+    {
+        $query = $this->query('month', 'urgency');
+        $result = $this->normalizedResult(
+            chartData: [
+                'type' => 'bar',
+                'labels' => ['Jan', 'Feb'],
+                'series' => [
+                    ['name' => 'U1', 'data' => [5, 3]],
+                    ['name' => 'U2', 'data' => [2, 1]],
+                ],
+            ],
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 5, 50.0, 62.5, '1', 'U1'),
+                new EnrichedAnalysisRow('1', 'Jan', 3, 30.0, 37.5, '2', 'U2'),
+            ],
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertTrue($recommendation->hasChart);
+        self::assertSame(GenericAnalysisChartType::StackedBar, $recommendation->defaultChartType);
+        self::assertContains(GenericAnalysisChartType::GroupedBar, $recommendation->allowedChartTypes);
+        self::assertContains(GenericAnalysisChartType::PercentStackedBar, $recommendation->allowedChartTypes);
+        self::assertSame('temporal_with_series', $recommendation->reason);
+    }
+
+    public function testGenderDistributionDefersPie(): void
+    {
+        $query = $this->query('gender');
+        $result = $this->normalizedResult(
+            chartData: [
+                'type' => 'pie',
+                'labels' => ['Male', 'Female'],
+                'values' => [10, 8],
+            ],
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertTrue($recommendation->hasChart);
+        self::assertSame(GenericAnalysisChartType::Bar, $recommendation->defaultChartType);
+        self::assertContains('stats.generic_analysis.chart.warning.pie_deferred', $recommendation->warnings);
+    }
+
+    public function testAgeDimensionHasNoApexChart(): void
+    {
+        $query = $this->query('age');
+        $result = $this->normalizedResult(
+            chartData: [
+                'type' => 'histogram',
+                'labels' => ['30'],
+                'values' => [5],
+            ],
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertFalse($recommendation->hasChart);
+        self::assertSame(GenericAnalysisChartType::Table, $recommendation->defaultChartType);
+        self::assertContains('stats.generic_analysis.chart.warning.numeric_dimension', $recommendation->warnings);
+    }
+
+    public function testManySeriesAddsWarning(): void
+    {
+        $series = [];
+        $rows = [];
+        for ($i = 1; $i <= 10; ++$i) {
+            $series[] = ['name' => 'S'.$i, 'data' => [1]];
+            $rows[] = new EnrichedAnalysisRow('1', 'Jan', 1, 10.0, 10.0, (string) $i, 'S'.$i);
+        }
+
+        $query = $this->query('month', 'urgency');
+        $result = $this->normalizedResult(
+            chartData: [
+                'labels' => ['Jan'],
+                'series' => $series,
+            ],
+            rows: $rows,
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertContains('stats.generic_analysis.chart.warning.many_series', $recommendation->warnings);
+    }
+
+    public function testHourWithWeekdaySeriesRecommendsHeatmapPlaceholder(): void
+    {
+        $query = $this->query('hour', 'weekday');
+        $result = $this->normalizedResult(
+            chartData: [
+                'labels' => ['0', '1'],
+                'series' => [['name' => 'Monday', 'data' => [1, 2]]],
+            ],
+        );
+
+        $recommendation = $this->service->recommend($query, $result);
+
+        self::assertFalse($recommendation->hasChart);
+        self::assertSame(GenericAnalysisChartType::Heatmap, $recommendation->defaultChartType);
+        self::assertContains('stats.generic_analysis.chart.warning.heatmap_not_implemented', $recommendation->warnings);
+    }
+
+    private function query(string $primary, ?string $series = null): AnalysisQuery
+    {
+        return new AnalysisQuery(
+            primaryDimensionKey: $primary,
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: $series,
+        );
+    }
+
+    /**
+     * @param array<string, mixed>      $chartData
+     * @param list<EnrichedAnalysisRow> $rows
+     */
+    private function normalizedResult(
+        int $grandTotal = 15,
+        array $chartData = [],
+        array $rows = [],
+    ): NormalizedAnalysisResult {
+        return new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Primary',
+            seriesDimensionLabel: null,
+            grandTotal: $grandTotal,
+            rows: $rows,
+            chartData: $chartData,
+        );
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartRecommendationServiceTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartRecommendationServiceTest.php
@@ -148,6 +148,57 @@ final class GenericAnalysisChartRecommendationServiceTest extends TestCase
         self::assertContains('stats.generic_analysis.chart.warning.many_series', $recommendation->warnings);
     }
 
+    public function testManyBucketsAddsHorizontalBarForTemporal(): void
+    {
+        $labels = [];
+        $values = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $labels[] = 'Bucket '.$i;
+            $values[] = $i;
+        }
+
+        $recommendation = $this->service->recommend(
+            $this->query('month'),
+            $this->normalizedResult(chartData: ['labels' => $labels, 'values' => $values]),
+        );
+
+        self::assertContains(GenericAnalysisChartType::HorizontalBar, $recommendation->allowedChartTypes);
+        self::assertContains('stats.generic_analysis.chart.warning.many_buckets', $recommendation->warnings);
+    }
+
+    public function testCategoricalWithSeriesRecommendation(): void
+    {
+        $recommendation = $this->service->recommend(
+            $this->query('hospital', 'urgency'),
+            $this->normalizedResult(
+                chartData: [
+                    'labels' => ['H1'],
+                    'series' => [['name' => 'U1', 'data' => [5]]],
+                ],
+            ),
+        );
+
+        self::assertTrue($recommendation->hasChart);
+        self::assertSame('categorical_with_series', $recommendation->reason);
+        self::assertContains(GenericAnalysisChartType::StackedBar, $recommendation->allowedChartTypes);
+        self::assertSame(GenericAnalysisChartType::StackedBar, $recommendation->defaultChartType);
+    }
+
+    public function testSeriesCountFromChartDataWhenRowsEmpty(): void
+    {
+        $recommendation = $this->service->recommend(
+            $this->query('month', 'urgency'),
+            $this->normalizedResult(
+                chartData: [
+                    'labels' => ['Jan'],
+                    'series' => [['name' => 'U1', 'data' => [1]], ['name' => 'U2', 'data' => [2]]],
+                ],
+            ),
+        );
+
+        self::assertTrue($recommendation->hasChart);
+    }
+
     public function testHourWithWeekdaySeriesRecommendsHeatmapPlaceholder(): void
     {
         $query = $this->query('hour', 'weekday');

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartDataReducer;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartSpecBuilder;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisChartSpecBuilderTest extends TestCase
+{
+    private GenericAnalysisChartSpecBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('Other');
+
+        $this->builder = new GenericAnalysisChartSpecBuilder(
+            new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator),
+        );
+    }
+
+    public function testBarSpecMapsValuesToCounts(): void
+    {
+        $query = $this->query('month');
+        $result = new NormalizedAnalysisResult(
+            title: 'By month',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 15,
+            rows: [],
+            chartData: [
+                'type' => 'bar',
+                'labels' => ['Jan', 'Feb'],
+                'values' => [10, 5],
+            ],
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::Bar, $query, $result);
+
+        self::assertNotNull($spec);
+        self::assertSame('bar', $spec['chartType']);
+        self::assertSame(['Jan', 'Feb'], $spec['labels']);
+        self::assertSame([10, 5], $spec['counts']);
+    }
+
+    public function testGroupedBarSpecSetsBarGrouped(): void
+    {
+        $query = $this->query('month', 'urgency');
+        $result = new NormalizedAnalysisResult(
+            title: 'Urgency by month',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 8,
+            rows: [],
+            chartData: [
+                'labels' => ['Jan'],
+                'series' => [['name' => 'U1', 'data' => [5]]],
+            ],
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::GroupedBar, $query, $result);
+
+        self::assertNotNull($spec);
+        self::assertTrue($spec['barGrouped']);
+    }
+
+    public function testPercentStackedUsesReducedCounts(): void
+    {
+        $query = $this->query('month', 'urgency');
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 8,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 5, 62.5, 62.5, '1', 'U1'),
+                new EnrichedAnalysisRow('1', 'Jan', 3, 37.5, 37.5, '2', 'U2'),
+            ],
+            chartData: [
+                'labels' => ['Jan'],
+                'series' => [
+                    ['name' => 'U1', 'data' => [5]],
+                    ['name' => 'U2', 'data' => [3]],
+                ],
+            ],
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::PercentStackedBar, $query, $result);
+
+        self::assertNotNull($spec);
+        self::assertTrue($spec['percentScale']);
+        self::assertEqualsWithDelta(62.5, $spec['series'][0]['data'][0], 0.01);
+        self::assertEqualsWithDelta(37.5, $spec['series'][1]['data'][0], 0.01);
+    }
+
+    public function testManyHospitalsAreReducedInChartSpec(): void
+    {
+        $query = $this->query('hospital');
+        $labels = [];
+        $values = [];
+        for ($i = 1; $i <= 8; ++$i) {
+            $labels[] = 'Hospital '.$i;
+            $values[] = 100 - $i;
+        }
+        $result = new NormalizedAnalysisResult(
+            title: 'By hospital',
+            primaryDimensionLabel: 'Hospital',
+            seriesDimensionLabel: null,
+            grandTotal: array_sum($values),
+            rows: [],
+            chartData: ['labels' => $labels, 'values' => $values],
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::Bar, $query, $result);
+
+        self::assertNotNull($spec);
+        self::assertCount(6, $spec['labels']);
+        self::assertSame('Other', $spec['labels'][5]);
+    }
+
+    private function query(string $primary, ?string $series = null): AnalysisQuery
+    {
+        return new AnalysisQuery(
+            primaryDimensionKey: $primary,
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            seriesDimensionKey: $series,
+        );
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
@@ -104,6 +104,78 @@ final class GenericAnalysisChartSpecBuilderTest extends TestCase
         self::assertEqualsWithDelta(37.5, $spec['series'][1]['data'][0], 0.01);
     }
 
+    public function testBuildsStackedLineAndHorizontalSpecs(): void
+    {
+        $query = $this->query('month', 'urgency');
+        $result = new NormalizedAnalysisResult(
+            title: 'Urgency by month',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 8,
+            rows: [],
+            chartData: [
+                'labels' => ['Jan'],
+                'series' => [
+                    ['name' => 'U1', 'data' => [5]],
+                    ['name' => 'U2', 'data' => [3]],
+                ],
+            ],
+        );
+
+        $stacked = $this->builder->buildSpec(GenericAnalysisChartType::StackedBar, $query, $result);
+        $line = $this->builder->buildSpec(GenericAnalysisChartType::Line, $query, $result);
+        $horizontal = $this->builder->buildSpec(GenericAnalysisChartType::HorizontalBar, $query, $result);
+
+        self::assertSame('bar', $stacked['chartType']);
+        self::assertSame('line', $line['chartType']);
+        self::assertTrue($horizontal['horizontal']);
+    }
+
+    public function testBuildSpecsForTypesSkipsUnsupported(): void
+    {
+        $query = $this->query('month');
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 5,
+            rows: [],
+            chartData: ['labels' => ['Jan'], 'values' => [5]],
+        );
+
+        $specs = $this->builder->buildSpecsForTypes(
+            [
+                GenericAnalysisChartType::Bar,
+                GenericAnalysisChartType::Table,
+                GenericAnalysisChartType::Heatmap,
+            ],
+            $query,
+            $result,
+        );
+
+        self::assertArrayHasKey('bar', $specs);
+        self::assertArrayNotHasKey('table', $specs);
+        self::assertArrayNotHasKey('heatmap', $specs);
+    }
+
+    public function testPercentStackedFallsBackToBarWithoutSeries(): void
+    {
+        $query = $this->query('month');
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 5,
+            rows: [],
+            chartData: ['labels' => ['Jan'], 'values' => [5]],
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::PercentStackedBar, $query, $result);
+
+        self::assertSame('bar', $spec['chartType']);
+        self::assertArrayHasKey('counts', $spec);
+    }
+
     public function testManyHospitalsAreReducedInChartSpec(): void
     {
         $query = $this->query('hospital');

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
@@ -86,4 +86,33 @@ final class GenericAnalysisChartViewModelFactoryTest extends TestCase
         self::assertFalse($viewModel->hasChart);
         self::assertNull($viewModel->initialSpec);
     }
+
+    public function testUrgencyByMonthIncludesTopLimitedWarningWhenManyHospitals(): void
+    {
+        $labels = [];
+        $values = [];
+        for ($i = 1; $i <= 8; ++$i) {
+            $labels[] = 'Hospital '.$i;
+            $values[] = 100 - $i;
+        }
+
+        $viewModel = $this->factory->create(
+            new AnalysisQuery(
+                primaryDimensionKey: 'hospital',
+                scopeCriteria: StatisticsScopeCriteria::public(),
+                periodBounds: new StatisticsPeriodBounds(null),
+            ),
+            new NormalizedAnalysisResult(
+                title: 'By hospital',
+                primaryDimensionLabel: 'Hospital',
+                seriesDimensionLabel: null,
+                grandTotal: array_sum($values),
+                rows: [],
+                chartData: ['labels' => $labels, 'values' => $values],
+            ),
+        );
+
+        self::assertTrue($viewModel->hasChart);
+        self::assertStringContainsString('top_limited', $viewModel->warnings[0]);
+    }
 }

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartDataReducer;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartRecommendationService;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartSpecBuilder;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\UI\Http\Controller\GenericAnalysisChartViewModelFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisChartViewModelFactoryTest extends TestCase
+{
+    private GenericAnalysisChartViewModelFactory $factory;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $params = []): string => [] === $params ? $id : $id.'|'.json_encode($params),
+        );
+
+        $reducer = new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator);
+        $this->factory = new GenericAnalysisChartViewModelFactory(
+            new GenericAnalysisChartRecommendationService(new DimensionRegistry(), $translator),
+            new GenericAnalysisChartSpecBuilder($reducer),
+            $reducer,
+            $translator,
+        );
+    }
+
+    public function testAllocationsByMonthHasBarSpec(): void
+    {
+        $query = new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+        );
+        $result = new NormalizedAnalysisResult(
+            title: 'Allocations by month',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 15,
+            rows: [],
+            chartData: [
+                'type' => 'bar',
+                'labels' => ['Jan', 'Feb'],
+                'values' => [10, 5],
+            ],
+        );
+
+        $viewModel = $this->factory->create($query, $result);
+
+        self::assertTrue($viewModel->hasChart);
+        self::assertSame('bar', $viewModel->defaultChartType);
+        self::assertNotNull($viewModel->initialSpec);
+        self::assertArrayHasKey('bar', $viewModel->specsByChartType);
+        self::assertTrue($viewModel->showChartTypeSelector);
+    }
+
+    public function testEmptyResultShowsEmptyState(): void
+    {
+        $query = new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+        );
+        $result = new NormalizedAnalysisResult(
+            title: 'Allocations by month',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 0,
+            rows: [],
+            chartData: ['labels' => [], 'values' => []],
+        );
+
+        $viewModel = $this->factory->create($query, $result);
+
+        self::assertFalse($viewModel->hasChart);
+        self::assertNull($viewModel->initialSpec);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisConfigResolverTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisConfigResolverTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\AnalysisPresetRegistry;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisConfigResolver;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisDimensionPolicy;
+use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisDimensionException;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisConfigResolverTest extends TestCase
+{
+    private GenericAnalysisConfigResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('Custom analysis');
+
+        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(true);
+
+        $this->resolver = new GenericAnalysisConfigResolver(
+            new AnalysisPresetRegistry(),
+            new DimensionRegistry(),
+            new GenericAnalysisDimensionPolicy($hospitalAccess),
+            $translator,
+        );
+    }
+
+    private function publicFilter(): StatisticsFilter
+    {
+        return new StatisticsFilter(
+            StatisticsFilterScope::Public,
+            null,
+            null,
+            StatisticsFilterPeriod::All,
+        );
+    }
+
+    public function testResolvesPresetWithoutOverrides(): void
+    {
+        $request = Request::create('/statistics/generic-analysis/allocations_by_month', Request::METHOD_GET, [
+            'scope' => 'public',
+        ]);
+
+        $config = $this->resolver->resolve(
+            'allocations_by_month',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+
+        self::assertFalse($config->isCustom);
+        self::assertSame('month', $config->primaryDimensionKey);
+        self::assertSame('Allocations by month', $config->displayTitle);
+    }
+
+    public function testResolvesCustomWhenOverridesDiffer(): void
+    {
+        $request = Request::create('/statistics/generic-analysis/allocations_by_month', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::PRIMARY => 'hour',
+        ]);
+
+        $config = $this->resolver->resolve(
+            'allocations_by_month',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+
+        self::assertTrue($config->isCustom);
+        self::assertSame('hour', $config->primaryDimensionKey);
+        self::assertSame('allocations_by_month', $config->referencePresetKey);
+    }
+
+    public function testCustomRouteUsesQueryDimensions(): void
+    {
+        $request = Request::create('/statistics/generic-analysis/custom', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::PRIMARY => 'weekday',
+            GenericAnalysisQueryKeys::REF_PRESET => 'allocations_by_hour',
+        ]);
+
+        $config = $this->resolver->resolve(
+            'custom',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+
+        self::assertTrue($config->isCustom);
+        self::assertSame('weekday', $config->primaryDimensionKey);
+        self::assertSame('allocations_by_hour', $config->referencePresetKey);
+    }
+
+    public function testUnknownDimensionThrows(): void
+    {
+        $request = Request::create('/statistics/generic-analysis/custom', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::PRIMARY => 'evil',
+        ]);
+
+        $this->expectException(UnknownAnalysisDimensionException::class);
+
+        $this->resolver->resolve(
+            'custom',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+    }
+
+    public function testDisallowedDimensionForScopeThrows(): void
+    {
+        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
+
+        $resolver = new GenericAnalysisConfigResolver(
+            new AnalysisPresetRegistry(),
+            new DimensionRegistry(),
+            new GenericAnalysisDimensionPolicy($hospitalAccess),
+            $this->createMock(TranslatorInterface::class),
+        );
+
+        $request = Request::create('/statistics/generic-analysis/custom', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::PRIMARY => 'hospital',
+        ]);
+
+        $this->expectException(UnknownAnalysisDimensionException::class);
+
+        $resolver->resolve(
+            'custom',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+    }
+
+    public function testFindMatchingSelectablePreset(): void
+    {
+        $match = $this->resolver->findMatchingSelectablePreset('month', null, false);
+
+        self::assertNotNull($match);
+        self::assertSame('allocations_by_month', $match->key);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisDimensionPolicyTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisDimensionPolicyTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\Cohort\HospitalCohortType;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisDimensionPolicy;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class GenericAnalysisDimensionPolicyTest extends TestCase
+{
+    private GenericAnalysisDimensionPolicy $policy;
+
+    private \PHPUnit\Framework\MockObject\MockObject $hospitalAccess;
+
+    protected function setUp(): void
+    {
+        $this->hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $this->policy = new GenericAnalysisDimensionPolicy($this->hospitalAccess);
+    }
+
+    public function testPublicScopeDisallowsHospitalForParticipant(): void
+    {
+        $user = $this->createMock(User::class);
+        $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
+
+        self::assertFalse($this->policy->isAllowed(
+            'hospital',
+            $this->filter(StatisticsFilterScope::Public),
+            $user,
+        ));
+    }
+
+    public function testCohortScopeAllowsHospitalForParticipant(): void
+    {
+        $user = $this->createMock(User::class);
+        $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
+
+        self::assertTrue($this->policy->isAllowed(
+            'hospital',
+            $this->filter(StatisticsFilterScope::HospitalCohort, cohortType: HospitalCohortType::RuralBasic),
+            $user,
+        ));
+    }
+
+    public function testAdminAllowsHospitalOnPublicScope(): void
+    {
+        $user = $this->createMock(User::class);
+        $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(true);
+
+        self::assertTrue($this->policy->isAllowed(
+            'hospital',
+            $this->filter(StatisticsFilterScope::Public),
+            $user,
+        ));
+    }
+
+    public function testStateDimensionRequiresStateScope(): void
+    {
+        $user = $this->createMock(User::class);
+        $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
+
+        self::assertFalse($this->policy->isAllowed(
+            'state',
+            $this->filter(StatisticsFilterScope::Public),
+            $user,
+        ));
+        self::assertTrue($this->policy->isAllowed(
+            'state',
+            $this->filter(StatisticsFilterScope::State, stateId: 1),
+            $user,
+        ));
+    }
+
+    public function testHospitalCohortDimensionAlwaysAllowed(): void
+    {
+        self::assertTrue($this->policy->isAllowed(
+            'hospital_cohort',
+            $this->filter(StatisticsFilterScope::Public),
+            null,
+        ));
+    }
+
+    private function filter(
+        StatisticsFilterScope $scope,
+        ?HospitalCohortType $cohortType = null,
+        ?int $stateId = null,
+        ?int $dispatchAreaId = null,
+    ): StatisticsFilter {
+        return new StatisticsFilter(
+            $scope,
+            null,
+            $cohortType,
+            StatisticsFilterPeriod::All,
+            stateId: $stateId,
+            dispatchAreaId: $dispatchAreaId,
+        );
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisEntityLabelResolverTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisEntityLabelResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisEntityLabelResolver;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class GenericAnalysisEntityLabelResolverTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private GenericAnalysisEntityLabelResolver $resolver;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        UserFactory::createOne();
+        $this->resolver = self::getContainer()->get(GenericAnalysisEntityLabelResolver::class);
+    }
+
+    public function testSupportsEntityDimensions(): void
+    {
+        self::assertTrue($this->resolver->supports('hospital'));
+        self::assertTrue($this->resolver->supports('state'));
+        self::assertFalse($this->resolver->supports('month'));
+    }
+
+    public function testResolveHospitalUsesLookup(): void
+    {
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['name' => 'Resolver Hospital']);
+
+        self::assertSame(
+            [(int) $hospital->getId() => 'Resolver Hospital'],
+            $this->resolver->resolve('hospital', [(int) $hospital->getId()]),
+        );
+    }
+
+    public function testResolveStateReturnsNames(): void
+    {
+        $state = StateFactory::createOne(['name' => 'Resolver State', 'createdBy' => UserFactory::random()]);
+
+        self::assertSame(
+            [(int) $state->getId() => 'Resolver State'],
+            $this->resolver->resolve('state', [(int) $state->getId()]),
+        );
+    }
+
+    public function testResolveEmptyIdsReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->resolver->resolve('hospital', []));
+    }
+
+    public function testResolveUnknownDimensionReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->resolver->resolve('month', [1]));
+    }
+
+    public function testResolveUnknownIdIsOmitted(): void
+    {
+        self::assertSame([], $this->resolver->resolve('hospital', [9_999_999]));
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisPageViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisPageViewModelFactoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\AnalysisPresetRegistry;
+use App\Statistics\GenericAnalysis\Application\DTO\ResolvedGenericAnalysisConfig;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisConfigResolver;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisDimensionPolicy;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\UI\Http\Controller\GenericAnalysisPageViewModelFactory;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisPageViewModelFactoryTest extends TestCase
+{
+    private GenericAnalysisPageViewModelFactory $factory;
+
+    protected function setUp(): void
+    {
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static function (string $name, array $params = []): string {
+                $presetKey = $params['presetKey'] ?? '';
+                unset($params['presetKey']);
+                $query = http_build_query($params);
+
+                return '/statistics/generic-analysis/'.$presetKey.('' !== $query ? '?'.$query : '');
+            },
+        );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(true);
+
+        $this->factory = new GenericAnalysisPageViewModelFactory(
+            new AnalysisPresetRegistry(),
+            new DimensionRegistry(),
+            new GenericAnalysisDimensionPolicy($hospitalAccess),
+            new StatisticsNavigationUrlBuilder($router),
+            $router,
+            $translator,
+        );
+    }
+
+    private function publicFilter(): StatisticsFilter
+    {
+        return new StatisticsFilter(
+            StatisticsFilterScope::Public,
+            null,
+            null,
+            StatisticsFilterPeriod::All,
+        );
+    }
+
+    public function testPresetMenuUrlRemovesCustomQueryKeys(): void
+    {
+        $request = Request::create(
+            '/statistics/generic-analysis/custom',
+            Request::METHOD_GET,
+            [
+                'scope' => 'public',
+                GenericAnalysisQueryKeys::PRIMARY => 'hour',
+                GenericAnalysisQueryKeys::SERIES => 'urgency',
+            ],
+            [
+                'presetKey' => 'custom',
+                '_route' => 'app_stats_generic_analysis',
+                '_route_params' => ['presetKey' => 'custom'],
+            ],
+        );
+
+        $config = $this->resolvedConfig('hour', 'urgency');
+        $viewModel = $this->factory->create($request, 'custom', $config, $this->publicFilter(), null);
+
+        $monthItem = array_values(array_filter(
+            $viewModel->presetMenu,
+            static fn (array $item): bool => 'allocations_by_month' === $item['key'],
+        ))[0];
+
+        self::assertStringContainsString('/statistics/generic-analysis/allocations_by_month', $monthItem['url']);
+        self::assertStringNotContainsString('ga_primary', $monthItem['url']);
+        self::assertStringContainsString('scope=public', $monthItem['url']);
+    }
+
+    public function testCustomFormActionUsesCustomRoute(): void
+    {
+        $request = Request::create(
+            '/statistics/generic-analysis/allocations_by_month',
+            Request::METHOD_GET,
+            ['scope' => 'public'],
+            [
+                'presetKey' => 'allocations_by_month',
+                '_route_params' => ['presetKey' => 'allocations_by_month'],
+            ],
+        );
+
+        $config = $this->resolvedConfig('month', null);
+        $viewModel = $this->factory->create($request, 'allocations_by_month', $config, $this->publicFilter(), null);
+
+        self::assertSame('/statistics/generic-analysis/custom', $viewModel->customFormAction);
+    }
+
+    private function resolvedConfig(
+        string $primary,
+        ?string $series,
+    ): ResolvedGenericAnalysisConfig {
+        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(true);
+
+        $resolver = new GenericAnalysisConfigResolver(
+            new AnalysisPresetRegistry(),
+            new DimensionRegistry(),
+            new GenericAnalysisDimensionPolicy($hospitalAccess),
+            $this->createMock(TranslatorInterface::class),
+        );
+
+        $request = Request::create('/statistics/generic-analysis/custom', Request::METHOD_GET, array_filter([
+            GenericAnalysisQueryKeys::PRIMARY => $primary,
+            GenericAnalysisQueryKeys::SERIES => $series,
+        ]));
+
+        return $resolver->resolve(
+            'custom',
+            $request,
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            $this->publicFilter(),
+            null,
+        );
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisServiceTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisService;
+use App\Statistics\GenericAnalysis\Application\RelativeDistributionCalculator;
+use App\Statistics\GenericAnalysis\Application\ResultNormalizer;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisPreset;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisSqlBuilder;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAnalysisScopeSqlFilter;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class GenericAnalysisServiceTest extends TestCase
+{
+    public function testRunReturnsNormalizedResultFromQuery(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result->method('fetchAllAssociative')->willReturn([
+            ['bucket' => 6, 'value' => 4],
+        ]);
+        $connection->method('executeQuery')->willReturn($result);
+
+        $service = new GenericAnalysisService(
+            new GenericAllocationAnalysisQuery(
+                $connection,
+                new GenericAllocationAnalysisSqlBuilder(
+                    new DimensionRegistry(),
+                    new GenericAnalysisScopeSqlFilter(),
+                ),
+            ),
+            new RelativeDistributionCalculator(),
+            $this->createResultNormalizer(),
+        );
+
+        $normalized = $service->run('Allocations by month', new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertSame('Allocations by month', $normalized->title);
+        self::assertSame(4, $normalized->grandTotal);
+        self::assertNotEmpty($normalized->chartData['labels'] ?? []);
+    }
+
+    public function testRunPresetUsesPresetTitle(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('executeQuery')->willReturn(
+            $this->createMock(\Doctrine\DBAL\Result::class),
+        );
+
+        $service = new GenericAnalysisService(
+            new GenericAllocationAnalysisQuery(
+                $connection,
+                new GenericAllocationAnalysisSqlBuilder(
+                    new DimensionRegistry(),
+                    new GenericAnalysisScopeSqlFilter(),
+                ),
+            ),
+            new RelativeDistributionCalculator(),
+            $this->createResultNormalizer(),
+        );
+
+        $normalized = $service->runPreset(
+            new AnalysisPreset(key: 'allocations_by_month', title: 'Allocations by month', primaryDimensionKey: 'month'),
+            new AnalysisQuery(
+                primaryDimensionKey: 'month',
+                scopeCriteria: StatisticsScopeCriteria::public(),
+                periodBounds: new StatisticsPeriodBounds(null),
+            ),
+        );
+
+        self::assertSame('Allocations by month', $normalized->title);
+    }
+
+    private function createResultNormalizer(): ResultNormalizer
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver->method('supports')->willReturn(false);
+
+        return new ResultNormalizer(new DimensionRegistry(), $translator, $entityLabelResolver);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisTableViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisTableViewModelFactoryTest.php
@@ -18,6 +18,7 @@ final class GenericAnalysisTableViewModelFactoryTest extends TestCase
 {
     private GenericAnalysisTableViewModelFactory $factory;
 
+    #[\Override]
     protected function setUp(): void
     {
         $router = $this->createMock(UrlGeneratorInterface::class);
@@ -110,6 +111,38 @@ final class GenericAnalysisTableViewModelFactoryTest extends TestCase
         self::assertStringContainsString('ga_layout=grouped', $viewModel->groupedLayoutUrl);
         self::assertStringContainsString('ga_layout=stacked', $viewModel->stackedLayoutUrl);
         self::assertStringContainsString('scope=public', $viewModel->groupedLayoutUrl);
+    }
+
+    public function testGroupedLayoutWithNumericBucketAndSeriesKeys(): void
+    {
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 8,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 5, 62.5, 62.5, '1', 'U1'),
+                new EnrichedAnalysisRow('1', 'Jan', 3, 37.5, 37.5, '2', 'U2'),
+                new EnrichedAnalysisRow('2', 'Feb', 8, 100.0, 100.0, '1', 'U1'),
+            ],
+            chartData: [],
+        );
+
+        $request = Request::create('/statistics/generic-analysis/custom', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::LAYOUT => 'grouped',
+        ]);
+
+        $viewModel = $this->factory->create($request, 'custom', $result);
+
+        self::assertTrue($viewModel->isGrouped());
+        self::assertCount(2, $viewModel->groupedRows);
+        self::assertSame('1', $viewModel->groupedRows[0]->bucketKey);
+        self::assertIsString($viewModel->groupedRows[0]->bucketKey);
+        self::assertCount(2, $viewModel->seriesColumns);
+        $firstSeriesKey = $viewModel->seriesColumns[0]['key'];
+        $secondSeriesKey = $viewModel->seriesColumns[1]['key'];
+        self::assertSame(5, $viewModel->groupedRows[0]->cellsBySeriesKey[$firstSeriesKey]?->value);
+        self::assertSame(3, $viewModel->groupedRows[0]->cellsBySeriesKey[$secondSeriesKey]?->value);
     }
 
     public function testFooterTotalsSumRowsAndPercentOfGrandTotal(): void

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisTableViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisTableViewModelFactoryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow;
+use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
+use App\Statistics\GenericAnalysis\Application\GenericAnalysisTableLayout;
+use App\Statistics\GenericAnalysis\UI\Http\Controller\GenericAnalysisTableViewModelFactory;
+use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
+use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class GenericAnalysisTableViewModelFactoryTest extends TestCase
+{
+    private GenericAnalysisTableViewModelFactory $factory;
+
+    protected function setUp(): void
+    {
+        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static function (string $name, array $params = []): string {
+                $presetKey = $params['presetKey'] ?? '';
+                unset($params['presetKey']);
+                $query = http_build_query($params);
+
+                return '/statistics/generic-analysis/'.$presetKey.('' !== $query ? '?'.$query : '');
+            },
+        );
+
+        $this->factory = new GenericAnalysisTableViewModelFactory(
+            new StatisticsNavigationUrlBuilder($router),
+        );
+    }
+
+    public function testGroupedLayoutPivotsSeriesIntoOneRowPerBucket(): void
+    {
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 15,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 10, 66.67, 66.67, 'u1', 'U1'),
+                new EnrichedAnalysisRow('1', 'Jan', 5, 33.33, 33.33, 'u2', 'U2'),
+                new EnrichedAnalysisRow('2', 'Feb', 3, 100.0, 100.0, 'u1', 'U1'),
+            ],
+            chartData: [],
+        );
+
+        $request = Request::create('/statistics/generic-analysis/urgency_by_month', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::LAYOUT => 'grouped',
+        ]);
+
+        $viewModel = $this->factory->create($request, 'urgency_by_month', $result);
+
+        self::assertTrue($viewModel->isGrouped());
+        self::assertCount(2, $viewModel->groupedRows);
+        self::assertSame(15, $viewModel->groupedRows[0]->bucketTotal);
+        self::assertSame(10, $viewModel->groupedRows[0]->cellsBySeriesKey['u1']?->value);
+        self::assertSame(5, $viewModel->groupedRows[0]->cellsBySeriesKey['u2']?->value);
+    }
+
+    public function testWithoutSeriesAlwaysUsesStackedLayout(): void
+    {
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: null,
+            grandTotal: 10,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 10, 100.0, 100.0),
+            ],
+            chartData: [],
+        );
+
+        $request = Request::create('/statistics/generic-analysis/allocations_by_month', Request::METHOD_GET, [
+            GenericAnalysisQueryKeys::LAYOUT => 'grouped',
+        ]);
+
+        $viewModel = $this->factory->create($request, 'allocations_by_month', $result);
+
+        self::assertFalse($viewModel->supportsGroupedLayout);
+        self::assertFalse($viewModel->isGrouped());
+        self::assertSame(GenericAnalysisTableLayout::Stacked, $viewModel->layout);
+    }
+
+    public function testLayoutToggleUrlsPreserveQueryParameter(): void
+    {
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 1,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 1, 100.0, 100.0, 'u1', 'U1'),
+            ],
+            chartData: [],
+        );
+
+        $request = Request::create('/statistics/generic-analysis/urgency_by_month', Request::METHOD_GET, [
+            'scope' => 'public',
+        ]);
+
+        $viewModel = $this->factory->create($request, 'urgency_by_month', $result);
+
+        self::assertStringContainsString('ga_layout=grouped', $viewModel->groupedLayoutUrl);
+        self::assertStringContainsString('ga_layout=stacked', $viewModel->stackedLayoutUrl);
+        self::assertStringContainsString('scope=public', $viewModel->groupedLayoutUrl);
+    }
+
+    public function testFooterTotalsSumRowsAndPercentOfGrandTotal(): void
+    {
+        $result = new NormalizedAnalysisResult(
+            title: 'Test',
+            primaryDimensionLabel: 'Month',
+            seriesDimensionLabel: 'Urgency',
+            grandTotal: 15,
+            rows: [
+                new EnrichedAnalysisRow('1', 'Jan', 10, 66.67, 66.67, 'u1', 'U1'),
+                new EnrichedAnalysisRow('1', 'Jan', 5, 33.33, 33.33, 'u2', 'U2'),
+            ],
+            chartData: [],
+        );
+
+        $request = Request::create('/statistics/generic-analysis/urgency_by_month', Request::METHOD_GET);
+
+        $viewModel = $this->factory->create($request, 'urgency_by_month', $result);
+
+        self::assertSame(15, $viewModel->grandTotal);
+        self::assertSame(15, $viewModel->footerTotals->totalValue);
+        self::assertEqualsWithDelta(100.0, $viewModel->footerTotals->percentOfGrandTotal, 0.01);
+        self::assertSame(10, $viewModel->footerTotals->seriesCellsByKey['u1']->value);
+        self::assertEqualsWithDelta(66.67, $viewModel->footerTotals->seriesCellsByKey['u1']->percentOfGrandTotal, 0.1);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/RelativeDistributionCalculatorTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/RelativeDistributionCalculatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\GenericAnalysis\Application\RelativeDistributionCalculator;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResultRow;
+use PHPUnit\Framework\TestCase;
+
+final class RelativeDistributionCalculatorTest extends TestCase
+{
+    private RelativeDistributionCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new RelativeDistributionCalculator();
+    }
+
+    public function testPercentOfTotalAndPercentOfBucket(): void
+    {
+        $result = new AnalysisResult(
+            rows: [
+                new AnalysisResultRow(bucket: 1, value: 30, series: 'A'),
+                new AnalysisResultRow(bucket: 1, value: 70, series: 'B'),
+                new AnalysisResultRow(bucket: 2, value: 100, series: 'A'),
+            ],
+            grandTotal: 200,
+            primaryDimensionKey: 'month',
+            seriesDimensionKey: 'urgency',
+        );
+
+        $enriched = $this->calculator->enrich($result);
+
+        self::assertSame(15.0, $enriched[0]['percent_of_total']);
+        self::assertSame(30.0, $enriched[0]['percent_of_bucket']);
+        self::assertSame(35.0, $enriched[1]['percent_of_total']);
+        self::assertSame(70.0, $enriched[1]['percent_of_bucket']);
+        self::assertSame(50.0, $enriched[2]['percent_of_total']);
+        self::assertSame(100.0, $enriched[2]['percent_of_bucket']);
+    }
+}

--- a/tests/Statistics/Unit/GenericAnalysis/ResultNormalizerTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/ResultNormalizerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\GenericAnalysis;
+
+use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
+use App\Statistics\GenericAnalysis\Application\ResultNormalizer;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResult;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisResultRow;
+use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ResultNormalizerTest extends TestCase
+{
+    private ResultNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'stats.overview.hospital_summary.urgency_u1' => 'U1',
+                'stats.overview.hospital_summary.urgency_u2' => 'U2',
+                'stats.overview.hospital_summary.urgency_u3' => 'U3',
+                default => $id,
+            },
+        );
+
+        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver->method('supports')->willReturn(false);
+
+        $this->normalizer = new ResultNormalizer(new DimensionRegistry(), $translator, $entityLabelResolver);
+    }
+
+    public function testHospitalDimensionUsesLookupNames(): void
+    {
+        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver->method('supports')->willReturnCallback(
+            static fn (string $key): bool => 'hospital' === $key,
+        );
+        $entityLabelResolver->method('resolve')->willReturnCallback(
+            static fn (string $key, array $ids): array => 'hospital' === $key ? [42 => 'Test Hospital'] : [],
+        );
+
+        $normalizer = new ResultNormalizer(
+            new DimensionRegistry(),
+            $this->createMock(TranslatorInterface::class),
+            $entityLabelResolver,
+        );
+
+        $result = new AnalysisResult(
+            rows: [new AnalysisResultRow(bucket: 42, value: 3)],
+            grandTotal: 3,
+            primaryDimensionKey: 'hospital',
+        );
+
+        $normalized = $normalizer->normalize($result, 'By hospital', [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 100.0,
+                'percent_of_bucket' => 100.0,
+            ],
+        ]);
+
+        self::assertSame('Test Hospital', $normalized->rows[0]->bucketLabel);
+    }
+
+    public function testDispatchAreaDimensionUsesEntityLabels(): void
+    {
+        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver->method('supports')->willReturnCallback(
+            static fn (string $key): bool => 'dispatchArea' === $key,
+        );
+        $entityLabelResolver->method('resolve')->willReturnCallback(
+            static fn (string $key, array $ids): array => 'dispatchArea' === $key ? [3 => 'North Region'] : [],
+        );
+
+        $normalizer = new ResultNormalizer(
+            new DimensionRegistry(),
+            $this->createMock(TranslatorInterface::class),
+            $entityLabelResolver,
+        );
+
+        $result = new AnalysisResult(
+            rows: [new AnalysisResultRow(bucket: 3, value: 8)],
+            grandTotal: 8,
+            primaryDimensionKey: 'dispatchArea',
+        );
+
+        $normalized = $normalizer->normalize($result, 'By dispatch area', [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 100.0,
+                'percent_of_bucket' => 100.0,
+            ],
+        ]);
+
+        self::assertSame('North Region', $normalized->rows[0]->bucketLabel);
+    }
+
+    public function testFillsMissingMonthBucketsWithZero(): void
+    {
+        $result = new AnalysisResult(
+            rows: [
+                new AnalysisResultRow(bucket: 3, value: 5),
+                new AnalysisResultRow(bucket: 6, value: 2),
+            ],
+            grandTotal: 7,
+            primaryDimensionKey: 'month',
+        );
+
+        $enriched = [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 71.43,
+                'percent_of_bucket' => 100.0,
+            ],
+            [
+                'row' => $result->rows[1],
+                'percent_of_total' => 28.57,
+                'percent_of_bucket' => 100.0,
+            ],
+        ];
+
+        $normalized = $this->normalizer->normalize($result, 'Test', $enriched);
+
+        self::assertCount(12, $normalized->rows);
+        self::assertSame(0, $normalized->rows[0]->value);
+        self::assertSame(5, $normalized->rows[2]->value);
+    }
+
+    public function testNormalizesWeekdayWithBooleanSeriesBuckets(): void
+    {
+        $result = new AnalysisResult(
+            rows: [
+                new AnalysisResultRow(bucket: 1, value: 10, series: 1),
+                new AnalysisResultRow(bucket: 1, value: 5, series: 0),
+                new AnalysisResultRow(bucket: 2, value: 3, series: 1),
+            ],
+            grandTotal: 18,
+            primaryDimensionKey: 'weekday',
+            seriesDimensionKey: 'resus',
+        );
+
+        $enriched = [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 55.56,
+                'percent_of_bucket' => 66.67,
+            ],
+            [
+                'row' => $result->rows[1],
+                'percent_of_total' => 27.78,
+                'percent_of_bucket' => 33.33,
+            ],
+            [
+                'row' => $result->rows[2],
+                'percent_of_total' => 16.67,
+                'percent_of_bucket' => 100.0,
+            ],
+        ];
+
+        $normalized = $this->normalizer->normalize($result, 'Test', $enriched);
+
+        self::assertGreaterThan(0, $normalized->grandTotal);
+        self::assertContains('Yes', array_map(
+            static fn (\App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow $row): ?string => $row->seriesLabel,
+            array_filter($normalized->rows, static fn (\App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow $row): bool => $row->value > 0),
+        ));
+    }
+
+    public function testUrgencySeriesUsesProjectTranslationKeys(): void
+    {
+        $result = new AnalysisResult(
+            rows: [
+                new AnalysisResultRow(bucket: 1, value: 5, series: 1),
+                new AnalysisResultRow(bucket: 1, value: 3, series: 2),
+            ],
+            grandTotal: 8,
+            primaryDimensionKey: 'month',
+            seriesDimensionKey: 'urgency',
+        );
+
+        $enriched = [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 62.5,
+                'percent_of_bucket' => 62.5,
+            ],
+            [
+                'row' => $result->rows[1],
+                'percent_of_total' => 37.5,
+                'percent_of_bucket' => 37.5,
+            ],
+        ];
+
+        $normalized = $this->normalizer->normalize($result, 'Test', $enriched);
+
+        $seriesLabels = array_values(array_unique(array_filter(array_map(
+            static fn (\App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow $row): ?string => $row->seriesLabel,
+            $normalized->rows,
+        ))));
+
+        self::assertSame(['U1', 'U2'], $seriesLabels);
+    }
+
+    public function testOmitsAgeGroupUnknownSeriesWhenNullBucketsDisabled(): void
+    {
+        $result = new AnalysisResult(
+            rows: [
+                new AnalysisResultRow(bucket: 1, value: 5, series: '0_18'),
+            ],
+            grandTotal: 5,
+            primaryDimensionKey: 'month',
+            seriesDimensionKey: 'age_group',
+            includeNullBuckets: false,
+        );
+
+        $enriched = [
+            [
+                'row' => $result->rows[0],
+                'percent_of_total' => 100.0,
+                'percent_of_bucket' => 100.0,
+            ],
+        ];
+
+        $normalized = $this->normalizer->normalize($result, 'Test', $enriched);
+
+        $seriesLabels = array_values(array_unique(array_filter(array_map(
+            static fn (\App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow $row): ?string => $row->seriesLabel,
+            $normalized->rows,
+        ))));
+
+        self::assertNotContains('Unknown', $seriesLabels);
+        self::assertNotContains('unknown', array_map(
+            static fn (\App\Statistics\GenericAnalysis\Application\DTO\EnrichedAnalysisRow $row): ?string => $row->seriesKey,
+            $normalized->rows,
+        ));
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3767,6 +3767,102 @@
         <source>stats.generic_analysis.chart_json_title</source>
         <target>Chart data (JSON)</target>
       </trans-unit>
+      <trans-unit id="statsGa24" resname="stats.generic_analysis.chart.empty">
+        <source>stats.generic_analysis.chart.empty</source>
+        <target>No chart data for the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsGa25" resname="stats.generic_analysis.chart.subtitle_with_series">
+        <source>stats.generic_analysis.chart.subtitle_with_series</source>
+        <target>{primary} by {series}</target>
+      </trans-unit>
+      <trans-unit id="statsGa26" resname="stats.generic_analysis.chart.y_axis_allocations">
+        <source>stats.generic_analysis.chart.y_axis_allocations</source>
+        <target>Allocations</target>
+      </trans-unit>
+      <trans-unit id="statsGa27" resname="stats.generic_analysis.chart.value_allocations">
+        <source>stats.generic_analysis.chart.value_allocations</source>
+        <target>Allocations</target>
+      </trans-unit>
+      <trans-unit id="statsGa28" resname="stats.generic_analysis.chart.type_selector_label">
+        <source>stats.generic_analysis.chart.type_selector_label</source>
+        <target>Chart type</target>
+      </trans-unit>
+      <trans-unit id="statsGa29" resname="stats.generic_analysis.chart.type.bar">
+        <source>stats.generic_analysis.chart.type.bar</source>
+        <target>Bar</target>
+      </trans-unit>
+      <trans-unit id="statsGa30" resname="stats.generic_analysis.chart.type.line">
+        <source>stats.generic_analysis.chart.type.line</source>
+        <target>Line</target>
+      </trans-unit>
+      <trans-unit id="statsGa31" resname="stats.generic_analysis.chart.type.stacked_bar">
+        <source>stats.generic_analysis.chart.type.stacked_bar</source>
+        <target>Stacked bar</target>
+      </trans-unit>
+      <trans-unit id="statsGa32" resname="stats.generic_analysis.chart.type.grouped_bar">
+        <source>stats.generic_analysis.chart.type.grouped_bar</source>
+        <target>Grouped bar</target>
+      </trans-unit>
+      <trans-unit id="statsGa33" resname="stats.generic_analysis.chart.type.horizontal_bar">
+        <source>stats.generic_analysis.chart.type.horizontal_bar</source>
+        <target>Horizontal bar</target>
+      </trans-unit>
+      <trans-unit id="statsGa34" resname="stats.generic_analysis.chart.type.percent_stacked_bar">
+        <source>stats.generic_analysis.chart.type.percent_stacked_bar</source>
+        <target>100% stacked</target>
+      </trans-unit>
+      <trans-unit id="statsGa35" resname="stats.generic_analysis.chart.type.pie">
+        <source>stats.generic_analysis.chart.type.pie</source>
+        <target>Pie</target>
+      </trans-unit>
+      <trans-unit id="statsGa36" resname="stats.generic_analysis.chart.type.heatmap">
+        <source>stats.generic_analysis.chart.type.heatmap</source>
+        <target>Heatmap</target>
+      </trans-unit>
+      <trans-unit id="statsGa37" resname="stats.generic_analysis.chart.type.table">
+        <source>stats.generic_analysis.chart.type.table</source>
+        <target>Table</target>
+      </trans-unit>
+      <trans-unit id="statsGa38" resname="stats.generic_analysis.chart.warning.numeric_dimension">
+        <source>stats.generic_analysis.chart.warning.numeric_dimension</source>
+        <target>Charts are not available for this numeric dimension. Use the table below.</target>
+      </trans-unit>
+      <trans-unit id="statsGa39" resname="stats.generic_analysis.chart.warning.histogram_not_supported">
+        <source>stats.generic_analysis.chart.warning.histogram_not_supported</source>
+        <target>Histogram charts are not yet supported. Use the table below.</target>
+      </trans-unit>
+      <trans-unit id="statsGa40" resname="stats.generic_analysis.chart.warning.heatmap_not_implemented">
+        <source>stats.generic_analysis.chart.warning.heatmap_not_implemented</source>
+        <target>Heatmap charts for hour and weekday are not yet available. Use the table below.</target>
+      </trans-unit>
+      <trans-unit id="statsGa41" resname="stats.generic_analysis.chart.warning.many_series">
+        <source>stats.generic_analysis.chart.warning.many_series</source>
+        <target>Many series — the legend may be hard to read.</target>
+      </trans-unit>
+      <trans-unit id="statsGa42" resname="stats.generic_analysis.chart.warning.many_buckets">
+        <source>stats.generic_analysis.chart.warning.many_buckets</source>
+        <target>Many categories — consider a horizontal bar chart.</target>
+      </trans-unit>
+      <trans-unit id="statsGa43" resname="stats.generic_analysis.chart.warning.pie_deferred">
+        <source>stats.generic_analysis.chart.warning.pie_deferred</source>
+        <target>Pie charts will be added later; showing a bar chart for now.</target>
+      </trans-unit>
+      <trans-unit id="statsGa44" resname="stats.generic_analysis.chart.export_planned">
+        <source>stats.generic_analysis.chart.export_planned</source>
+        <target>Chart export (PNG/CSV) is planned.</target>
+      </trans-unit>
+      <trans-unit id="statsGa45" resname="stats.generic_analysis.chart.remainder_bucket">
+        <source>stats.generic_analysis.chart.remainder_bucket</source>
+        <target>Other</target>
+      </trans-unit>
+      <trans-unit id="statsGa46" resname="stats.generic_analysis.chart.remainder_series">
+        <source>stats.generic_analysis.chart.remainder_series</source>
+        <target>Other</target>
+      </trans-unit>
+      <trans-unit id="statsGa47" resname="stats.generic_analysis.chart.warning.top_limited">
+        <source>stats.generic_analysis.chart.warning.top_limited</source>
+        <target>Chart shows the top {limit} values; remaining values are grouped as “Other”.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -1265,6 +1265,10 @@
         <source>link.stats.analysis</source>
         <target>Analysis</target>
       </trans-unit>
+      <trans-unit id="statsLnkAe01" resname="link.stats.analysis_explorer">
+        <source>link.stats.analysis_explorer</source>
+        <target>Analysis Explorer</target>
+      </trans-unit>
       <trans-unit id="statsLnkRp01" resname="link.stats.reports">
         <source>link.stats.reports</source>
         <target>Reports</target>
@@ -3630,6 +3634,138 @@
       <trans-unit id="media027" resname="label.open_in_new_tab">
         <source>label.open_in_new_tab</source>
         <target>Open in new tab</target>
+      </trans-unit>
+      <trans-unit id="statsGa01" resname="stats.generic_analysis.preset_label">
+        <source>stats.generic_analysis.preset_label</source>
+        <target>Predefined analysis</target>
+      </trans-unit>
+      <trans-unit id="statsGa01a" resname="stats.generic_analysis.config_card_title">
+        <source>stats.generic_analysis.config_card_title</source>
+        <target>Analysis configuration</target>
+      </trans-unit>
+      <trans-unit id="statsGa01f" resname="stats.generic_analysis.restricted_dimensions_hint">
+        <source>stats.generic_analysis.restricted_dimensions_hint</source>
+        <target>Some dimensions (hospital, state, dispatch area) are only available in the matching scope filter above.</target>
+      </trans-unit>
+      <trans-unit id="statsGa02" resname="stats.generic_analysis.custom_title">
+        <source>stats.generic_analysis.custom_title</source>
+        <target>Custom analysis</target>
+      </trans-unit>
+      <trans-unit id="statsGa03" resname="stats.generic_analysis.custom_section">
+        <source>stats.generic_analysis.custom_section</source>
+        <target>Custom configuration</target>
+      </trans-unit>
+      <trans-unit id="statsGa04" resname="stats.generic_analysis.based_on_preset">
+        <source>stats.generic_analysis.based_on_preset</source>
+        <target>Based on {preset}</target>
+      </trans-unit>
+      <trans-unit id="statsGa05" resname="stats.generic_analysis.primary_dimension">
+        <source>stats.generic_analysis.primary_dimension</source>
+        <target>Primary dimension</target>
+      </trans-unit>
+      <trans-unit id="statsGa06" resname="stats.generic_analysis.series_dimension">
+        <source>stats.generic_analysis.series_dimension</source>
+        <target>Series dimension</target>
+      </trans-unit>
+      <trans-unit id="statsGa07" resname="stats.generic_analysis.series_none">
+        <source>stats.generic_analysis.series_none</source>
+        <target>— no series —</target>
+      </trans-unit>
+      <trans-unit id="statsGa08" resname="stats.generic_analysis.include_null_buckets">
+        <source>stats.generic_analysis.include_null_buckets</source>
+        <target>Include unknown values</target>
+      </trans-unit>
+      <trans-unit id="statsGa09" resname="stats.generic_analysis.apply">
+        <source>stats.generic_analysis.apply</source>
+        <target>Apply</target>
+      </trans-unit>
+      <trans-unit id="statsGa10" resname="stats.generic_analysis.reset_to_preset">
+        <source>stats.generic_analysis.reset_to_preset</source>
+        <target>Reset to predefined analysis</target>
+      </trans-unit>
+      <trans-unit id="statsGa11" resname="stats.generic_analysis.page_pretitle">
+        <source>stats.generic_analysis.page_pretitle</source>
+        <target>Generic analysis</target>
+      </trans-unit>
+      <trans-unit id="statsGa12" resname="stats.generic_analysis.dimension_type.temporal">
+        <source>stats.generic_analysis.dimension_type.temporal</source>
+        <target>Time</target>
+      </trans-unit>
+      <trans-unit id="statsGa13" resname="stats.generic_analysis.dimension_type.categorical">
+        <source>stats.generic_analysis.dimension_type.categorical</source>
+        <target>Categories</target>
+      </trans-unit>
+      <trans-unit id="statsGa14" resname="stats.generic_analysis.dimension_type.boolean">
+        <source>stats.generic_analysis.dimension_type.boolean</source>
+        <target>Yes / No</target>
+      </trans-unit>
+      <trans-unit id="statsGa15" resname="stats.generic_analysis.dimension_type.numeric">
+        <source>stats.generic_analysis.dimension_type.numeric</source>
+        <target>Numeric</target>
+      </trans-unit>
+      <trans-unit id="statsGa16" resname="stats.generic_analysis.meta.dimension">
+        <source>stats.generic_analysis.meta.dimension</source>
+        <target>Dimension</target>
+      </trans-unit>
+      <trans-unit id="statsGa17" resname="stats.generic_analysis.meta.series">
+        <source>stats.generic_analysis.meta.series</source>
+        <target>Series</target>
+      </trans-unit>
+      <trans-unit id="statsGa18" resname="stats.generic_analysis.meta.total">
+        <source>stats.generic_analysis.meta.total</source>
+        <target>Total</target>
+      </trans-unit>
+      <trans-unit id="statsGa19" resname="stats.generic_analysis.table.count">
+        <source>stats.generic_analysis.table.count</source>
+        <target>Count</target>
+      </trans-unit>
+      <trans-unit id="statsGa19a" resname="stats.generic_analysis.results_table_title">
+        <source>stats.generic_analysis.results_table_title</source>
+        <target>Results</target>
+      </trans-unit>
+      <trans-unit id="statsGa19a2" resname="stats.generic_analysis.results_count">
+        <source>stats.generic_analysis.results_count</source>
+        <target>{count} results</target>
+      </trans-unit>
+      <trans-unit id="statsGa19f" resname="stats.generic_analysis.table.footer_total">
+        <source>stats.generic_analysis.table.footer_total</source>
+        <target>Total</target>
+      </trans-unit>
+      <trans-unit id="statsGa19b" resname="stats.generic_analysis.table_layout_label">
+        <source>stats.generic_analysis.table_layout_label</source>
+        <target>Table layout</target>
+      </trans-unit>
+      <trans-unit id="statsGa19c" resname="stats.generic_analysis.table_layout_stacked">
+        <source>stats.generic_analysis.table_layout_stacked</source>
+        <target>One row per series</target>
+      </trans-unit>
+      <trans-unit id="statsGa19d" resname="stats.generic_analysis.table_layout_grouped">
+        <source>stats.generic_analysis.table_layout_grouped</source>
+        <target>Grouped by bucket</target>
+      </trans-unit>
+      <trans-unit id="statsGa19e" resname="stats.generic_analysis.table.bucket_total">
+        <source>stats.generic_analysis.table.bucket_total</source>
+        <target>Bucket total</target>
+      </trans-unit>
+      <trans-unit id="statsGa20" resname="stats.generic_analysis.table.percent_total">
+        <source>stats.generic_analysis.table.percent_total</source>
+        <target>% of total</target>
+      </trans-unit>
+      <trans-unit id="statsGa21" resname="stats.generic_analysis.table.percent_bucket">
+        <source>stats.generic_analysis.table.percent_bucket</source>
+        <target>% of bucket</target>
+      </trans-unit>
+      <trans-unit id="statsGa21a" resname="stats.generic_analysis.table.percent_total_tooltip">
+        <source>stats.generic_analysis.table.percent_total_tooltip</source>
+        <target>% of total: {percent}%</target>
+      </trans-unit>
+      <trans-unit id="statsGa22" resname="stats.generic_analysis.no_data">
+        <source>stats.generic_analysis.no_data</source>
+        <target>No data for the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsGa23" resname="stats.generic_analysis.chart_json_title">
+        <source>stats.generic_analysis.chart_json_title</source>
+        <target>Chart data (JSON)</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
### Summary

- Added a generic **statistics analysis explorer**
- Introduced reusable analysis structures for dimensions and comparisons
- Improved flexibility for exploring statistics beyond fixed dashboard panels
- Added support for configurable analysis views and chart rendering
- Refactored related statistics UI and query handling where needed
- Added or updated tests for explorer behavior and analysis rendering

### Motivation

- Make statistics exploration more flexible and reusable
- Reduce the need for dedicated custom views for every analysis use case
- Provide a foundation for future interactive analytics features
- Improve maintainability by centralizing analysis configuration and rendering logic
- Enable users to compare different dimensions in a more consistent workflow

### Notes for Reviewers

- Review the generic analysis abstraction and configuration model
- Verify dimension and comparison handling across supported analysis types
- Check chart rendering and UI behavior for different explorer states
- Ensure existing statistics pages still behave as expected
- Confirm tests cover the new explorer flow and important edge cases