### PR TITLE
feat: Add CMS lightbox support and reusable media snippets

### DIFF
--- a/assets/admin-page-form.js
+++ b/assets/admin-page-form.js
@@ -1,2 +1,3 @@
 import './bootstrap.js';
+import './admin-trix-media.js';
 import './styles/admin/collection-reorder.css';

--- a/assets/admin-trix-media.js
+++ b/assets/admin-trix-media.js
@@ -1,0 +1,21 @@
+document.addEventListener('trix-before-initialize', () => {
+    if (typeof window.Trix === 'undefined') {
+        return
+    }
+
+    window.Trix.config.dompurify = window.Trix.config.dompurify || {}
+    const dompurify = window.Trix.config.dompurify
+
+    dompurify.ADD_TAGS = [...new Set([...(dompurify.ADD_TAGS || []), 'img', 'figure', 'figcaption'])]
+    dompurify.ADD_ATTR = [...new Set([
+        ...(dompurify.ADD_ATTR || []),
+        'src',
+        'alt',
+        'loading',
+        'class',
+        'data-fslightbox',
+        'href',
+        'target',
+        'rel',
+    ])]
+})

--- a/assets/controllers/lightbox_controller.js
+++ b/assets/controllers/lightbox_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from '@hotwired/stimulus'
+
+let fslightboxLoaded = false
+
+export default class extends Controller {
+    static values = {
+        gallery: { type: String, default: 'content-gallery' },
+    }
+
+    connect () {
+        this.boundRefresh = this.refresh.bind(this)
+        this.refresh()
+        document.addEventListener('turbo:load', this.boundRefresh)
+        document.addEventListener('turbo:frame-load', this.boundRefresh)
+    }
+
+    disconnect () {
+        document.removeEventListener('turbo:load', this.boundRefresh)
+        document.removeEventListener('turbo:frame-load', this.boundRefresh)
+    }
+
+    refresh () {
+        this.wrapBareImages()
+        this.initLightbox()
+    }
+
+    wrapBareImages () {
+        this.element.querySelectorAll('img[src]').forEach((img) => {
+            if (img.closest('[data-fslightbox]')) {
+                return
+            }
+
+            if (img.closest('a')) {
+                return
+            }
+
+            const src = img.getAttribute('src')
+            if (!src) {
+                return
+            }
+
+            const link = document.createElement('a')
+            link.href = src
+            link.setAttribute('data-fslightbox', this.galleryValue)
+            link.classList.add('page-content-image__link')
+            img.parentNode.insertBefore(link, img)
+            link.appendChild(img)
+        })
+    }
+
+    initLightbox () {
+        if (!fslightboxLoaded) {
+            import('fslightbox').then(() => {
+                fslightboxLoaded = true
+                if (typeof refreshFsLightbox === 'function') {
+                    refreshFsLightbox()
+                }
+            })
+            return
+        }
+
+        if (typeof refreshFsLightbox === 'function') {
+            refreshFsLightbox()
+        }
+    }
+}

--- a/assets/styles/admin/media-detail.css
+++ b/assets/styles/admin/media-detail.css
@@ -1,0 +1,61 @@
+.media-detail-usage {
+    margin-top: 1.5rem;
+}
+
+.media-detail-usage .form-fieldset-body {
+    padding: 1rem 1.25rem 1.25rem;
+}
+
+.media-detail-usage__toolbar {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.media-detail-usage__toolbar label {
+    color: var(--bs-secondary-color);
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-bottom: 0;
+}
+
+.media-detail-usage__copy {
+    align-items: center;
+    display: inline-flex;
+    flex-shrink: 0;
+    height: 2rem;
+    justify-content: center;
+    padding: 0;
+    width: 2rem;
+}
+
+.media-detail-usage__code {
+    background-color: var(--bs-secondary-bg);
+    border-radius: var(--bs-border-radius);
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    min-height: 9rem;
+    resize: vertical;
+    width: 100%;
+}
+
+.media-detail-usage__hint {
+    font-size: 0.875rem;
+    line-height: 1.55;
+}
+
+.media-detail-usage__hint-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.media-detail-usage__hint ul {
+    margin-bottom: 0;
+    padding-left: 1.25rem;
+}
+
+.media-detail-usage__hint li + li {
+    margin-top: 0.35rem;
+}

--- a/assets/styles/pages/content-blocks.css
+++ b/assets/styles/pages/content-blocks.css
@@ -22,6 +22,21 @@
     display: block;
 }
 
+.page-content-image__link {
+    cursor: zoom-in;
+}
+
+.page-content-image__link:hover .card-img-top,
+.page-content-image__link:hover img,
+[data-controller="lightbox"] img:hover {
+    opacity: 0.92;
+}
+
+[data-controller="lightbox"] img {
+    cursor: zoom-in;
+    transition: opacity 0.15s ease-in-out;
+}
+
 .page-content-image--size-sm {
     width: 33%;
 }

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -28,7 +28,15 @@ framework:
                     - a
                     - blockquote
                     - img
+                    - figure
+                    - figcaption
                 allow_attributes:
+                    data-fslightbox:
+                        - a
+                    class:
+                        - figure
+                        - a
+                        - img
                     a:
                         - href
                         - title

--- a/importmap.php
+++ b/importmap.php
@@ -56,4 +56,7 @@ return [
     '@symfony/ux-live-component' => [
         'path' => './vendor/symfony/ux-live-component/assets/dist/live_controller.js',
     ],
+    'fslightbox' => [
+        'version' => '3.7.5',
+    ],
 ];

--- a/importmap.php
+++ b/importmap.php
@@ -24,6 +24,10 @@ return [
         'path' => './assets/admin-page-form.js',
         'entrypoint' => true,
     ],
+    'admin-trix-media' => [
+        'path' => './assets/admin-trix-media.js',
+        'entrypoint' => true,
+    ],
     'error_page' => [
         'path' => './assets/error-page.js',
         'entrypoint' => true,

--- a/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Http\Controller\Blog;
 
-use App\Admin\UI\Http\Controller\Media\MediaCrudController;
+use App\Content\Application\Blog\PostContentSanitizer;
+use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
 use App\Content\Domain\Entity\Post;
 use App\Content\Domain\Enum\PostStatus;
 use App\Content\Infrastructure\Repository\PostRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -19,7 +22,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -32,8 +34,9 @@ final class PostCrudController extends AbstractCrudController
 {
     public function __construct(
         private readonly PostRepository $postRepository,
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
         private readonly TranslatorInterface $translator,
+        private readonly PostContentSanitizer $postContentSanitizer,
+        private readonly MediaLibraryAdminUrlProvider $mediaLibraryAdminUrlProvider,
     ) {
     }
 
@@ -41,6 +44,12 @@ final class PostCrudController extends AbstractCrudController
     public static function getEntityFqcn(): string
     {
         return Post::class;
+    }
+
+    #[\Override]
+    public function configureAssets(Assets $assets): Assets
+    {
+        return $assets->addAssetMapperEntry(Asset::new('admin-trix-media')->onlyOnForms());
     }
 
     #[\Override]
@@ -79,7 +88,13 @@ final class PostCrudController extends AbstractCrudController
             ->setHelp('help.blog.published_at');
         yield TextEditorField::new('content', 'label.content')
             ->setNumOfRows(20)
-            ->setHelp($this->buildMediaLibraryHelp())
+            ->setTrixEditorConfig([
+                'dompurify' => [
+                    'ADD_TAGS' => ['img', 'figure', 'figcaption'],
+                    'ADD_ATTR' => ['src', 'alt', 'loading', 'class', 'data-fslightbox', 'href', 'target', 'rel'],
+                ],
+            ])
+            ->setHelp($this->buildContentHelp())
             ->setFormTypeOption('help_html', true)
             ->hideOnIndex();
         yield DateTimeField::new('createdAt', 'label.created')->setFormat('dd.MM.yy HH:mm')->hideOnForm();
@@ -95,6 +110,7 @@ final class PostCrudController extends AbstractCrudController
 
         $this->ensurePublishDataConsistency($entityInstance);
         $entityInstance->setSlug($this->buildUniqueSlug($entityInstance, null));
+        $entityInstance->setContent($this->postContentSanitizer->sanitize((string) $entityInstance->getContent()));
 
         parent::persistEntity($entityManager, $entityInstance);
     }
@@ -108,6 +124,7 @@ final class PostCrudController extends AbstractCrudController
 
         $this->ensurePublishDataConsistency($entityInstance);
         $entityInstance->setSlug($this->buildUniqueSlug($entityInstance, $entityInstance->getId()));
+        $entityInstance->setContent($this->postContentSanitizer->sanitize((string) $entityInstance->getContent()));
 
         parent::updateEntity($entityManager, $entityInstance);
     }
@@ -134,12 +151,16 @@ final class PostCrudController extends AbstractCrudController
         return $candidate;
     }
 
+    private function buildContentHelp(): string
+    {
+        return $this->buildMediaLibraryHelp()
+            .' '.$this->translator->trans('help.blog.image_layout');
+    }
+
     private function buildMediaLibraryHelp(): string
     {
         $url = htmlspecialchars(
-            $this->adminUrlGenerator
-                ->setController(MediaCrudController::class)
-                ->generateUrl(),
+            $this->mediaLibraryAdminUrlProvider->getIndexUrl(),
             ENT_QUOTES | ENT_HTML5,
         );
 

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Admin\UI\Http\Controller\Page;
 
 use App\Admin\UI\Form\PageContentBlockType;
-use App\Admin\UI\Http\Controller\Media\MediaCrudController;
+use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
 use App\Content\Application\Page\PageContentBlockDataNormalizer;
 use App\Content\Application\Page\PageContentMediaResolver;
 use App\Content\Application\Page\PageContentSanitizer;
@@ -31,7 +31,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -50,7 +49,7 @@ final class PageCrudController extends AbstractCrudController
         private readonly PageContentMediaResolver $pageContentMediaResolver,
         private readonly PageContentSanitizer $pageContentSanitizer,
         private readonly PagePathResolver $pagePathResolver,
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
+        private readonly MediaLibraryAdminUrlProvider $mediaLibraryAdminUrlProvider,
         private readonly TranslatorInterface $translator,
     ) {
     }
@@ -275,9 +274,7 @@ final class PageCrudController extends AbstractCrudController
     private function buildMediaLibraryHelp(): string
     {
         $url = htmlspecialchars(
-            $this->adminUrlGenerator
-                ->setController(MediaCrudController::class)
-                ->generateUrl(),
+            $this->mediaLibraryAdminUrlProvider->getIndexUrl(),
             ENT_QUOTES | ENT_HTML5,
         );
 

--- a/src/Admin/UI/Twig/templates/media/detail.html.twig
+++ b/src/Admin/UI/Twig/templates/media/detail.html.twig
@@ -1,37 +1,94 @@
 {% extends '@EasyAdmin/crud/detail.html.twig' %}
 
-{% block detail_fields %}
+{% block configured_stylesheets %}
+    {{ parent() }}
+    {% if media_public_url is defined and media_public_url is not empty %}
+        <link rel="stylesheet" href="{{ asset('styles/admin/media-detail.css') }}">
+    {% endif %}
+{% endblock %}
+
+{% block main %}
     {{ parent() }}
 
     {% if media_public_url is defined and media_public_url is not empty %}
-        <div class="field-group mt-4">
-            <h3 class="h5">{{ 'label.media_usage'|trans }}</h3>
+        {% set media = entity.instance %}
+        <section class="media-detail-usage">
+            <div class="form-fieldset">
+                <fieldset>
+                    <div class="form-fieldset-header">
+                        <div class="form-fieldset-title">
+                            <span class="not-collapsible form-fieldset-title-content">
+                                {{ 'label.media_usage'|trans }}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="form-fieldset-body show">
+                        <div class="media-detail-usage__snippet">
+                            <div class="media-detail-usage__toolbar">
+                                <label for="media-snippet">{{ 'label.html_snippet'|trans }}</label>
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-secondary media-detail-usage__copy"
+                                        id="media-snippet-copy"
+                                        title="{{ 'action.copy_snippet'|trans }}"
+                                        aria-label="{{ 'action.copy_snippet'|trans }}">
+                                    <twig:ux:icon name="tabler:clipboard" class="media-detail-usage__copy-icon media-detail-usage__copy-icon--default w-4 h-4" />
+                                    <twig:ux:icon name="tabler:check" class="media-detail-usage__copy-icon media-detail-usage__copy-icon--success w-4 h-4 d-none" />
+                                </button>
+                            </div>
+                            <textarea id="media-snippet"
+                                      class="media-detail-usage__code form-control font-monospace"
+                                      rows="6"
+                                      readonly>{{ media_snippet }}</textarea>
+                        </div>
 
-            {% set media = entity.instance %}
-            {% if media.type.value == 'image' %}
-                <p class="mb-2">
-                    <img src="{{ media_public_url }}" alt="{{ media.altText|default(media.title|default('')) }}" class="img-fluid rounded" style="max-height: 240px;">
-                </p>
-            {% else %}
-                <p class="mb-2">
-                    <a href="{{ media_public_url }}" target="_blank" rel="noopener">{{ media_public_url }}</a>
-                </p>
-            {% endif %}
-
-            <label class="form-label" for="media-snippet">{{ 'label.html_snippet'|trans }}</label>
-            <textarea id="media-snippet" class="form-control font-monospace" rows="4" readonly>{{ media_snippet }}</textarea>
-            <button type="button" class="btn btn-secondary btn-sm mt-2" data-copy-target="media-snippet">
-                {{ 'action.copy_snippet'|trans }}
-            </button>
-        </div>
+                        {% if media.type.value == 'image' %}
+                            <div class="alert alert-secondary media-detail-usage__hint mt-3 mb-0">
+                                <p class="media-detail-usage__hint-title mb-2">{{ 'help.media.image_layout.title'|trans }}</p>
+                                <ul>
+                                    <li>{{ 'help.media.image_layout.size'|trans }}</li>
+                                    <li>{{ 'help.media.image_layout.float'|trans }}</li>
+                                    <li>{{ 'help.media.image_layout.mobile'|trans }}</li>
+                                </ul>
+                            </div>
+                        {% endif %}
+                    </div>
+                </fieldset>
+            </div>
+        </section>
 
         <script>
-            document.querySelector('[data-copy-target="media-snippet"]')?.addEventListener('click', function () {
-                const el = document.getElementById('media-snippet');
-                if (!el) return;
-                el.select();
-                navigator.clipboard?.writeText(el.value);
-            });
+            (function () {
+                const button = document.getElementById('media-snippet-copy');
+                const textarea = document.getElementById('media-snippet');
+                if (!button || !textarea) {
+                    return;
+                }
+
+                button.addEventListener('click', async function () {
+                    textarea.focus();
+                    textarea.select();
+
+                    try {
+                        await navigator.clipboard.writeText(textarea.value);
+                    } catch (error) {
+                        document.execCommand('copy');
+                    }
+
+                    const defaultIcon = button.querySelector('.media-detail-usage__copy-icon--default');
+                    const successIcon = button.querySelector('.media-detail-usage__copy-icon--success');
+                    defaultIcon?.classList.add('d-none');
+                    successIcon?.classList.remove('d-none');
+                    button.classList.remove('btn-outline-secondary');
+                    button.classList.add('btn-outline-success');
+
+                    window.setTimeout(function () {
+                        defaultIcon?.classList.remove('d-none');
+                        successIcon?.classList.add('d-none');
+                        button.classList.remove('btn-outline-success');
+                        button.classList.add('btn-outline-secondary');
+                    }, 1800);
+                });
+            })();
         </script>
     {% endif %}
 {% endblock %}

--- a/src/Content/Application/Blog/PostContentSanitizer.php
+++ b/src/Content/Application/Blog/PostContentSanitizer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Blog;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+
+final readonly class PostContentSanitizer
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        #[Autowire(service: 'html_sanitizer.sanitizer.page_richtext')]
+        private HtmlSanitizerInterface $pageRichtextSanitizer,
+    ) {
+    }
+
+    public function sanitize(string $content): string
+    {
+        if ('' === $content) {
+            return '';
+        }
+
+        $decoded = html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return $this->pageRichtextSanitizer->sanitize($decoded);
+    }
+}

--- a/src/Content/Application/Media/MediaImageFigureHtmlBuilder.php
+++ b/src/Content/Application/Media/MediaImageFigureHtmlBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Media;
+
+final readonly class MediaImageFigureHtmlBuilder
+{
+    public function build(string $url, string $alt, string $size = 'lg', string $float = 'none'): string
+    {
+        $size = \in_array($size, ['sm', 'md', 'lg'], true) ? $size : 'lg';
+        $float = \in_array($float, ['none', 'left', 'right'], true) ? $float : 'none';
+
+        $classes = ['card', 'card-sm', 'page-content-image', 'page-content-image--size-'.$size, 'mb-0'];
+
+        if ('left' === $float) {
+            $classes = [...$classes, 'page-content-image--float-left', 'float-start', 'me-3', 'mb-3'];
+        } elseif ('right' === $float) {
+            $classes = [...$classes, 'page-content-image--float-right', 'float-end', 'ms-3', 'mb-3'];
+        }
+
+        $classAttr = htmlspecialchars(implode(' ', $classes), ENT_QUOTES | ENT_HTML5);
+        $urlEsc = htmlspecialchars($url, ENT_QUOTES | ENT_HTML5);
+        $altEsc = htmlspecialchars($alt, ENT_QUOTES | ENT_HTML5);
+
+        return sprintf(
+            '<figure class="%s"><a href="%s" data-fslightbox="content-gallery" class="d-block page-content-image__link"><img class="card-img-top" src="%s" alt="%s" loading="lazy"></a></figure>',
+            $classAttr,
+            $urlEsc,
+            $urlEsc,
+            $altEsc,
+        );
+    }
+}

--- a/src/Content/Application/Media/MediaLibraryAdminUrlProvider.php
+++ b/src/Content/Application/Media/MediaLibraryAdminUrlProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Media;
+
+use App\Admin\UI\Http\Controller\Media\MediaCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+
+final readonly class MediaLibraryAdminUrlProvider
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+    ) {
+    }
+
+    public function getIndexUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->setController(MediaCrudController::class)
+            ->setAction(Crud::PAGE_INDEX)
+            ->generateUrl();
+    }
+}

--- a/src/Content/Application/Media/MediaSnippetGenerator.php
+++ b/src/Content/Application/Media/MediaSnippetGenerator.php
@@ -12,6 +12,7 @@ final readonly class MediaSnippetGenerator
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private MediaPublicUrlResolver $publicUrlResolver,
+        private MediaImageFigureHtmlBuilder $imageFigureHtmlBuilder,
     ) {
     }
 
@@ -22,20 +23,30 @@ final readonly class MediaSnippetGenerator
 
     public function generateHtml(Media $media): string
     {
-        $url = htmlspecialchars($this->getPublicUrl($media), ENT_QUOTES | ENT_HTML5);
-
         if (MediaType::IMAGE === $media->getType()) {
-            $alt = htmlspecialchars($this->resolveAltText($media), ENT_QUOTES | ENT_HTML5);
-
-            return sprintf('<img src="%s" alt="%s">', $url, $alt);
+            return $this->generateImageFigureHtml($media);
         }
 
+        $url = htmlspecialchars($this->getPublicUrl($media), ENT_QUOTES | ENT_HTML5);
         $label = htmlspecialchars($this->resolveLinkLabel($media), ENT_QUOTES | ENT_HTML5);
 
         return sprintf(
             '<a href="%s" target="_blank" rel="noopener">%s</a>',
             $url,
             $label,
+        );
+    }
+
+    public function generateImageFigureHtml(
+        Media $media,
+        string $size = 'lg',
+        string $float = 'none',
+    ): string {
+        return $this->imageFigureHtmlBuilder->build(
+            $this->getPublicUrl($media),
+            $this->resolveAltText($media),
+            $size,
+            $float,
         );
     }
 

--- a/src/Content/UI/Http/Controller/BlogController.php
+++ b/src/Content/UI/Http/Controller/BlogController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Content\UI\Http\Controller;
 
+use App\Content\Application\Blog\PostContentSanitizer;
 use App\Content\Domain\Entity\PostComment;
 use App\Content\Infrastructure\Repository\PostCategoryRepository;
 use App\Content\Infrastructure\Repository\PostCommentRepository;
@@ -28,6 +29,7 @@ final class BlogController extends AbstractController
         private readonly PostCategoryRepository $categoryRepository,
         private readonly PostTagRepository $tagRepository,
         private readonly PostCommentRepository $postCommentRepository,
+        private readonly PostContentSanitizer $postContentSanitizer,
         private readonly TranslatorInterface $translator,
         private readonly EntityManagerInterface $entityManager,
     ) {
@@ -105,6 +107,7 @@ final class BlogController extends AbstractController
 
         return $this->render('@Content/blog/show.html.twig', [
             'post' => $post,
+            'content' => $this->postContentSanitizer->sanitize((string) $post->getContent()),
             'comments' => $this->postCommentRepository->findRootCommentsForPost($post),
             'previous_post' => $this->postRepository->findPreviousPublishedPost($post),
             'next_post' => $this->postRepository->findNextPublishedPost($post),

--- a/src/Content/UI/Twig/templates/blog/show.html.twig
+++ b/src/Content/UI/Twig/templates/blog/show.html.twig
@@ -52,8 +52,10 @@
                 <div class="col-lg-8">
                     <article class="card mb-4">
                         <div class="card-body">
-                            <div class="content">
-                                {{ post.content|raw }}
+                            <div class="content page-content-blocks"
+                                 data-controller="lightbox"
+                                 data-lightbox-gallery-value="content-gallery">
+                                {{ content|raw }}
                             </div>
                         </div>
                     </article>

--- a/src/Content/UI/Twig/templates/page/blocks/image.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/image.html.twig
@@ -12,10 +12,14 @@
 {% endif %}
 
 <figure class="{{ figureClasses|join(' ') }}">
-    <img class="card-img-top"
-         src="{{ block.data.src|default('') }}"
-         alt="{{ block.data.alt|default('') }}"
-         loading="lazy">
+    <a href="{{ block.data.src|default('') }}"
+       data-fslightbox="content-gallery"
+       class="d-block page-content-image__link">
+        <img class="card-img-top"
+             src="{{ block.data.src|default('') }}"
+             alt="{{ block.data.alt|default('') }}"
+             loading="lazy">
+    </a>
     {% if block.data.caption|default('') is not empty %}
         <figcaption class="card-body py-2">
             <p class="text-secondary small mb-0">{{ block.data.caption }}</p>

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -16,7 +16,9 @@
                 <div class="col-lg-8">
                     <article class="card mb-4">
                         <div class="card-body">
-                            <div class="page-content-blocks content">
+                            <div class="page-content-blocks content"
+                                 data-controller="lightbox"
+                                 data-lightbox-gallery-value="content-gallery">
                                 {% for block in page.content %}
                                     {% if block.enabled is not defined or block.enabled %}
                                         {% if block.type in page_content_block_types() %}

--- a/tests/Content/Functional/Controller/BlogControllerTest.php
+++ b/tests/Content/Functional/Controller/BlogControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Content\Functional\Controller;
 
+use App\Content\Application\Media\MediaImageFigureHtmlBuilder;
 use App\Content\Domain\Entity\Post;
 use App\Content\Domain\Enum\PostStatus;
 use App\Content\Infrastructure\Factory\PostCategoryFactory;
@@ -217,6 +218,49 @@ final class BlogControllerTest extends WebTestCase
         self::assertSelectorTextContains('body', 'Mein Kommentar');
         self::assertSelectorTextContains('body', $user->getUserIdentifier());
         self::assertSelectorTextContains('body', (string) $post->getTitle());
+    }
+
+    public function testShowRendersEntityEncodedImageSnippet(): void
+    {
+        $client = self::createClient();
+        $category = PostCategoryFactory::createOne(['name' => 'Media', 'slug' => 'media']);
+
+        PostFactory::createOne([
+            'title' => 'Post With Image',
+            'slug' => 'post-with-image',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-1 hour'),
+            'category' => $category,
+            'content' => '<p>Intro</p>&lt;img src=&quot;/uploads/media/sample.png&quot; alt=&quot;Sample&quot;&gt;',
+        ]);
+
+        $crawler = $client->request(Request::METHOD_GET, '/blog/post-with-image');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('img[src="/uploads/media/sample.png"]'));
+    }
+
+    public function testShowRendersFloatedFigureWithLayoutClasses(): void
+    {
+        $client = self::createClient();
+        $category = PostCategoryFactory::createOne(['name' => 'Layout', 'slug' => 'layout']);
+        $figure = new MediaImageFigureHtmlBuilder()->build('/uploads/media/sample.png', 'Sample', 'md', 'left');
+
+        PostFactory::createOne([
+            'title' => 'Post With Floated Image',
+            'slug' => 'post-with-floated-image',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-1 hour'),
+            'category' => $category,
+            'content' => '<p>Intro</p>'.$figure.'<p>More text</p>',
+        ]);
+
+        $crawler = $client->request(Request::METHOD_GET, '/blog/post-with-floated-image');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.content.page-content-blocks');
+        self::assertSelectorExists('figure.page-content-image--size-md.page-content-image--float-left');
+        self::assertCount(1, $crawler->filter('img[src="/uploads/media/sample.png"]'));
     }
 
     public function testShowRendersPrevNextNavigation(): void

--- a/tests/Content/Integration/Blog/PostContentSanitizerTest.php
+++ b/tests/Content/Integration/Blog/PostContentSanitizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Blog;
+
+use App\Content\Application\Blog\PostContentSanitizer;
+use App\Content\Application\Media\MediaImageFigureHtmlBuilder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class PostContentSanitizerTest extends KernelTestCase
+{
+    public function testSanitizerDecodesEntityEncodedImageSnippet(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+
+        $raw = '<p>Intro</p>&lt;a href=&quot;/uploads/media/sample.png&quot; data-fslightbox=&quot;content-gallery&quot;&gt;&lt;img src=&quot;/uploads/media/sample.png&quot; alt=&quot;Sample&quot;&gt;&lt;/a&gt;';
+
+        $html = $sut->sanitize($raw);
+
+        self::assertStringContainsString('<img', $html);
+        self::assertStringContainsString('/uploads/media/sample.png', $html);
+        self::assertStringContainsString('data-fslightbox="content-gallery"', $html);
+        self::assertStringNotContainsString('&lt;img', $html);
+    }
+
+    public function testSanitizerKeepsPlainImageTag(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+
+        $raw = '<p>Text</p><img src="/uploads/media/sample.png" alt="Sample">';
+
+        $html = $sut->sanitize($raw);
+
+        self::assertStringContainsString('<img', $html);
+        self::assertStringContainsString('/uploads/media/sample.png', $html);
+        self::assertStringContainsString('alt="Sample"', $html);
+    }
+
+    public function testSanitizerKeepsFigureWithLayoutClasses(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+
+        $raw = new MediaImageFigureHtmlBuilder()->build(
+            '/uploads/media/sample.png',
+            'Sample',
+            'md',
+            'left',
+        );
+
+        $html = $sut->sanitize('<p>Intro</p>'.$raw);
+
+        self::assertStringContainsString('<figure', $html);
+        self::assertStringContainsString('page-content-image--size-md', $html);
+        self::assertStringContainsString('page-content-image--float-left', $html);
+        self::assertStringContainsString('float-start', $html);
+    }
+}

--- a/tests/Content/Integration/Page/PageContentSanitizerTest.php
+++ b/tests/Content/Integration/Page/PageContentSanitizerTest.php
@@ -60,6 +60,23 @@ HTML;
         self::assertStringContainsString('alt="Sample"', $html);
     }
 
+    public function testSanitizerKeepsLightboxWrappedImageTagsFromMediaSnippets(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PageContentSanitizer::class);
+
+        $raw = '<p>Text</p><a href="/uploads/media/sample.png" data-fslightbox="content-gallery"><img src="/uploads/media/sample.png" alt="Sample"></a>';
+
+        $out = $sut->sanitize([['type' => 'richtext', 'data' => ['html' => $raw]]]);
+        $html = (string) ($out[0]['data']['html'] ?? '');
+
+        self::assertStringContainsString('data-fslightbox="content-gallery"', $html);
+        self::assertStringContainsString('<img', $html);
+        self::assertStringContainsString('/uploads/media/sample.png', $html);
+        self::assertStringContainsString('alt="Sample"', $html);
+    }
+
     public function testSanitizerSanitizesHighlightHtml(): void
     {
         self::bootKernel();

--- a/tests/Content/Unit/Media/MediaImageFigureHtmlBuilderTest.php
+++ b/tests/Content/Unit/Media/MediaImageFigureHtmlBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Media;
+
+use App\Content\Application\Media\MediaImageFigureHtmlBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class MediaImageFigureHtmlBuilderTest extends TestCase
+{
+    public function testBuildsFullWidthFigureByDefault(): void
+    {
+        $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo');
+
+        self::assertStringContainsString('<figure class="card card-sm page-content-image page-content-image--size-lg mb-0">', $html);
+        self::assertStringContainsString('data-fslightbox="content-gallery"', $html);
+        self::assertStringContainsString('<img class="card-img-top" src="/uploads/media/photo.webp" alt="A photo" loading="lazy">', $html);
+    }
+
+    public function testBuildsFloatedMediumFigure(): void
+    {
+        $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo', 'md', 'left');
+
+        self::assertStringContainsString('page-content-image--size-md', $html);
+        self::assertStringContainsString('page-content-image--float-left', $html);
+        self::assertStringContainsString('float-start', $html);
+    }
+
+    public function testIgnoresInvalidSizeAndFloat(): void
+    {
+        $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo', 'xl', 'center');
+
+        self::assertStringContainsString('page-content-image--size-lg', $html);
+        self::assertStringNotContainsString('float-start', $html);
+        self::assertStringNotContainsString('float-end', $html);
+    }
+
+    private function builder(): MediaImageFigureHtmlBuilder
+    {
+        return new MediaImageFigureHtmlBuilder();
+    }
+}

--- a/tests/Content/Unit/Media/MediaLibraryAdminUrlProviderTest.php
+++ b/tests/Content/Unit/Media/MediaLibraryAdminUrlProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Media;
+
+use App\Admin\UI\Http\Controller\Media\MediaCrudController;
+use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use PHPUnit\Framework\TestCase;
+
+final class MediaLibraryAdminUrlProviderTest extends TestCase
+{
+    public function testGetIndexUrlTargetsMediaLibraryIndex(): void
+    {
+        $generator = $this->createMock(AdminUrlGeneratorInterface::class);
+        $generator->expects(self::once())
+            ->method('setController')
+            ->with(MediaCrudController::class)
+            ->willReturnSelf();
+        $generator->expects(self::once())
+            ->method('setAction')
+            ->with(Crud::PAGE_INDEX)
+            ->willReturnSelf();
+        $generator->expects(self::once())
+            ->method('generateUrl')
+            ->willReturn('/admin?crudAction=index&crudControllerFqcn=MediaCrudController');
+
+        self::assertSame(
+            '/admin?crudAction=index&crudControllerFqcn=MediaCrudController',
+            new MediaLibraryAdminUrlProvider($generator)->getIndexUrl(),
+        );
+    }
+}

--- a/tests/Content/Unit/Media/MediaSnippetGeneratorTest.php
+++ b/tests/Content/Unit/Media/MediaSnippetGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Content\Unit\Media;
 
+use App\Content\Application\Media\MediaImageFigureHtmlBuilder;
 use App\Content\Application\Media\MediaPublicUrlResolver;
 use App\Content\Application\Media\MediaSnippetGenerator;
 use App\Content\Domain\Entity\Media;
@@ -18,7 +19,21 @@ final class MediaSnippetGeneratorTest extends TestCase
 
         $html = $this->generator()->generateHtml($media);
 
-        self::assertSame('<img src="/uploads/media/photo.webp" alt="A photo">', $html);
+        self::assertSame(
+            new MediaImageFigureHtmlBuilder()->build('/uploads/media/photo.webp', 'A photo'),
+            $html,
+        );
+    }
+
+    public function testImageFigureSnippetSupportsCustomLayout(): void
+    {
+        $media = $this->imageMedia('photo.webp', 'A photo');
+
+        $html = $this->generator()->generateImageFigureHtml($media, 'md', 'right');
+
+        self::assertStringContainsString('page-content-image--size-md', $html);
+        self::assertStringContainsString('page-content-image--float-right', $html);
+        self::assertStringContainsString('float-end', $html);
     }
 
     public function testPdfSnippetContainsNoopener(): void
@@ -35,7 +50,7 @@ final class MediaSnippetGeneratorTest extends TestCase
 
     private function generator(): MediaSnippetGenerator
     {
-        return new MediaSnippetGenerator(new MediaPublicUrlResolver());
+        return new MediaSnippetGenerator(new MediaPublicUrlResolver(), new MediaImageFigureHtmlBuilder());
     }
 
     private function imageMedia(string $filename, string $alt): Media

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3277,7 +3277,7 @@
       </trans-unit>
       <trans-unit id="page0019" resname="help.page.richtext_allowed_tags">
         <source>help.page.richtext_allowed_tags</source>
-        <target>Allowed tags: p, br, h2-h4, strong, em, ul, ol, li, a, blockquote, img</target>
+        <target>Allowed tags: p, br, h2-h4, strong, em, ul, ol, li, a, blockquote, img, figure, figcaption</target>
       </trans-unit>
       <trans-unit id="page0020" resname="label.image_url">
         <source>label.image_url</source>
@@ -3846,6 +3846,30 @@
       <trans-unit id="media016" resname="help.blog.media_library">
         <source>help.blog.media_library</source>
         <target>Upload images or PDFs in the media library, then copy the HTML snippet into the editor.</target>
+      </trans-unit>
+      <trans-unit id="media016b" resname="help.blog.image_layout">
+        <source>help.blog.image_layout</source>
+        <target>After inserting the snippet, adjust the figure classes for size (page-content-image--size-sm, --size-md, --size-lg) and text wrap (page-content-image--float-left float-start or --float-right float-end).</target>
+      </trans-unit>
+      <trans-unit id="media016c" resname="help.media.image_layout.title">
+        <source>help.media.image_layout.title</source>
+        <target>Adjust layout via figure classes</target>
+      </trans-unit>
+      <trans-unit id="media016c1" resname="help.media.image_layout.size">
+        <source>help.media.image_layout.size</source>
+        <target>Size: replace page-content-image--size-lg with --size-sm (33%) or --size-md (66%).</target>
+      </trans-unit>
+      <trans-unit id="media016c2" resname="help.media.image_layout.float">
+        <source>help.media.image_layout.float</source>
+        <target>Text wrap: add page-content-image--float-left float-start me-3 mb-3 or --float-right float-end ms-3 mb-3 (only with sm or md).</target>
+      </trans-unit>
+      <trans-unit id="media016c3" resname="help.media.image_layout.mobile">
+        <source>help.media.image_layout.mobile</source>
+        <target>On small screens, floated images automatically span the full width.</target>
+      </trans-unit>
+      <trans-unit id="media016e" resname="action.snippet_copied">
+        <source>action.snippet_copied</source>
+        <target>Copied!</target>
       </trans-unit>
       <trans-unit id="media017" resname="help.page.media_library">
         <source>help.page.media_library</source>


### PR DESCRIPTION
### Summary

- Added lightbox support for media elements in CMS content
- Introduced reusable media snippets for embedding images and other media assets
- Improved media rendering and presentation within pages and content blocks
- Integrated media snippets with the existing media library and CMS infrastructure
- Updated templates and frontend behavior to support lightbox interactions
- Added or updated tests covering media snippet rendering and lightbox functionality

### Motivation

- Improve the user experience when viewing embedded media
- Provide content editors with reusable building blocks for media-rich pages
- Reduce duplication by centralizing media rendering logic
- Enhance the CMS with more flexible and visually appealing content capabilities
- Build upon the existing media library foundation to create richer content experiences

### Notes for Reviewers

- Verify lightbox behavior across different media types and screen sizes
- Check media snippet rendering within pages and content blocks
- Ensure media library integration works correctly when selecting or embedding assets
- Review frontend interactions and accessibility considerations
- Confirm tests cover snippet rendering and lightbox-related behavior