### PR TITLE
fix(home): strengthen screenshot carousel caption overlay

### DIFF
--- a/assets/styles/pages/home.css
+++ b/assets/styles/pages/home.css
@@ -213,7 +213,7 @@
 .home-screenshot-carousel {
     --home-screenshot-frame: #9aa8b8;
     --home-screenshot-frame-strong: #6b7280;
-    --tblr-carousel-caption-color: #4b5563;
+    --tblr-carousel-caption-color: #fff;
     --tblr-carousel-indicator-active-bg: var(--home-screenshot-frame-strong);
 }
 
@@ -304,15 +304,24 @@
 }
 
 .home-screenshot-carousel .carousel-caption-background {
-    height: 26%;
-    background: linear-gradient(0deg, rgba(255, 255, 255, 0.68), rgba(255, 255, 255, 0));
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 45%;
+    background: linear-gradient(
+        0deg,
+        rgba(15, 23, 42, 0.92) 0%,
+        rgba(15, 23, 42, 0.75) 35%,
+        rgba(15, 23, 42, 0) 100%
+    );
     pointer-events: none;
     z-index: 1;
 }
 
 .home-screenshot-carousel .carousel-caption {
     right: 10%;
-    bottom: 2.75rem;
+    bottom: 2rem;
     left: 10%;
     padding-top: 0;
     padding-bottom: 0;
@@ -323,4 +332,5 @@
 .home-screenshot-carousel .carousel-caption p {
     font-size: var(--tblr-font-size-h4);
     line-height: 1.5;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -61,6 +61,7 @@ final class DefaultControllerTest extends WebTestCase
         self::assertSelectorExists('a[data-fslightbox="home-screenshots"][href*="/assets/images/home/benchmarking"]');
         self::assertSelectorExists('a[data-fslightbox="home-screenshots"][href*="/assets/images/home/indication-insights"]');
         self::assertSelectorExists('a[data-fslightbox="home-screenshots"][href*="/assets/images/home/analytics"]');
+        self::assertSelectorExists('.home-screenshot-carousel .carousel-caption-background');
         self::assertSelectorExists('.home-screenshot-carousel .carousel-caption[data-testid="home-screenshot-caption"]');
         self::assertSelectorTextContains('body', 'Shared overview of allocations, trends and clinical distributions across the network.');
     }


### PR DESCRIPTION
Replace the weak white gradient with Tabler's dark overlay pattern and white caption text so carousel descriptions stay readable across all homepage screenshots. Closes #172.