### PR TITLE
feat: Restore page content blocks and modular page rendering

### DIFF
--- a/assets/admin-page-form.js
+++ b/assets/admin-page-form.js
@@ -1,0 +1,2 @@
+import './bootstrap.js';
+import './styles/admin/collection-reorder.css';

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,6 +1,7 @@
 import './bootstrap.js';
 
 import './styles/app.css';
+import './styles/pages/content-blocks.css';
 
 import '@tabler/core/dist/css/tabler.min.css';
 import '@tabler/core';

--- a/assets/controllers/collection-reorder_controller.js
+++ b/assets/controllers/collection-reorder_controller.js
@@ -1,0 +1,273 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        moveUpLabel: { type: String, default: 'Move block up' },
+        moveDownLabel: { type: String, default: 'Move block down' },
+    };
+
+    connect() {
+        this.collection = this.element.matches('[data-ea-collection-field]')
+            ? this.element
+            : this.element.querySelector('[data-ea-collection-field]');
+
+        if (!this.collection) {
+            return;
+        }
+
+        this.onCollectionChange = this.onCollectionChange.bind(this);
+        document.addEventListener('ea.collection.item-added', this.onCollectionChange);
+        document.addEventListener('ea.collection.item-removed', this.onCollectionChange);
+
+        this.observer = new MutationObserver(() => {
+            this.decorateItems();
+        });
+        this.observer.observe(this.collection, { childList: true, subtree: true });
+
+        this.decorateItems();
+    }
+
+    disconnect() {
+        document.removeEventListener('ea.collection.item-added', this.onCollectionChange);
+        document.removeEventListener('ea.collection.item-removed', this.onCollectionChange);
+        this.observer?.disconnect();
+    }
+
+    onCollectionChange(event) {
+        if (event.detail?.collection !== this.collection) {
+            return;
+        }
+
+        this.decorateItems();
+    }
+
+    getItemsContainer() {
+        const compound = this.collection.querySelector(
+            '.ea-form-collection-items > .accordion > .form-widget-compound',
+        );
+        if (!compound) {
+            return null;
+        }
+
+        // EasyAdmin/Symfony wrap entries in the collection root widget (e.g. #Page_content).
+        return compound.querySelector(':scope > [data-empty-collection]') ?? compound;
+    }
+
+    getItems() {
+        const container = this.getItemsContainer();
+        if (!container) {
+            return [];
+        }
+
+        return Array.from(container.children).filter((element) =>
+            element.classList.contains('field-collection-item'),
+        );
+    }
+
+    decorateItems() {
+        this.getItems().forEach((item) => {
+            const header = item.querySelector(':scope > .accordion-item > .accordion-header')
+                ?? item.querySelector('.accordion-header');
+            if (!header || header.querySelector('[data-collection-reorder-control]')) {
+                return;
+            }
+
+            const toolbar = document.createElement('div');
+            toolbar.className = 'collection-reorder-toolbar';
+            toolbar.setAttribute('data-collection-reorder-control', '');
+
+            toolbar.append(
+                this.createButton('up', this.moveUpLabelValue, this.moveUp.bind(this)),
+                this.createButton('down', this.moveDownLabelValue, this.moveDown.bind(this)),
+            );
+
+            const deleteButton = header.querySelector('.field-collection-delete-button');
+            if (deleteButton) {
+                header.insertBefore(toolbar, deleteButton);
+            } else {
+                header.appendChild(toolbar);
+            }
+        });
+
+        this.updateButtonStates();
+    }
+
+    createButton(direction, label, handler) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-link collection-reorder-button px-1';
+        button.setAttribute('aria-label', label);
+        button.title = label;
+        button.dataset.direction = direction;
+        button.textContent = direction === 'up' ? '↑' : '↓';
+        button.addEventListener('click', handler);
+
+        return button;
+    }
+
+    moveUp(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const item = event.currentTarget.closest('.field-collection-item');
+        this.moveItem(item, 'up');
+    }
+
+    moveDown(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const item = event.currentTarget.closest('.field-collection-item');
+        this.moveItem(item, 'down');
+    }
+
+    moveItem(item, direction) {
+        const container = this.getItemsContainer();
+        const items = this.getItems();
+        const currentIndex = items.indexOf(item);
+
+        if (!container || currentIndex === -1) {
+            return;
+        }
+
+        const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+        if (targetIndex < 0 || targetIndex >= items.length) {
+            return;
+        }
+
+        const targetItem = items[targetIndex];
+
+        this.observer.disconnect();
+        try {
+            if (direction === 'up') {
+                container.insertBefore(item, targetItem);
+            } else {
+                container.insertBefore(item, targetItem.nextElementSibling);
+            }
+
+            this.reindex();
+        } finally {
+            this.observer.observe(this.collection, { childList: true, subtree: true });
+        }
+    }
+
+    reindex() {
+        const items = this.getItems();
+
+        items.forEach((item, index) => {
+            this.reindexItem(item, index);
+        });
+
+        this.collection.dataset.numItems = String(items.length);
+        this.refreshCollectionItemClasses();
+        this.updateButtonStates();
+    }
+
+    reindexItem(item, newIndex) {
+        const firstNamedField = item.querySelector('[name*="[content]["]');
+        if (!firstNamedField?.name) {
+            return;
+        }
+
+        const match = firstNamedField.name.match(/\[content\]\[(\d+)\]/);
+        if (!match) {
+            return;
+        }
+
+        const oldIndex = match[1];
+        if (oldIndex === String(newIndex)) {
+            return;
+        }
+
+        const oldNameToken = `[content][${oldIndex}]`;
+        const newNameToken = `[content][${newIndex}]`;
+        const idPattern = new RegExp(`_content_${oldIndex}(?=_|-|$)`);
+        const newIdToken = `_content_${newIndex}`;
+
+        item.querySelectorAll('[name]').forEach((element) => {
+            if (element.name.includes(oldNameToken)) {
+                element.name = element.name.split(oldNameToken).join(newNameToken);
+            }
+        });
+
+        item.querySelectorAll('[id]').forEach((element) => {
+            const oldId = element.id;
+            const newId = oldId.replace(idPattern, newIdToken);
+            if (oldId === newId) {
+                return;
+            }
+
+            const styleElement = document.getElementById(`ea-trix-editor-size-${oldId}`);
+            if (styleElement) {
+                styleElement.id = `ea-trix-editor-size-${newId}`;
+                styleElement.textContent = styleElement.textContent.replaceAll(oldId, newId);
+            }
+
+            element.id = newId;
+        });
+
+        item.querySelectorAll('trix-editor[input]').forEach((element) => {
+            const inputId = element.getAttribute('input');
+            if (!inputId) {
+                return;
+            }
+
+            element.setAttribute('input', inputId.replace(idPattern, newIdToken));
+        });
+
+        item.querySelectorAll('[for]').forEach((element) => {
+            const labelFor = element.getAttribute('for');
+            if (labelFor) {
+                element.setAttribute('for', labelFor.replace(idPattern, newIdToken));
+            }
+        });
+
+        item.querySelectorAll('[data-bs-target]').forEach((element) => {
+            const target = element.getAttribute('data-bs-target');
+            if (target) {
+                element.setAttribute('data-bs-target', target.replace(idPattern, newIdToken));
+            }
+        });
+
+        item.querySelectorAll('[aria-controls]').forEach((element) => {
+            const controls = element.getAttribute('aria-controls');
+            if (controls) {
+                element.setAttribute('aria-controls', controls.replace(idPattern, newIdToken));
+            }
+        });
+    }
+
+    refreshCollectionItemClasses() {
+        const items = this.getItems();
+        items.forEach((item) => item.classList.remove('field-collection-item-first', 'field-collection-item-last'));
+
+        if (items.length === 0) {
+            return;
+        }
+
+        items[0].classList.add('field-collection-item-first');
+        items[items.length - 1].classList.add('field-collection-item-last');
+
+        if (typeof EaCollectionProperty !== 'undefined') {
+            EaCollectionProperty.updateCollectionItemCssClasses(this.collection);
+        }
+    }
+
+    updateButtonStates() {
+        const items = this.getItems();
+
+        items.forEach((item, index) => {
+            const upButton = item.querySelector('[data-direction="up"]');
+            const downButton = item.querySelector('[data-direction="down"]');
+
+            if (upButton) {
+                upButton.disabled = index === 0;
+            }
+
+            if (downButton) {
+                downButton.disabled = index === items.length - 1;
+            }
+        });
+    }
+}

--- a/assets/styles/admin/collection-reorder.css
+++ b/assets/styles/admin/collection-reorder.css
@@ -1,0 +1,32 @@
+.accordion-header {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.accordion-header .accordion-button {
+    flex: 1 1 auto;
+    width: auto;
+}
+
+.collection-reorder-toolbar {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.collection-reorder-button {
+    line-height: 1;
+    min-width: 1.75rem;
+}
+
+.collection-reorder-button:disabled {
+    opacity: 0.35;
+    pointer-events: none;
+}
+
+.accordion-header .field-collection-delete-button {
+    flex-shrink: 0;
+}

--- a/assets/styles/pages/content-blocks.css
+++ b/assets/styles/pages/content-blocks.css
@@ -1,0 +1,56 @@
+.page-content-blocks {
+    width: 100%;
+}
+
+.page-content-blocks > .page-content-block + .page-content-block {
+    margin-top: 1.5rem;
+}
+
+.page-content-blocks::after {
+    content: '';
+    display: block;
+    clear: both;
+}
+
+.page-content-image {
+    max-width: 100%;
+    overflow: hidden;
+}
+
+.page-content-image .card-img-top {
+    width: 100%;
+    display: block;
+}
+
+.page-content-image--size-sm {
+    width: 33%;
+}
+
+.page-content-image--size-md {
+    width: 66%;
+}
+
+.page-content-image--size-lg {
+    width: 100%;
+}
+
+.page-content-highlight .content > :last-child {
+    margin-bottom: 0;
+}
+
+.page-content-block:first-child .page-content-cta {
+    border-top: 0 !important;
+    padding-top: 0 !important;
+}
+
+@media (max-width: 767.98px) {
+    .page-content-image--float-left,
+    .page-content-image--float-right,
+    .page-content-image--size-sm,
+    .page-content-image--size-md {
+        float: none !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        margin-inline: 0 !important;
+    }
+}

--- a/importmap.php
+++ b/importmap.php
@@ -20,6 +20,10 @@ return [
         'path' => './assets/admin-kpi.js',
         'entrypoint' => true,
     ],
+    'admin-page-form' => [
+        'path' => './assets/admin-page-form.js',
+        'entrypoint' => true,
+    ],
     'error_page' => [
         'path' => './assets/error-page.js',
         'entrypoint' => true,

--- a/src/Admin/UI/Form/PageContentAccordionItemType.php
+++ b/src/Admin/UI/Form/PageContentAccordionItemType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Form;
+
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\TextEditorType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
+final class PageContentAccordionItemType extends AbstractType
+{
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'label.accordion_item_title',
+                'required' => true,
+            ])
+            ->add('html', TextEditorType::class, [
+                'label' => 'label.html',
+                'required' => true,
+                'attr' => ['rows' => 10],
+                'help' => 'help.page.richtext_allowed_tags',
+            ])
+            ->add('openByDefault', CheckboxType::class, [
+                'label' => 'label.accordion_open_by_default',
+                'required' => false,
+            ])
+        ;
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => null,
+        ]);
+    }
+}

--- a/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
+++ b/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
@@ -7,11 +7,13 @@ namespace App\Admin\UI\Form;
 use App\Admin\UI\Http\Controller\Media\MediaCrudController;
 use App\Content\Domain\Entity\Media;
 use App\Content\Domain\Enum\MediaType;
+use App\Content\Domain\Enum\PageContentBlockType;
 use App\Content\Infrastructure\Repository\MediaRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\TextEditorType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
@@ -27,6 +29,10 @@ final readonly class PageContentBlockDataFieldsConfigurator
     public const array DATA_FIELD_NAMES = [
         'html', 'src', 'alt', 'caption', 'headline', 'buttonLabel', 'buttonUrl',
         'mediaId', 'linkType', 'openInNewTab', 'text',
+        'level', 'align', 'spacingBefore', 'spacingAfter',
+        'variant', 'title', 'iconMode', 'icon',
+        'size', 'float',
+        'items',
     ];
 
     /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
@@ -49,9 +55,12 @@ final readonly class PageContentBlockDataFieldsConfigurator
         }
 
         match ($type) {
-            'image' => $this->addImageFields($dataForm),
-            'cta' => $this->addCtaFields($dataForm),
-            'quote' => $this->addQuoteFields($dataForm),
+            PageContentBlockType::Image->value => $this->addImageFields($dataForm),
+            PageContentBlockType::Cta->value => $this->addCtaFields($dataForm),
+            PageContentBlockType::Quote->value => $this->addQuoteFields($dataForm),
+            PageContentBlockType::Headline->value => $this->addHeadlineFields($dataForm),
+            PageContentBlockType::Highlight->value => $this->addHighlightFields($dataForm),
+            PageContentBlockType::Accordion->value => $this->addAccordionFields($dataForm),
             default => $this->addRichtextFields($dataForm),
         };
     }
@@ -124,7 +133,28 @@ final readonly class PageContentBlockDataFieldsConfigurator
             ->add('caption', TextType::class, [
                 'label' => 'label.image_caption',
                 'required' => false,
-            ]);
+            ])
+            ->add('size', ChoiceType::class, [
+                'label' => 'label.image_size',
+                'choices' => [
+                    'label.image_size.sm' => 'sm',
+                    'label.image_size.md' => 'md',
+                    'label.image_size.lg' => 'lg',
+                ],
+                'empty_data' => 'lg',
+                'help' => 'help.page.image_size',
+            ])
+            ->add('float', ChoiceType::class, [
+                'label' => 'label.image_float',
+                'choices' => [
+                    'label.image_float.none' => 'none',
+                    'label.image_float.left' => 'left',
+                    'label.image_float.right' => 'right',
+                ],
+                'empty_data' => 'none',
+                'help' => 'help.page.image_float',
+            ])
+        ;
     }
 
     /**
@@ -168,7 +198,8 @@ final readonly class PageContentBlockDataFieldsConfigurator
             ->add('openInNewTab', CheckboxType::class, [
                 'label' => 'label.open_in_new_tab',
                 'required' => false,
-            ]);
+            ])
+        ;
     }
 
     /**
@@ -180,6 +211,119 @@ final readonly class PageContentBlockDataFieldsConfigurator
             'label' => 'label.quote_text',
             'required' => true,
             'attr' => ['rows' => 4],
+        ]);
+    }
+
+    /**
+     * @param FormInterface<array<string, mixed>> $dataForm
+     */
+    private function addHeadlineFields(FormInterface $dataForm): void
+    {
+        $dataForm
+            ->add('text', TextType::class, [
+                'label' => 'label.headline_text',
+                'required' => true,
+            ])
+            ->add('level', ChoiceType::class, [
+                'label' => 'label.headline_level',
+                'choices' => [
+                    'label.headline_level.h1' => 'h1',
+                    'label.headline_level.h2' => 'h2',
+                    'label.headline_level.h3' => 'h3',
+                    'label.headline_level.h4' => 'h4',
+                ],
+                'empty_data' => 'h2',
+                'help' => 'help.page.headline_level',
+            ])
+            ->add('align', ChoiceType::class, [
+                'label' => 'label.headline_align',
+                'choices' => [
+                    'label.headline_align.left' => 'left',
+                    'label.headline_align.center' => 'center',
+                    'label.headline_align.right' => 'right',
+                ],
+                'empty_data' => 'left',
+            ])
+            ->add('spacingBefore', ChoiceType::class, [
+                'label' => 'label.headline_spacing_before',
+                'choices' => [
+                    'label.spacing.none' => 'none',
+                    'label.spacing.sm' => 'sm',
+                    'label.spacing.md' => 'md',
+                    'label.spacing.lg' => 'lg',
+                ],
+                'empty_data' => 'none',
+            ])
+            ->add('spacingAfter', ChoiceType::class, [
+                'label' => 'label.headline_spacing_after',
+                'choices' => [
+                    'label.spacing.none' => 'none',
+                    'label.spacing.sm' => 'sm',
+                    'label.spacing.md' => 'md',
+                    'label.spacing.lg' => 'lg',
+                ],
+                'empty_data' => 'md',
+            ])
+        ;
+    }
+
+    /**
+     * @param FormInterface<array<string, mixed>> $dataForm
+     */
+    private function addHighlightFields(FormInterface $dataForm): void
+    {
+        $dataForm
+            ->add('variant', ChoiceType::class, [
+                'label' => 'label.highlight_variant',
+                'choices' => [
+                    'label.highlight_variant.info' => 'info',
+                    'label.highlight_variant.success' => 'success',
+                    'label.highlight_variant.warning' => 'warning',
+                    'label.highlight_variant.danger' => 'danger',
+                    'label.highlight_variant.note' => 'note',
+                ],
+                'empty_data' => 'info',
+            ])
+            ->add('title', TextType::class, [
+                'label' => 'label.highlight_title',
+                'required' => false,
+            ])
+            ->add('html', TextEditorType::class, [
+                'label' => 'label.html',
+                'required' => true,
+                'attr' => ['rows' => 10],
+                'help' => 'help.page.richtext_allowed_tags',
+            ])
+            ->add('iconMode', ChoiceType::class, [
+                'label' => 'label.highlight_icon_mode',
+                'choices' => [
+                    'label.highlight_icon_mode.auto' => 'auto',
+                    'label.highlight_icon_mode.custom' => 'custom',
+                    'label.highlight_icon_mode.none' => 'none',
+                ],
+                'empty_data' => 'auto',
+            ])
+            ->add('icon', TextType::class, [
+                'label' => 'label.highlight_icon',
+                'required' => false,
+                'help' => 'help.page.highlight_icon',
+            ])
+        ;
+    }
+
+    /**
+     * @param FormInterface<array<string, mixed>> $dataForm
+     */
+    private function addAccordionFields(FormInterface $dataForm): void
+    {
+        $dataForm->add('items', CollectionType::class, [
+            'label' => 'label.accordion_items',
+            'entry_type' => PageContentAccordionItemType::class,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'by_reference' => false,
+            'prototype' => true,
+            'required' => true,
         ]);
     }
 }

--- a/src/Admin/UI/Form/PageContentBlockType.php
+++ b/src/Admin/UI/Form/PageContentBlockType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Form;
 
+use App\Content\Domain\Enum\PageContentBlockType as ContentBlockTypeEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -30,12 +31,7 @@ final class PageContentBlockType extends AbstractType
         $builder
             ->add('type', ChoiceType::class, [
                 'label' => 'label.block_type',
-                'choices' => [
-                    'label.block_type.richtext' => 'richtext',
-                    'label.block_type.image' => 'image',
-                    'label.block_type.cta' => 'cta',
-                    'label.block_type.quote' => 'quote',
-                ],
+                'choices' => ContentBlockTypeEnum::formChoices(),
             ])
             ->add('enabled', CheckboxType::class, [
                 'label' => 'label.enabled',
@@ -70,7 +66,7 @@ final class PageContentBlockType extends AbstractType
         $resolver->setDefaults([
             'data_class' => null,
             'empty_data' => static fn (): array => [
-                'type' => 'richtext',
+                'type' => ContentBlockTypeEnum::Richtext->value,
                 'enabled' => true,
                 'data' => [],
             ],

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -257,12 +257,13 @@ final class PageCrudController extends AbstractCrudController
 
     private function formatBlockTypeLabel(string $type): string
     {
-        return match ($type) {
-            'image' => $this->translator->trans('label.block_type.image'),
-            'cta' => $this->translator->trans('label.block_type.cta'),
-            'quote' => $this->translator->trans('label.block_type.quote'),
-            default => $this->translator->trans('label.block_type.richtext'),
-        };
+        $blockType = \App\Content\Domain\Enum\PageContentBlockType::tryFromString($type);
+
+        if ($blockType instanceof \App\Content\Domain\Enum\PageContentBlockType) {
+            return $this->translator->trans($blockType->translationKey());
+        }
+
+        return $this->translator->trans('label.block_type.richtext');
     }
 
     private function buildMediaLibraryHelp(): string

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -104,7 +104,8 @@ final class PageCrudController extends AbstractCrudController
     {
         return $assets
             ->addCssFile(Asset::fromEasyAdminAssetPackage('field-text-editor.css')->onlyOnForms())
-            ->addJsFile(Asset::fromEasyAdminAssetPackage('field-text-editor.js')->onlyOnForms());
+            ->addJsFile(Asset::fromEasyAdminAssetPackage('field-text-editor.js')->onlyOnForms())
+            ->addAssetMapperEntry(Asset::new('admin-page-form')->onlyOnForms());
     }
 
     #[\Override]
@@ -135,10 +136,15 @@ final class PageCrudController extends AbstractCrudController
             ->hideOnForm()
             ->hideOnIndex();
         yield CollectionField::new('content', 'label.content_blocks')
-            ->setHelp($this->buildMediaLibraryHelp())
+            ->setHelp($this->buildMediaLibraryHelp().' '.$this->translator->trans('help.page.content_blocks_reorder'))
             ->setFormTypeOption('help_html', true)
             ->setEntryType(PageContentBlockType::class)
             ->setEntryIsComplex()
+            ->setFormTypeOption('row_attr', [
+                'data-controller' => 'collection-reorder',
+                'data-collection-reorder-move-up-label-value' => $this->translator->trans('label.move_block_up'),
+                'data-collection-reorder-move-down-label-value' => $this->translator->trans('label.move_block_down'),
+            ])
             ->setEntryToStringMethod(function (mixed $value): string {
                 if (!is_array($value)) {
                     return $this->translator->trans('label.block');

--- a/src/Content/Application/Page/PageContentBlockDataNormalizer.php
+++ b/src/Content/Application/Page/PageContentBlockDataNormalizer.php
@@ -4,14 +4,27 @@ declare(strict_types=1);
 
 namespace App\Content\Application\Page;
 
+use App\Content\Domain\Enum\PageContentBlockType;
+
 final readonly class PageContentBlockDataNormalizer
 {
     /** @var array<string, list<string>> */
     private const array ALLOWED_FIELDS_BY_TYPE = [
-        'richtext' => ['html'],
-        'image' => ['mediaId', 'src', 'alt', 'caption'],
-        'cta' => ['headline', 'buttonLabel', 'buttonUrl', 'mediaId', 'linkType', 'openInNewTab'],
-        'quote' => ['text'],
+        PageContentBlockType::Richtext->value => ['html'],
+        PageContentBlockType::Image->value => [
+            'mediaId', 'src', 'alt', 'caption', 'size', 'float',
+        ],
+        PageContentBlockType::Cta->value => [
+            'headline', 'buttonLabel', 'buttonUrl', 'mediaId', 'linkType', 'openInNewTab',
+        ],
+        PageContentBlockType::Quote->value => ['text'],
+        PageContentBlockType::Headline->value => [
+            'text', 'level', 'align', 'spacingBefore', 'spacingAfter',
+        ],
+        PageContentBlockType::Highlight->value => [
+            'variant', 'title', 'html', 'iconMode', 'icon',
+        ],
+        PageContentBlockType::Accordion->value => ['items'],
     ];
 
     /**
@@ -32,7 +45,7 @@ final readonly class PageContentBlockDataNormalizer
             $typeValue = $block['type'] ?? null;
             $type = is_string($typeValue) && '' !== trim($typeValue)
                 ? $typeValue
-                : 'richtext';
+                : PageContentBlockType::Richtext->value;
 
             $dataValue = $block['data'] ?? null;
             $data = is_array($dataValue) ? $dataValue : [];
@@ -42,6 +55,15 @@ final readonly class PageContentBlockDataNormalizer
             $filteredData = [] === $allowed
                 ? []
                 : array_intersect_key($data, array_flip($allowed));
+
+            if (PageContentBlockType::Accordion->value === $type) {
+                $filteredData['items'] = $this->normalizeAccordionItems($data['items'] ?? []);
+            }
+
+            if (PageContentBlockType::Image->value === $type) {
+                $filteredData['size'] = $this->normalizeImageSize($data);
+                $filteredData['float'] = $this->normalizeImageFloat($data);
+            }
 
             $normalizedBlock = ['type' => $type];
 
@@ -55,5 +77,72 @@ final readonly class PageContentBlockDataNormalizer
         }
 
         return $normalized;
+    }
+
+    /**
+     * @return list<array{title?: string, html?: string, openByDefault?: bool}>
+     */
+    private function normalizeAccordionItems(mixed $items): array
+    {
+        if (!is_array($items)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $normalizedItem = [];
+
+            if (array_key_exists('title', $item) && is_string($item['title'])) {
+                $normalizedItem['title'] = $item['title'];
+            }
+
+            if (array_key_exists('html', $item) && is_string($item['html'])) {
+                $normalizedItem['html'] = $item['html'];
+            }
+
+            if (array_key_exists('openByDefault', $item)) {
+                $normalizedItem['openByDefault'] = (bool) $item['openByDefault'];
+            }
+
+            if ([] !== $normalizedItem) {
+                $normalized[] = $normalizedItem;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function normalizeImageSize(array $data): string
+    {
+        $size = $data['size'] ?? null;
+        if (is_string($size) && in_array($size, ['sm', 'md', 'lg'], true)) {
+            return $size;
+        }
+
+        $preset = (string) ($data['widthPreset'] ?? '');
+
+        return match ($preset) {
+            'sm' => 'sm',
+            'md' => 'md',
+            default => 'lg',
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function normalizeImageFloat(array $data): string
+    {
+        $float = (string) ($data['float'] ?? 'none');
+
+        return in_array($float, ['none', 'left', 'right'], true) ? $float : 'none';
     }
 }

--- a/src/Content/Application/Page/PageContentSanitizer.php
+++ b/src/Content/Application/Page/PageContentSanitizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Content\Application\Page;
 
+use App\Content\Domain\Enum\PageContentBlockType;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
@@ -26,18 +27,68 @@ final readonly class PageContentSanitizer
         $sanitized = [];
 
         foreach ($content as $block) {
-            if (($block['type'] ?? null) !== 'richtext') {
-                $sanitized[] = $block;
+            $type = $block['type'] ?? null;
+
+            if (PageContentBlockType::Richtext->value === $type) {
+                $sanitized[] = $this->sanitizeHtmlField($block, 'html');
                 continue;
             }
 
-            $data = is_array($block['data'] ?? null) ? $block['data'] : [];
-            $html = (string) ($data['html'] ?? '');
-            $data['html'] = $this->pageRichtextSanitizer->sanitize($html);
-            $block['data'] = $data;
+            if (PageContentBlockType::Highlight->value === $type) {
+                $sanitized[] = $this->sanitizeHtmlField($block, 'html');
+                continue;
+            }
+
+            if (PageContentBlockType::Accordion->value === $type) {
+                $sanitized[] = $this->sanitizeAccordionBlock($block);
+                continue;
+            }
+
             $sanitized[] = $block;
         }
 
         return $sanitized;
+    }
+
+    /**
+     * @param array{type: string, data: array<string, mixed>, enabled?: bool} $block
+     *
+     * @return array{type: string, data: array<string, mixed>, enabled?: bool}
+     */
+    private function sanitizeHtmlField(array $block, string $field): array
+    {
+        $data = is_array($block['data'] ?? null) ? $block['data'] : [];
+        $html = (string) ($data[$field] ?? '');
+        $data[$field] = $this->pageRichtextSanitizer->sanitize($html);
+        $block['data'] = $data;
+
+        return $block;
+    }
+
+    /**
+     * @param array{type: string, data: array<string, mixed>, enabled?: bool} $block
+     *
+     * @return array{type: string, data: array<string, mixed>, enabled?: bool}
+     */
+    private function sanitizeAccordionBlock(array $block): array
+    {
+        $data = is_array($block['data'] ?? null) ? $block['data'] : [];
+        $items = is_array($data['items'] ?? null) ? $data['items'] : [];
+        $sanitizedItems = [];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $html = (string) ($item['html'] ?? '');
+            $item['html'] = $this->pageRichtextSanitizer->sanitize($html);
+            $sanitizedItems[] = $item;
+        }
+
+        $data['items'] = $sanitizedItems;
+        $block['data'] = $data;
+
+        return $block;
     }
 }

--- a/src/Content/Application/Page/PageContentValidator.php
+++ b/src/Content/Application/Page/PageContentValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Content\Application\Page;
 
 use App\Content\Domain\Entity\Media;
+use App\Content\Domain\Enum\PageContentBlockType;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class PageContentValidator
@@ -17,9 +18,32 @@ final readonly class PageContentValidator
 
     /** @var array<string, list<string>> */
     private const array REQUIRED_FIELDS = [
-        'richtext' => ['html'],
-        'quote' => ['text'],
+        PageContentBlockType::Richtext->value => ['html'],
+        PageContentBlockType::Quote->value => ['text'],
+        PageContentBlockType::Headline->value => ['text'],
+        PageContentBlockType::Highlight->value => ['html'],
     ];
+
+    /** @var list<string> */
+    private const array HEADLINE_LEVELS = ['h1', 'h2', 'h3', 'h4'];
+
+    /** @var list<string> */
+    private const array HEADLINE_ALIGNS = ['left', 'center', 'right'];
+
+    /** @var list<string> */
+    private const array SPACING_OPTIONS = ['none', 'sm', 'md', 'lg'];
+
+    /** @var list<string> */
+    private const array HIGHLIGHT_VARIANTS = ['info', 'success', 'warning', 'danger', 'note'];
+
+    /** @var list<string> */
+    private const array HIGHLIGHT_ICON_MODES = ['auto', 'custom', 'none'];
+
+    /** @var list<string> */
+    private const array IMAGE_SIZES = ['sm', 'md', 'lg'];
+
+    /** @var list<string> */
+    private const array IMAGE_FLOATS = ['none', 'left', 'right'];
 
     /**
      * @return list<string>
@@ -69,12 +93,24 @@ final readonly class PageContentValidator
      */
     private function validateBlock(string $prefix, string $type, array $data): array
     {
-        if ('image' === $type) {
+        if (PageContentBlockType::Image->value === $type) {
             return $this->validateImageBlock($prefix, $data);
         }
 
-        if ('cta' === $type) {
+        if (PageContentBlockType::Cta->value === $type) {
             return $this->validateCtaBlock($prefix, $data);
+        }
+
+        if (PageContentBlockType::Headline->value === $type) {
+            return $this->validateHeadlineBlock($prefix, $data);
+        }
+
+        if (PageContentBlockType::Highlight->value === $type) {
+            return $this->validateHighlightBlock($prefix, $data);
+        }
+
+        if (PageContentBlockType::Accordion->value === $type) {
+            return $this->validateAccordionBlock($prefix, $data);
         }
 
         if (!array_key_exists($type, self::REQUIRED_FIELDS)) {
@@ -111,7 +147,35 @@ final readonly class PageContentValidator
             $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.image_src_or_media_required', [], 'validators'));
         }
 
+        $size = (string) ($data['size'] ?? $this->resolveLegacyImageSize($data));
+        if ('' !== $size && !in_array($size, self::IMAGE_SIZES, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.image_invalid_size', [], 'validators'));
+        }
+
+        $float = (string) ($data['float'] ?? 'none');
+        if ('' !== $float && !in_array($float, self::IMAGE_FLOATS, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.image_invalid_float', [], 'validators'));
+        }
+
+        if (in_array($float, ['left', 'right'], true) && 'lg' === $size) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.image_float_requires_non_full_width', [], 'validators'));
+        }
+
         return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function resolveLegacyImageSize(array $data): string
+    {
+        $preset = (string) ($data['widthPreset'] ?? 'lg');
+
+        return match ($preset) {
+            'sm' => 'sm',
+            'md' => 'md',
+            default => 'lg',
+        };
     }
 
     /**
@@ -137,6 +201,105 @@ final readonly class PageContentValidator
             }
         } elseif (!$this->isNonEmptyString($data['buttonUrl'] ?? null)) {
             $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.block_required_field', ['{field}' => 'buttonUrl'], 'validators'));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<string>
+     */
+    private function validateHeadlineBlock(string $prefix, array $data): array
+    {
+        $errors = [];
+
+        if (!$this->isNonEmptyString($data['text'] ?? null)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.block_required_field', ['{field}' => 'text'], 'validators'));
+        }
+
+        $level = (string) ($data['level'] ?? 'h2');
+        if ('' !== $level && !in_array($level, self::HEADLINE_LEVELS, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.headline_invalid_level', [], 'validators'));
+        }
+
+        $align = (string) ($data['align'] ?? 'left');
+        if ('' !== $align && !in_array($align, self::HEADLINE_ALIGNS, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.headline_invalid_align', [], 'validators'));
+        }
+
+        foreach (['spacingBefore', 'spacingAfter'] as $field) {
+            $value = (string) ($data[$field] ?? '');
+            if ('' !== $value && !in_array($value, self::SPACING_OPTIONS, true)) {
+                $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.headline_invalid_spacing', ['{field}' => $field], 'validators'));
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<string>
+     */
+    private function validateHighlightBlock(string $prefix, array $data): array
+    {
+        $errors = [];
+
+        if (!$this->isNonEmptyString($data['html'] ?? null)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.block_required_field', ['{field}' => 'html'], 'validators'));
+        }
+
+        $variant = (string) ($data['variant'] ?? 'info');
+        if ('' !== $variant && !in_array($variant, self::HIGHLIGHT_VARIANTS, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.highlight_invalid_variant', [], 'validators'));
+        }
+
+        $iconMode = (string) ($data['iconMode'] ?? 'auto');
+        if ('' !== $iconMode && !in_array($iconMode, self::HIGHLIGHT_ICON_MODES, true)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.highlight_invalid_icon_mode', [], 'validators'));
+        }
+
+        if ('custom' === $iconMode && !$this->isNonEmptyString($data['icon'] ?? null)) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.highlight_icon_required', [], 'validators'));
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<string>
+     */
+    private function validateAccordionBlock(string $prefix, array $data): array
+    {
+        $errors = [];
+        $items = $data['items'] ?? null;
+
+        if (!is_array($items) || [] === $items) {
+            $errors[] = sprintf('%s: %s', $prefix, $this->translator->trans('page.validation.accordion_items_required', [], 'validators'));
+
+            return $errors;
+        }
+
+        foreach ($items as $itemIndex => $item) {
+            $itemPrefix = sprintf('%s item %d', $prefix, (int) $itemIndex + 1);
+
+            if (!is_array($item)) {
+                $errors[] = sprintf('%s: %s', $itemPrefix, $this->translator->trans('page.validation.accordion_item_must_be_object', [], 'validators'));
+                continue;
+            }
+
+            if (!$this->isNonEmptyString($item['title'] ?? null)) {
+                $errors[] = sprintf('%s: %s', $itemPrefix, $this->translator->trans('page.validation.block_required_field', ['{field}' => 'title'], 'validators'));
+            }
+
+            if (!$this->isNonEmptyString($item['html'] ?? null)) {
+                $errors[] = sprintf('%s: %s', $itemPrefix, $this->translator->trans('page.validation.block_required_field', ['{field}' => 'html'], 'validators'));
+            }
         }
 
         return $errors;

--- a/src/Content/Domain/Enum/PageContentBlockType.php
+++ b/src/Content/Domain/Enum/PageContentBlockType.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Domain\Enum;
+
+enum PageContentBlockType: string
+{
+    case Richtext = 'richtext';
+    case Image = 'image';
+    case Cta = 'cta';
+    case Quote = 'quote';
+    case Headline = 'headline';
+    case Highlight = 'highlight';
+    case Accordion = 'accordion';
+
+    public function translationKey(): string
+    {
+        return 'label.block_type.'.$this->value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $case): string => $case->value, self::cases());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function formChoices(): array
+    {
+        $choices = [];
+        foreach (self::cases() as $case) {
+            $choices[$case->translationKey()] = $case->value;
+        }
+
+        return $choices;
+    }
+
+    public static function tryFromString(?string $value): ?self
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        return self::tryFrom($value);
+    }
+}

--- a/src/Content/UI/Twig/PageExtension.php
+++ b/src/Content/UI/Twig/PageExtension.php
@@ -7,6 +7,7 @@ namespace App\Content\UI\Twig;
 use App\Content\Application\Page\DTO\PageNavigationLink;
 use App\Content\Application\Page\PageNavigationProvider;
 use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageContentBlockType;
 use App\Content\Domain\Enum\PageKey;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -26,6 +27,7 @@ final class PageExtension extends AbstractExtension
             new TwigFunction('page_url_by_key', $this->pageUrlByKey(...)),
             new TwigFunction('page_nav_header_items', $this->pageNavHeaderItems(...)),
             new TwigFunction('page_nav_footer_items', $this->pageNavFooterItems(...)),
+            new TwigFunction('page_content_block_types', $this->pageContentBlockTypes(...)),
         ];
     }
 
@@ -63,5 +65,13 @@ final class PageExtension extends AbstractExtension
     public function pageNavFooterItems(): array
     {
         return $this->pageNavigationProvider->getFooterPages();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function pageContentBlockTypes(): array
+    {
+        return PageContentBlockType::values();
     }
 }

--- a/src/Content/UI/Twig/templates/page/blocks/accordion.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/accordion.html.twig
@@ -1,0 +1,29 @@
+{% set accordionId = 'page-accordion-' ~ blockIndex|default(1) %}
+{% set items = block.data.items|default([]) %}
+{% if items is not empty %}
+    <div class="accordion page-content-accordion" id="{{ accordionId }}">
+        {% for item in items %}
+            {% set itemId = accordionId ~ '-item-' ~ loop.index %}
+            {% set isOpen = item.openByDefault|default(false) %}
+            <div class="accordion-item">
+                <h3 class="accordion-header" id="{{ itemId }}-heading">
+                    <button class="accordion-button{% if not isOpen %} collapsed{% endif %}"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#{{ itemId }}-panel"
+                            aria-expanded="{{ isOpen ? 'true' : 'false' }}"
+                            aria-controls="{{ itemId }}-panel">
+                        {{ item.title|default('') }}
+                    </button>
+                </h3>
+                <div id="{{ itemId }}-panel"
+                     class="accordion-collapse collapse{% if isOpen %} show{% endif %}"
+                     aria-labelledby="{{ itemId }}-heading">
+                    <div class="accordion-body content">
+                        {{ item.html|default('')|raw }}
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/src/Content/UI/Twig/templates/page/blocks/cta.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/cta.html.twig
@@ -1,10 +1,8 @@
-<section class="card mb-3">
-    <div class="card-body">
-        <h3 class="h4">{{ block.data.headline|default('') }}</h3>
-        <a class="btn btn-primary"
-           href="{{ block.data.buttonUrl|default('#') }}"
-           {% if block.data.openInNewTab|default(false) %}target="_blank" rel="noopener"{% endif %}>
-            {{ block.data.buttonLabel|default('Mehr erfahren') }}
-        </a>
-    </div>
-</section>
+<div class="page-content-cta border-top pt-3">
+    <h3 class="h4">{{ block.data.headline|default('') }}</h3>
+    <a class="btn btn-primary"
+       href="{{ block.data.buttonUrl|default('#') }}"
+       {% if block.data.openInNewTab|default(false) %}target="_blank" rel="noopener"{% endif %}>
+        {{ block.data.buttonLabel|default('Mehr erfahren') }}
+    </a>
+</div>

--- a/src/Content/UI/Twig/templates/page/blocks/headline.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/headline.html.twig
@@ -1,0 +1,25 @@
+{% set level = block.data.level|default('h2') %}
+{% if level not in ['h1', 'h2', 'h3', 'h4'] %}
+    {% set level = 'h2' %}
+{% endif %}
+{% set align = block.data.align|default('left') %}
+{% set alignClass = {
+    left: 'text-start',
+    center: 'text-center',
+    right: 'text-end',
+}[align] ?? 'text-start' %}
+{% set spacingBefore = block.data.spacingBefore|default('none') %}
+{% set spacingAfter = block.data.spacingAfter|default('md') %}
+{% set spacingBeforeClass = {
+    none: '',
+    sm: 'mt-2',
+    md: 'mt-3',
+    lg: 'mt-4',
+}[spacingBefore] ?? '' %}
+{% set spacingAfterClass = {
+    none: 'mb-0',
+    sm: 'mb-2',
+    md: 'mb-3',
+    lg: 'mb-4',
+}[spacingAfter] ?? 'mb-3' %}
+<{{ level }} class="page-content-headline fw-bold {{ alignClass }} {{ spacingBeforeClass }} {{ spacingAfterClass }}">{{ block.data.text|default('') }}</{{ level }}>

--- a/src/Content/UI/Twig/templates/page/blocks/highlight.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/highlight.html.twig
@@ -1,0 +1,32 @@
+{% set variant = block.data.variant|default('info') %}
+{% if variant not in ['info', 'success', 'warning', 'danger', 'note'] %}
+    {% set variant = 'info' %}
+{% endif %}
+{% set alertClass = variant == 'note' ? 'alert-secondary' : 'alert-' ~ variant %}
+{% set iconMode = block.data.iconMode|default('auto') %}
+{% set autoIcons = {
+    info: 'tabler:info-circle',
+    success: 'tabler:circle-check',
+    warning: 'tabler:alert-triangle',
+    danger: 'tabler:alert-circle',
+    note: 'tabler:notes',
+} %}
+{% set iconName = null %}
+{% if iconMode == 'auto' %}
+    {% set iconName = autoIcons[variant] ?? 'tabler:info-circle' %}
+{% elseif iconMode == 'custom' and block.data.icon|default('') is not empty %}
+    {% set iconName = block.data.icon %}
+{% endif %}
+<div class="alert {{ alertClass }} page-content-highlight mb-0" role="alert">
+    {% if block.data.title|default('') is not empty or iconName %}
+        <div class="d-flex align-items-center gap-2 mb-2">
+            {% if iconName %}
+                <twig:ux:icon name="{{ iconName }}" class="w-4 h-4 flex-shrink-0" />
+            {% endif %}
+            {% if block.data.title|default('') is not empty %}
+                <div class="alert-title fw-semibold mb-0">{{ block.data.title }}</div>
+            {% endif %}
+        </div>
+    {% endif %}
+    <div class="content mb-0">{{ block.data.html|default('')|raw }}</div>
+</div>

--- a/src/Content/UI/Twig/templates/page/blocks/image.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/image.html.twig
@@ -1,6 +1,24 @@
-<figure class="mb-3">
-    <img class="img-fluid rounded" src="{{ block.data.src|default('') }}" alt="{{ block.data.alt|default('') }}" loading="lazy">
+{% set size = block.data.size|default('lg') %}
+{% if size not in ['sm', 'md', 'lg'] %}
+    {% set size = 'lg' %}
+{% endif %}
+{% set float = block.data.float|default('none') %}
+{% set figureClasses = ['card', 'card-sm', 'page-content-image', 'page-content-image--size-' ~ size, 'mb-0'] %}
+
+{% if float == 'left' %}
+    {% set figureClasses = figureClasses|merge(['page-content-image--float-left', 'float-start', 'me-3', 'mb-3']) %}
+{% elseif float == 'right' %}
+    {% set figureClasses = figureClasses|merge(['page-content-image--float-right', 'float-end', 'ms-3', 'mb-3']) %}
+{% endif %}
+
+<figure class="{{ figureClasses|join(' ') }}">
+    <img class="card-img-top"
+         src="{{ block.data.src|default('') }}"
+         alt="{{ block.data.alt|default('') }}"
+         loading="lazy">
     {% if block.data.caption|default('') is not empty %}
-        <figcaption class="text-secondary mt-1">{{ block.data.caption }}</figcaption>
+        <figcaption class="card-body py-2">
+            <p class="text-secondary small mb-0">{{ block.data.caption }}</p>
+        </figcaption>
     {% endif %}
 </figure>

--- a/src/Content/UI/Twig/templates/page/blocks/quote.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/quote.html.twig
@@ -1,3 +1,3 @@
-<blockquote class="blockquote border-start ps-3 my-3">
+<blockquote class="blockquote border-start border-3 ps-3 mb-0">
     <p class="mb-0">{{ block.data.text|default('') }}</p>
 </blockquote>

--- a/src/Content/UI/Twig/templates/page/blocks/richtext.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/richtext.html.twig
@@ -1,5 +1,1 @@
-<section class="card mb-3">
-    <div class="card-body content">
-        {{ block.data.html|default('')|raw }}
-    </div>
-</section>
+{{ block.data.html|default('')|raw }}

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -12,20 +12,24 @@
 {% block page_body %}
     <div class="page-body">
         <div class="container-xl">
-            <div class="row g-3">
-                <div class="col-lg-8">
-                    {% for block in page.content %}
-                        {% if block.enabled is not defined or block.enabled %}
-                            {% if block.type in ['richtext', 'image', 'cta', 'quote'] %}
-                                {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {block: block}) }}
+            <article class="card mb-4">
+                <div class="card-body">
+                    <div class="page-content-blocks content">
+                        {% for block in page.content %}
+                            {% if block.enabled is not defined or block.enabled %}
+                                {% if block.type in page_content_block_types() %}
+                                    <div class="page-content-block page-content-block--{{ block.type }}">
+                                        {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {
+                                            block: block,
+                                            blockIndex: loop.index,
+                                        }) }}
+                                    </div>
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                    {% endfor %}
+                        {% endfor %}
+                    </div>
                 </div>
-                <div class="col-lg-4">
-                    {{ include('@Content/page/_sidebar.html.twig') }}
-                </div>
-            </div>
+            </article>
         </div>
     </div>
 {% endblock %}

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -12,24 +12,31 @@
 {% block page_body %}
     <div class="page-body">
         <div class="container-xl">
-            <article class="card mb-4">
-                <div class="card-body">
-                    <div class="page-content-blocks content">
-                        {% for block in page.content %}
-                            {% if block.enabled is not defined or block.enabled %}
-                                {% if block.type in page_content_block_types() %}
-                                    <div class="page-content-block page-content-block--{{ block.type }}">
-                                        {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {
-                                            block: block,
-                                            blockIndex: loop.index,
-                                        }) }}
-                                    </div>
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
+            <div class="row g-3">
+                <div class="col-lg-8">
+                    <article class="card mb-4">
+                        <div class="card-body">
+                            <div class="page-content-blocks content">
+                                {% for block in page.content %}
+                                    {% if block.enabled is not defined or block.enabled %}
+                                        {% if block.type in page_content_block_types() %}
+                                            <div class="page-content-block page-content-block--{{ block.type }}">
+                                                {{ include('@Content/page/blocks/' ~ block.type ~ '.html.twig', {
+                                                    block: block,
+                                                    blockIndex: loop.index,
+                                                }) }}
+                                            </div>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </article>
                 </div>
-            </article>
+                <div class="col-lg-4">
+                    {{ include('@Content/page/_sidebar.html.twig') }}
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -97,10 +97,31 @@ final class AppFixtures extends Fixture
             'sortOrder' => 10,
             'content' => [
                 [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => [
+                        'text' => 'About our platform',
+                        'level' => 'h2',
+                        'align' => 'left',
+                        'spacingBefore' => 'none',
+                        'spacingAfter' => 'md',
+                    ],
+                ],
+                [
                     'type' => 'richtext',
                     'enabled' => true,
                     'data' => [
-                        'html' => '<h2>Lorem Ipsum</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>',
+                        'html' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>',
+                    ],
+                ],
+                [
+                    'type' => 'highlight',
+                    'enabled' => true,
+                    'data' => [
+                        'variant' => 'info',
+                        'title' => 'Did you know?',
+                        'html' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>',
+                        'iconMode' => 'auto',
                     ],
                 ],
                 [
@@ -108,6 +129,24 @@ final class AppFixtures extends Fixture
                     'enabled' => true,
                     'data' => [
                         'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+                    ],
+                ],
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            [
+                                'title' => 'What is Lorem Ipsum?',
+                                'html' => '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>',
+                                'openByDefault' => true,
+                            ],
+                            [
+                                'title' => 'Why do we use it?',
+                                'html' => '<p>It is a long established fact that a reader will be distracted.</p>',
+                                'openByDefault' => false,
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -178,6 +217,15 @@ final class AppFixtures extends Fixture
                         'src' => '/uploads/example-hosting.jpg',
                         'alt' => 'Server Rack',
                         'caption' => 'Lorem ipsum caption',
+                        'size' => 'md',
+                        'float' => 'left',
+                    ],
+                ],
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<p>Additional hosting details wrap around the floated image on larger screens. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>',
                     ],
                 ],
             ],

--- a/tests/Admin/Functional/Controller/PageCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/PageCrudControllerTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Admin\Functional\Controller;
 
+use App\Content\Domain\Entity\Page;
+use App\Content\Infrastructure\Factory\PageFactory;
 use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -47,5 +51,72 @@ final class PageCrudControllerTest extends WebTestCase
             ->visit('/admin/page')
             ->assertStatus(403)
         ;
+    }
+
+    public function testPageContentBlockOrderIsPersistedWhenSubmittedInReverseOrder(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'page-reorder-'.bin2hex(random_bytes(4)),
+            ])
+        ;
+
+        $page = PageFactory::createOne([
+            'title' => 'Reorder Test',
+            'slug' => 'reorder-test',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'First block', 'level' => 'h2'],
+                ],
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'Second block', 'level' => 'h2'],
+                ],
+            ],
+        ])->_real();
+
+        $client->loginUser($admin->_real());
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            sprintf('/admin/page/%d/edit', $page->getId()),
+        );
+
+        self::assertResponseIsSuccessful();
+
+        $saveButton = $crawler->selectButton('Save changes');
+        if (0 === $saveButton->count()) {
+            $saveButton = $crawler->selectButton('Save');
+        }
+
+        $form = $saveButton->form();
+        $form['Page[content][0][type]'] = 'headline';
+        $form['Page[content][0][enabled]'] = '1';
+        $form['Page[content][0][data][text]'] = 'Second block';
+        $form['Page[content][0][data][level]'] = 'h2';
+        $form['Page[content][1][type]'] = 'headline';
+        $form['Page[content][1][enabled]'] = '1';
+        $form['Page[content][1][data][text]'] = 'First block';
+        $form['Page[content][1][data][level]'] = 'h2';
+
+        $client->submit($form);
+        self::assertResponseRedirects();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->clear();
+
+        $updated = PageFactory::repository()->findOneBy(['slug' => 'reorder-test'])?->_real();
+        self::assertInstanceOf(Page::class, $updated);
+
+        $content = $updated->getContent();
+        self::assertSame('Second block', $content[0]['data']['text'] ?? null);
+        self::assertSame('First block', $content[1]['data']['text'] ?? null);
     }
 }

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -145,4 +145,67 @@ final class PageControllerTest extends WebTestCase
         self::assertSelectorExists('.page-content-image--float-left');
         self::assertSelectorExists('.page-content-accordion .accordion-button');
     }
+
+    public function testSidebarShowsOnlyPublicPagesForGuest(): void
+    {
+        $client = self::createClient();
+
+        $parent = PageFactory::createOne([
+            'title' => 'Öffentlich',
+            'slug' => 'oeffentlich',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Öffentlich</p>']]],
+        ])->_real();
+
+        PageFactory::createOne([
+            'title' => 'Geschwister',
+            'slug' => 'geschwister',
+            'parent' => $parent,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Geschwister</p>']]],
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Nur Mitglieder',
+            'slug' => 'nur-mitglieder',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $client->request(Request::METHOD_GET, '/oeffentlich');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="page-sidebar"]');
+        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Geschwister');
+        self::assertSelectorTextNotContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
+    }
+
+    public function testSidebarShowsAuthenticatedPagesForLoggedInUser(): void
+    {
+        $client = self::createClient();
+
+        PageFactory::createOne([
+            'title' => 'Start',
+            'slug' => 'start',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Start</p>']]],
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Nur Mitglieder',
+            'slug' => 'nur-mitglieder',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $user = UserFactory::createOne()->_real();
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/start');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
+    }
 }

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -82,66 +82,67 @@ final class PageControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
     }
 
-    public function testSidebarShowsOnlyPublicPagesForGuest(): void
-    {
-        $client = self::createClient();
-
-        $parent = PageFactory::createOne([
-            'title' => 'Öffentlich',
-            'slug' => 'oeffentlich',
-            'status' => Page::STATUS_PUBLISHED,
-            'visibility' => Page::VISIBILITY_PUBLIC,
-            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Öffentlich</p>']]],
-        ])->_real();
-
-        PageFactory::createOne([
-            'title' => 'Geschwister',
-            'slug' => 'geschwister',
-            'parent' => $parent,
-            'status' => Page::STATUS_PUBLISHED,
-            'visibility' => Page::VISIBILITY_PUBLIC,
-            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Geschwister</p>']]],
-        ]);
-
-        PageFactory::createOne([
-            'title' => 'Nur Mitglieder',
-            'slug' => 'nur-mitglieder',
-            'status' => Page::STATUS_PUBLISHED,
-            'visibility' => Page::VISIBILITY_AUTHENTICATED,
-        ]);
-
-        $client->request(Request::METHOD_GET, '/oeffentlich');
-
-        self::assertResponseIsSuccessful();
-        self::assertSelectorExists('[data-testid="page-sidebar"]');
-        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Geschwister');
-        self::assertSelectorTextNotContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
-    }
-
-    public function testSidebarShowsAuthenticatedPagesForLoggedInUser(): void
+    public function testPageRendersNewBlockTypesInSharedCard(): void
     {
         $client = self::createClient();
 
         PageFactory::createOne([
-            'title' => 'Start',
-            'slug' => 'start',
+            'title' => 'Demo Blocks',
+            'slug' => 'demo-blocks',
             'status' => Page::STATUS_PUBLISHED,
             'visibility' => Page::VISIBILITY_PUBLIC,
-            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Start</p>']]],
+            'content' => [
+                [
+                    'type' => 'headline',
+                    'data' => [
+                        'text' => 'Demo Headline',
+                        'level' => 'h2',
+                    ],
+                ],
+                [
+                    'type' => 'highlight',
+                    'data' => [
+                        'variant' => 'warning',
+                        'title' => 'Important',
+                        'html' => '<p>Warning content</p>',
+                    ],
+                ],
+                [
+                    'type' => 'image',
+                    'data' => [
+                        'src' => '/uploads/demo.jpg',
+                        'alt' => 'Demo',
+                        'size' => 'md',
+                        'float' => 'left',
+                    ],
+                ],
+                [
+                    'type' => 'richtext',
+                    'data' => ['html' => '<p>Wrapped text</p>'],
+                ],
+                [
+                    'type' => 'accordion',
+                    'data' => [
+                        'items' => [
+                            [
+                                'title' => 'FAQ question',
+                                'html' => '<p>FAQ answer</p>',
+                                'openByDefault' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ]);
 
-        PageFactory::createOne([
-            'title' => 'Nur Mitglieder',
-            'slug' => 'nur-mitglieder',
-            'status' => Page::STATUS_PUBLISHED,
-            'visibility' => Page::VISIBILITY_AUTHENTICATED,
-        ]);
-
-        $user = UserFactory::createOne()->_real();
-        $client->loginUser($user);
-        $client->request(Request::METHOD_GET, '/start');
+        $client->request(Request::METHOD_GET, '/demo-blocks');
 
         self::assertResponseIsSuccessful();
-        self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
+        self::assertSelectorExists('article.card .page-content-blocks');
+        self::assertSelectorTextContains('h2.page-content-headline', 'Demo Headline');
+        self::assertSelectorExists('.page-content-highlight.alert-warning');
+        self::assertSelectorExists('.page-content-image--size-md');
+        self::assertSelectorExists('.page-content-image--float-left');
+        self::assertSelectorExists('.page-content-accordion .accordion-button');
     }
 }

--- a/tests/Content/Integration/Page/PageContentSanitizerTest.php
+++ b/tests/Content/Integration/Page/PageContentSanitizerTest.php
@@ -59,4 +59,44 @@ HTML;
         self::assertStringContainsString('/uploads/media/sample.png', $html);
         self::assertStringContainsString('alt="Sample"', $html);
     }
+
+    public function testSanitizerSanitizesHighlightHtml(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PageContentSanitizer::class);
+
+        $raw = '<p>Notice</p><script>alert(1)</script>';
+
+        $out = $sut->sanitize([['type' => 'highlight', 'data' => ['html' => $raw]]]);
+        $html = (string) ($out[0]['data']['html'] ?? '');
+
+        self::assertStringContainsString('Notice', $html);
+        self::assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testSanitizerSanitizesAccordionItemHtml(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PageContentSanitizer::class);
+
+        $raw = '<p>Answer</p><script>alert(1)</script>';
+
+        $out = $sut->sanitize([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        ['title' => 'Q', 'html' => $raw],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = (string) ($out[0]['data']['items'][0]['html'] ?? '');
+
+        self::assertStringContainsString('Answer', $html);
+        self::assertStringNotContainsString('<script>', $html);
+    }
 }

--- a/tests/Content/Integration/Page/PageContentSanitizerTest.php
+++ b/tests/Content/Integration/Page/PageContentSanitizerTest.php
@@ -99,4 +99,40 @@ HTML;
         self::assertStringContainsString('Answer', $html);
         self::assertStringNotContainsString('<script>', $html);
     }
+
+    public function testSanitizerSkipsInvalidAccordionItems(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PageContentSanitizer::class);
+
+        $out = $sut->sanitize([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        'invalid-item',
+                        ['title' => 'Q', 'html' => '<p>Answer</p>'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $out[0]['data']['items']);
+        self::assertSame('Answer', strip_tags((string) $out[0]['data']['items'][0]['html']));
+    }
+
+    public function testSanitizerPassesThroughNonHtmlBlocks(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PageContentSanitizer::class);
+
+        $block = [
+            'type' => 'headline',
+            'data' => ['text' => 'Title', 'level' => 'h2'],
+        ];
+
+        self::assertSame([$block], $sut->sanitize([$block]));
+    }
 }

--- a/tests/Content/Unit/Enum/PageContentBlockTypeTest.php
+++ b/tests/Content/Unit/Enum/PageContentBlockTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Enum;
+
+use App\Content\Domain\Enum\PageContentBlockType;
+use PHPUnit\Framework\TestCase;
+
+final class PageContentBlockTypeTest extends TestCase
+{
+    public function testTranslationKeyUsesBlockValue(): void
+    {
+        self::assertSame('label.block_type.headline', PageContentBlockType::Headline->translationKey());
+    }
+
+    public function testValuesReturnsAllCaseValues(): void
+    {
+        self::assertSame(
+            ['richtext', 'image', 'cta', 'quote', 'headline', 'highlight', 'accordion'],
+            PageContentBlockType::values(),
+        );
+    }
+
+    public function testFormChoicesMapsTranslationKeysToValues(): void
+    {
+        $choices = PageContentBlockType::formChoices();
+
+        self::assertSame('headline', $choices['label.block_type.headline']);
+        self::assertSame('accordion', $choices['label.block_type.accordion']);
+        self::assertCount(count(PageContentBlockType::cases()), $choices);
+    }
+
+    public function testTryFromStringReturnsNullForEmptyValues(): void
+    {
+        self::assertNull(PageContentBlockType::tryFromString(null));
+        self::assertNull(PageContentBlockType::tryFromString(''));
+        self::assertNull(PageContentBlockType::tryFromString('   '));
+    }
+
+    public function testTryFromStringReturnsMatchingCase(): void
+    {
+        self::assertSame(PageContentBlockType::Highlight, PageContentBlockType::tryFromString('highlight'));
+    }
+}

--- a/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
+++ b/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
@@ -156,4 +156,113 @@ final class PageContentBlockDataNormalizerTest extends TestCase
 
         self::assertSame('sm', $normalized[0]['data']['size']);
     }
+
+    public function testSkipsNonArrayBlocks(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            'invalid-block',
+            [
+                'type' => 'quote',
+                'data' => ['text' => 'Quote'],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'quote',
+                'data' => ['text' => 'Quote'],
+            ],
+        ], $normalized);
+    }
+
+    public function testDefaultsMissingTypeToRichtext(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'data' => ['html' => '<p>Fallback</p>'],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'richtext',
+                'data' => ['html' => '<p>Fallback</p>'],
+            ],
+        ], $normalized);
+    }
+
+    public function testNormalizesInvalidImageFloatToNone(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'float' => 'center',
+                ],
+            ],
+        ]);
+
+        self::assertSame('none', $normalized[0]['data']['float']);
+    }
+
+    public function testNormalizesLegacyWidthPresetMdToSize(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'md',
+                ],
+            ],
+        ]);
+
+        self::assertSame('md', $normalized[0]['data']['size']);
+    }
+
+    public function testNormalizesAccordionItemsToEmptyListWhenInvalid(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => 'invalid',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $normalized[0]['data']['items']);
+    }
+
+    public function testUnknownBlockTypeProducesEmptyData(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'unknown',
+                'data' => ['foo' => 'bar'],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'unknown',
+                'data' => [],
+            ],
+        ], $normalized);
+    }
 }

--- a/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
+++ b/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
@@ -32,8 +32,128 @@ final class PageContentBlockDataNormalizerTest extends TestCase
                 'data' => [
                     'alt' => 'Alt text',
                     'src' => '/uploads/media/x.png',
+                    'size' => 'lg',
+                    'float' => 'none',
                 ],
             ],
         ], $normalized);
+    }
+
+    public function testNormalizesHeadlineBlockFields(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'headline',
+                'data' => [
+                    'text' => 'Section title',
+                    'level' => 'h3',
+                    'align' => 'center',
+                    'spacingBefore' => 'sm',
+                    'spacingAfter' => 'lg',
+                    'html' => '<p>ignored</p>',
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'headline',
+                'data' => [
+                    'text' => 'Section title',
+                    'level' => 'h3',
+                    'align' => 'center',
+                    'spacingBefore' => 'sm',
+                    'spacingAfter' => 'lg',
+                ],
+            ],
+        ], $normalized);
+    }
+
+    public function testNormalizesAccordionItems(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        [
+                            'title' => 'Question',
+                            'html' => '<p>Answer</p>',
+                            'openByDefault' => true,
+                            'extra' => 'ignored',
+                        ],
+                        'invalid-item',
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        [
+                            'title' => 'Question',
+                            'html' => '<p>Answer</p>',
+                            'openByDefault' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ], $normalized);
+    }
+
+    public function testNormalizesImageSizeAndFloat(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'size' => 'md',
+                    'float' => 'right',
+                    'widthMode' => 'percent',
+                    'widthPercent' => 50,
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'size' => 'md',
+                    'float' => 'right',
+                ],
+            ],
+        ], $normalized);
+    }
+
+    public function testNormalizesLegacyImageWidthPresetToSize(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'sm',
+                ],
+            ],
+        ]);
+
+        self::assertSame('sm', $normalized[0]['data']['size']);
     }
 }

--- a/tests/Content/Unit/Page/PageContentValidatorTest.php
+++ b/tests/Content/Unit/Page/PageContentValidatorTest.php
@@ -19,6 +19,16 @@ final class PageContentValidatorTest extends TestCase
             ['type' => 'image', 'data' => ['src' => '/img.jpg', 'alt' => 'Alt']],
             ['type' => 'cta', 'data' => ['headline' => 'Mehr', 'buttonLabel' => 'Los', 'buttonUrl' => '/x']],
             ['type' => 'quote', 'data' => ['text' => 'Zitat']],
+            ['type' => 'headline', 'data' => ['text' => 'Title']],
+            ['type' => 'highlight', 'data' => ['html' => '<p>Info</p>']],
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        ['title' => 'Q', 'html' => '<p>A</p>'],
+                    ],
+                ],
+            ],
         ];
 
         self::assertSame([], $validator->validate($content));
@@ -38,6 +48,56 @@ final class PageContentValidatorTest extends TestCase
         self::assertStringContainsString('unknown block type "unknown"', implode(' ', $errors));
         self::assertStringContainsString('image src or media required', implode(' ', $errors));
         self::assertStringContainsString('data.html is required', implode(' ', $errors));
+    }
+
+    public function testAccordionRequiresAtLeastOneItem(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            ['type' => 'accordion', 'data' => ['items' => []]],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('accordion item', implode(' ', $errors));
+    }
+
+    public function testImageFloatRequiresNonFullWidth(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'size' => 'lg',
+                    'float' => 'left',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('non-full-width', implode(' ', $errors));
+    }
+
+    public function testHighlightCustomIconRequiresIconName(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'highlight',
+                'data' => [
+                    'html' => '<p>Info</p>',
+                    'iconMode' => 'custom',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('custom icon', implode(' ', $errors));
     }
 
     public function testNonArrayContentReturnsSingleError(): void
@@ -82,6 +142,9 @@ final class PageContentValidatorTest extends TestCase
                     'page.validation.block_enabled_must_be_bool' => 'field "enabled" must be true or false.',
                     'page.validation.block_required_field' => 'data.{field} is required.',
                     'page.validation.image_src_or_media_required' => 'image src or media required.',
+                    'page.validation.accordion_items_required' => 'At least one accordion item is required.',
+                    'page.validation.image_float_requires_non_full_width' => 'Text wrap requires a non-full-width image.',
+                    'page.validation.highlight_icon_required' => 'A custom icon is required when icon mode is custom.',
                 ];
 
                 $message = $messages[$id] ?? $id;

--- a/tests/Content/Unit/Page/PageContentValidatorTest.php
+++ b/tests/Content/Unit/Page/PageContentValidatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Content\Unit\Page;
 
 use App\Content\Application\Page\PageContentValidator;
+use App\Content\Domain\Entity\Media;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -122,6 +123,332 @@ final class PageContentValidatorTest extends TestCase
         self::assertStringContainsString('must be an object.', $errors[0]);
     }
 
+    public function testMissingBlockTypeIsRejected(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            ['data' => ['html' => '<p>x</p>']],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('field "type" is required', $errors[0]);
+    }
+
+    public function testBlockDataMustBeObject(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            ['type' => 'richtext', 'data' => 'invalid'],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('field "data" must be an object', $errors[0]);
+    }
+
+    public function testEnabledMustBeBoolean(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            ['type' => 'richtext', 'enabled' => 'yes', 'data' => ['html' => '<p>x</p>']],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('field "enabled" must be true or false', $errors[0]);
+    }
+
+    public function testHeadlineRejectsInvalidOptions(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'headline',
+                'data' => [
+                    'text' => 'Title',
+                    'level' => 'h5',
+                    'align' => 'justify',
+                    'spacingBefore' => 'xl',
+                ],
+            ],
+        ]);
+
+        self::assertCount(3, $errors);
+        self::assertStringContainsString('invalid headline level', implode(' ', $errors));
+        self::assertStringContainsString('invalid headline alignment', implode(' ', $errors));
+        self::assertStringContainsString('invalid spacingBefore', implode(' ', $errors));
+    }
+
+    public function testHighlightRejectsInvalidVariantAndIconMode(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'highlight',
+                'data' => [
+                    'html' => '<p>Info</p>',
+                    'variant' => 'purple',
+                    'iconMode' => 'emoji',
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $errors);
+        self::assertStringContainsString('invalid highlight variant', implode(' ', $errors));
+        self::assertStringContainsString('invalid icon mode', implode(' ', $errors));
+    }
+
+    public function testImageRejectsInvalidSizeAndFloat(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'size' => 'xl',
+                    'float' => 'center',
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $errors);
+        self::assertStringContainsString('invalid image size', implode(' ', $errors));
+        self::assertStringContainsString('invalid float option', implode(' ', $errors));
+    }
+
+    public function testImageAcceptsLegacyWidthPresetForSize(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'md',
+                    'float' => 'none',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testImageAcceptsLegacySmallWidthPresetForSize(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'sm',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testCtaRequiresButtonLabel(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'cta',
+                'data' => [
+                    'headline' => 'More',
+                    'buttonUrl' => '/go',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('data.buttonLabel is required', $errors[0]);
+    }
+
+    public function testHeadlineRequiresText(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'headline',
+                'data' => ['level' => 'h2'],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('data.text is required', $errors[0]);
+    }
+
+    public function testHighlightRequiresHtml(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'highlight',
+                'data' => ['variant' => 'info'],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('data.html is required', $errors[0]);
+    }
+
+    public function testImageAcceptsMediaEntityReference(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+        $media = $this->createMock(Media::class);
+        $media->method('getId')->willReturn(7);
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'mediaId' => $media,
+                    'alt' => 'Alt',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testImageAcceptsStringMediaId(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'mediaId' => '42',
+                    'alt' => 'Alt',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testCtaWithMediaLinkRequiresMediaReference(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'cta',
+                'data' => [
+                    'headline' => 'Download',
+                    'buttonLabel' => 'PDF',
+                    'linkType' => 'media',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('media library PDF', $errors[0]);
+    }
+
+    public function testCtaWithUrlLinkRequiresButtonUrl(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'cta',
+                'data' => [
+                    'headline' => 'More',
+                    'buttonLabel' => 'Go',
+                    'linkType' => 'url',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('data.buttonUrl is required', $errors[0]);
+    }
+
+    public function testAccordionItemMustBeObject(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        'invalid-item',
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('must be an object', $errors[0]);
+    }
+
+    public function testAccordionItemRequiresTitleAndHtml(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'accordion',
+                'data' => [
+                    'items' => [
+                        ['title' => '', 'html' => ''],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $errors);
+        self::assertStringContainsString('data.title is required', implode(' ', $errors));
+        self::assertStringContainsString('data.html is required', implode(' ', $errors));
+    }
+
+    public function testImageAcceptsNumericMediaId(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'mediaId' => 42,
+                    'alt' => 'Alt',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testAssertValidThrowsWhenInvalid(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "type" is required');
+
+        $validator->assertValid([
+            ['data' => []],
+        ]);
+    }
+
     private function translator(): TranslatorInterface
     {
         return new class implements TranslatorInterface {
@@ -142,9 +469,18 @@ final class PageContentValidatorTest extends TestCase
                     'page.validation.block_enabled_must_be_bool' => 'field "enabled" must be true or false.',
                     'page.validation.block_required_field' => 'data.{field} is required.',
                     'page.validation.image_src_or_media_required' => 'image src or media required.',
+                    'page.validation.image_invalid_size' => 'invalid image size.',
+                    'page.validation.image_invalid_float' => 'invalid float option.',
                     'page.validation.accordion_items_required' => 'At least one accordion item is required.',
+                    'page.validation.accordion_item_must_be_object' => 'must be an object.',
                     'page.validation.image_float_requires_non_full_width' => 'Text wrap requires a non-full-width image.',
                     'page.validation.highlight_icon_required' => 'A custom icon is required when icon mode is custom.',
+                    'page.validation.headline_invalid_level' => 'invalid headline level.',
+                    'page.validation.headline_invalid_align' => 'invalid headline alignment.',
+                    'page.validation.headline_invalid_spacing' => 'invalid {field} spacing.',
+                    'page.validation.highlight_invalid_variant' => 'invalid highlight variant.',
+                    'page.validation.highlight_invalid_icon_mode' => 'invalid icon mode.',
+                    'page.validation.cta_media_required' => 'media library PDF is required.',
                 ];
 
                 $message = $messages[$id] ?? $id;

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3271,6 +3271,18 @@
         <source>label.block_type.quote</source>
         <target>Quote</target>
       </trans-unit>
+      <trans-unit id="page0017a" resname="label.block_type.headline">
+        <source>label.block_type.headline</source>
+        <target>Headline</target>
+      </trans-unit>
+      <trans-unit id="page0017b" resname="label.block_type.highlight">
+        <source>label.block_type.highlight</source>
+        <target>Highlight</target>
+      </trans-unit>
+      <trans-unit id="page0017c" resname="label.block_type.accordion">
+        <source>label.block_type.accordion</source>
+        <target>Accordion</target>
+      </trans-unit>
       <trans-unit id="page0018" resname="label.html">
         <source>label.html</source>
         <target>HTML</target>
@@ -3306,6 +3318,250 @@
       <trans-unit id="page0026" resname="label.quote_text">
         <source>label.quote_text</source>
         <target>Quote text</target>
+      </trans-unit>
+      <trans-unit id="page0026a" resname="label.headline_text">
+        <source>label.headline_text</source>
+        <target>Headline text</target>
+      </trans-unit>
+      <trans-unit id="page0026b" resname="label.headline_level">
+        <source>label.headline_level</source>
+        <target>Heading level</target>
+      </trans-unit>
+      <trans-unit id="page0026c" resname="label.headline_level.h1">
+        <source>label.headline_level.h1</source>
+        <target>H1</target>
+      </trans-unit>
+      <trans-unit id="page0026d" resname="label.headline_level.h2">
+        <source>label.headline_level.h2</source>
+        <target>H2</target>
+      </trans-unit>
+      <trans-unit id="page0026e" resname="label.headline_level.h3">
+        <source>label.headline_level.h3</source>
+        <target>H3</target>
+      </trans-unit>
+      <trans-unit id="page0026f" resname="label.headline_level.h4">
+        <source>label.headline_level.h4</source>
+        <target>H4</target>
+      </trans-unit>
+      <trans-unit id="page0026g" resname="help.page.headline_level">
+        <source>help.page.headline_level</source>
+        <target>The page title is already rendered as H1. Use H1 here only when you intentionally need a second top-level heading.</target>
+      </trans-unit>
+      <trans-unit id="page0026h" resname="label.headline_align">
+        <source>label.headline_align</source>
+        <target>Alignment</target>
+      </trans-unit>
+      <trans-unit id="page0026i" resname="label.headline_align.left">
+        <source>label.headline_align.left</source>
+        <target>Left</target>
+      </trans-unit>
+      <trans-unit id="page0026j" resname="label.headline_align.center">
+        <source>label.headline_align.center</source>
+        <target>Center</target>
+      </trans-unit>
+      <trans-unit id="page0026k" resname="label.headline_align.right">
+        <source>label.headline_align.right</source>
+        <target>Right</target>
+      </trans-unit>
+      <trans-unit id="page0026l" resname="label.headline_spacing_before">
+        <source>label.headline_spacing_before</source>
+        <target>Spacing before</target>
+      </trans-unit>
+      <trans-unit id="page0026m" resname="label.headline_spacing_after">
+        <source>label.headline_spacing_after</source>
+        <target>Spacing after</target>
+      </trans-unit>
+      <trans-unit id="page0026n" resname="label.spacing.none">
+        <source>label.spacing.none</source>
+        <target>None</target>
+      </trans-unit>
+      <trans-unit id="page0026o" resname="label.spacing.sm">
+        <source>label.spacing.sm</source>
+        <target>Small</target>
+      </trans-unit>
+      <trans-unit id="page0026p" resname="label.spacing.md">
+        <source>label.spacing.md</source>
+        <target>Medium</target>
+      </trans-unit>
+      <trans-unit id="page0026q" resname="label.spacing.lg">
+        <source>label.spacing.lg</source>
+        <target>Large</target>
+      </trans-unit>
+      <trans-unit id="page0026r" resname="label.highlight_variant">
+        <source>label.highlight_variant</source>
+        <target>Variant</target>
+      </trans-unit>
+      <trans-unit id="page0026s" resname="label.highlight_variant.info">
+        <source>label.highlight_variant.info</source>
+        <target>Info</target>
+      </trans-unit>
+      <trans-unit id="page0026t" resname="label.highlight_variant.success">
+        <source>label.highlight_variant.success</source>
+        <target>Success</target>
+      </trans-unit>
+      <trans-unit id="page0026u" resname="label.highlight_variant.warning">
+        <source>label.highlight_variant.warning</source>
+        <target>Warning</target>
+      </trans-unit>
+      <trans-unit id="page0026v" resname="label.highlight_variant.danger">
+        <source>label.highlight_variant.danger</source>
+        <target>Danger</target>
+      </trans-unit>
+      <trans-unit id="page0026w" resname="label.highlight_variant.note">
+        <source>label.highlight_variant.note</source>
+        <target>Note</target>
+      </trans-unit>
+      <trans-unit id="page0026x" resname="label.highlight_title">
+        <source>label.highlight_title</source>
+        <target>Title (optional)</target>
+      </trans-unit>
+      <trans-unit id="page0026y" resname="label.highlight_icon_mode">
+        <source>label.highlight_icon_mode</source>
+        <target>Icon mode</target>
+      </trans-unit>
+      <trans-unit id="page0026z" resname="label.highlight_icon_mode.auto">
+        <source>label.highlight_icon_mode.auto</source>
+        <target>Automatic by variant</target>
+      </trans-unit>
+      <trans-unit id="page0026aa" resname="label.highlight_icon_mode.custom">
+        <source>label.highlight_icon_mode.custom</source>
+        <target>Custom icon</target>
+      </trans-unit>
+      <trans-unit id="page0026ab" resname="label.highlight_icon_mode.none">
+        <source>label.highlight_icon_mode.none</source>
+        <target>No icon</target>
+      </trans-unit>
+      <trans-unit id="page0026ac" resname="label.highlight_icon">
+        <source>label.highlight_icon</source>
+        <target>Custom icon</target>
+      </trans-unit>
+      <trans-unit id="page0026ad" resname="help.page.highlight_icon">
+        <source>help.page.highlight_icon</source>
+        <target>Tabler icon name, e.g. tabler:info-circle</target>
+      </trans-unit>
+      <trans-unit id="page0026ae" resname="label.accordion_items">
+        <source>label.accordion_items</source>
+        <target>Accordion items</target>
+      </trans-unit>
+      <trans-unit id="page0026af" resname="label.accordion_item_title">
+        <source>label.accordion_item_title</source>
+        <target>Item title</target>
+      </trans-unit>
+      <trans-unit id="page0026ag" resname="label.accordion_open_by_default">
+        <source>label.accordion_open_by_default</source>
+        <target>Open by default</target>
+      </trans-unit>
+      <trans-unit id="page0026ah" resname="label.image_width_mode">
+        <source>label.image_width_mode</source>
+        <target>Width mode</target>
+      </trans-unit>
+      <trans-unit id="page0026ai" resname="label.image_width_mode.preset">
+        <source>label.image_width_mode.preset</source>
+        <target>Preset</target>
+      </trans-unit>
+      <trans-unit id="page0026aj" resname="label.image_width_mode.px">
+        <source>label.image_width_mode.px</source>
+        <target>Fixed pixels</target>
+      </trans-unit>
+      <trans-unit id="page0026ak" resname="label.image_width_mode.percent">
+        <source>label.image_width_mode.percent</source>
+        <target>Percent</target>
+      </trans-unit>
+      <trans-unit id="page0026al" resname="label.image_width_preset">
+        <source>label.image_width_preset</source>
+        <target>Width preset</target>
+      </trans-unit>
+      <trans-unit id="page0026am" resname="label.image_width_preset.sm">
+        <source>label.image_width_preset.sm</source>
+        <target>Small (25%)</target>
+      </trans-unit>
+      <trans-unit id="page0026an" resname="label.image_width_preset.md">
+        <source>label.image_width_preset.md</source>
+        <target>Medium (50%)</target>
+      </trans-unit>
+      <trans-unit id="page0026ao" resname="label.image_width_preset.lg">
+        <source>label.image_width_preset.lg</source>
+        <target>Large (75%)</target>
+      </trans-unit>
+      <trans-unit id="page0026ap" resname="label.image_width_preset.full">
+        <source>label.image_width_preset.full</source>
+        <target>Full width</target>
+      </trans-unit>
+      <trans-unit id="page0026aq" resname="label.image_width_px">
+        <source>label.image_width_px</source>
+        <target>Width in pixels</target>
+      </trans-unit>
+      <trans-unit id="page0026ar" resname="help.page.image_width_px">
+        <source>help.page.image_width_px</source>
+        <target>Used when width mode is fixed pixels.</target>
+      </trans-unit>
+      <trans-unit id="page0026as" resname="label.image_width_percent">
+        <source>label.image_width_percent</source>
+        <target>Width in percent</target>
+      </trans-unit>
+      <trans-unit id="page0026at" resname="help.page.image_width_percent">
+        <source>help.page.image_width_percent</source>
+        <target>Used when width mode is percent (1–100).</target>
+      </trans-unit>
+      <trans-unit id="page0026au" resname="label.image_alignment">
+        <source>label.image_alignment</source>
+        <target>Alignment</target>
+      </trans-unit>
+      <trans-unit id="page0026av" resname="label.image_alignment.left">
+        <source>label.image_alignment.left</source>
+        <target>Left</target>
+      </trans-unit>
+      <trans-unit id="page0026aw" resname="label.image_alignment.center">
+        <source>label.image_alignment.center</source>
+        <target>Center</target>
+      </trans-unit>
+      <trans-unit id="page0026ax" resname="label.image_alignment.right">
+        <source>label.image_alignment.right</source>
+        <target>Right</target>
+      </trans-unit>
+      <trans-unit id="page0026ay" resname="label.image_alignment.full">
+        <source>label.image_alignment.full</source>
+        <target>Full width</target>
+      </trans-unit>
+      <trans-unit id="page0026az" resname="label.image_float">
+        <source>label.image_float</source>
+        <target>Text wrap</target>
+      </trans-unit>
+      <trans-unit id="page0026ba" resname="label.image_float.none">
+        <source>label.image_float.none</source>
+        <target>No wrap</target>
+      </trans-unit>
+      <trans-unit id="page0026bb" resname="label.image_float.left">
+        <source>label.image_float.left</source>
+        <target>Image left, text wraps right</target>
+      </trans-unit>
+      <trans-unit id="page0026bc" resname="label.image_float.right">
+        <source>label.image_float.right</source>
+        <target>Image right, text wraps left</target>
+      </trans-unit>
+      <trans-unit id="page0026bd" resname="help.page.image_float">
+        <source>help.page.image_float</source>
+        <target>Following rich text blocks will wrap around the image. On small screens the image becomes full width.</target>
+      </trans-unit>
+      <trans-unit id="page0026be" resname="label.image_size">
+        <source>label.image_size</source>
+        <target>Image size</target>
+      </trans-unit>
+      <trans-unit id="page0026bf" resname="label.image_size.sm">
+        <source>label.image_size.sm</source>
+        <target>Small</target>
+      </trans-unit>
+      <trans-unit id="page0026bg" resname="label.image_size.md">
+        <source>label.image_size.md</source>
+        <target>Medium</target>
+      </trans-unit>
+      <trans-unit id="page0026bh" resname="label.image_size.lg">
+        <source>label.image_size.lg</source>
+        <target>Large (full width)</target>
+      </trans-unit>
+      <trans-unit id="page0026bi" resname="help.page.image_size">
+        <source>help.page.image_size</source>
+        <target>Relative to the content card width, not the full page.</target>
       </trans-unit>
       <trans-unit id="page0027" resname="error.page.auth_required">
         <source>error.page.auth_required</source>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3563,6 +3563,18 @@
         <source>help.page.image_size</source>
         <target>Relative to the content card width, not the full page.</target>
       </trans-unit>
+      <trans-unit id="page0026bj" resname="label.move_block_up">
+        <source>label.move_block_up</source>
+        <target>Move block up</target>
+      </trans-unit>
+      <trans-unit id="page0026bk" resname="label.move_block_down">
+        <source>label.move_block_down</source>
+        <target>Move block down</target>
+      </trans-unit>
+      <trans-unit id="page0026bl" resname="help.page.content_blocks_reorder">
+        <source>help.page.content_blocks_reorder</source>
+        <target>Use the up and down arrows on each block to change the order.</target>
+      </trans-unit>
       <trans-unit id="page0027" resname="error.page.auth_required">
         <source>error.page.auth_required</source>
         <target>This page is only available to signed-in users.</target>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -765,6 +765,66 @@
         <source>page.validation.cta_media_required</source>
         <target>Select a PDF from the media library for this button.</target>
       </trans-unit>
+      <trans-unit id="pagev016" resname="page.validation.headline_invalid_level">
+        <source>page.validation.headline_invalid_level</source>
+        <target>Invalid headline level.</target>
+      </trans-unit>
+      <trans-unit id="pagev017" resname="page.validation.headline_invalid_align">
+        <source>page.validation.headline_invalid_align</source>
+        <target>Invalid headline alignment.</target>
+      </trans-unit>
+      <trans-unit id="pagev018" resname="page.validation.headline_invalid_spacing">
+        <source>page.validation.headline_invalid_spacing</source>
+        <target>Invalid spacing value for {field}.</target>
+      </trans-unit>
+      <trans-unit id="pagev019" resname="page.validation.highlight_invalid_variant">
+        <source>page.validation.highlight_invalid_variant</source>
+        <target>Invalid highlight variant.</target>
+      </trans-unit>
+      <trans-unit id="pagev020" resname="page.validation.highlight_invalid_icon_mode">
+        <source>page.validation.highlight_invalid_icon_mode</source>
+        <target>Invalid highlight icon mode.</target>
+      </trans-unit>
+      <trans-unit id="pagev021" resname="page.validation.highlight_icon_required">
+        <source>page.validation.highlight_icon_required</source>
+        <target>A custom icon is required when icon mode is custom.</target>
+      </trans-unit>
+      <trans-unit id="pagev022" resname="page.validation.accordion_items_required">
+        <source>page.validation.accordion_items_required</source>
+        <target>At least one accordion item is required.</target>
+      </trans-unit>
+      <trans-unit id="pagev023" resname="page.validation.accordion_item_must_be_object">
+        <source>page.validation.accordion_item_must_be_object</source>
+        <target>Accordion item must be an object.</target>
+      </trans-unit>
+      <trans-unit id="pagev024" resname="page.validation.image_invalid_size">
+        <source>page.validation.image_invalid_size</source>
+        <target>Invalid image size.</target>
+      </trans-unit>
+      <trans-unit id="pagev025" resname="page.validation.image_invalid_width_preset">
+        <source>page.validation.image_invalid_width_preset</source>
+        <target>Invalid image width preset.</target>
+      </trans-unit>
+      <trans-unit id="pagev026" resname="page.validation.image_width_px_required">
+        <source>page.validation.image_width_px_required</source>
+        <target>Width in pixels is required when width mode is fixed pixels.</target>
+      </trans-unit>
+      <trans-unit id="pagev027" resname="page.validation.image_width_percent_invalid">
+        <source>page.validation.image_width_percent_invalid</source>
+        <target>Width in percent must be between 1 and 100.</target>
+      </trans-unit>
+      <trans-unit id="pagev028" resname="page.validation.image_invalid_alignment">
+        <source>page.validation.image_invalid_alignment</source>
+        <target>Invalid image alignment.</target>
+      </trans-unit>
+      <trans-unit id="pagev029" resname="page.validation.image_invalid_float">
+        <source>page.validation.image_invalid_float</source>
+        <target>Invalid image float option.</target>
+      </trans-unit>
+      <trans-unit id="pagev030" resname="page.validation.image_float_requires_non_full_width">
+        <source>page.validation.image_float_requires_non_full_width</source>
+        <target>Text wrap requires a non-full-width image.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
### Summary

- Restored support for page content blocks
- Reintroduced modular page content composition using reusable block structures
- Updated page rendering to support block-based content layouts
- Integrated content blocks with the existing page and content system
- Added or adjusted tests for block rendering and page display behavior
- Performed cleanup and refactoring around page content handling

### Motivation

- Bring back flexible content composition for pages
- Allow complex page layouts to be built from reusable content blocks
- Improve maintainability and extensibility of the content system
- Prepare the foundation for richer content editing and future CMS-related features

### Notes for Reviewers

- Verify content blocks render correctly on all affected pages
- Check compatibility with existing page content and templates
- Review block ordering and layout behavior
- Ensure pages without content blocks continue to render correctly
- Confirm tests cover rendering, ordering, and fallback scenarios