### PR TITLE
feat: Add safe import deletion workflow

### DIFF
--- a/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Http\Controller\Import;
 
+use App\Import\Application\Service\ImportDeletionService;
 use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
+use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -30,6 +32,11 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_ADMIN')]
 final class ImportCrudController extends AbstractCrudController
 {
+    public function __construct(
+        private readonly ImportDeletionService $importDeletionService,
+    ) {
+    }
+
     #[\Override]
     public static function getEntityFqcn(): string
     {
@@ -101,5 +108,11 @@ final class ImportCrudController extends AbstractCrudController
             ->onlyOnDetail();
         yield TextField::new('rejectFilePath', 'Reject file')
             ->onlyOnDetail();
+    }
+
+    #[\Override]
+    public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    {
+        $this->importDeletionService->delete($entityInstance);
     }
 }

--- a/src/Import/Application/Service/ImportDeletionService.php
+++ b/src/Import/Application/Service/ImportDeletionService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Repository\ImportBatchRunItemRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class ImportDeletionService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private ImportRelatedDataCleanupService $relatedDataCleanup,
+        private ImportBatchRunItemRepository $importBatchRunItemRepository,
+    ) {
+    }
+
+    public function delete(Import $import): void
+    {
+        $importId = (int) $import->getId();
+
+        $this->relatedDataCleanup->removeAll($import);
+        $this->relatedDataCleanup->deleteRejectFile($import);
+        $this->relatedDataCleanup->deleteSourceFile($import);
+        $this->importBatchRunItemRepository->deleteByImportId($importId);
+
+        $this->em->remove($import);
+        $this->em->flush();
+    }
+}

--- a/src/Import/Application/Service/ImportPreviousRunCleanupService.php
+++ b/src/Import/Application/Service/ImportPreviousRunCleanupService.php
@@ -4,175 +4,22 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
-use App\Allocation\Infrastructure\Repository\AllocationRepository;
-use App\Allocation\Infrastructure\Repository\MciCaseRepository;
 use App\Import\Domain\Entity\Import;
-use App\Import\Infrastructure\Repository\ImportRejectRepository;
-use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
-use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Path;
 
 final readonly class ImportPreviousRunCleanupService
 {
     public function __construct(
         private EntityManagerInterface $em,
-        private Connection $connection,
-        private ImportRejectRepository $importRejectRepository,
-        private AllocationRepository $allocationRepository,
-        private MciCaseRepository $mciCaseRepository,
-        private AllocationStatsProjectionRebuildInterface $statsProjectionRebuilder,
-        private LoggerInterface $importLogger,
-        #[Autowire('%kernel.project_dir%')]
-        private string $projectDir,
+        private ImportRelatedDataCleanupService $relatedDataCleanup,
     ) {
     }
 
     public function cleanup(Import $import): void
     {
-        $importId = (int) $import->getId();
-
-        $counts = $this->em->wrapInTransaction(function () use ($import, $importId): array {
-            $assessmentIds = $this->collectAssessmentIdsForImport($importId);
-
-            return [
-                'projection' => $this->statsProjectionRebuilder->deleteForImport($importId),
-                'rejects' => $this->importRejectRepository->deleteByImport($import),
-                'allocations' => $this->allocationRepository->deleteByImport($import),
-                'assessments' => $this->deleteAssessmentsByIds($assessmentIds),
-                'mci_cases' => $this->mciCaseRepository->deleteByImport($import),
-            ];
-        });
-
-        $this->logCleanup(
-            $importId,
-            $counts['projection'],
-            $counts['rejects'],
-            $counts['assessments'],
-            $counts['allocations'],
-            $counts['mci_cases'],
-        );
-
-        $this->deleteRejectFile($import);
+        $this->relatedDataCleanup->removeAll($import);
+        $this->relatedDataCleanup->deleteRejectFile($import);
         $import->resetForReimport();
         $this->em->flush();
-    }
-
-    /** @return list<int> */
-    private function collectAssessmentIdsForImport(int $importId): array
-    {
-        $ids = $this->connection->fetchFirstColumn(
-            <<<'SQL'
-SELECT DISTINCT assessment_id
-FROM allocation
-WHERE import_id = :importId
-  AND assessment_id IS NOT NULL
-SQL,
-            ['importId' => $importId],
-        );
-
-        return array_map(static fn (mixed $id): int => (int) $id, $ids);
-    }
-
-    /** @param list<int> $assessmentIds */
-    private function deleteAssessmentsByIds(array $assessmentIds): int
-    {
-        if ([] === $assessmentIds) {
-            return 0;
-        }
-
-        $placeholders = implode(', ', array_fill(0, \count($assessmentIds), '?'));
-
-        return $this->connection->executeStatement(
-            'DELETE FROM assessment WHERE id IN ('.$placeholders.')',
-            $assessmentIds,
-        );
-    }
-
-    private function deleteRejectFile(Import $import): void
-    {
-        $rejectPath = $import->getRejectFilePath();
-        if (null === $rejectPath) {
-            return;
-        }
-
-        $absPath = $this->resolvePath($rejectPath);
-        if (!\is_file($absPath)) {
-            return;
-        }
-
-        @\unlink($absPath);
-        $this->importLogger->info('import.reject_file.deleted', [
-            'import_id' => $import->getId(),
-            'path' => $absPath,
-        ]);
-    }
-
-    private function resolvePath(string $stored): string
-    {
-        if ($this->isAbsolutePath($stored)) {
-            return $stored;
-        }
-
-        return Path::join($this->projectDir, $stored);
-    }
-
-    private function isAbsolutePath(string $path): bool
-    {
-        if ('' === $path) {
-            return false;
-        }
-
-        if (DIRECTORY_SEPARATOR === $path[0]) {
-            return true;
-        }
-
-        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
-    }
-
-    private function logCleanup(
-        int $importId,
-        int $deletedProjectionRows,
-        int $deletedRejects,
-        int $deletedAssessments,
-        int $deletedAllocations,
-        int $deletedMciCases,
-    ): void {
-        if ($deletedProjectionRows > 0) {
-            $this->importLogger->info('import.stats_projection.cleared', [
-                'import_id' => $importId,
-                'deleted' => $deletedProjectionRows,
-            ]);
-        }
-
-        if ($deletedRejects > 0) {
-            $this->importLogger->info('import.rejects.cleared', [
-                'import_id' => $importId,
-                'deleted' => $deletedRejects,
-            ]);
-        }
-
-        if ($deletedAssessments > 0) {
-            $this->importLogger->info('import.assessments.cleared', [
-                'import_id' => $importId,
-                'deleted' => $deletedAssessments,
-            ]);
-        }
-
-        if ($deletedAllocations > 0) {
-            $this->importLogger->info('import.allocations.cleared', [
-                'import_id' => $importId,
-                'deleted' => $deletedAllocations,
-            ]);
-        }
-
-        if ($deletedMciCases > 0) {
-            $this->importLogger->info('import.mci_cases.cleared', [
-                'import_id' => $importId,
-                'deleted' => $deletedMciCases,
-            ]);
-        }
     }
 }

--- a/src/Import/Application/Service/ImportRelatedDataCleanupService.php
+++ b/src/Import/Application/Service/ImportRelatedDataCleanupService.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Allocation\Infrastructure\Repository\AllocationRepository;
+use App\Allocation\Infrastructure\Repository\MciCaseRepository;
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Repository\ImportRejectRepository;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Path;
+
+final readonly class ImportRelatedDataCleanupService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private Connection $connection,
+        private ImportRejectRepository $importRejectRepository,
+        private AllocationRepository $allocationRepository,
+        private MciCaseRepository $mciCaseRepository,
+        private AllocationStatsProjectionRebuildInterface $statsProjectionRebuilder,
+        private LoggerInterface $importLogger,
+        #[Autowire('%kernel.project_dir%')]
+        private string $projectDir,
+    ) {
+    }
+
+    public function removeAll(Import $import): void
+    {
+        $importId = (int) $import->getId();
+
+        $counts = $this->em->wrapInTransaction(function () use ($import, $importId): array {
+            $assessmentIds = $this->collectAssessmentIdsForImport($importId);
+
+            return [
+                'projection' => $this->statsProjectionRebuilder->deleteForImport($importId),
+                'rejects' => $this->importRejectRepository->deleteByImport($import),
+                'allocations' => $this->allocationRepository->deleteByImport($import),
+                'assessments' => $this->deleteAssessmentsByIds($assessmentIds),
+                'mci_cases' => $this->mciCaseRepository->deleteByImport($import),
+            ];
+        });
+
+        $this->logCleanup(
+            $importId,
+            $counts['projection'],
+            $counts['rejects'],
+            $counts['assessments'],
+            $counts['allocations'],
+            $counts['mci_cases'],
+        );
+    }
+
+    public function deleteRejectFile(Import $import): void
+    {
+        $this->deleteStoredFile($import->getRejectFilePath(), 'import.reject_file.deleted', $import);
+    }
+
+    public function deleteSourceFile(Import $import): void
+    {
+        $this->deleteStoredFile($import->getFilePath(), 'import.source_file.deleted', $import);
+    }
+
+    /** @return list<int> */
+    private function collectAssessmentIdsForImport(int $importId): array
+    {
+        $ids = $this->connection->fetchFirstColumn(
+            <<<'SQL'
+SELECT DISTINCT assessment_id
+FROM allocation
+WHERE import_id = :importId
+  AND assessment_id IS NOT NULL
+SQL,
+            ['importId' => $importId],
+        );
+
+        return array_map(static fn (mixed $id): int => (int) $id, $ids);
+    }
+
+    /** @param list<int> $assessmentIds */
+    private function deleteAssessmentsByIds(array $assessmentIds): int
+    {
+        if ([] === $assessmentIds) {
+            return 0;
+        }
+
+        $placeholders = implode(', ', array_fill(0, \count($assessmentIds), '?'));
+
+        return $this->connection->executeStatement(
+            'DELETE FROM assessment WHERE id IN ('.$placeholders.')',
+            $assessmentIds,
+        );
+    }
+
+    private function deleteStoredFile(?string $storedPath, string $logEvent, Import $import): void
+    {
+        if (null === $storedPath || '' === $storedPath) {
+            return;
+        }
+
+        $absPath = $this->resolvePath($storedPath);
+        if (!\is_file($absPath)) {
+            return;
+        }
+
+        @\unlink($absPath);
+        $this->importLogger->info($logEvent, [
+            'import_id' => $import->getId(),
+            'path' => $absPath,
+        ]);
+    }
+
+    private function resolvePath(string $stored): string
+    {
+        if ($this->isAbsolutePath($stored)) {
+            return $stored;
+        }
+
+        return Path::join($this->projectDir, $stored);
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        if (DIRECTORY_SEPARATOR === $path[0]) {
+            return true;
+        }
+
+        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
+    }
+
+    private function logCleanup(
+        int $importId,
+        int $deletedProjectionRows,
+        int $deletedRejects,
+        int $deletedAssessments,
+        int $deletedAllocations,
+        int $deletedMciCases,
+    ): void {
+        if ($deletedProjectionRows > 0) {
+            $this->importLogger->info('import.stats_projection.cleared', [
+                'import_id' => $importId,
+                'deleted' => $deletedProjectionRows,
+            ]);
+        }
+
+        if ($deletedRejects > 0) {
+            $this->importLogger->info('import.rejects.cleared', [
+                'import_id' => $importId,
+                'deleted' => $deletedRejects,
+            ]);
+        }
+
+        if ($deletedAssessments > 0) {
+            $this->importLogger->info('import.assessments.cleared', [
+                'import_id' => $importId,
+                'deleted' => $deletedAssessments,
+            ]);
+        }
+
+        if ($deletedAllocations > 0) {
+            $this->importLogger->info('import.allocations.cleared', [
+                'import_id' => $importId,
+                'deleted' => $deletedAllocations,
+            ]);
+        }
+
+        if ($deletedMciCases > 0) {
+            $this->importLogger->info('import.mci_cases.cleared', [
+                'import_id' => $importId,
+                'deleted' => $deletedMciCases,
+            ]);
+        }
+    }
+}

--- a/src/Import/Infrastructure/Repository/ImportBatchRunItemRepository.php
+++ b/src/Import/Infrastructure/Repository/ImportBatchRunItemRepository.php
@@ -18,4 +18,14 @@ final class ImportBatchRunItemRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, ImportBatchRunItem::class);
     }
+
+    public function deleteByImportId(int $importId): void
+    {
+        $this->createQueryBuilder('item')
+            ->delete()
+            ->where('item.importId = :importId')
+            ->setParameter('importId', $importId)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/Import/Infrastructure/Security/Voter/ImportVoter.php
+++ b/src/Import/Infrastructure/Security/Voter/ImportVoter.php
@@ -17,6 +17,8 @@ final class ImportVoter extends Voter
 {
     public const string VIEW = 'VIEW';
 
+    public const string DELETE = 'DELETE';
+
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private readonly ImportListAccess $importListAccess,
@@ -32,7 +34,7 @@ final class ImportVoter extends Voter
     #[\Override]
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return $subject instanceof Import && self::VIEW === $attribute;
+        return $subject instanceof Import && \in_array($attribute, [self::VIEW, self::DELETE], true);
     }
 
     #[\Override]
@@ -43,11 +45,26 @@ final class ImportVoter extends Voter
             return false;
         }
 
-        $hospitalId = $subject->getHospital()?->getId();
-        if (null === $hospitalId) {
-            return false;
+        if (self::VIEW === $attribute) {
+            $hospitalId = $subject->getHospital()?->getId();
+            if (null === $hospitalId) {
+                return false;
+            }
+
+            return $this->importListAccess->canAccessImportHospital($user, $hospitalId);
         }
 
-        return $this->importListAccess->canAccessImportHospital($user, $hospitalId);
+        if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+            return true;
+        }
+
+        $hospitalId = $subject->getHospital()?->getId();
+        if (null !== $hospitalId && $this->importListAccess->canAccessImportHospital($user, $hospitalId)) {
+            return true;
+        }
+
+        $createdBy = $subject->getCreatedBy();
+
+        return null !== $createdBy && $createdBy->getId() === $user->getId();
     }
 }

--- a/src/Import/UI/Http/Controller/DeleteImportController.php
+++ b/src/Import/UI/Http/Controller/DeleteImportController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Http\Controller;
+
+use App\Import\Application\Service\ImportDeletionService;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Security\Voter\ImportVoter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class DeleteImportController extends AbstractController
+{
+    public function __construct(
+        private readonly ImportDeletionService $importDeletionService,
+    ) {
+    }
+
+    #[Route('/import/{id}/delete', name: 'app_import_delete', methods: ['POST'])]
+    #[IsGranted(ImportVoter::DELETE, subject: 'import')]
+    public function __invoke(Import $import, Request $request): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        $importId = (int) $import->getId();
+
+        if (!$this->isCsrfTokenValid('import_delete_'.$importId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        if (ImportStatus::RUNNING === $import->getStatus()) {
+            $this->addFlash('error', 'flash.import.delete_running_blocked');
+
+            return $this->redirectToRoute('app_import_show', ['id' => $importId]);
+        }
+
+        $this->importDeletionService->delete($import);
+
+        $this->addFlash('success', 'flash.import.deleted');
+
+        return $this->redirectToRoute('app_import_index');
+    }
+}

--- a/src/Import/UI/Twig/templates/show.html.twig
+++ b/src/Import/UI/Twig/templates/show.html.twig
@@ -226,6 +226,17 @@
                                 <a class="btn btn-outline-secondary" href="{{ path('app_explore_mci_case_list', {importId: import.id}) }}">
                                     <twig:ux:icon name="tabler:ambulance" class="w-3 h-3" /> {{ 'import.action.preview_mci_cases'|trans }}
                                 </a>
+                                {% if is_granted(constant('App\\Import\\Infrastructure\\Security\\Voter\\ImportVoter::DELETE'), import) %}
+                                    {% if import.status.value == 'Running' %}
+                                        <button type="button" class="btn btn-outline-danger" disabled title="{{ 'import.delete.running_blocked_hint'|trans }}">
+                                            <twig:ux:icon name="tabler:trash" class="w-3 h-3" /> {{ 'import.action.delete'|trans }}
+                                        </button>
+                                    {% else %}
+                                        <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#import-delete-modal">
+                                            <twig:ux:icon name="tabler:trash" class="w-3 h-3" /> {{ 'import.action.delete'|trans }}
+                                        </button>
+                                    {% endif %}
+                                {% endif %}
                                 </div>
                             </twig:Card>
                         </div>
@@ -234,5 +245,28 @@
             </div>
         </div>
     </div>
+
+    {% if is_granted(constant('App\\Import\\Infrastructure\\Security\\Voter\\ImportVoter::DELETE'), import) and import.status.value != 'Running' %}
+        <div class="modal modal-blur fade" id="import-delete-modal" tabindex="-1" aria-labelledby="import-delete-modal-label" aria-hidden="true">
+            <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <form method="post" action="{{ path('app_import_delete', {id: import.id}) }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('import_delete_' ~ import.id) }}">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="import-delete-modal-label">{{ 'import.delete.modal.title'|trans }}</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'import.delete.modal.cancel'|trans }}"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p class="mb-0">{{ 'import.delete.modal.body'|trans({'%name%': import.name ?? ('#' ~ import.id)}) }}</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-link link-secondary" data-bs-dismiss="modal">{{ 'import.delete.modal.cancel'|trans }}</button>
+                            <button type="submit" class="btn btn-danger">{{ 'import.delete.modal.confirm'|trans }}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 
 {% endblock %}

--- a/src/Shared/Infrastructure/Monitoring/Sentry/SentryLogScrubber.php
+++ b/src/Shared/Infrastructure/Monitoring/Sentry/SentryLogScrubber.php
@@ -18,6 +18,7 @@ final readonly class SentryLogScrubber
         'import.abort.flush_failed',
         'import.rejects.cleared',
         'import.reject_file.deleted',
+        'import.source_file.deleted',
     ];
 
     /** @psalm-suppress PossiblyUnusedMethod */

--- a/tests/Admin/Functional/Controller/ImportCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/ImportCrudControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Admin\UI\Http\Controller\Import\ImportCrudController;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ImportCrudControllerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDeleteEntityRemovesImportViaDeletionService(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $owner = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Admin Delete Import',
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::COMPLETED,
+            'filePath' => '/tmp/admin-delete.csv',
+        ]);
+
+        $importId = (int) $import->getId();
+        $em = $container->get(EntityManagerInterface::class);
+        $entity = $em->find(Import::class, $importId);
+        self::assertInstanceOf(Import::class, $entity);
+
+        $controller = $container->get(ImportCrudController::class);
+        $controller->deleteEntity($em, $entity);
+
+        self::assertNull($container->get(ImportRepository::class)->find($importId));
+    }
+}

--- a/tests/Import/Functional/Controller/DeleteImportControllerTest.php
+++ b/tests/Import/Functional/Controller/DeleteImportControllerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class DeleteImportControllerTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testHospitalOwnerCanDeleteImportViaModal(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner();
+
+        $this->browser()
+            ->actingAs($owner)
+            ->interceptRedirects()
+            ->visit('/import/'.$importId)
+            ->assertSuccessful()
+            ->click('Delete permanently')
+            ->assertRedirectedTo('/import');
+
+        self::assertNull(self::getContainer()->get(ImportRepository::class)->find($importId));
+    }
+
+    public function testForeignParticipantCannotDeleteImport(): void
+    {
+        [, $importId] = $this->createImportForOwner();
+        $intruder = UserFactory::createOne([
+            'username' => 'delete-intruder-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+
+        $browser = $this->browser()->actingAs($intruder);
+        $browser->client()->request(
+            Request::METHOD_POST,
+            '/import/'.$importId.'/delete',
+            ['_token' => 'unused-token'],
+        );
+
+        $browser->assertStatus(403);
+
+        self::assertNotNull(self::getContainer()->get(ImportRepository::class)->find($importId));
+    }
+
+    public function testDeleteRequiresValidCsrfToken(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner();
+
+        $browser = $this->browser()->actingAs($owner);
+        $browser->visit('/import/'.$importId)->assertSuccessful();
+        $browser->client()->request(
+            Request::METHOD_POST,
+            '/import/'.$importId.'/delete',
+            ['_token' => 'invalid-token'],
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testRunningImportShowsDisabledDeleteButton(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner(ImportStatus::RUNNING);
+
+        $this->browser()
+            ->actingAs($owner)
+            ->visit('/import/'.$importId)
+            ->assertSuccessful()
+            ->assertSeeElement('button.btn-outline-danger[disabled]');
+
+        self::assertNotNull(self::getContainer()->get(ImportRepository::class)->find($importId));
+    }
+
+    public function testShowPageDisplaysDeleteButtonForOwner(): void
+    {
+        [$owner, $importId] = $this->createImportForOwner();
+
+        $this->browser()
+            ->actingAs($owner)
+            ->visit('/import/'.$importId)
+            ->assertSuccessful()
+            ->assertSeeElement('#import-delete-modal')
+            ->assertSee('Delete import');
+    }
+
+    /**
+     * @return array{0: User, 1: int}
+     */
+    private function createImportForOwner(ImportStatus $status = ImportStatus::COMPLETED): array
+    {
+        $owner = UserFactory::createOne([
+            'username' => 'delete-owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $createdBy = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => 'Delete Me Import',
+            'hospital' => $hospital,
+            'createdBy' => $createdBy,
+            'type' => ImportType::ALLOCATION,
+            'status' => $status,
+            'filePath' => '/tmp/delete-me.csv',
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => 12,
+            'rowCount' => 1,
+            'rowsPassed' => 1,
+            'rowsRejected' => 0,
+            'runCount' => 1,
+            'runTime' => 100,
+        ]);
+
+        return [$owner->_real(), (int) $import->getId()];
+    }
+}

--- a/tests/Import/Integration/Service/ImportDeletionServiceTest.php
+++ b/tests/Import/Integration/Service/ImportDeletionServiceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Service;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Application\Service\ImportDeletionService;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Entity\ImportBatchRun;
+use App\Import\Domain\Entity\ImportBatchRunItem;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ImportDeletionServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private EntityManagerInterface $em;
+    private ImportRepository $imports;
+    private ImportDeletionService $deletionService;
+    private Connection $connection;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->imports = $container->get(ImportRepository::class);
+        $this->deletionService = $container->get(ImportDeletionService::class);
+        $this->connection = $container->get(Connection::class);
+    }
+
+    public function testDeleteRemovesImportRelatedDataAndFiles(): void
+    {
+        ['import' => $import, 'csvPath' => $csvPath, 'importId' => $importId] = $this->arrangeImportWithAllocation();
+
+        try {
+            self::assertFileExists($csvPath);
+            self::assertSame(1, $this->countAllocationsForImport($importId));
+            self::assertSame(1, $this->countProjectionRowsForImport($importId));
+
+            $run = new ImportBatchRun(['reason' => 'test-delete']);
+            $run->addItem(new ImportBatchRunItem($importId, $import->getName()));
+            $this->em->persist($run);
+            $this->em->flush();
+
+            $this->deletionService->delete($import);
+
+            self::assertNull($this->imports->find($importId));
+            self::assertSame(0, $this->countAllocationsForImport($importId));
+            self::assertSame(0, $this->countProjectionRowsForImport($importId));
+            self::assertSame(0, $this->countBatchRunItemsForImport($importId));
+            self::assertFileDoesNotExist($csvPath);
+        } finally {
+            if (\is_file($csvPath)) {
+                @unlink($csvPath);
+            }
+        }
+    }
+
+    /**
+     * @return array{import: Import, importId: int, csvPath: string}
+     */
+    private function arrangeImportWithAllocation(): array
+    {
+        UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
+        file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+
+        $importProxy = ImportFactory::createOne([
+            'name' => 'Delete Service IT',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::COMPLETED,
+            'filePath' => $csvPath,
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => (int) filesize($csvPath),
+            'rowCount' => 1,
+            'rowsPassed' => 1,
+            'rowsRejected' => 0,
+            'runCount' => 1,
+            'runTime' => 50,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'Delete Speciality']);
+        DepartmentFactory::createOne(['name' => 'Delete Department']);
+        AssignmentFactory::createOne(['name' => 'Delete Assignment']);
+        OccasionFactory::createOne(['name' => 'Delete Occasion']);
+        InfectionFactory::createOne(['name' => 'Delete Infection']);
+        $raw = IndicationRawFactory::createOne(['name' => 'Delete Raw']);
+        $normalized = IndicationNormalizedFactory::createOne(['name' => 'Delete Normalized']);
+
+        AllocationFactory::createOne([
+            'import' => $importProxy,
+            'hospital' => $hospital,
+            'dispatchArea' => $dispatch,
+            'state' => $state,
+            'indicationRaw' => $raw,
+            'indicationNormalized' => $normalized,
+        ]);
+
+        $importId = (int) $importProxy->getId();
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($importId);
+
+        /** @var Import $import */
+        $import = $this->imports->find($importId);
+
+        return ['import' => $import, 'importId' => $importId, 'csvPath' => $csvPath];
+    }
+
+    private function countAllocationsForImport(int $importId): int
+    {
+        return (int) $this->em->createQueryBuilder()
+            ->select('COUNT(a.id)')
+            ->from(Allocation::class, 'a')
+            ->where('a.import = :importId')
+            ->setParameter('importId', $importId)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function countProjectionRowsForImport(int $importId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM allocation_stats_projection WHERE import_id = :importId',
+            ['importId' => $importId],
+        );
+    }
+
+    private function countBatchRunItemsForImport(int $importId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM import_batch_run_item WHERE import_id = :importId',
+            ['importId' => $importId],
+        );
+    }
+}

--- a/tests/Import/Unit/Infrastructure/Security/ImportVoterTest.php
+++ b/tests/Import/Unit/Infrastructure/Security/ImportVoterTest.php
@@ -83,15 +83,62 @@ final class ImportVoterTest extends KernelTestCase
         );
     }
 
+    public function testDeleteGrantedForHospitalOwner(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($owner->_real()), $import->_real(), [ImportVoter::DELETE]),
+        );
+    }
+
+    public function testDeleteGrantedForAdmin(): void
+    {
+        $admin = UserFactory::new()->asAdmin()->create();
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($admin->_real()), $import->_real(), [ImportVoter::DELETE]),
+        );
+    }
+
+    public function testDeleteGrantedForCreatorWithoutHospitalAccess(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $creator = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner, $creator);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($creator->_real()), $import->_real(), [ImportVoter::DELETE]),
+        );
+    }
+
+    public function testDeleteDeniedForForeignParticipant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($intruder->_real()), $import->_real(), [ImportVoter::DELETE]),
+        );
+    }
+
     public function testSupportsTypeForImportOnly(): void
     {
         self::assertTrue($this->voter->supportsType(Import::class));
         self::assertFalse($this->voter->supportsType(Hospital::class));
     }
 
-    private function createImportForOwner(object $owner): object
+    private function createImportForOwner(object $owner, ?object $createdBy = null): object
     {
-        $createdBy = UserFactory::createOne();
+        $createdBy ??= UserFactory::createOne();
         $state = StateFactory::createOne();
         $dispatch = DispatchAreaFactory::createOne();
         $hospital = HospitalFactory::createOne([

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -321,6 +321,14 @@
         <source>flash.import.created</source>
         <target>New Import has been created successfully!</target>
       </trans-unit>
+      <trans-unit id="impFlDelOk" resname="flash.import.deleted">
+        <source>flash.import.deleted</source>
+        <target>Import has been deleted successfully.</target>
+      </trans-unit>
+      <trans-unit id="impFlDelRun" resname="flash.import.delete_running_blocked">
+        <source>flash.import.delete_running_blocked</source>
+        <target>This import is currently running and cannot be deleted.</target>
+      </trans-unit>
       <trans-unit id="qCQxM_A" resname="flash.indication.assigned">
         <source>flash.indication.assigned</source>
         <target>Normalized indication has been assigned.</target>
@@ -432,6 +440,30 @@
       <trans-unit id="2_8EtuE" resname="import.action.preview_rows">
         <source>import.action.preview_rows</source>
         <target>Preview Rows</target>
+      </trans-unit>
+      <trans-unit id="impActDel" resname="import.action.delete">
+        <source>import.action.delete</source>
+        <target>Delete import</target>
+      </trans-unit>
+      <trans-unit id="impDelTit" resname="import.delete.modal.title">
+        <source>import.delete.modal.title</source>
+        <target>Delete import?</target>
+      </trans-unit>
+      <trans-unit id="impDelBody" resname="import.delete.modal.body">
+        <source>import.delete.modal.body</source>
+        <target>Are you sure you want to permanently delete "{name}"? All allocations, projections, and related data will be removed. This action cannot be undone.</target>
+      </trans-unit>
+      <trans-unit id="impDelConf" resname="import.delete.modal.confirm">
+        <source>import.delete.modal.confirm</source>
+        <target>Delete permanently</target>
+      </trans-unit>
+      <trans-unit id="impDelCanc" resname="import.delete.modal.cancel">
+        <source>import.delete.modal.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="impDelRunH" resname="import.delete.running_blocked_hint">
+        <source>import.delete.running_blocked_hint</source>
+        <target>This import is currently running and cannot be deleted.</target>
       </trans-unit>
       <trans-unit id="T_sGody" resname="import.field.fileExtension">
         <source>import.field.fileExtension</source>


### PR DESCRIPTION
### Summary

- Added support for deleting imports
- Implemented cleanup of data associated with a deleted import
- Prevented orphaned records and inconsistent import states after deletion
- Added safeguards around destructive operations
- Updated UI and backend workflows related to import management
- Added or updated tests covering import deletion scenarios

### Motivation

- Allow administrators to remove incorrectly imported or obsolete datasets
- Ensure import-related data can be cleaned up safely and consistently
- Improve maintainability of imported data and operational workflows
- Resolve Issue #171 by providing a dedicated import deletion workflow

### Notes for Reviewers

- Verify that deleting an import removes all associated data correctly
- Check behavior for imports that have already been processed
- Review safeguards and confirmation mechanisms around deletion
- Ensure no orphaned allocations, rejects, assessments, or related records remain
- Confirm repeated deletion attempts are handled gracefully
- Review test coverage for deletion and cleanup scenarios

Closes #171