### PR TITLE
fix: Correct dispatch area import mapping for “Zuweisung durch”

### DIFF
--- a/src/Import/Application/Analysis/RejectMessageNormalizer.php
+++ b/src/Import/Application/Analysis/RejectMessageNormalizer.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Analysis;
 
+use App\Import\Infrastructure\Mapping\DispatchAreaSourceResolver;
+
 /**
  * @phpstan-type NormalizedReject array{field: string, rejected_value: string, reason: string}
  */
-final class RejectMessageNormalizer
+final readonly class RejectMessageNormalizer
 {
     private const string UNKNOWN_FIELD = '(unknown)';
 
@@ -15,7 +17,6 @@ final class RejectMessageNormalizer
 
     /** @var array<string, string> */
     private const array DTO_FIELD_TO_ROW_KEY = [
-        'dispatchArea' => 'versorgungsbereich',
         'hospital' => 'krankenhaus_kurzname',
         'createdAt' => 'datum_erstellungsdatum',
         'arrivalAt' => 'datum_eintreffzeit',
@@ -45,6 +46,11 @@ final class RejectMessageNormalizer
         'caseId' => 'enr',
         'notes' => 'freitext',
     ];
+
+    public function __construct(
+        private DispatchAreaSourceResolver $dispatchAreaSourceResolver = new DispatchAreaSourceResolver(),
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $row
@@ -91,7 +97,7 @@ final class RejectMessageNormalizer
         }
 
         if (self::UNKNOWN_FIELD !== $field) {
-            $rowKey = self::DTO_FIELD_TO_ROW_KEY[$field] ?? $field;
+            $rowKey = $this->resolveRowKey($field, $row);
             if (\array_key_exists($rowKey, $row)) {
                 return $this->normalizeScalarValue($row[$rowKey], $message);
             }
@@ -127,5 +133,17 @@ final class RejectMessageNormalizer
             || str_contains($lower, 'should not be null')
             || str_contains($lower, 'cannot be empty')
             || str_contains($lower, 'is required');
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function resolveRowKey(string $field, array $row): string
+    {
+        if ('dispatchArea' === $field) {
+            return $this->dispatchAreaSourceResolver->resolveRowKey($row);
+        }
+
+        return self::DTO_FIELD_TO_ROW_KEY[$field] ?? $field;
     }
 }

--- a/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowMapper.php
@@ -22,9 +22,15 @@ use App\Import\Application\DTO\AllocationRowDTO;
  * Actual validity (required fields, ranges, choices, cross-field rules) is enforced by
  * the DTO's Symfony constraints.
  */
-final class AllocationRowMapper implements RowToDtoMapperInterface
+final readonly class AllocationRowMapper implements RowToDtoMapperInterface
 {
     use AllocationRowNormalizationTrait;
+
+    public function __construct(
+        private DispatchAreaSourceResolver $dispatchAreaSourceResolver = new DispatchAreaSourceResolver(),
+        private DispatchAreaNameNormalizer $dispatchAreaNameNormalizer = new DispatchAreaNameNormalizer(),
+    ) {
+    }
 
     /**
      * @param array<string,string> $row
@@ -37,12 +43,8 @@ final class AllocationRowMapper implements RowToDtoMapperInterface
         // Direct string fields
         $dto->hospital = self::getStringOrNull($row, 'krankenhaus_kurzname');
 
-        $dispatchSource = $row['zuweisung_durch'] ?? null;
-        if (null === $dispatchSource || '' === $dispatchSource) {
-            $dispatchSource = $row['versorgungsbereich'] ?? null;
-        }
-
-        $dto->dispatchArea = self::normalizeDispatchArea($dispatchSource);
+        $dispatchSource = $this->dispatchAreaSourceResolver->resolve($row);
+        $dto->dispatchArea = $this->dispatchAreaNameNormalizer->normalize($dispatchSource->value);
 
         // Date fields
         $date_created = self::getStringOrNull($row, 'datum_erstellungsdatum');

--- a/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
+++ b/src/Import/Infrastructure/Mapping/AllocationRowNormalizationTrait.php
@@ -255,35 +255,7 @@ trait AllocationRowNormalizationTrait
 
     protected static function normalizeDispatchArea(?string $value): ?string
     {
-        if (null === $value) {
-            return null;
-        }
-
-        $value = preg_replace([
-            '/^Leitstelle\s+/u',
-            '/^Kreis\s+/u',
-            '/\s*\(.+$/u',
-            '/\s*-\s*Kreis$/u',
-            '/\s*Kreis$/u',
-        ], ['', ''], $value);
-
-        if (null === $value) {
-            return null;
-        }
-
-        $value = trim($value);
-        if ('' === $value) {
-            return null;
-        }
-
-        $knownTypos = [
-            'Groá-Gerau' => 'Groß-Gerau',
-        ];
-        if (isset($knownTypos[$value])) {
-            $value = $knownTypos[$value];
-        }
-
-        return $value;
+        return new DispatchAreaNameNormalizer()->normalize($value);
     }
 
     private static function stripAssessmentPrefix(?string $value): ?string

--- a/src/Import/Infrastructure/Mapping/DispatchAreaImportSource.php
+++ b/src/Import/Infrastructure/Mapping/DispatchAreaImportSource.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Mapping;
+
+final readonly class DispatchAreaImportSource
+{
+    public function __construct(
+        public ?string $value,
+        public string $column,
+    ) {
+    }
+}

--- a/src/Import/Infrastructure/Mapping/DispatchAreaNameNormalizer.php
+++ b/src/Import/Infrastructure/Mapping/DispatchAreaNameNormalizer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Mapping;
+
+final class DispatchAreaNameNormalizer
+{
+    public function normalize(?string $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $value = preg_replace([
+            '/^Leitstelle\s+/u',
+            '/^Kreis\s+/u',
+            '/\s*\(.+$/u',
+            '/\s*-\s*Kreis$/u',
+            '/\s*Kreis$/u',
+        ], ['', ''], $value);
+
+        if (null === $value) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ('' === $value) {
+            return null;
+        }
+
+        $knownTypos = [
+            'Groá-Gerau' => 'Groß-Gerau',
+        ];
+        if (isset($knownTypos[$value])) {
+            $value = $knownTypos[$value];
+        }
+
+        return $value;
+    }
+}

--- a/src/Import/Infrastructure/Mapping/DispatchAreaSourceResolver.php
+++ b/src/Import/Infrastructure/Mapping/DispatchAreaSourceResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Mapping;
+
+final class DispatchAreaSourceResolver
+{
+    private const string COORDINATION_MARKER = 'Koordinierungsstelle';
+
+    /**
+     * @param array<string, string|null> $row
+     */
+    public function resolve(array $row): DispatchAreaImportSource
+    {
+        $zuweisungDurch = $this->getStringOrNull($row, 'zuweisung_durch');
+
+        if (null !== $zuweisungDurch && str_contains($zuweisungDurch, self::COORDINATION_MARKER)) {
+            return new DispatchAreaImportSource(
+                $this->getStringOrNull($row, 'versorgungsbereich'),
+                'versorgungsbereich',
+            );
+        }
+
+        if (null !== $zuweisungDurch && '' !== $zuweisungDurch) {
+            return new DispatchAreaImportSource($zuweisungDurch, 'zuweisung_durch');
+        }
+
+        return new DispatchAreaImportSource(
+            $this->getStringOrNull($row, 'versorgungsbereich'),
+            'versorgungsbereich',
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $row
+     */
+    public function resolveRowKey(array $row): string
+    {
+        return $this->resolve($row)->column;
+    }
+
+    /**
+     * @param array<string, string|null> $row
+     */
+    private function getStringOrNull(array $row, string $key): ?string
+    {
+        if (!\array_key_exists($key, $row)) {
+            return null;
+        }
+
+        $value = \trim((string) $row[$key]);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/src/Import/Infrastructure/Mapping/MciCaseRowMapper.php
+++ b/src/Import/Infrastructure/Mapping/MciCaseRowMapper.php
@@ -11,9 +11,15 @@ use App\Import\Application\DTO\MciCaseRowDTO;
  * Maps a normalized associative CSV row (snake_case keys produced by
  * SplCsvRowReader::rowsAssoc()) into an MciCaseRowDTO.
  */
-final class MciCaseRowMapper implements MciCaseRowToDtoMapperInterface
+final readonly class MciCaseRowMapper implements MciCaseRowToDtoMapperInterface
 {
     use AllocationRowNormalizationTrait;
+
+    public function __construct(
+        private DispatchAreaSourceResolver $dispatchAreaSourceResolver = new DispatchAreaSourceResolver(),
+        private DispatchAreaNameNormalizer $dispatchAreaNameNormalizer = new DispatchAreaNameNormalizer(),
+    ) {
+    }
 
     /**
      * @param array<string,string> $row
@@ -26,12 +32,9 @@ final class MciCaseRowMapper implements MciCaseRowToDtoMapperInterface
         // Required direct string fields
         $dto->hospital = self::getStringOrNull($row, 'krankenhaus_kurzname');
 
-        // Dispatch area source (single-hospital import may still vary)
-        $dispatchSource = $row['zuweisung_durch'] ?? null;
-        if (null === $dispatchSource || '' === $dispatchSource) {
-            $dispatchSource = $row['versorgungsbereich'] ?? null;
-        }
-        $dto->dispatchArea = self::normalizeDispatchArea($dispatchSource);
+        // Dispatch area: disponierende Leitstelle from Zuweisung durch (see DispatchAreaSourceResolver)
+        $dispatchSource = $this->dispatchAreaSourceResolver->resolve($row);
+        $dto->dispatchArea = $this->dispatchAreaNameNormalizer->normalize($dispatchSource->value);
 
         // Date fields (string format "d.m.Y H:i")
         $dto->createdAt = self::combineDateAndTime(

--- a/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
+++ b/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
@@ -85,7 +85,7 @@ final class FeedbackSubmitControllerTest extends WebTestCase
 
     public function testSubmitRedirectsBackToPathWithQueryAndStoresContext(): void
     {
-        $client = $this->createClientAsRoleUser();
+        $client = $this->createClientAsParticipant();
         $this->acceptEssentialCookiesOnly($client);
         $client->followRedirects(false);
 

--- a/tests/Import/Fixtures/allocation_import_zuweisung_durch.csv
+++ b/tests/Import/Fixtures/allocation_import_zuweisung_durch.csv
@@ -1,0 +1,4 @@
+Versorgungsbereich;Zuweisung durch;Krankenhaus-Kurzname;Datum (Erstellungsdatum);Uhrzeit (Erstellungsdatum);Datum (Eintreffzeit);Uhrzeit (Eintreffzeit);Geschlecht;PZC
+Leitstelle Waldeck-Frankenberg;Leitstelle Schwalm-Eder (Disponent);KH Test;07.01.2025;10:19;07.01.2025;13:14;M;123741
+Leitstelle Frankfurt;Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter KST Hessen);KH Test;07.01.2025;10:19;07.01.2025;13:14;M;123741
+Leitstelle Waldeck-Frankenberg;Berlin (Disponent);KH Test;07.01.2025;10:19;07.01.2025;13:14;M;123741

--- a/tests/Import/Integration/Service/Mapping/DispatchAreaImportMappingTest.php
+++ b/tests/Import/Integration/Service/Mapping/DispatchAreaImportMappingTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Service\Mapping;
+
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Application\Exception\ReferenceNotFoundException;
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Mapping\AllocationImportFactory;
+use App\Import\Infrastructure\Mapping\AllocationRowMapper;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class DispatchAreaImportMappingTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private AllocationImportFactory $factory;
+    private AllocationRowMapper $mapper;
+    private Import $import;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        UserFactory::createOne();
+
+        $state = StateFactory::createOne(['name' => 'Hessen']);
+        DispatchAreaFactory::createOne(['name' => 'Schwalm-Eder', 'state' => $state]);
+        DispatchAreaFactory::createOne(['name' => 'Frankfurt', 'state' => $state]);
+
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Test Hospital',
+            'state' => $state,
+            'dispatchArea' => DispatchAreaFactory::find(['name' => 'Schwalm-Eder']),
+        ]);
+
+        AssignmentFactory::createOne(['name' => 'Patient']);
+        OccasionFactory::createOne(['name' => 'Sonstiger Einsatz']);
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication', 'code' => 123]);
+
+        $this->import = $em->getRepository(Import::class)->find(
+            ImportFactory::createOne(['name' => 'Dispatch Area Import', 'hospital' => $hospital])->getId()
+        );
+
+        $this->factory = self::getContainer()->get(AllocationImportFactory::class);
+        $this->factory->warm();
+        $this->mapper = self::getContainer()->get(AllocationRowMapper::class);
+    }
+
+    public function testSchwalmEderDisponentResolvesToDispatchAreaEntity(): void
+    {
+        $dto = $this->mapper->mapAssoc($this->baseRow([
+            'zuweisung_durch' => 'Leitstelle Schwalm-Eder (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+        ]));
+
+        $allocation = $this->factory->fromDto($dto, $this->import);
+
+        self::assertSame('Schwalm-Eder', $allocation->getDispatchArea()->getName());
+    }
+
+    public function testKoordinierungsstelleUsesVersorgungsbereichForLookup(): void
+    {
+        $dto = $this->mapper->mapAssoc($this->baseRow([
+            'zuweisung_durch' => 'Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter KST Hessen)',
+            'versorgungsbereich' => 'Leitstelle Frankfurt',
+        ]));
+
+        $allocation = $this->factory->fromDto($dto, $this->import);
+
+        self::assertSame('Frankfurt', $allocation->getDispatchArea()->getName());
+    }
+
+    public function testBerlinAccountFailsLookup(): void
+    {
+        $dto = $this->mapper->mapAssoc($this->baseRow([
+            'zuweisung_durch' => 'Berlin (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+        ]));
+
+        $this->expectException(ReferenceNotFoundException::class);
+        $this->factory->fromDto($dto, $this->import);
+    }
+
+    /**
+     * @param array<string, string> $override
+     *
+     * @return array<string, string>
+     */
+    private function baseRow(array $override = []): array
+    {
+        return array_merge([
+            'krankenhaus_kurzname' => 'KH Test',
+            'datum_erstellungsdatum' => '07.01.2025',
+            'uhrzeit_erstellungsdatum' => '10:19',
+            'datum_eintreffzeit' => '07.01.2025',
+            'uhrzeit_eintreffzeit' => '13:14',
+            'geschlecht' => 'M',
+            'alter' => '74',
+            'schockraum' => 'false',
+            'herzkatheter' => 'false',
+            'reanimation' => 'false',
+            'beatmet' => 'false',
+            'schock' => 'false',
+            'schwanger' => 'false',
+            'arbeits_wege_schulunfall' => 'false',
+            'arztbegleitet' => 'false',
+            'transportmittel' => 'Boden',
+            'pzc' => '123741',
+            'fachgebiet' => 'Innere Medizin',
+            'fachbereich' => 'Kardiologie',
+            'fachbereich_war_abgemeldet' => 'false',
+            'grund' => 'Patient',
+            'anlass' => 'Sonstiger Einsatz',
+            'sekundaeranlass' => 'Kapazitätsengpass',
+            'ansteckungsfaehig' => 'Keine',
+            'pzc_und_text' => '123 Test Indication',
+        ], $override);
+    }
+}

--- a/tests/Import/Unit/Application/Analysis/RejectMessageNormalizerTest.php
+++ b/tests/Import/Unit/Application/Analysis/RejectMessageNormalizerTest.php
@@ -49,6 +49,32 @@ final class RejectMessageNormalizerTest extends TestCase
         self::assertSame('Unknown', $result['rejected_value']);
     }
 
+    public function testDispatchAreaRejectUsesZuweisungDurchColumn(): void
+    {
+        $message = 'REF_NOT_FOUND | Reference not found for "dispatchArea" | field=dispatchArea';
+
+        $result = $this->normalizer->normalize($message, [
+            'zuweisung_durch' => 'Berlin (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+        ]);
+
+        self::assertSame('dispatchArea', $result['field']);
+        self::assertSame('Berlin (Disponent)', $result['rejected_value']);
+    }
+
+    public function testDispatchAreaRejectUsesVersorgungsbereichForKoordinierungsstelle(): void
+    {
+        $message = 'REF_NOT_FOUND | field=dispatchArea';
+
+        $result = $this->normalizer->normalize($message, [
+            'zuweisung_durch' => 'Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter)',
+            'versorgungsbereich' => 'Leitstelle Frankfurt',
+        ]);
+
+        self::assertSame('dispatchArea', $result['field']);
+        self::assertSame('Leitstelle Frankfurt', $result['rejected_value']);
+    }
+
     public function testUnknownMessageUsesUnknownField(): void
     {
         $result = $this->normalizer->normalize('Unable to detect a supported row type.', []);

--- a/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaSourceTest.php
+++ b/tests/Import/Unit/Service/Mapping/AllocationRowMapperDispatchAreaSourceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use App\Import\Infrastructure\Mapping\AllocationRowMapper;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationRowMapperDispatchAreaSourceTest extends TestCase
+{
+    private AllocationRowMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AllocationRowMapper();
+    }
+
+    public function testZuweisungDurchOverridesVersorgungsbereich(): void
+    {
+        $dto = $this->mapper->mapAssoc([
+            'krankenhaus_kurzname' => 'KH Test',
+            'zuweisung_durch' => 'Leitstelle Schwalm-Eder (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+            'datum_erstellungsdatum' => '07.01.2025',
+            'uhrzeit_erstellungsdatum' => '10:19',
+            'datum_eintreffzeit' => '07.01.2025',
+            'uhrzeit_eintreffzeit' => '13:14',
+            'geschlecht' => 'M',
+            'pzc' => '123001',
+        ]);
+
+        self::assertSame('Schwalm-Eder', $dto->dispatchArea);
+    }
+
+    public function testKoordinierungsstelleUsesVersorgungsbereich(): void
+    {
+        $dto = $this->mapper->mapAssoc([
+            'krankenhaus_kurzname' => 'KH Test',
+            'zuweisung_durch' => 'Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter KST Hessen)',
+            'versorgungsbereich' => 'Leitstelle Frankfurt',
+            'datum_erstellungsdatum' => '07.01.2025',
+            'uhrzeit_erstellungsdatum' => '10:19',
+            'datum_eintreffzeit' => '07.01.2025',
+            'uhrzeit_eintreffzeit' => '13:14',
+            'geschlecht' => 'M',
+            'pzc' => '123001',
+        ]);
+
+        self::assertSame('Frankfurt', $dto->dispatchArea);
+    }
+
+    public function testBerlinAccountNormalizesToDispatchAreaName(): void
+    {
+        $dto = $this->mapper->mapAssoc([
+            'krankenhaus_kurzname' => 'KH Test',
+            'zuweisung_durch' => 'Berlin (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+            'datum_erstellungsdatum' => '07.01.2025',
+            'uhrzeit_erstellungsdatum' => '10:19',
+            'datum_eintreffzeit' => '07.01.2025',
+            'uhrzeit_eintreffzeit' => '13:14',
+            'geschlecht' => 'M',
+            'pzc' => '123001',
+        ]);
+
+        self::assertSame('Berlin', $dto->dispatchArea);
+    }
+}

--- a/tests/Import/Unit/Service/Mapping/DispatchAreaNameNormalizerTest.php
+++ b/tests/Import/Unit/Service/Mapping/DispatchAreaNameNormalizerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use App\Import\Infrastructure\Mapping\DispatchAreaNameNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DispatchAreaNameNormalizerTest extends TestCase
+{
+    private DispatchAreaNameNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new DispatchAreaNameNormalizer();
+    }
+
+    #[DataProvider('dispatchAreaProvider')]
+    public function testNormalize(?string $input, ?string $expected): void
+    {
+        self::assertSame($expected, $this->normalizer->normalize($input));
+    }
+
+    /**
+     * @return iterable<string, array{0: string|null, 1: string|null}>
+     */
+    public static function dispatchAreaProvider(): iterable
+    {
+        yield 'issue 126 Groá-Gerau typo' => ['Groá-Gerau', 'Groß-Gerau'];
+        yield 'issue 122 trailing Kreis without dash' => ['Rheingau Taunus Kreis', 'Rheingau Taunus'];
+        yield 'unchanged canonical name' => ['Rheingau Taunus', 'Rheingau Taunus'];
+        yield 'leading Leitstelle prefix' => ['Leitstelle Nord', 'Nord'];
+        yield 'leading Kreis prefix' => ['Kreis Offenbach', 'Offenbach'];
+        yield 'parenthetical suffix' => ['Frankfurt (Main)', 'Frankfurt'];
+        yield 'trailing dash Kreis suffix' => ['Main-Taunus - Kreis', 'Main-Taunus'];
+        yield 'null' => [null, null];
+        yield 'empty string' => ['', null];
+        yield 'whitespace only' => ['   ', null];
+        yield 'disponent plain' => ['Leitstelle Schwalm-Eder (Disponent)', 'Schwalm-Eder'];
+        yield 'disponent5' => ['Leitstelle Kassel (Disponent5)', 'Kassel'];
+        yield 'disponent-gi' => ['Leitstelle Gießen (Disponent-Gi)', 'Gießen'];
+        yield 'zlst-disponent' => ['Leitstelle Lahn-Dill-Kreis (ZLST-Disponent)', 'Lahn-Dill'];
+        yield 'disponent mtk variant' => ['Leitstelle Main-Taunus (Disponent - MTK)', 'Main-Taunus'];
+        yield 'c4 schnittstelle' => ['Leitstelle Marburg-Biedenkopf (Schnittstelle Einsatzleitsystem ISE C4)', 'Marburg-Biedenkopf'];
+        yield 'berlin disponent account' => ['Berlin (Disponent)', 'Berlin'];
+        yield 'test area account' => ['Test Area (Disponent)', 'Test Area'];
+    }
+}

--- a/tests/Import/Unit/Service/Mapping/DispatchAreaSourceResolverTest.php
+++ b/tests/Import/Unit/Service/Mapping/DispatchAreaSourceResolverTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Service\Mapping;
+
+use App\Import\Infrastructure\Mapping\DispatchAreaSourceResolver;
+use PHPUnit\Framework\TestCase;
+
+final class DispatchAreaSourceResolverTest extends TestCase
+{
+    private DispatchAreaSourceResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new DispatchAreaSourceResolver();
+    }
+
+    public function testPrefersZuweisungDurchWhenPresent(): void
+    {
+        $source = $this->resolver->resolve([
+            'zuweisung_durch' => 'Leitstelle Schwalm-Eder (Disponent)',
+            'versorgungsbereich' => 'Leitstelle Waldeck-Frankenberg',
+        ]);
+
+        self::assertSame('Leitstelle Schwalm-Eder (Disponent)', $source->value);
+        self::assertSame('zuweisung_durch', $source->column);
+    }
+
+    public function testFallsBackToVersorgungsbereichWhenZuweisungDurchEmpty(): void
+    {
+        $source = $this->resolver->resolve([
+            'zuweisung_durch' => '',
+            'versorgungsbereich' => 'Leitstelle Kassel',
+        ]);
+
+        self::assertSame('Leitstelle Kassel', $source->value);
+        self::assertSame('versorgungsbereich', $source->column);
+    }
+
+    public function testUsesVersorgungsbereichForKoordinierungsstelle(): void
+    {
+        $source = $this->resolver->resolve([
+            'zuweisung_durch' => 'Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter KST Hessen)',
+            'versorgungsbereich' => 'Leitstelle Frankfurt',
+        ]);
+
+        self::assertSame('Leitstelle Frankfurt', $source->value);
+        self::assertSame('versorgungsbereich', $source->column);
+    }
+
+    public function testResolveRowKeyMatchesSourceColumn(): void
+    {
+        $row = [
+            'zuweisung_durch' => 'Koordinierungsstelle für Sekundärtransporte - HE (Einsatzbearbeiter)',
+            'versorgungsbereich' => 'Leitstelle Frankfurt',
+        ];
+
+        self::assertSame('versorgungsbereich', $this->resolver->resolveRowKey($row));
+    }
+}


### PR DESCRIPTION
### Summary

- Fixed dispatch area assignment during allocation imports
- Corrected mapping and resolution logic for the **"Zuweisung durch"** import field
- Improved dispatch area matching and assignment consistency
- Prevented allocations from being linked to incorrect or missing dispatch areas
- Added or updated tests covering the affected import scenarios

### Motivation

- Ensure dispatch areas are assigned correctly during imports
- Improve data quality and consistency for imported allocations
- Prevent incorrect analytics and reporting caused by missing or wrong dispatch area assignments
- Resolve edge cases in dispatch area mapping originating from source data

### Notes for Reviewers

- Verify dispatch area assignment for imports containing a valid "Zuweisung durch" value
- Check behavior when the referenced dispatch area cannot be resolved
- Ensure existing dispatch area mappings continue to work as expected
- Review test coverage for import mapping and dispatch area resolution edge cases