### PR TITLE
feat: Add sidebar navigation for content pages

### DIFF
--- a/src/Content/Application/Page/PageSidebarDataProvider.php
+++ b/src/Content/Application/Page/PageSidebarDataProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Infrastructure\Repository\PageRepository;
+use App\Content\Infrastructure\Repository\PostRepository;
+
+final readonly class PageSidebarDataProvider
+{
+    public function __construct(
+        private PageRepository $pageRepository,
+        private PageAccessChecker $pageAccessChecker,
+        private PageNavigationTreeBuilder $pageNavigationTreeBuilder,
+        private PostRepository $postRepository,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   pageTree: array<int, array{page: Page, children: array<int, mixed>}>,
+     *   latest_posts: list<\App\Content\Domain\Entity\Post>
+     * }
+     */
+    public function getData(): array
+    {
+        $pages = array_values(array_filter(
+            $this->pageRepository->findAllPublished(),
+            $this->pageAccessChecker->canView(...),
+        ));
+
+        return [
+            'pageTree' => $this->pageNavigationTreeBuilder->build($pages),
+            'latest_posts' => $this->postRepository->findPublishedForIndex(5),
+        ];
+    }
+}

--- a/src/Content/Infrastructure/Repository/PageRepository.php
+++ b/src/Content/Infrastructure/Repository/PageRepository.php
@@ -83,6 +83,23 @@ final class PageRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return list<Page>
+     */
+    public function findAllPublished(): array
+    {
+        /** @var list<Page> $pages */
+        $pages = $this->createQueryBuilder('p')
+            ->addSelect('parent')
+            ->leftJoin('p.parent', 'parent')
+            ->andWhere('p.status = :status')
+            ->setParameter('status', Page::STATUS_PUBLISHED)
+            ->getQuery()
+            ->getResult();
+
+        return $pages;
+    }
+
+    /**
      * Published pages visible to authenticated users (public + authenticated visibility).
      *
      * @return list<Page>

--- a/src/Content/UI/Http/Controller/DefaultController.php
+++ b/src/Content/UI/Http/Controller/DefaultController.php
@@ -6,8 +6,7 @@ namespace App\Content\UI\Http\Controller;
 
 use App\Allocation\Infrastructure\Repository\AllocationRepository;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
-use App\Content\Application\Page\PageNavigationTreeBuilder;
-use App\Content\Infrastructure\Repository\PageRepository;
+use App\Content\Application\Page\PageSidebarDataProvider;
 use App\Content\Infrastructure\Repository\PostRepository;
 use App\Import\Infrastructure\Repository\ImportRepository;
 use App\User\Infrastructure\Repository\UserRepository;
@@ -23,8 +22,7 @@ final class DefaultController extends AbstractController
         private readonly ImportRepository $importRepository,
         private readonly AllocationRepository $allocationRepository,
         private readonly PostRepository $postRepository,
-        private readonly PageRepository $pageRepository,
-        private readonly PageNavigationTreeBuilder $pageNavigationTreeBuilder,
+        private readonly PageSidebarDataProvider $pageSidebarDataProvider,
     ) {
     }
 
@@ -32,11 +30,9 @@ final class DefaultController extends AbstractController
     public function index(): Response
     {
         if ($this->isGranted('ROLE_USER')) {
-            $pages = $this->pageRepository->findAllPublishedVisibleToAuthenticatedUser();
-
             return $this->render('@Content/dashboard/dashboard.html.twig', [
                 'recentPosts' => $this->postRepository->findPublishedForIndex(5),
-                'pageTree' => $this->pageNavigationTreeBuilder->build($pages),
+                ...$this->pageSidebarDataProvider->getData(),
             ]);
         }
 

--- a/src/Content/UI/Http/Controller/PageController.php
+++ b/src/Content/UI/Http/Controller/PageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Content\UI\Http\Controller;
 
 use App\Content\Application\Page\PageAccessChecker;
+use App\Content\Application\Page\PageSidebarDataProvider;
 use App\Content\Domain\Entity\Page;
 use App\Content\Infrastructure\Repository\PageRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -17,6 +18,7 @@ final class PageController extends AbstractController
     public function __construct(
         private readonly PageRepository $pageRepository,
         private readonly PageAccessChecker $pageAccessChecker,
+        private readonly PageSidebarDataProvider $pageSidebarDataProvider,
         private readonly TranslatorInterface $translator,
     ) {
     }
@@ -38,6 +40,8 @@ final class PageController extends AbstractController
         return $this->render('@Content/page/show.html.twig', [
             'page' => $page,
             'breadcrumbItems' => $this->buildBreadcrumbItems($page),
+            'currentPage' => $page,
+            ...$this->pageSidebarDataProvider->getData(),
         ]);
     }
 

--- a/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
@@ -106,7 +106,7 @@
                         <p class="text-secondary mb-0">{{ 'dashboard.pages.empty'|trans }}</p>
                     {% else %}
                         <ul class="list-unstyled mb-0">
-                            {{ include('@Content/dashboard/_dashboard_page_tree_nodes.html.twig', {nodes: pageTree}, false) }}
+                            {{ include('@Content/page/_page_tree_nodes.html.twig', {nodes: pageTree}, false) }}
                         </ul>
                     {% endif %}
                 </div>

--- a/src/Content/UI/Twig/templates/page/_page_tree_nodes.html.twig
+++ b/src/Content/UI/Twig/templates/page/_page_tree_nodes.html.twig
@@ -1,27 +1,28 @@
 {% for node in nodes %}
     {% set pathSegment = node.page.path|default('')|trim('/') %}
+    {% set isCurrent = currentPage is defined and currentPage and node.page.id == currentPage.id %}
     <li class="mb-1">
         {% if node.children is not empty %}
             <details open class="border-0">
                 <summary class="d-flex align-items-center gap-1 small fw-medium">
                     <twig:ux:icon name="tabler:folder" class="icon text-muted flex-shrink-0" />
                     {% if pathSegment != '' %}
-                        <a href="{{ path('app_page_show', {path: pathSegment}) }}" onclick="event.stopPropagation()">{{ node.page.title }}</a>
+                        <a href="{{ path('app_page_show', {path: pathSegment}) }}" class="{{ isCurrent ? 'fw-semibold' : '' }}" onclick="event.stopPropagation()">{{ node.page.title }}</a>
                     {% else %}
-                        <span>{{ node.page.title }}</span>
+                        <span class="{{ isCurrent ? 'fw-semibold' : '' }}">{{ node.page.title }}</span>
                     {% endif %}
                 </summary>
                 <ul class="list-unstyled ps-3 mt-1 mb-0 border-start ms-1">
-                    {{ include('@Content/dashboard/_dashboard_page_tree_nodes.html.twig', {nodes: node.children}, false) }}
+                    {{ include('@Content/page/_page_tree_nodes.html.twig', {nodes: node.children, currentPage: currentPage|default(null)}, false) }}
                 </ul>
             </details>
         {% else %}
             <div class="d-flex align-items-center gap-1 small">
                 <twig:ux:icon name="tabler:file-text" class="icon text-muted flex-shrink-0" />
                 {% if pathSegment != '' %}
-                    <a href="{{ path('app_page_show', {path: pathSegment}) }}">{{ node.page.title }}</a>
+                    <a href="{{ path('app_page_show', {path: pathSegment}) }}" class="{{ isCurrent ? 'fw-semibold' : '' }}">{{ node.page.title }}</a>
                 {% else %}
-                    <span>{{ node.page.title }}</span>
+                    <span class="{{ isCurrent ? 'fw-semibold' : '' }}">{{ node.page.title }}</span>
                 {% endif %}
             </div>
         {% endif %}

--- a/src/Content/UI/Twig/templates/page/_sidebar.html.twig
+++ b/src/Content/UI/Twig/templates/page/_sidebar.html.twig
@@ -1,0 +1,41 @@
+<div class="row row-cards" data-testid="page-sidebar">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header bg-light">
+                <h3 class="card-title d-flex align-items-center gap-2">
+                    <twig:ux:icon name="tabler:sitemap" class="w-4 h-4" />
+                    {{ 'dashboard.pages.card_title'|trans }}
+                </h3>
+            </div>
+            <div class="card-body">
+                {% if pageTree is empty %}
+                    <p class="text-secondary mb-0">{{ 'dashboard.pages.empty'|trans }}</p>
+                {% else %}
+                    <ul class="list-unstyled mb-0">
+                        {{ include('@Content/page/_page_tree_nodes.html.twig', {nodes: pageTree, currentPage: currentPage|default(null)}, false) }}
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header bg-light">
+                <h3 class="card-title d-flex align-items-center gap-2">
+                    <twig:ux:icon name="tabler:clock-hour-4" class="w-4 h-4" />
+                    {{ 'blog.sidebar.latest_posts'|trans }}
+                </h3>
+            </div>
+            <div class="list-group list-group-flush">
+                {% for latest in latest_posts %}
+                    <a href="{{ path('app_blog_show', {slug: latest.slug}) }}" class="list-group-item list-group-item-action">
+                        {{ latest.title }}
+                    </a>
+                {% else %}
+                    <div class="list-group-item text-secondary">{{ 'blog.sidebar.no_latest_posts'|trans }}</div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -12,13 +12,20 @@
 {% block page_body %}
     <div class="page-body">
         <div class="container-xl">
-            {% for block in page.content %}
-                {% if block.enabled is not defined or block.enabled %}
-                    {% if block.type in ['richtext', 'image', 'cta', 'quote'] %}
-                        {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {block: block}) }}
-                    {% endif %}
-                {% endif %}
-            {% endfor %}
+            <div class="row g-3">
+                <div class="col-lg-8">
+                    {% for block in page.content %}
+                        {% if block.enabled is not defined or block.enabled %}
+                            {% if block.type in ['richtext', 'image', 'cta', 'quote'] %}
+                                {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {block: block}) }}
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </div>
+                <div class="col-lg-4">
+                    {{ include('@Content/page/_sidebar.html.twig') }}
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -81,4 +81,67 @@ final class PageControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, '/mitgliederbereich');
         self::assertResponseIsSuccessful();
     }
+
+    public function testSidebarShowsOnlyPublicPagesForGuest(): void
+    {
+        $client = self::createClient();
+
+        $parent = PageFactory::createOne([
+            'title' => 'Öffentlich',
+            'slug' => 'oeffentlich',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Öffentlich</p>']]],
+        ])->_real();
+
+        PageFactory::createOne([
+            'title' => 'Geschwister',
+            'slug' => 'geschwister',
+            'parent' => $parent,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Geschwister</p>']]],
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Nur Mitglieder',
+            'slug' => 'nur-mitglieder',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $client->request(Request::METHOD_GET, '/oeffentlich');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="page-sidebar"]');
+        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Geschwister');
+        self::assertSelectorTextNotContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
+    }
+
+    public function testSidebarShowsAuthenticatedPagesForLoggedInUser(): void
+    {
+        $client = self::createClient();
+
+        PageFactory::createOne([
+            'title' => 'Start',
+            'slug' => 'start',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Start</p>']]],
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Nur Mitglieder',
+            'slug' => 'nur-mitglieder',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $user = UserFactory::createOne()->_real();
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/start');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
+    }
 }

--- a/tests/Content/Integration/Page/PageSidebarDataProviderTest.php
+++ b/tests/Content/Integration/Page/PageSidebarDataProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PageSidebarDataProvider;
+use App\Content\Domain\Entity\Page;
+use App\Content\Infrastructure\Factory\PageFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageSidebarDataProviderTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testGetDataExcludesPagesGuestCannotView(): void
+    {
+        self::bootKernel();
+
+        PageFactory::createOne([
+            'slug' => 'sidebar-public',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageFactory::createOne([
+            'slug' => 'sidebar-auth',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $provider = self::getContainer()->get(PageSidebarDataProvider::class);
+        $data = $provider->getData();
+
+        $slugs = $this->collectSlugsFromTree($data['pageTree']);
+
+        self::assertContains('sidebar-public', $slugs);
+        self::assertNotContains('sidebar-auth', $slugs);
+    }
+
+    /**
+     * @param array<int, array{page: Page, children: array<int, mixed>}> $nodes
+     *
+     * @return list<string>
+     */
+    private function collectSlugsFromTree(array $nodes): array
+    {
+        $slugs = [];
+        foreach ($nodes as $node) {
+            $slug = $node['page']->getSlug();
+            if (null !== $slug) {
+                $slugs[] = $slug;
+            }
+            $slugs = array_merge($slugs, $this->collectSlugsFromTree($node['children']));
+        }
+
+        return $slugs;
+    }
+}

--- a/tests/Content/Integration/Repository/PageRepositoryQueryTest.php
+++ b/tests/Content/Integration/Repository/PageRepositoryQueryTest.php
@@ -26,6 +26,29 @@ final class PageRepositoryQueryTest extends KernelTestCase
         $this->repo = self::getContainer()->get(PageRepository::class);
     }
 
+    public function testFindAllPublishedExcludesDraft(): void
+    {
+        PageFactory::createOne([
+            'slug' => 'all-draft',
+            'status' => Page::STATUS_DRAFT,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageFactory::createOne([
+            'slug' => 'all-published',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $slugs = array_map(
+            static fn (Page $p): ?string => $p->getSlug(),
+            $this->repo->findAllPublished(),
+        );
+
+        self::assertContains('all-published', $slugs);
+        self::assertNotContains('all-draft', $slugs);
+    }
+
     public function testFindAllPublishedVisibleToAuthenticatedUserExcludesDraft(): void
     {
         PageFactory::createOne([


### PR DESCRIPTION
### Summary

- Added sidebar navigation for content/basic pages
- Updated page templates to support a sidebar layout
- Improved navigation between related pages
- Integrated sidebar rendering into the existing content structure
- Added or adjusted tests for page rendering and navigation behavior

### Motivation

- Improve usability and discoverability of content pages
- Provide clearer structure for related static/content pages
- Make the page system easier to navigate as more pages are added
- Keep content presentation consistent with the broader application layout

### Notes for Reviewers

- Verify sidebar navigation displays the expected pages
- Check active/current page highlighting behavior
- Ensure page layout remains responsive and consistent
- Confirm existing page routes and rendering still work as expected