### PR TITLE
feat(statistics): Add generic analysis metrics MVP

### DIFF
--- a/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
+++ b/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
@@ -96,7 +96,7 @@ final class BackfillAllocationIndicationNormalizedCommand extends Command
                 $output->writeln('');
             }
         } else {
-            $io->writeln('<comment>Projection not rebuilt. Use --rebuild-projection or <info>app:seed:projection</info> so Top diagnoses reflect the backfill.</comment>');
+            $io->writeln('<comment>Projection not rebuilt. Use --rebuild-projection or <info>app:seed:projection</info> so Top indications reflect the backfill.</comment>');
         }
 
         $io->success(sprintf('Backfill finished in %.2fs.', microtime(true) - $startedAt));

--- a/src/Shared/UI/Twig/templates/_includes/subnav_stats.html.twig
+++ b/src/Shared/UI/Twig/templates/_includes/subnav_stats.html.twig
@@ -32,7 +32,7 @@
                     <li class="nav-item {{ route in ['app_stats_indication_insights', 'app_stats_indication_dashboard'] ? 'active' : '' }}">
                         <a class="nav-link" href="{{ path('app_stats_indication_insights') }}">
                             <span class="nav-link-title">
-                                <twig:ux:icon name="tabler:notes" style="height: 1.2em;" />
+                                <twig:ux:icon name="tabler:search" style="height: 1.2em;" />
                                 {{ 'link.stats.indication_insights'|trans }}
                             </span>
                         </a>

--- a/src/Statistics/GenericAnalysis/Application/AnalysisPresetRegistry.php
+++ b/src/Statistics/GenericAnalysis/Application/AnalysisPresetRegistry.php
@@ -122,6 +122,27 @@ final class AnalysisPresetRegistry
             metricKeys: ['count', 'percent_of_bucket'],
         ));
         $this->register(new AnalysisPreset(
+            key: 'transport_time_by_department',
+            title: 'Transport time by department',
+            primaryDimensionKey: 'department',
+            metricKeys: ['count', 'median_transport_time', 'p90_transport_time'],
+            visualMetricKey: 'median_transport_time',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'resus_by_department',
+            title: 'Resuscitation by department',
+            primaryDimensionKey: 'department',
+            metricKeys: ['count', 'resus_rate'],
+            visualMetricKey: 'resus_rate',
+        ));
+        $this->register(new AnalysisPreset(
+            key: 'cpr_by_month',
+            title: 'CPR by month',
+            primaryDimensionKey: 'month',
+            metricKeys: ['count', 'cpr_rate'],
+            visualMetricKey: 'cpr_rate',
+        ));
+        $this->register(new AnalysisPreset(
             key: 'custom',
             title: 'Custom analysis',
             primaryDimensionKey: 'month',

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartDataReducer.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartDataReducer.php
@@ -9,7 +9,9 @@ use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
+use App\Statistics\GenericAnalysis\Domain\Enum\MetricFormat;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class GenericAnalysisChartDataReducer
@@ -18,6 +20,7 @@ final readonly class GenericAnalysisChartDataReducer
 
     public function __construct(
         private DimensionRegistry $dimensionRegistry,
+        private MetricRegistry $metricRegistry,
         private TranslatorInterface $translator,
     ) {
     }
@@ -31,7 +34,7 @@ final readonly class GenericAnalysisChartDataReducer
 
         $labels = $this->extractLabels($result);
         $counts = $this->extractVisualValues($result, $labels);
-        $series = $this->extractSeries($result);
+        $series = $this->extractSeries($result, $result->visualMetricKey);
 
         $limitedSeries = false;
         $limitedBuckets = false;
@@ -70,10 +73,10 @@ final readonly class GenericAnalysisChartDataReducer
     }
 
     /**
-     * @param list<array{name: string, data: list<int>}> $series
-     * @param list<string>                               $labels
+     * @param list<array{name: string, data: list<int|float>}> $series
+     * @param list<string>                                     $labels
      *
-     * @return list<array{name: string, data: list<int>}>
+     * @return list<array{name: string, data: list<int|float>}>
      */
     private function limitSeries(array $series, array $labels, int $cap): array
     {
@@ -86,13 +89,13 @@ final readonly class GenericAnalysisChartDataReducer
         arsort($totals);
         $topIndices = array_slice(array_keys($totals), 0, $cap);
 
-        $restData = array_fill(0, $labelCount, 0);
+        $restData = array_fill(0, $labelCount, 0.0);
         foreach ($series as $index => $item) {
             if (\in_array($index, $topIndices, true)) {
                 continue;
             }
             foreach ($item['data'] as $labelIndex => $value) {
-                $restData[$labelIndex] += $value;
+                $restData[$labelIndex] += (float) $value;
             }
         }
 
@@ -112,11 +115,11 @@ final readonly class GenericAnalysisChartDataReducer
     }
 
     /**
-     * @param list<string>                               $labels
-     * @param list<int>                                  $counts
-     * @param list<array{name: string, data: list<int>}> $series
+     * @param list<string>                                     $labels
+     * @param list<int>                                        $counts
+     * @param list<array{name: string, data: list<int|float>}> $series
      *
-     * @return array{0: list<string>, 1: list<int>, 2: list<array{name: string, data: list<int>}>}
+     * @return array{0: list<string>, 1: list<int|float>, 2: list<array{name: string, data: list<int|float>}>}
      */
     private function limitPrimaryBuckets(array $labels, array $counts, array $series, int $cap): array
     {
@@ -124,9 +127,9 @@ final readonly class GenericAnalysisChartDataReducer
 
         if ([] !== $series) {
             foreach ($labels as $labelIndex => $label) {
-                $sum = 0;
+                $sum = 0.0;
                 foreach ($series as $item) {
-                    $sum += $item['data'][$labelIndex] ?? 0;
+                    $sum += (float) ($item['data'][$labelIndex] ?? 0);
                 }
                 $bucketTotals[$label] = $sum;
             }
@@ -139,10 +142,10 @@ final readonly class GenericAnalysisChartDataReducer
         arsort($bucketTotals);
         $topLabels = array_slice(array_keys($bucketTotals), 0, $cap);
 
-        $restTotal = 0;
+        $restTotal = 0.0;
         foreach ($bucketTotals as $label => $total) {
             if (!\in_array($label, $topLabels, true)) {
-                $restTotal += $total;
+                $restTotal += (float) $total;
             }
         }
 
@@ -171,14 +174,14 @@ final readonly class GenericAnalysisChartDataReducer
                 $newData[] = false !== $labelIndex ? ($item['data'][$labelIndex] ?? 0) : 0;
             }
             if ($restTotal > 0) {
-                $restForSeries = 0;
+                $restForSeries = 0.0;
                 foreach (array_keys($bucketTotals) as $label) {
                     if (\in_array($label, $topLabels, true)) {
                         continue;
                     }
                     $labelIndex = array_search($label, $labels, true);
                     if (false !== $labelIndex) {
-                        $restForSeries += $item['data'][$labelIndex] ?? 0;
+                        $restForSeries += (float) ($item['data'][$labelIndex] ?? 0);
                     }
                 }
                 $newData[] = $restForSeries;
@@ -251,11 +254,15 @@ final readonly class GenericAnalysisChartDataReducer
             return 0;
         }
 
-        if (str_starts_with($visualKey, 'percent_')) {
-            return (float) $value;
+        if (!$this->metricRegistry->has($visualKey)) {
+            return (int) round((float) $value);
         }
 
-        return (int) round((float) $value);
+        $format = $this->metricRegistry->get($visualKey)->defaultFormat;
+
+        return MetricFormat::Integer === $format
+            ? (int) round((float) $value)
+            : (float) $value;
     }
 
     /**
@@ -272,9 +279,9 @@ final readonly class GenericAnalysisChartDataReducer
     }
 
     /**
-     * @return list<array{name: string, data: list<int>}>
+     * @return list<array{name: string, data: list<int|float>}>
      */
-    private function extractSeries(NormalizedAnalysisResult $result): array
+    private function extractSeries(NormalizedAnalysisResult $result, string $visualKey): array
     {
         $raw = $result->chartData['series'] ?? null;
         if (!\is_array($raw)) {
@@ -293,7 +300,10 @@ final readonly class GenericAnalysisChartDataReducer
             }
             $series[] = [
                 'name' => $name,
-                'data' => array_values(array_map(static fn (mixed $v): int => (int) $v, $data)),
+                'data' => array_values(array_map(
+                    fn (mixed $v): int|float => $this->chartScalar($v, $visualKey),
+                    $data,
+                )),
             ];
         }
 

--- a/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartSpecBuilder.php
+++ b/src/Statistics/GenericAnalysis/Application/GenericAnalysisChartSpecBuilder.php
@@ -8,11 +8,14 @@ use App\Statistics\GenericAnalysis\Application\DTO\GenericAnalysisReducedChartDa
 use App\Statistics\GenericAnalysis\Application\DTO\NormalizedAnalysisResult;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
+use App\Statistics\GenericAnalysis\Domain\Enum\MetricFormat;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 
 final readonly class GenericAnalysisChartSpecBuilder
 {
     public function __construct(
         private GenericAnalysisChartDataReducer $chartDataReducer,
+        private MetricRegistry $metricRegistry,
     ) {
     }
 
@@ -34,13 +37,15 @@ final readonly class GenericAnalysisChartSpecBuilder
             return null;
         }
 
+        $percentScale = $this->usesPercentScale($result->visualMetricKey);
+
         return match ($chartType) {
-            GenericAnalysisChartType::Line => $this->buildLineSpec($data),
-            GenericAnalysisChartType::GroupedBar => $this->buildGroupedBarSpec($data),
+            GenericAnalysisChartType::Line => $this->buildLineSpec($data, $percentScale),
+            GenericAnalysisChartType::GroupedBar => $this->buildGroupedBarSpec($data, $percentScale),
             GenericAnalysisChartType::PercentStackedBar => $this->buildPercentStackedBarSpec($data),
-            GenericAnalysisChartType::HorizontalBar => $this->buildHorizontalBarSpec($data),
-            GenericAnalysisChartType::StackedBar => $this->buildStackedBarSpec($data),
-            GenericAnalysisChartType::Bar => $this->buildBarSpec($data),
+            GenericAnalysisChartType::HorizontalBar => $this->buildHorizontalBarSpec($data, $percentScale),
+            GenericAnalysisChartType::StackedBar => $this->buildStackedBarSpec($data, $percentScale),
+            GenericAnalysisChartType::Bar => $this->buildBarSpec($data, $percentScale),
             default => null,
         };
     }
@@ -73,82 +78,94 @@ final readonly class GenericAnalysisChartSpecBuilder
     /**
      * @return array<string, mixed>
      */
-    private function buildBarSpec(GenericAnalysisReducedChartData $data): array
+    private function buildBarSpec(GenericAnalysisReducedChartData $data, bool $percentScale): array
     {
         if (null !== $data->series && [] !== $data->series) {
-            return [
+            $spec = [
                 'chartType' => 'bar',
                 'labels' => $data->labels,
                 'series' => $data->series,
             ];
+
+            return $this->applyPercentScale($spec, $percentScale);
         }
 
-        return [
+        $spec = [
             'chartType' => 'bar',
             'labels' => $data->labels,
             'counts' => $data->counts ?? [],
         ];
+
+        return $this->applyPercentScale($spec, $percentScale);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function buildStackedBarSpec(GenericAnalysisReducedChartData $data): array
+    private function buildStackedBarSpec(GenericAnalysisReducedChartData $data, bool $percentScale): array
     {
         if (null === $data->series || [] === $data->series) {
-            return $this->buildBarSpec($data);
+            return $this->buildBarSpec($data, $percentScale);
         }
 
-        return [
+        $spec = [
             'chartType' => 'bar',
             'labels' => $data->labels,
             'series' => $data->series,
         ];
+
+        return $this->applyPercentScale($spec, $percentScale);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function buildGroupedBarSpec(GenericAnalysisReducedChartData $data): array
+    private function buildGroupedBarSpec(GenericAnalysisReducedChartData $data, bool $percentScale): array
     {
         if (null === $data->series || [] === $data->series) {
-            return $this->buildBarSpec($data);
+            return $this->buildBarSpec($data, $percentScale);
         }
 
-        return [
+        $spec = [
             'chartType' => 'bar',
             'labels' => $data->labels,
             'series' => $data->series,
             'barGrouped' => true,
         ];
+
+        return $this->applyPercentScale($spec, $percentScale);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function buildLineSpec(GenericAnalysisReducedChartData $data): array
+    private function buildLineSpec(GenericAnalysisReducedChartData $data, bool $percentScale): array
     {
         if (null !== $data->series && [] !== $data->series) {
-            return [
+            $spec = [
                 'chartType' => 'line',
                 'labels' => $data->labels,
                 'series' => $data->series,
             ];
+
+            return $this->applyPercentScale($spec, $percentScale);
         }
 
-        return [
+        $spec = [
             'chartType' => 'line',
             'labels' => $data->labels,
             'counts' => $data->counts ?? [],
         ];
+
+        return $this->applyPercentScale($spec, $percentScale);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function buildHorizontalBarSpec(GenericAnalysisReducedChartData $data): array
+    private function buildHorizontalBarSpec(GenericAnalysisReducedChartData $data, bool $percentScale): array
     {
-        $spec = $this->buildBarSpec($data);
+        $spec = $this->buildBarSpec($data, $percentScale);
         $spec['horizontal'] = true;
 
         return $spec;
@@ -161,7 +178,7 @@ final readonly class GenericAnalysisChartSpecBuilder
     {
         $percentSeries = $this->buildPercentSeriesFromCounts($data);
         if ([] === $percentSeries) {
-            return $this->buildBarSpec($data);
+            return $this->buildBarSpec($data, false);
         }
 
         return [
@@ -170,6 +187,29 @@ final readonly class GenericAnalysisChartSpecBuilder
             'series' => $percentSeries,
             'percentScale' => true,
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     *
+     * @return array<string, mixed>
+     */
+    private function applyPercentScale(array $spec, bool $percentScale): array
+    {
+        if ($percentScale) {
+            $spec['percentScale'] = true;
+        }
+
+        return $spec;
+    }
+
+    private function usesPercentScale(string $visualMetricKey): bool
+    {
+        if (!$this->metricRegistry->has($visualMetricKey)) {
+            return false;
+        }
+
+        return MetricFormat::Percent === $this->metricRegistry->get($visualMetricKey)->defaultFormat;
     }
 
     /**

--- a/src/Statistics/GenericAnalysis/Application/MetricCompatibilityChecker.php
+++ b/src/Statistics/GenericAnalysis/Application/MetricCompatibilityChecker.php
@@ -17,11 +17,15 @@ use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 final readonly class MetricCompatibilityChecker
 {
     /** @var list<string> */
-    private const array TRANSPORT_TIME_METRIC_KEYS = [
-        'median_transport_time',
-        'p90_transport_time',
-        'p25_transport_time',
-        'p75_transport_time',
+    private const array PROJECTION_SOURCE_COLUMNS = [
+        'transport_time_minutes',
+        'requires_resus',
+        'is_cpr',
+        'is_shock',
+        'is_ventilated',
+        'requires_cathlab',
+        'is_pregnant',
+        'is_work_accident',
     ];
 
     public function __construct(
@@ -36,16 +40,17 @@ final readonly class MetricCompatibilityChecker
         ?AnalysisDimension $_series,
         MetricDefinition $metric,
     ): MetricCompatibilityResult {
-        if (\in_array($metric->key, self::TRANSPORT_TIME_METRIC_KEYS, true)) {
-            return MetricCompatibilityResult::denied('Transport time is not yet part of the domain models.');
-        }
-
         if (MetricComputationKind::InferentialStub === $metric->computationKind) {
             return MetricCompatibilityResult::denied('Metric is not implemented yet.');
         }
 
         if ('count' === $metric->key) {
             return MetricCompatibilityResult::allowed();
+        }
+
+        if (null !== $metric->sourceColumn
+            && !\in_array($metric->sourceColumn, self::PROJECTION_SOURCE_COLUMNS, true)) {
+            return MetricCompatibilityResult::denied('Source field not available.');
         }
 
         if ($metric->requiresSeriesDimension && null === $query->seriesDimensionKey) {

--- a/src/Statistics/GenericAnalysis/Registry/AnalysisViewRegistry.php
+++ b/src/Statistics/GenericAnalysis/Registry/AnalysisViewRegistry.php
@@ -226,6 +226,45 @@ final class AnalysisViewRegistry
             secondary: 'urgency',
             metrics: ['count', 'percent_of_bucket'],
         ));
+
+        $this->register($this->view(
+            key: 'transport_time_by_department',
+            title: 'Transport time by department',
+            description: 'Median and P90 transport time by department.',
+            category: AnalysisViewCategory::Operations,
+            tags: ['transport', 'department', 'operations'],
+            primary: 'department',
+            chart: GenericAnalysisChartType::Bar,
+            allowed: $bar,
+            metrics: ['count', 'median_transport_time', 'p90_transport_time'],
+            visualMetricKey: 'median_transport_time',
+        ));
+
+        $this->register($this->view(
+            key: 'resus_by_department',
+            title: 'Resuscitation by department',
+            description: 'Resuscitation rate by department.',
+            category: AnalysisViewCategory::Clinical,
+            tags: ['resus', 'department', 'clinical'],
+            primary: 'department',
+            chart: GenericAnalysisChartType::Bar,
+            allowed: $bar,
+            metrics: ['count', 'resus_rate'],
+            visualMetricKey: 'resus_rate',
+        ));
+
+        $this->register($this->view(
+            key: 'cpr_by_month',
+            title: 'CPR by month',
+            description: 'CPR rate by month.',
+            category: AnalysisViewCategory::TimeAndTrends,
+            tags: ['cpr', 'month', 'clinical'],
+            primary: 'month',
+            chart: GenericAnalysisChartType::Line,
+            allowed: $line,
+            metrics: ['count', 'cpr_rate'],
+            visualMetricKey: 'cpr_rate',
+        ));
     }
 
     /**
@@ -244,6 +283,7 @@ final class AnalysisViewRegistry
         array $allowed,
         ?string $secondary = null,
         array $metrics = [],
+        ?string $visualMetricKey = null,
         bool $featured = false,
         bool $includeNullBuckets = false,
     ): AnalysisViewDefinition {
@@ -256,6 +296,7 @@ final class AnalysisViewRegistry
             primaryDimensionKey: $primary,
             secondaryDimensionKey: $secondary,
             metricKeys: $metrics,
+            visualMetricKey: $visualMetricKey,
             chartType: $chart,
             allowedChartTypes: [] === $allowed ? [$chart] : $allowed,
             includeNullBuckets: $includeNullBuckets,

--- a/src/Statistics/GenericAnalysis/Registry/MetricRegistry.php
+++ b/src/Statistics/GenericAnalysis/Registry/MetricRegistry.php
@@ -7,6 +7,7 @@ namespace App\Statistics\GenericAnalysis\Registry;
 use App\Statistics\GenericAnalysis\Domain\DTO\MetricDefinition;
 use App\Statistics\GenericAnalysis\Domain\Enum\MetricComputationKind;
 use App\Statistics\GenericAnalysis\Domain\Enum\MetricFormat;
+use App\Statistics\GenericAnalysis\Domain\Enum\MetricSourceType;
 use App\Statistics\GenericAnalysis\Domain\Enum\MetricType;
 use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisMetricException;
 
@@ -56,7 +57,7 @@ final class MetricRegistry
             sortPriority: 10,
         ));
 
-        // TODO: mean_age, median_age — register when age_group (or similar) dimension exists.
+        // Age aggregate metrics (mean_age, median_age, …) are intentionally out of scope for MVP.
 
         $this->register(new MetricDefinition(
             key: 'percent_of_total',
@@ -85,8 +86,118 @@ final class MetricRegistry
             sortPriority: 21,
         ));
 
-        // TODO: median_transport_time, p90_transport_time — register when transport time is in domain models.
-        // TODO: min_*, max_*, p25_*, p75_*, p95_*, stddev_*, distinct_* aggregates.
+        $this->registerTransportMetrics();
+        $this->registerBooleanRateMetrics();
+
+        // TODO: min_*, max_*, p95_*, stddev_*, distinct_* aggregates.
         // TODO: ci95_percent (Wilson interval), ci95_mean (classic CI) — MetricComputationKind::InferentialStub.
+    }
+
+    private function registerTransportMetrics(): void
+    {
+        $column = 'transport_time_minutes';
+
+        $this->register(new MetricDefinition(
+            key: 'mean_transport_time',
+            label: 'Mean transport time',
+            metricType: MetricType::NumericAggregate,
+            computationKind: MetricComputationKind::SqlAggregate,
+            sqlSelectExpression: sprintf('AVG(%s)::DOUBLE PRECISION AS mean_transport_time', $column),
+            sourceColumn: $column,
+            requiredSourceType: MetricSourceType::Numeric,
+            defaultFormat: MetricFormat::Minutes,
+            defaultPrecision: 0,
+            sortPriority: 30,
+        ));
+
+        $this->registerPercentileMetric(
+            key: 'median_transport_time',
+            label: 'Median transport time',
+            column: $column,
+            percentile: 0.5,
+            sortPriority: 31,
+        );
+        $this->registerPercentileMetric(
+            key: 'p25_transport_time',
+            label: 'P25 transport time',
+            column: $column,
+            percentile: 0.25,
+            sortPriority: 32,
+        );
+        $this->registerPercentileMetric(
+            key: 'p75_transport_time',
+            label: 'P75 transport time',
+            column: $column,
+            percentile: 0.75,
+            sortPriority: 33,
+        );
+        $this->registerPercentileMetric(
+            key: 'p90_transport_time',
+            label: 'P90 transport time',
+            column: $column,
+            percentile: 0.9,
+            sortPriority: 34,
+        );
+    }
+
+    private function registerPercentileMetric(
+        string $key,
+        string $label,
+        string $column,
+        float $percentile,
+        int $sortPriority,
+    ): void {
+        $this->register(new MetricDefinition(
+            key: $key,
+            label: $label,
+            metricType: MetricType::NumericAggregate,
+            computationKind: MetricComputationKind::SqlAggregate,
+            sqlSelectExpression: sprintf(
+                '(PERCENTILE_CONT(%s) WITHIN GROUP (ORDER BY %s))::DOUBLE PRECISION AS %s',
+                $percentile,
+                $column,
+                $key,
+            ),
+            sourceColumn: $column,
+            requiredSourceType: MetricSourceType::Numeric,
+            defaultFormat: MetricFormat::Minutes,
+            defaultPrecision: 0,
+            sortPriority: $sortPriority,
+        ));
+    }
+
+    private function registerBooleanRateMetrics(): void
+    {
+        $this->registerBooleanRateMetric('resus_rate', 'Resus rate', 'requires_resus', 40);
+        $this->registerBooleanRateMetric('cpr_rate', 'CPR rate', 'is_cpr', 41);
+        $this->registerBooleanRateMetric('shock_rate', 'Shock rate', 'is_shock', 42);
+        $this->registerBooleanRateMetric('ventilation_rate', 'Ventilation rate', 'is_ventilated', 43);
+        $this->registerBooleanRateMetric('cathlab_rate', 'Cath lab rate', 'requires_cathlab', 44);
+        $this->registerBooleanRateMetric('pregnancy_rate', 'Pregnancy rate', 'is_pregnant', 45);
+        $this->registerBooleanRateMetric('work_accident_rate', 'Work accident rate', 'is_work_accident', 46);
+    }
+
+    private function registerBooleanRateMetric(
+        string $key,
+        string $label,
+        string $column,
+        int $sortPriority,
+    ): void {
+        $this->register(new MetricDefinition(
+            key: $key,
+            label: $label,
+            metricType: MetricType::NumericAggregate,
+            computationKind: MetricComputationKind::SqlAggregate,
+            sqlSelectExpression: sprintf(
+                '(COUNT(*) FILTER (WHERE %s IS TRUE)::DOUBLE PRECISION / NULLIF(COUNT(*), 0) * 100)::DOUBLE PRECISION AS %s',
+                $column,
+                $key,
+            ),
+            sourceColumn: $column,
+            requiredSourceType: MetricSourceType::Boolean,
+            defaultFormat: MetricFormat::Percent,
+            defaultPrecision: 1,
+            sortPriority: $sortPriority,
+        ));
     }
 }

--- a/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModelFactory.php
+++ b/src/Statistics/GenericAnalysis/UI/Http/Controller/GenericAnalysisChartViewModelFactory.php
@@ -13,7 +13,9 @@ use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
 use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
 use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisTableRowLimit;
+use App\Statistics\GenericAnalysis\Domain\Enum\MetricFormat;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisQueryKeys;
 use App\Statistics\GenericAnalysis\UI\Http\Navigation\GenericAnalysisRouteContext;
 use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
@@ -27,6 +29,7 @@ final readonly class GenericAnalysisChartViewModelFactory
         private GenericAnalysisChartSpecBuilder $specBuilder,
         private GenericAnalysisChartDataReducer $chartDataReducer,
         private DimensionRegistry $dimensionRegistry,
+        private MetricRegistry $metricRegistry,
         private StatisticsNavigationUrlBuilder $navigationUrlBuilder,
         private TranslatorInterface $translator,
     ) {
@@ -90,6 +93,16 @@ final readonly class GenericAnalysisChartViewModelFactory
             ]);
         }
 
+        $visualMetric = $this->metricRegistry->get($result->visualMetricKey);
+        $isRelative = MetricFormat::Percent === $visualMetric->defaultFormat;
+        $metricLabel = $visualMetric->label;
+        $yAxisLabel = 'count' === $result->visualMetricKey
+            ? $this->translator->trans('stats.generic_analysis.chart.y_axis_allocations')
+            : $metricLabel;
+        $valueLabel = 'count' === $result->visualMetricKey
+            ? $this->translator->trans('stats.generic_analysis.chart.value_allocations')
+            : $metricLabel;
+
         return new GenericAnalysisChartViewModel(
             title: $result->title,
             subtitle: $subtitle,
@@ -105,9 +118,9 @@ final readonly class GenericAnalysisChartViewModelFactory
             initialSpec: $initialSpec,
             specsByChartType: $specsByChartType,
             xAxisLabel: $result->primaryDimensionLabel,
-            yAxisLabel: $this->translator->trans('stats.generic_analysis.chart.y_axis_allocations'),
-            isRelative: false,
-            valueLabel: $this->translator->trans('stats.generic_analysis.chart.value_allocations'),
+            yAxisLabel: $yAxisLabel,
+            isRelative: $isRelative,
+            valueLabel: $valueLabel,
             warnings: $warnings,
             emptyStateMessage: $this->translator->trans('stats.generic_analysis.chart.empty'),
             chartTypeOptions: $chartTypeOptions,

--- a/tests/Statistics/Functional/Controller/ReportsControllerTest.php
+++ b/tests/Statistics/Functional/Controller/ReportsControllerTest.php
@@ -66,7 +66,7 @@ class ReportsControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-reports-widget"]');
         $this->assertSelectorExists('[data-testid="stats-analysis-table-card"]');
         $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Rank');
-        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Diagnosis');
+        $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Indication');
         $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Count');
         $this->assertSelectorTextContains('[data-testid="stats-analysis-table-card"]', 'Share');
     }
@@ -174,7 +174,7 @@ class ReportsControllerTest extends WebTestCase
         yield 'top_departments' => ['top_departments', 'Department', 'Seeded Report Department'];
         yield 'top_assignments' => ['top_assignments', 'Assignment type', 'Seeded Report Assignment'];
         yield 'top_infections' => ['top_infections', 'Infection', 'Seeded Report Infection'];
-        yield 'top_secondary_diagnoses' => ['top_secondary_diagnoses', 'Secondary diagnosis', 'Seeded Report Secondary Diagnosis'];
+        yield 'top_secondary_diagnoses' => ['top_secondary_diagnoses', 'Secondary indication', 'Seeded Report Secondary Diagnosis'];
         yield 'top_specialities' => ['top_specialities', 'Speciality', 'Seeded Report Speciality'];
         yield 'top_occasions' => ['top_occasions', 'Occasion', 'Seeded Report Occasion'];
     }

--- a/tests/Statistics/Unit/GenericAnalysis/AnalysisPresetRegistryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/AnalysisPresetRegistryTest.php
@@ -42,6 +42,22 @@ final class AnalysisPresetRegistryTest extends TestCase
         self::assertSame(['count', 'percent_of_total'], $preset->metricKeys);
     }
 
+    public function testNewMetricPresetsAreRegistered(): void
+    {
+        $transport = $this->registry->get('transport_time_by_department');
+        self::assertSame('department', $transport->primaryDimensionKey);
+        self::assertSame(['count', 'median_transport_time', 'p90_transport_time'], $transport->metricKeys);
+        self::assertSame('median_transport_time', $transport->visualMetricKey);
+
+        $resus = $this->registry->get('resus_by_department');
+        self::assertSame(['count', 'resus_rate'], $resus->metricKeys);
+        self::assertSame('resus_rate', $resus->visualMetricKey);
+
+        $cpr = $this->registry->get('cpr_by_month');
+        self::assertSame('month', $cpr->primaryDimensionKey);
+        self::assertSame(['count', 'cpr_rate'], $cpr->metricKeys);
+    }
+
     public function testLegacyPresetsDefaultToEmptyMetrics(): void
     {
         $preset = $this->registry->get('allocations_by_month');

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
@@ -132,4 +132,33 @@ final class GenericAllocationAnalysisSqlBuilderTest extends TestCase
         self::assertStringContainsString('NOT IN (:exclude_null_bucket_age_group)', $sql);
         self::assertSame(['unknown'], $params['exclude_null_bucket_age_group']);
     }
+
+    public function testIncludesTransportMetricsInSql(): void
+    {
+        [$sql] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'department',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            metricKeys: ['count', 'median_transport_time', 'p90_transport_time'],
+        ));
+
+        self::assertStringContainsString('COUNT(*)::INT AS count', $sql);
+        self::assertStringContainsString('PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY transport_time_minutes)', $sql);
+        self::assertStringContainsString('PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY transport_time_minutes)', $sql);
+        self::assertStringNotContainsString('age IS NOT NULL', $sql);
+    }
+
+    public function testIncludesRateMetricsInSql(): void
+    {
+        [$sql] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'department',
+            scopeCriteria: StatisticsScopeCriteria::public(),
+            periodBounds: new StatisticsPeriodBounds(null),
+            metricKeys: ['count', 'resus_rate'],
+        ));
+
+        self::assertStringContainsString('COUNT(*) FILTER (WHERE requires_resus IS TRUE)', $sql);
+        self::assertStringContainsString('NULLIF(COUNT(*), 0)', $sql);
+        self::assertStringContainsString('AS resus_rate', $sql);
+    }
 }

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartDataReducerTest.php
@@ -9,6 +9,7 @@ use App\Statistics\Application\DTO\StatisticsScopeCriteria;
 use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartDataReducer;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -27,7 +28,11 @@ final class GenericAnalysisChartDataReducerTest extends TestCase
             },
         );
 
-        $this->reducer = new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator);
+        $this->reducer = new GenericAnalysisChartDataReducer(
+            new DimensionRegistry(),
+            new MetricRegistry(),
+            $translator,
+        );
     }
 
     public function testLimitsCategoricalPrimaryBucketsToTopFivePlusOther(): void
@@ -42,7 +47,7 @@ final class GenericAnalysisChartDataReducerTest extends TestCase
         self::assertTrue($reduced->limitedPrimaryBuckets);
         self::assertCount(6, $reduced->labels);
         self::assertSame('Other', $reduced->labels[5]);
-        self::assertSame(6, $reduced->counts[5]);
+        self::assertEquals(6, $reduced->counts[5]);
     }
 
     public function testDoesNotLimitTemporalPrimaryBuckets(): void
@@ -80,8 +85,8 @@ final class GenericAnalysisChartDataReducerTest extends TestCase
         self::assertNotNull($reduced->series);
         self::assertCount(6, $reduced->series);
         self::assertSame('Other', $reduced->series[5]['name']);
-        self::assertSame(30, $reduced->series[5]['data'][0]);
-        self::assertSame(0, $reduced->series[5]['data'][1]);
+        self::assertEquals(30, $reduced->series[5]['data'][0]);
+        self::assertEquals(0, $reduced->series[5]['data'][1]);
     }
 
     public function testLimitsCategoricalBucketsWithSeries(): void
@@ -140,6 +145,29 @@ final class GenericAnalysisChartDataReducerTest extends TestCase
         $reduced = $this->reducer->reduce($query, $result);
 
         self::assertSame([62.5, 37.5], $reduced->counts);
+    }
+
+    public function testPreservesMinutesVisualMetricAsFloat(): void
+    {
+        $query = $this->query(
+            'department',
+            metricKeys: ['count', 'median_transport_time'],
+            visualMetricKey: 'median_transport_time',
+        );
+        $result = GenericAnalysisTestFixtures::normalizedResult(
+            rows: [
+                GenericAnalysisTestFixtures::enrichedRow('1', 'Dept A', 10, extraMetrics: ['median_transport_time' => 18.6]),
+                GenericAnalysisTestFixtures::enrichedRow('2', 'Dept B', 5, extraMetrics: ['median_transport_time' => 22.4]),
+            ],
+            grandTotal: 15,
+            metricKeys: ['count', 'median_transport_time'],
+            chartData: ['labels' => ['Dept A', 'Dept B']],
+            visualMetricKey: 'median_transport_time',
+        );
+
+        $reduced = $this->reducer->reduce($query, $result);
+
+        self::assertSame([18.6, 22.4], $reduced->counts);
     }
 
     public function testReturnsEmptyLabelsWhenChartDataInvalid(): void

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartSpecBuilderTest.php
@@ -11,6 +11,7 @@ use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartSpecBuilder;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisChartType;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -24,7 +25,12 @@ final class GenericAnalysisChartSpecBuilderTest extends TestCase
         $translator->method('trans')->willReturn('Other');
 
         $this->builder = new GenericAnalysisChartSpecBuilder(
-            new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator),
+            new GenericAnalysisChartDataReducer(
+                new DimensionRegistry(),
+                new MetricRegistry(),
+                $translator,
+            ),
+            new MetricRegistry(),
         );
     }
 
@@ -152,6 +158,26 @@ final class GenericAnalysisChartSpecBuilderTest extends TestCase
 
         self::assertSame('bar', $spec['chartType']);
         self::assertArrayHasKey('counts', $spec);
+    }
+
+    public function testBarSpecUsesPercentScaleForRateVisualMetric(): void
+    {
+        $query = $this->query('department');
+        $result = GenericAnalysisTestFixtures::normalizedResult(
+            grandTotal: 100,
+            metricKeys: ['count', 'resus_rate'],
+            chartData: [
+                'labels' => ['Dept A', 'Dept B'],
+                'values' => [8.4, 4.1],
+            ],
+            visualMetricKey: 'resus_rate',
+        );
+
+        $spec = $this->builder->buildSpec(GenericAnalysisChartType::Bar, $query, $result);
+
+        self::assertNotNull($spec);
+        self::assertTrue($spec['percentScale']);
+        self::assertSame([8.4, 4.1], $spec['counts']);
     }
 
     public function testManyHospitalsAreReducedInChartSpec(): void

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisChartViewModelFactoryTest.php
@@ -12,6 +12,7 @@ use App\Statistics\GenericAnalysis\Application\GenericAnalysisChartSpecBuilder;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Enum\GenericAnalysisTableRowLimit;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use App\Statistics\GenericAnalysis\UI\Http\Controller\GenericAnalysisChartViewModelFactory;
 use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
 use PHPUnit\Framework\TestCase;
@@ -41,12 +42,17 @@ final class GenericAnalysisChartViewModelFactoryTest extends TestCase
             },
         );
 
-        $reducer = new GenericAnalysisChartDataReducer(new DimensionRegistry(), $translator);
+        $reducer = new GenericAnalysisChartDataReducer(
+            new DimensionRegistry(),
+            new MetricRegistry(),
+            $translator,
+        );
         $this->factory = new GenericAnalysisChartViewModelFactory(
             new GenericAnalysisChartRecommendationService(new DimensionRegistry(), $translator),
-            new GenericAnalysisChartSpecBuilder($reducer),
+            new GenericAnalysisChartSpecBuilder($reducer, new MetricRegistry()),
             $reducer,
             new DimensionRegistry(),
+            new MetricRegistry(),
             new StatisticsNavigationUrlBuilder($router),
             $translator,
         );

--- a/tests/Statistics/Unit/GenericAnalysis/MetricCompatibilityCheckerTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/MetricCompatibilityCheckerTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Unit\GenericAnalysis;
 
-use App\Statistics\Application\DTO\StatisticsPeriodBounds;
-use App\Statistics\Application\DTO\StatisticsScopeCriteria;
 use App\Statistics\GenericAnalysis\Application\MetricCompatibilityChecker;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\Exception\IncompatibleAnalysisMetricException;
@@ -36,13 +34,39 @@ final class MetricCompatibilityCheckerTest extends TestCase
     {
         $query = new AnalysisQuery(
             primaryDimensionKey: 'month',
-            scopeCriteria: StatisticsScopeCriteria::public(),
-            periodBounds: new StatisticsPeriodBounds(null),
+            scopeCriteria: GenericAnalysisTestFixtures::defaultQuery()->scopeCriteria,
+            periodBounds: GenericAnalysisTestFixtures::defaultQuery()->periodBounds,
             metricKeys: ['count', 'percent_of_bucket'],
         );
 
         $this->expectException(IncompatibleAnalysisMetricException::class);
         $this->checker->resolveAndValidate($query);
+    }
+
+    public function testTransportMetricsAreAllowed(): void
+    {
+        $query = GenericAnalysisTestFixtures::defaultQuery(
+            'department',
+            metricKeys: ['count', 'median_transport_time', 'p90_transport_time'],
+        );
+
+        $definitions = $this->checker->resolveAndValidate($query);
+
+        self::assertCount(3, $definitions);
+        self::assertSame('median_transport_time', $definitions[1]->key);
+    }
+
+    public function testRateMetricsAreAllowed(): void
+    {
+        $query = GenericAnalysisTestFixtures::defaultQuery(
+            'department',
+            metricKeys: ['count', 'resus_rate'],
+        );
+
+        $definitions = $this->checker->resolveAndValidate($query);
+
+        self::assertCount(2, $definitions);
+        self::assertSame('resus_rate', $definitions[1]->key);
     }
 
     public function testEmptyMetricKeysResolveToCount(): void

--- a/tests/Statistics/Unit/GenericAnalysis/MetricRegistryTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/MetricRegistryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Statistics\Unit\GenericAnalysis;
 
 use App\Statistics\GenericAnalysis\Domain\Enum\MetricComputationKind;
+use App\Statistics\GenericAnalysis\Domain\Enum\MetricFormat;
 use App\Statistics\GenericAnalysis\Domain\Exception\UnknownAnalysisMetricException;
 use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +26,49 @@ final class MetricRegistryTest extends TestCase
         self::assertFalse($this->registry->has('median_age'));
         self::assertTrue($this->registry->has('percent_of_total'));
         self::assertTrue($this->registry->has('percent_of_bucket'));
+    }
+
+    public function testRegistersTransportMetrics(): void
+    {
+        foreach ([
+            'mean_transport_time',
+            'median_transport_time',
+            'p25_transport_time',
+            'p75_transport_time',
+            'p90_transport_time',
+        ] as $key) {
+            self::assertTrue($this->registry->has($key), $key);
+            $metric = $this->registry->get($key);
+            self::assertSame(MetricComputationKind::SqlAggregate, $metric->computationKind);
+            self::assertSame(MetricFormat::Minutes, $metric->defaultFormat);
+            self::assertSame('transport_time_minutes', $metric->sourceColumn);
+            self::assertStringContainsString('AS '.$key, $metric->sqlSelectExpression ?? '');
+        }
+
+        self::assertStringContainsString('AVG(transport_time_minutes)', $this->registry->get('mean_transport_time')->sqlSelectExpression ?? '');
+        self::assertStringContainsString('PERCENTILE_CONT(0.5)', $this->registry->get('median_transport_time')->sqlSelectExpression ?? '');
+    }
+
+    public function testRegistersBooleanRateMetrics(): void
+    {
+        $rates = [
+            'resus_rate' => 'requires_resus',
+            'cpr_rate' => 'is_cpr',
+            'shock_rate' => 'is_shock',
+            'ventilation_rate' => 'is_ventilated',
+            'cathlab_rate' => 'requires_cathlab',
+            'pregnancy_rate' => 'is_pregnant',
+            'work_accident_rate' => 'is_work_accident',
+        ];
+
+        foreach ($rates as $key => $column) {
+            self::assertTrue($this->registry->has($key), $key);
+            $metric = $this->registry->get($key);
+            self::assertSame(MetricFormat::Percent, $metric->defaultFormat);
+            self::assertSame($column, $metric->sourceColumn);
+            self::assertStringContainsString(sprintf('FILTER (WHERE %s IS TRUE)', $column), $metric->sqlSelectExpression ?? '');
+            self::assertStringContainsString('NULLIF(COUNT(*), 0)', $metric->sqlSelectExpression ?? '');
+        }
     }
 
     public function testCountSqlAliasIsWhitelisted(): void

--- a/tests/Statistics/Unit/GenericAnalysis/MetricValueFormatterTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/MetricValueFormatterTest.php
@@ -17,11 +17,13 @@ final class MetricValueFormatterTest extends TestCase
         $this->formatter = new MetricValueFormatter(new MetricRegistry());
     }
 
-    public function testFormatsPercentAndDecimal(): void
+    public function testFormatsPercentMinutesAndDecimal(): void
     {
         $registry = new MetricRegistry();
 
         self::assertSame('8,40 %', $this->formatter->format($registry->get('percent_of_total'), 8.4));
+        self::assertSame('8,4 %', $this->formatter->format($registry->get('resus_rate'), 8.4));
+        self::assertSame('18 min', $this->formatter->format($registry->get('median_transport_time'), 18));
         self::assertSame('123', $this->formatter->format($registry->get('count'), 123));
     }
 }

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -3045,11 +3045,11 @@
       </trans-unit>
       <trans-unit id="statsRpTdLb" resname="stats.reports.top_diagnoses.label">
         <source>stats.reports.top_diagnoses.label</source>
-        <target>Top diagnoses</target>
+        <target>Top indications</target>
       </trans-unit>
       <trans-unit id="statsRpTdDs" resname="stats.reports.top_diagnoses.description">
         <source>stats.reports.top_diagnoses.description</source>
-        <target>Most frequent diagnosis labels in the selected scope and period.</target>
+        <target>Most frequent indication labels in the selected scope and period.</target>
       </trans-unit>
       <trans-unit id="statsRpTbRk" resname="stats.reports.table.rank">
         <source>stats.reports.table.rank</source>
@@ -3057,7 +3057,7 @@
       </trans-unit>
       <trans-unit id="statsRpTbDx" resname="stats.reports.table.diagnosis">
         <source>stats.reports.table.diagnosis</source>
-        <target>Diagnosis</target>
+        <target>Indication</target>
       </trans-unit>
       <trans-unit id="statsRpTbCnt" resname="stats.reports.table.count">
         <source>stats.reports.table.count</source>
@@ -3081,7 +3081,7 @@
       </trans-unit>
       <trans-unit id="statsRpTbSd" resname="stats.reports.table.secondary_diagnosis">
         <source>stats.reports.table.secondary_diagnosis</source>
-        <target>Secondary diagnosis</target>
+        <target>Secondary indication</target>
       </trans-unit>
       <trans-unit id="statsRpTbSp" resname="stats.reports.table.speciality">
         <source>stats.reports.table.speciality</source>
@@ -3117,11 +3117,11 @@
       </trans-unit>
       <trans-unit id="statsRpSdLb" resname="stats.reports.top_secondary_diagnoses.label">
         <source>stats.reports.top_secondary_diagnoses.label</source>
-        <target>Top secondary diagnoses</target>
+        <target>Top secondary indications</target>
       </trans-unit>
       <trans-unit id="statsRpSdDs" resname="stats.reports.top_secondary_diagnoses.description">
         <source>stats.reports.top_secondary_diagnoses.description</source>
-        <target>Most frequent secondary diagnosis labels in the selected scope and period.</target>
+        <target>Most frequent secondary indication labels in the selected scope and period.</target>
       </trans-unit>
       <trans-unit id="statsRpSlLb" resname="stats.reports.top_specialities.label">
         <source>stats.reports.top_specialities.label</source>
@@ -4537,11 +4537,11 @@
       </trans-unit>
       <trans-unit id="statsInd65" resname="stats.indication.insights.index.pretitle">
         <source>stats.indication.insights.index.pretitle</source>
-        <target>Diagnosis profiles</target>
+        <target>Indication profiles</target>
       </trans-unit>
       <trans-unit id="statsInd66" resname="stats.indication.insights.index.top_title">
         <source>stats.indication.insights.index.top_title</source>
-        <target>Top 25 diagnoses</target>
+        <target>Top 25 indications</target>
       </trans-unit>
       <trans-unit id="statsInd67" resname="stats.indication.insights.index.picker_title">
         <source>stats.indication.insights.index.picker_title</source>


### PR DESCRIPTION
### Summary

- Added an MVP implementation for **generic analysis metrics**
- Introduced reusable metric definitions for statistics analysis
- Added infrastructure for configurable metric selection and aggregation
- Integrated generic metrics into the existing statistics analysis flow
- Updated templates/controllers where needed to expose the new metric options
- Added or updated tests for metric calculation and analysis integration

### Motivation

- Provide a flexible foundation for future statistics analysis features
- Reduce duplication between specific metric implementations
- Make it easier to add and compare metrics across different analysis views
- Improve consistency in how metric calculations are defined and consumed

### Notes for Reviewers

- Review the generic metric abstraction and MVP scope
- Verify metric calculations match expectations for existing datasets
- Check integration with the current statistics analysis UI
- Ensure the implementation remains extensible without overcomplicating the MVP
- Confirm tests cover both calculation behavior and integration paths