### PR TITLE
feat: Add Top-N reports for statistics analysis

### DIFF
--- a/src/Statistics/Application/Report/AbstractTopNTableReport.php
+++ b/src/Statistics/Application/Report/AbstractTopNTableReport.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticWidget;
+use App\Statistics\Application\DTO\StatisticWidgetNavigationTarget;
+use App\Statistics\Application\DTO\StatisticWidgetType;
+use App\Statistics\Application\DTO\WidgetPayload\TableWidgetPayload;
+use App\Statistics\Application\DTO\WidgetPayload\WidgetPayloadNormalizer;
+use App\Statistics\Application\TopEntityQuery;
+
+abstract readonly class AbstractTopNTableReport implements ReportDefinitionInterface
+{
+    public function __construct(
+        private TopEntityQuery $topEntityQuery,
+        private ReportLimitPolicy $reportLimitPolicy,
+        private WidgetPayloadNormalizer $widgetPayloadNormalizer,
+    ) {
+    }
+
+    abstract protected function projectionJoinProperty(): string;
+
+    abstract protected function entityFqcn(): string;
+
+    abstract protected function tableLabelColumnTranslationKey(): string;
+
+    #[\Override]
+    public function supports(StatisticsFilter $filter): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function build(StatisticsContext $context, int $limit): StatisticWidget
+    {
+        $data = $this->topEntityQuery->fetch(
+            $context,
+            $limit,
+            $this->projectionJoinProperty(),
+            $this->entityFqcn(),
+        );
+        $total = $data['totalAllocations'];
+        $rows = [];
+        $rank = 1;
+
+        foreach ($data['rows'] as $row) {
+            $count = $row['count'];
+            $pct = $total > 0 ? round(100 * $count / $total, 1) : 0.0;
+            $rows[] = [
+                (string) $rank,
+                $row['label'],
+                (string) $count,
+                sprintf('%.1f%%', $pct),
+            ];
+            ++$rank;
+        }
+
+        $payload = new TableWidgetPayload(
+            [
+                'stats.reports.table.rank',
+                $this->tableLabelColumnTranslationKey(),
+                'stats.reports.table.count',
+                'stats.reports.table.share',
+            ],
+            $rows,
+            ['numericColumnStartIndex' => 3],
+        );
+
+        return new StatisticWidget(
+            StatisticWidgetType::Table,
+            $this->key().'_table',
+            $this->widgetPayloadNormalizer->normalize($payload),
+            null,
+            [
+                new StatisticWidgetNavigationTarget(
+                    'stats.nav.report_to_analysis_allocations_by_month',
+                    'app_stats_analysis',
+                    ['analysis' => 'allocations_by_month'],
+                    ['report', 'limit', 'view', 'chart'],
+                ),
+            ],
+        );
+    }
+
+    #[\Override]
+    public function allowedLimits(): array
+    {
+        return $this->reportLimitPolicy->allowed();
+    }
+}

--- a/src/Statistics/Application/Report/TopAssignmentsReport.php
+++ b/src/Statistics/Application/Report/TopAssignmentsReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\Assignment;
+
+final readonly class TopAssignmentsReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_assignments';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_assignments.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_assignments.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'assignmentId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return Assignment::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.assignment';
+    }
+}

--- a/src/Statistics/Application/Report/TopDepartmentsReport.php
+++ b/src/Statistics/Application/Report/TopDepartmentsReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\Department;
+
+final readonly class TopDepartmentsReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_departments';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_departments.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_departments.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'departmentId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return Department::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.department';
+    }
+}

--- a/src/Statistics/Application/Report/TopInfectionsReport.php
+++ b/src/Statistics/Application/Report/TopInfectionsReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\Infection;
+
+final readonly class TopInfectionsReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_infections';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_infections.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_infections.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'infectionId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return Infection::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.infection';
+    }
+}

--- a/src/Statistics/Application/Report/TopOccasionsReport.php
+++ b/src/Statistics/Application/Report/TopOccasionsReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\Occasion;
+
+final readonly class TopOccasionsReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_occasions';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_occasions.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_occasions.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'occasionId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return Occasion::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.occasion';
+    }
+}

--- a/src/Statistics/Application/Report/TopSecondaryDiagnosesReport.php
+++ b/src/Statistics/Application/Report/TopSecondaryDiagnosesReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\IndicationNormalized;
+
+final readonly class TopSecondaryDiagnosesReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_secondary_diagnoses';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_secondary_diagnoses.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_secondary_diagnoses.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'secondaryIndicationNormalizedId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return IndicationNormalized::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.secondary_diagnosis';
+    }
+}

--- a/src/Statistics/Application/Report/TopSpecialitiesReport.php
+++ b/src/Statistics/Application/Report/TopSpecialitiesReport.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Report;
+
+use App\Allocation\Domain\Entity\Speciality;
+
+final readonly class TopSpecialitiesReport extends AbstractTopNTableReport
+{
+    #[\Override]
+    public function key(): string
+    {
+        return 'top_specialities';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.top_specialities.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.top_specialities.description';
+    }
+
+    #[\Override]
+    protected function projectionJoinProperty(): string
+    {
+        return 'specialityId';
+    }
+
+    #[\Override]
+    protected function entityFqcn(): string
+    {
+        return Speciality::class;
+    }
+
+    #[\Override]
+    protected function tableLabelColumnTranslationKey(): string
+    {
+        return 'stats.reports.table.speciality';
+    }
+}

--- a/src/Statistics/Application/TopEntityQuery.php
+++ b/src/Statistics/Application/TopEntityQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application;
+
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\Statistics\Infrastructure\Query\ProjectionTopEntityQuery;
+
+/**
+ * @phpstan-type Row array{label: string, count: int}
+ */
+final readonly class TopEntityQuery
+{
+    public function __construct(
+        private ProjectionTopEntityQuery $projectionTopEntityQuery,
+        private ProjectionTimeSeriesQuery $timeSeriesQuery,
+        private StatisticsScopeResolver $scopeResolver,
+    ) {
+    }
+
+    /**
+     * @return array{rows: list<Row>, totalAllocations: int}
+     */
+    public function fetch(
+        StatisticsContext $context,
+        int $limit,
+        string $projectionJoinProperty,
+        string $entityFqcn,
+    ): array {
+        $bounds = StatisticsPeriodResolver::resolve($context->filter);
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
+
+        $rows = $this->projectionTopEntityQuery->fetchTopAggregates(
+            $bounds->from,
+            $bounds->toExclusive,
+            $scopeCriteria->hospitalIds,
+            $limit,
+            $projectionJoinProperty,
+            $entityFqcn,
+        );
+
+        $total = $this->timeSeriesQuery->countCreatedInPeriod(
+            $bounds->from,
+            $bounds->toExclusive,
+            $scopeCriteria->hospitalIds,
+        );
+
+        return [
+            'rows' => $rows,
+            'totalAllocations' => $total,
+        ];
+    }
+}

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisEntityLabelResolver.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisEntityLabelResolver.php
@@ -10,6 +10,8 @@ use App\Allocation\Infrastructure\Repository\DepartmentRepository;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
 use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
 use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\OccasionRepository;
+use App\Allocation\Infrastructure\Repository\SpecialityRepository;
 use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
 
@@ -21,6 +23,8 @@ final readonly class GenericAnalysisEntityLabelResolver implements GenericAnalys
         'state',
         'dispatchArea',
         'department',
+        'speciality',
+        'occasion',
         'assignment',
         'indication',
         'infection',
@@ -31,6 +35,8 @@ final readonly class GenericAnalysisEntityLabelResolver implements GenericAnalys
         private StateRepository $stateRepository,
         private DispatchAreaRepository $dispatchAreaRepository,
         private DepartmentRepository $departmentRepository,
+        private SpecialityRepository $specialityRepository,
+        private OccasionRepository $occasionRepository,
         private AssignmentRepository $assignmentRepository,
         private IndicationNormalizedRepository $indicationNormalizedRepository,
         private InfectionRepository $infectionRepository,
@@ -62,6 +68,8 @@ final readonly class GenericAnalysisEntityLabelResolver implements GenericAnalys
             'state' => $this->loadIdNameMap($this->stateRepository, 's', $uniqueIds),
             'dispatchArea' => $this->loadIdNameMap($this->dispatchAreaRepository, 'da', $uniqueIds),
             'department' => $this->loadIdNameMap($this->departmentRepository, 'd', $uniqueIds),
+            'speciality' => $this->loadIdNameMap($this->specialityRepository, 'sp', $uniqueIds),
+            'occasion' => $this->loadIdNameMap($this->occasionRepository, 'oc', $uniqueIds),
             'assignment' => $this->loadIdNameMap($this->assignmentRepository, 'a', $uniqueIds),
             'indication' => $this->loadIdNameMap($this->indicationNormalizedRepository, 'i', $uniqueIds),
             'infection' => $this->loadIdNameMap($this->infectionRepository, 'i', $uniqueIds),

--- a/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
+++ b/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
@@ -152,6 +152,8 @@ SQL;
         $this->register($this->hospitalCohortDimension());
 
         $this->register($categorical('department', 'department_id', 'Department'));
+        $this->register($categorical('speciality', 'speciality_id', 'Speciality'));
+        $this->register($categorical('occasion', 'occasion_id', 'Occasion'));
         $this->register($categorical('assignment', 'assignment_id', 'Assignment type'));
         $this->register($categorical('indication', 'indication_normalized_id', 'Indication'));
         $this->register($categorical('infection', 'infection_id', 'Infection'));

--- a/src/Statistics/Infrastructure/Query/ProjectionTopEntityQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTopEntityQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query;
+
+use App\Statistics\Infrastructure\Entity\AllocationStatsProjection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final readonly class ProjectionTopEntityQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ProjectionFilterApplier $filterApplier,
+    ) {
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return list<array{label:string,count:int}>
+     */
+    public function fetchTopAggregates(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $toExclusive,
+        ?array $hospitalIds,
+        int $limit,
+        string $projectionJoinProperty,
+        string $entityFqcn,
+    ): array {
+        $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds)
+            ->leftJoin($entityFqcn, 'ent', 'WITH', sprintf('ent.id = p.%s', $projectionJoinProperty))
+            ->select('COALESCE(ent.name, :unknown) AS label', 'COUNT(p.id) AS cnt')
+            ->setParameter('unknown', 'Unknown')
+            ->groupBy('label')
+            ->orderBy('cnt', 'DESC')
+            ->setMaxResults($limit);
+
+        /** @var list<array{label:string,cnt:numeric-string|int}> $rows */
+        $rows = $qb->getQuery()->getArrayResult();
+
+        return array_map(
+            static fn (array $row): array => ['label' => $row['label'], 'count' => (int) $row['cnt']],
+            $rows,
+        );
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     */
+    private function createBaseQb(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): QueryBuilder
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->from(AllocationStatsProjection::class, 'p');
+        $this->filterApplier->applyCreatedAtRange($qb, 'p.createdAt', $from, $toExclusive);
+        $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+
+        return $qb;
+    }
+}

--- a/tests/Statistics/Functional/Controller/ReportsControllerTest.php
+++ b/tests/Statistics/Functional/Controller/ReportsControllerTest.php
@@ -84,6 +84,101 @@ class ReportsControllerTest extends WebTestCase
         }
     }
 
+    public function testTopDepartmentsReportIsDisplayedWithTable(): void
+    {
+        $client = $this->createClientAsRoleUser();
+
+        UserFactory::createOne(['username' => 'stats-report-dept-test']);
+        StateFactory::createOne(['name' => 'Hessen']);
+        DispatchAreaFactory::createOne(['name' => 'Dispatch Area']);
+        HospitalFactory::createOne(['name' => 'Test Hospital']);
+        $import = ImportFactory::createOne(['name' => 'Test Import']);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        $department = DepartmentFactory::createOne(['name' => 'Seeded Report Department']);
+        AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        OccasionFactory::createOne(['name' => 'Test Occasion']);
+        InfectionFactory::createOne(['name' => 'Test Infection']);
+        $raw = IndicationRawFactory::createOne(['name' => 'Seeded Report Diagnosis Raw']);
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Seeded Report Diagnosis']);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('today'),
+            'import' => $import,
+            'department' => $department,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => $normalized,
+        ]);
+        $this->rebuildProjection([(int) $import->getId()]);
+
+        $client->request(
+            Request::METHOD_GET,
+            '/statistics/reports?scope=public&period=all&report=top_departments',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="stats-reports-widget"]');
+        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Department');
+        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Seeded Report Department');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('newTopReportCases')]
+    public function testAllNewTopReportsAreRenderedWithExpectedColumnAndValue(
+        string $reportKey,
+        string $expectedColumnLabel,
+        string $expectedValue,
+    ): void {
+        $client = $this->createClientAsRoleUser();
+
+        UserFactory::createOne(['username' => 'stats-report-all-new-test']);
+        StateFactory::createOne(['name' => 'Hessen']);
+        DispatchAreaFactory::createOne(['name' => 'Dispatch Area']);
+        HospitalFactory::createOne(['name' => 'Test Hospital']);
+        $import = ImportFactory::createOne(['name' => 'Test Import']);
+        $speciality = SpecialityFactory::createOne(['name' => 'Seeded Report Speciality']);
+        $department = DepartmentFactory::createOne(['name' => 'Seeded Report Department']);
+        $assignment = AssignmentFactory::createOne(['name' => 'Seeded Report Assignment']);
+        $occasion = OccasionFactory::createOne(['name' => 'Seeded Report Occasion']);
+        $infection = InfectionFactory::createOne(['name' => 'Seeded Report Infection']);
+        $raw = IndicationRawFactory::createOne(['name' => 'Seeded Report Diagnosis Raw']);
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Seeded Report Diagnosis']);
+        $secondaryNormalized = IndicationNormalizedFactory::createOne(['name' => 'Seeded Report Secondary Diagnosis']);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('today'),
+            'import' => $import,
+            'speciality' => $speciality,
+            'department' => $department,
+            'assignment' => $assignment,
+            'occasion' => $occasion,
+            'infection' => $infection,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => $normalized,
+            'secondaryIndicationNormalized' => $secondaryNormalized,
+        ]);
+        $this->rebuildProjection([(int) $import->getId()]);
+
+        $client->request(
+            Request::METHOD_GET,
+            sprintf('/statistics/reports?scope=public&period=all&report=%s', $reportKey),
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="stats-reports-widget"]');
+        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', $expectedColumnLabel);
+        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', $expectedValue);
+    }
+
+    /**
+     * @return iterable<string, array{0:string,1:string,2:string}>
+     */
+    public static function newTopReportCases(): iterable
+    {
+        yield 'top_departments' => ['top_departments', 'Department', 'Seeded Report Department'];
+        yield 'top_assignments' => ['top_assignments', 'Assignment type', 'Seeded Report Assignment'];
+        yield 'top_infections' => ['top_infections', 'Infection', 'Seeded Report Infection'];
+        yield 'top_secondary_diagnoses' => ['top_secondary_diagnoses', 'Secondary diagnosis', 'Seeded Report Secondary Diagnosis'];
+        yield 'top_specialities' => ['top_specialities', 'Speciality', 'Seeded Report Speciality'];
+        yield 'top_occasions' => ['top_occasions', 'Occasion', 'Seeded Report Occasion'];
+    }
+
     public function testLimitParameterTenIsAccepted(): void
     {
         $client = $this->createClientAsRoleUser();

--- a/tests/Statistics/Unit/GenericAnalysis/DimensionRegistryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/DimensionRegistryTest.php
@@ -52,6 +52,17 @@ final class DimensionRegistryTest extends TestCase
         self::assertSame(HospitalCohortKey::all()[0]->value(), $cohort->fixedBuckets[0]);
     }
 
+    public function testResolvesSpecialityAndOccasionDimensions(): void
+    {
+        $speciality = $this->registry->get('speciality');
+        $occasion = $this->registry->get('occasion');
+
+        self::assertSame('speciality_id', $speciality->column);
+        self::assertSame(AnalysisDimensionType::Categorical, $speciality->type);
+        self::assertSame('occasion_id', $occasion->column);
+        self::assertSame(AnalysisDimensionType::Categorical, $occasion->type);
+    }
+
     public function testUnknownDimensionThrows(): void
     {
         $this->expectException(UnknownAnalysisDimensionException::class);

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisEntityLabelResolverTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisEntityLabelResolverTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Statistics\Unit\GenericAnalysis;
 
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Statistics\GenericAnalysis\Application\GenericAnalysisEntityLabelResolver;
 use App\User\Domain\Factory\UserFactory;
@@ -32,6 +34,8 @@ final class GenericAnalysisEntityLabelResolverTest extends KernelTestCase
     {
         self::assertTrue($this->resolver->supports('hospital'));
         self::assertTrue($this->resolver->supports('state'));
+        self::assertTrue($this->resolver->supports('speciality'));
+        self::assertTrue($this->resolver->supports('occasion'));
         self::assertFalse($this->resolver->supports('month'));
     }
 
@@ -70,5 +74,25 @@ final class GenericAnalysisEntityLabelResolverTest extends KernelTestCase
     public function testResolveUnknownIdIsOmitted(): void
     {
         self::assertSame([], $this->resolver->resolve('hospital', [9_999_999]));
+    }
+
+    public function testResolveSpecialityReturnsNames(): void
+    {
+        $speciality = SpecialityFactory::createOne(['name' => 'Resolver Speciality']);
+
+        self::assertSame(
+            [(int) $speciality->getId() => 'Resolver Speciality'],
+            $this->resolver->resolve('speciality', [(int) $speciality->getId()]),
+        );
+    }
+
+    public function testResolveOccasionReturnsNames(): void
+    {
+        $occasion = OccasionFactory::createOne(['name' => 'Resolver Occasion']);
+
+        self::assertSame(
+            [(int) $occasion->getId() => 'Resolver Occasion'],
+            $this->resolver->resolve('occasion', [(int) $occasion->getId()]),
+        );
     }
 }

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -2783,6 +2783,78 @@
         <source>stats.reports.table.share</source>
         <target>Share</target>
       </trans-unit>
+      <trans-unit id="statsRpTbDp" resname="stats.reports.table.department">
+        <source>stats.reports.table.department</source>
+        <target>Department</target>
+      </trans-unit>
+      <trans-unit id="statsRpTbAs" resname="stats.reports.table.assignment">
+        <source>stats.reports.table.assignment</source>
+        <target>Assignment type</target>
+      </trans-unit>
+      <trans-unit id="statsRpTbIf" resname="stats.reports.table.infection">
+        <source>stats.reports.table.infection</source>
+        <target>Infection</target>
+      </trans-unit>
+      <trans-unit id="statsRpTbSd" resname="stats.reports.table.secondary_diagnosis">
+        <source>stats.reports.table.secondary_diagnosis</source>
+        <target>Secondary diagnosis</target>
+      </trans-unit>
+      <trans-unit id="statsRpTbSp" resname="stats.reports.table.speciality">
+        <source>stats.reports.table.speciality</source>
+        <target>Speciality</target>
+      </trans-unit>
+      <trans-unit id="statsRpTbOc" resname="stats.reports.table.occasion">
+        <source>stats.reports.table.occasion</source>
+        <target>Occasion</target>
+      </trans-unit>
+      <trans-unit id="statsRpDpLb" resname="stats.reports.top_departments.label">
+        <source>stats.reports.top_departments.label</source>
+        <target>Top departments</target>
+      </trans-unit>
+      <trans-unit id="statsRpDpDs" resname="stats.reports.top_departments.description">
+        <source>stats.reports.top_departments.description</source>
+        <target>Most frequent departments in the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsRpAtLb" resname="stats.reports.top_assignments.label">
+        <source>stats.reports.top_assignments.label</source>
+        <target>Top assignment types</target>
+      </trans-unit>
+      <trans-unit id="statsRpAtDs" resname="stats.reports.top_assignments.description">
+        <source>stats.reports.top_assignments.description</source>
+        <target>Most frequent assignment types in the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsRpInLb" resname="stats.reports.top_infections.label">
+        <source>stats.reports.top_infections.label</source>
+        <target>Top infections</target>
+      </trans-unit>
+      <trans-unit id="statsRpInDs" resname="stats.reports.top_infections.description">
+        <source>stats.reports.top_infections.description</source>
+        <target>Most frequent infection labels in the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsRpSdLb" resname="stats.reports.top_secondary_diagnoses.label">
+        <source>stats.reports.top_secondary_diagnoses.label</source>
+        <target>Top secondary diagnoses</target>
+      </trans-unit>
+      <trans-unit id="statsRpSdDs" resname="stats.reports.top_secondary_diagnoses.description">
+        <source>stats.reports.top_secondary_diagnoses.description</source>
+        <target>Most frequent secondary diagnosis labels in the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsRpSlLb" resname="stats.reports.top_specialities.label">
+        <source>stats.reports.top_specialities.label</source>
+        <target>Top specialities</target>
+      </trans-unit>
+      <trans-unit id="statsRpSlDs" resname="stats.reports.top_specialities.description">
+        <source>stats.reports.top_specialities.description</source>
+        <target>Most frequent specialities in the selected scope and period.</target>
+      </trans-unit>
+      <trans-unit id="statsRpOcLb" resname="stats.reports.top_occasions.label">
+        <source>stats.reports.top_occasions.label</source>
+        <target>Top occasions</target>
+      </trans-unit>
+      <trans-unit id="statsRpOcDs" resname="stats.reports.top_occasions.description">
+        <source>stats.reports.top_occasions.description</source>
+        <target>Most frequent occasions in the selected scope and period.</target>
+      </trans-unit>
       <trans-unit id="statsNavKpi" resname="stats.nav.overview_kpi_to_analysis">
         <source>stats.nav.overview_kpi_to_analysis</source>
         <target>Open allocations over time</target>


### PR DESCRIPTION
### Summary

- Added support for **Top-N reports** within the statistics framework
- Introduced reusable ranking and aggregation logic for Top-N analyses
- Added report views to display the highest-ranking entities across selected metrics
- Integrated Top-N reports into the existing statistics and analysis infrastructure
- Extended filtering and period handling where required
- Added or updated tests covering ranking, aggregation, and report rendering

### Motivation

- Provide quick visibility into the most relevant entities and metrics
- Enable users to identify trends, outliers, and leading performers more easily
- Reuse the existing statistics infrastructure for ranking-based analysis
- Lay the foundation for future leaderboard and benchmarking reports
- Improve the analytical value of the statistics module with minimal additional complexity

### Notes for Reviewers

- Verify ranking and aggregation logic for correctness and tie handling
- Check behavior when fewer than N results are available
- Review filtering and period interactions with Top-N reports
- Ensure report rendering remains performant for larger datasets
- Confirm tests cover ranking calculations, empty states, and edge cases