### PR TITLE
feat: Add hospital scope picker for statistics and analytics

### DIFF
--- a/assets/controllers/dropdown_typeahead_controller.js
+++ b/assets/controllers/dropdown_typeahead_controller.js
@@ -1,0 +1,128 @@
+import { Controller } from '@hotwired/stimulus';
+
+const PREFIX_TIMEOUT_MS = 700;
+const FOCUS_CLASS = 'dropdown-item-typeahead-focus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['menu'];
+
+    connect() {
+        this.prefix = '';
+        this.prefixTimeoutId = null;
+        this.focusedItem = null;
+        this.toggle = this.element.querySelector('[data-bs-toggle="dropdown"]');
+
+        if (!this.toggle) {
+            return;
+        }
+
+        this.onShown = this.onShown.bind(this);
+        this.onHidden = this.onHidden.bind(this);
+        this.onKeydown = this.onKeydown.bind(this);
+
+        this.toggle.addEventListener('shown.bs.dropdown', this.onShown);
+        this.toggle.addEventListener('hidden.bs.dropdown', this.onHidden);
+    }
+
+    disconnect() {
+        if (!this.toggle) {
+            return;
+        }
+
+        this.toggle.removeEventListener('shown.bs.dropdown', this.onShown);
+        this.toggle.removeEventListener('hidden.bs.dropdown', this.onHidden);
+        this.stopListening();
+    }
+
+    onShown() {
+        this.prefix = '';
+        document.addEventListener('keydown', this.onKeydown);
+    }
+
+    onHidden() {
+        this.stopListening();
+    }
+
+    stopListening() {
+        document.removeEventListener('keydown', this.onKeydown);
+        this.clearPrefixTimeout();
+        this.clearFocus();
+    }
+
+    onKeydown(event) {
+        if (!this.isOpen()) {
+            return;
+        }
+
+        if (event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
+            return;
+        }
+
+        if (1 !== event.key.length) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const char = event.key.toLowerCase();
+        this.prefix += char;
+        this.schedulePrefixReset();
+
+        const items = this.menuItems();
+        let match = items.find((item) => this.itemLabel(item).startsWith(this.prefix));
+
+        if (!match) {
+            this.prefix = char;
+            match = items.find((item) => this.itemLabel(item).startsWith(this.prefix));
+        }
+
+        if (match) {
+            this.focusItem(match);
+        }
+    }
+
+    isOpen() {
+        return 'true' === this.toggle.getAttribute('aria-expanded');
+    }
+
+    menuItems() {
+        return Array.from(this.menuTarget.querySelectorAll('a.dropdown-item, button.dropdown-item'));
+    }
+
+    itemLabel(item) {
+        return item.textContent.trim().toLowerCase();
+    }
+
+    focusItem(item) {
+        this.clearFocus();
+        this.focusedItem = item;
+        item.classList.add(FOCUS_CLASS);
+        item.scrollIntoView({ block: 'nearest' });
+    }
+
+    clearFocus() {
+        if (!this.focusedItem) {
+            return;
+        }
+
+        this.focusedItem.classList.remove(FOCUS_CLASS);
+        this.focusedItem = null;
+    }
+
+    schedulePrefixReset() {
+        this.clearPrefixTimeout();
+        this.prefixTimeoutId = window.setTimeout(() => {
+            this.prefix = '';
+        }, PREFIX_TIMEOUT_MS);
+    }
+
+    clearPrefixTimeout() {
+        if (null === this.prefixTimeoutId) {
+            return;
+        }
+
+        window.clearTimeout(this.prefixTimeoutId);
+        this.prefixTimeoutId = null;
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -38,6 +38,16 @@
     margin-top: 0.75rem;
 }
 
+.dropdown-menu-scrollable {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.dropdown-item-typeahead-focus {
+    background-color: var(--tblr-dropdown-link-hover-bg, rgba(0, 0, 0, 0.04));
+    color: var(--tblr-dropdown-link-hover-color, inherit);
+}
+
 .benchmark-delta-heatmap__tooltip {
     position: fixed;
     z-index: 1080;

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -213,4 +213,26 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
 
         return $out;
     }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function findAccessibleParticipatingHospitalSummaries(User $user): array
+    {
+        $rows = $this->getQueryBuilderForAccessibleHospitals($user)
+            ->andWhere('h.isParticipating = true')
+            ->select('h.id AS id', 'h.name AS name')
+            ->getQuery()
+            ->getArrayResult();
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = [
+                'id' => (int) $row['id'],
+                'name' => (string) $row['name'],
+            ];
+        }
+
+        return $out;
+    }
 }

--- a/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPageViewModelFactory.php
+++ b/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPageViewModelFactory.php
@@ -68,7 +68,7 @@ final readonly class BenchmarkComparisonPageViewModelFactory
         $accessibleHospitals = [];
         $hospitalUrls = [];
         if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
-            $accessibleHospitals = $this->hospitalRepository->findAccessibleHospitalSummaries($user);
+            $accessibleHospitals = $this->hospitalRepository->findAccessibleParticipatingHospitalSummaries($user);
             foreach ($accessibleHospitals as $row) {
                 $hospitalUrls[(string) $row['id']] = $this->statisticsNavigationUrlBuilder->build(
                     $request,

--- a/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsPageViewModelFactory.php
@@ -67,7 +67,7 @@ final readonly class StatisticsPageViewModelFactory
         $accessibleHospitals = [];
         $hospitalUrls = [];
         if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
-            $accessibleHospitals = $this->hospitalRepository->findAccessibleHospitalSummaries($user);
+            $accessibleHospitals = $this->hospitalRepository->findAccessibleParticipatingHospitalSummaries($user);
             foreach ($accessibleHospitals as $row) {
                 $hospitalUrls[(string) $row['id']] = $this->statisticsNavigationUrlBuilder->build(
                     $request,

--- a/src/Statistics/UI/Twig/templates/_header_controls.html.twig
+++ b/src/Statistics/UI/Twig/templates/_header_controls.html.twig
@@ -14,11 +14,11 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group" role="group" data-controller="dropdown-typeahead">
                     <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                         {{ statsScopeSecondaryDropdownLabel|default('') }}
                     </button>
-                    <div class="dropdown-menu dropdown-menu-end">
+                    <div class="dropdown-menu dropdown-menu-end dropdown-menu-scrollable" data-dropdown-typeahead-target="menu">
                         {% for row in statsScopeSecondaryMenu|default([]) %}
                             <a class="dropdown-item{% if row.active %} active{% endif %}" href="{{ row.url }}">{{ row.label }}</a>
                         {% endfor %}

--- a/src/Statistics/UI/Twig/templates/benchmarking/_filter_column.html.twig
+++ b/src/Statistics/UI/Twig/templates/benchmarking/_filter_column.html.twig
@@ -21,7 +21,7 @@
                         {% endfor %}
                     </div>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group" role="group" data-controller="dropdown-typeahead">
                     <button type="button"
                             class="btn dropdown-toggle"
                             data-bs-toggle="dropdown"
@@ -29,7 +29,7 @@
                             data-testid="{{ testIdPrefix }}-scope-secondary">
                         {{ pageViewModel.scopeSecondaryDropdownLabel|default('') }}
                     </button>
-                    <div class="dropdown-menu dropdown-menu-end">
+                    <div class="dropdown-menu dropdown-menu-end dropdown-menu-scrollable" data-dropdown-typeahead-target="menu">
                         {% for row in pageViewModel.scopeSecondaryMenu %}
                             <a class="dropdown-item{% if row.active %} active{% endif %}" href="{{ row.url }}">{{ row.label }}</a>
                         {% endfor %}

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_period_controls.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_period_controls.html.twig
@@ -17,7 +17,7 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="btn-group" role="group">
+        <div class="btn-group" role="group" data-controller="dropdown-typeahead">
             <button type="button"
                     class="btn dropdown-toggle"
                     data-bs-toggle="dropdown"
@@ -25,7 +25,7 @@
                     data-testid="{{ periodTestIdPrefix }}-secondary">
                 {{ periodVm.secondaryDropdownLabel }}
             </button>
-            <div class="dropdown-menu dropdown-menu-end" style="max-height: 20rem; overflow-y: auto;">
+            <div class="dropdown-menu dropdown-menu-end dropdown-menu-scrollable" data-dropdown-typeahead-target="menu">
                 {% for row in periodVm.secondaryMenu %}
                     {% if row.divider|default(false) %}
                         <div class="dropdown-divider"></div>

--- a/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
+++ b/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
@@ -86,4 +86,45 @@ final class HospitalRepositoryQueryTest extends KernelTestCase
     {
         self::assertSame([], $this->repo->findNamesByIds([]));
     }
+
+    public function testAdminSeesOnlyParticipatingHospitalsInParticipatingSummaries(): void
+    {
+        $admin = UserFactory::createOne([
+            'roles' => ['ROLE_ADMIN'],
+            'username' => 'admin-'.bin2hex(random_bytes(6)),
+        ]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $participating = HospitalFactory::createOne();
+        $nonParticipating = HospitalFactory::createOne();
+        $nonParticipating->setParticipating(false);
+        $nonParticipating->_save();
+
+        $summaries = $this->repo->findAccessibleParticipatingHospitalSummaries($admin);
+        $ids = array_column($summaries, 'id');
+
+        self::assertContains((int) $participating->getId(), $ids);
+        self::assertCount(1, $summaries);
+    }
+
+    public function testOwnerSeesOnlyOwnedParticipatingHospitalsInParticipatingSummaries(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'owner-'.bin2hex(random_bytes(6))]);
+        $other = UserFactory::createOne(['username' => 'other-'.bin2hex(random_bytes(6))]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        $participating = HospitalFactory::createOne(['owner' => $owner]);
+        $nonParticipating = HospitalFactory::createOne(['owner' => $owner]);
+        $nonParticipating->setParticipating(false);
+        $nonParticipating->_save();
+        HospitalFactory::createOne(['owner' => $other]);
+
+        $summaries = $this->repo->findAccessibleParticipatingHospitalSummaries($owner);
+        $ids = array_column($summaries, 'id');
+
+        self::assertSame([(int) $participating->getId()], $ids);
+    }
 }

--- a/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
+++ b/tests/Statistics/Unit/Controller/StatisticsPageViewModelFactoryAccessTest.php
@@ -123,6 +123,49 @@ final class StatisticsPageViewModelFactoryAccessTest extends KernelTestCase
         self::assertSame('Public', $model->headingScope);
     }
 
+    public function testParticipantSeesOnlyParticipatingHospitalsInAccessibleList(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $participating = HospitalFactory::createOne(['owner' => $user]);
+        $nonParticipating = HospitalFactory::createOne(['owner' => $user]);
+        $nonParticipating->setParticipating(false);
+        $nonParticipating->_save();
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        self::assertCount(1, $model->accessibleHospitals);
+        self::assertSame((int) $participating->getId(), $model->accessibleHospitals[0]['id']);
+    }
+
+    public function testAdminSeesOnlyParticipatingHospitalsInAccessibleList(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $participating = HospitalFactory::createOne();
+        $nonParticipating = HospitalFactory::createOne();
+        $nonParticipating->setParticipating(false);
+        $nonParticipating->_save();
+
+        $model = $this->factory->create(
+            new Request(query: ['scope' => 'my_hospitals', 'period' => 'all']),
+            'app_stats_dashboard',
+            $user,
+            new StatisticsFilter(StatisticsFilterScope::MyHospitals, null, null, StatisticsFilterPeriod::All),
+        );
+
+        $ids = array_column($model->accessibleHospitals, 'id');
+        self::assertContains((int) $participating->getId(), $ids);
+        self::assertNotContains((int) $nonParticipating->getId(), $ids);
+    }
+
     /**
      * @param list<array{key: string, label: string, url: string, active: bool}> $menu
      */


### PR DESCRIPTION
### Summary

- Added a dedicated **hospital scope picker** for statistics and analytics pages
- Introduced a consistent way to switch between hospital-specific and broader analysis scopes
- Integrated scope selection into existing statistics, dashboard, benchmarking, and analysis workflows
- Improved query handling and filter propagation for selected hospital scopes
- Updated UI components and navigation to surface scope selection more clearly
- Added or updated tests covering scope selection and filtering behavior

### Motivation

- Make hospital-based analysis easier to access and understand
- Reduce friction when switching between hospitals and broader scopes
- Improve consistency across statistics, benchmarking, and dashboard features
- Provide a clearer foundation for future cohort and hospital-comparison analyses
- Ensure scope selection remains a first-class concept throughout the analytics experience

### Notes for Reviewers

- Verify hospital scope selection updates all affected statistics and dashboards correctly
- Check interaction with existing filters, cohorts, periods, and benchmarking views
- Ensure scope changes are preserved across navigation where appropriate
- Review access-control implications for users with restricted hospital visibility
- Confirm tests cover both single-hospital and broader scope scenarios