### PR TITLE
feat: Preserve natural image width in CMS page rendering

### DIFF
--- a/assets/styles/pages/content-blocks.css
+++ b/assets/styles/pages/content-blocks.css
@@ -18,8 +18,8 @@
 }
 
 .page-content-image .card-img-top {
-    width: 100%;
     display: block;
+    height: auto;
 }
 
 .page-content-image__link {
@@ -37,15 +37,37 @@
     transition: opacity 0.15s ease-in-out;
 }
 
+.page-content-image--size-auto {
+    width: fit-content;
+    max-width: 100%;
+}
+
+.page-content-image--size-auto .card-img-top {
+    width: auto;
+    max-width: 100%;
+}
+
 .page-content-image--size-sm {
     width: 33%;
+}
+
+.page-content-image--size-sm .card-img-top {
+    width: 100%;
 }
 
 .page-content-image--size-md {
     width: 66%;
 }
 
+.page-content-image--size-md .card-img-top {
+    width: 100%;
+}
+
 .page-content-image--size-lg {
+    width: 100%;
+}
+
+.page-content-image--size-lg .card-img-top {
     width: 100%;
 }
 
@@ -61,11 +83,16 @@
 @media (max-width: 767.98px) {
     .page-content-image--float-left,
     .page-content-image--float-right,
+    .page-content-image--size-auto,
     .page-content-image--size-sm,
     .page-content-image--size-md {
         float: none !important;
         width: 100% !important;
         max-width: 100% !important;
         margin-inline: 0 !important;
+    }
+
+    .page-content-image--size-auto .card-img-top {
+        width: 100%;
     }
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,7 @@ parameters:
     app.imports_base_dir: '%kernel.project_dir%/var/imports'
     app.media_max_size: '10M'
     app.media_upload_dir: '%kernel.project_dir%/public/uploads/media'
+    app.page_content_width_estimate: 800
     app.rejects_base_dir: '%kernel.project_dir%/var/imports/rejects'
     env(APP_URL): ''
     env(MAILER_FROM): 'no-reply@localhost'
@@ -151,3 +152,11 @@ services:
 
     App\Statistics\GenericAnalysis\Application\Contract\AnalysisExportServiceInterface:
         alias: App\Statistics\GenericAnalysis\Application\AnalysisExportService
+
+    App\Content\Infrastructure\Media\LocalMediaFileLocator:
+        arguments:
+            $uploadDir: '%app.media_upload_dir%'
+
+    App\Content\Application\Page\PageImageContentAnalyzer:
+        arguments:
+            $contentWidthEstimate: '%app.page_content_width_estimate%'

--- a/deploy.php
+++ b/deploy.php
@@ -45,9 +45,11 @@ add('shared_files', [
 ]);
 add('shared_dirs', [
     'var/imports',
+    'public/uploads/media',
 ]);
 add('writable_dirs', [
     'var/imports',
+    'public/uploads/media',
 ]);
 
 /*
@@ -112,3 +114,42 @@ before('deploy:publish', 'database:migrate');
 after('deploy:publish', 'messenger:restart');
 
 after('deploy:failed', 'deploy:unlock');
+
+desc('Copy media uploads from the richest previous release into shared/public/uploads/media');
+task('media:migrate-to-shared', function () {
+    $deployPath = get('deploy_path');
+    $sharedMedia = $deployPath.'/shared/public/uploads/media';
+
+    $source = trim(run(<<<BASH
+        best=''
+        best_count=0
+        for dir in {$deployPath}/releases/*/public/uploads/media; do
+            [ -d "\$dir" ] || continue
+            count=\$(find "\$dir" -maxdepth 1 -type f ! -name '.gitkeep' | wc -l | tr -d ' ')
+            if [ "\$count" -gt "\$best_count" ]; then
+                best_count=\$count
+                best="\$dir"
+            fi
+        done
+        printf '%s' "\$best"
+    BASH));
+
+    if ('' === $source) {
+        writeln('<comment>No release media directory with files found; nothing to migrate.</comment>');
+
+        return;
+    }
+
+    writeln('<info>Migrating media from '.$source.' to '.$sharedMedia.'</info>');
+    run('mkdir -p '.escapeshellarg($sharedMedia));
+    run('cp -a '.escapeshellarg($source.'/').'. '.escapeshellarg($sharedMedia.'/'));
+    run('chmod -R ug+rwX '.escapeshellarg($sharedMedia));
+});
+
+set('content_analyze_page_images_options', '--apply --backfill-dimensions --migrate-size');
+
+desc('Analyze page images, backfill media dimensions, and migrate layout sizes on the server');
+task('content:analyze-page-images', function () {
+    $options = get('content_analyze_page_images_options');
+    run('cd {{current_path}} && {{bin/console}} app:content:analyze-page-images '.$options.' {{console_options}}');
+});

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -14,6 +14,30 @@ cd ~/www/current && php bin/console messenger:stats
 cd ~/www/current && php bin/console messenger:failed:show
 ```
 
+### Media uploads (shared across releases)
+
+Uploaded images and PDFs live in `public/uploads/media`, which Deployer keeps in
+`shared/public/uploads/media` so files survive release changes.
+
+**One-time migration** after enabling the shared directory (copies from the release
+that currently holds the most media files):
+
+```bash
+vendor/bin/dep media:migrate-to-shared coishub.uber.space
+vendor/bin/dep deploy coishub.uber.space
+```
+
+**Post-deploy maintenance** (requires the `app:content:analyze-page-images` console
+command in the deployed release):
+
+```bash
+# Dry-run (default console flags can be overridden)
+vendor/bin/dep content:analyze-page-images coishub.uber.space
+
+# Custom flags, e.g. analysis only
+vendor/bin/dep content:analyze-page-images coishub.uber.space -o content_analyze_page_images_options="--dry-run"
+```
+
 Related docs:
 - Configuration details: [Configuration.md](Configuration.md)
 - Runtime issues and diagnostics: [Troubleshooting.md](Troubleshooting.md)

--- a/migrations/Version20260609120000.php
+++ b/migrations/Version20260609120000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260609120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add image width and height columns to media table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media ADD width INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE media ADD height INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media DROP width');
+        $this->addSql('ALTER TABLE media DROP height');
+    }
+}

--- a/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
+++ b/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
@@ -137,11 +137,12 @@ final readonly class PageContentBlockDataFieldsConfigurator
             ->add('size', ChoiceType::class, [
                 'label' => 'label.image_size',
                 'choices' => [
+                    'label.image_size.auto' => 'auto',
                     'label.image_size.sm' => 'sm',
                     'label.image_size.md' => 'md',
                     'label.image_size.lg' => 'lg',
                 ],
-                'empty_data' => 'lg',
+                'empty_data' => 'auto',
                 'help' => 'help.page.image_size',
             ])
             ->add('float', ChoiceType::class, [

--- a/src/Content/Application/Media/MediaDimensionsBackfillService.php
+++ b/src/Content/Application/Media/MediaDimensionsBackfillService.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Media;
+
+use App\Content\Domain\Enum\MediaType;
+use App\Content\Domain\ValueObject\ImageDimensions;
+use App\Content\Infrastructure\Media\LocalMediaFileLocator;
+use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
+use App\Content\Infrastructure\Repository\MediaRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class MediaDimensionsBackfillService
+{
+    /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
+    public function __construct(
+        private MediaRepository $mediaRepository,
+        private LocalMediaFileLocator $fileLocator,
+        private MediaDimensionsExtractor $dimensionsExtractor,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function backfill(bool $dryRun): MediaDimensionsBackfillResult
+    {
+        $updated = 0;
+        $missingFile = 0;
+        $unknownDimensions = 0;
+
+        foreach ($this->mediaRepository->findByType(MediaType::IMAGE) as $media) {
+            if (null !== $media->getWidth() && null !== $media->getHeight()) {
+                continue;
+            }
+
+            $absolutePath = $this->fileLocator->resolveAbsolutePath($media);
+            if (null === $absolutePath || !is_file($absolutePath)) {
+                ++$missingFile;
+                continue;
+            }
+
+            $dimensions = $this->dimensionsExtractor->extract($absolutePath);
+            if (!$dimensions instanceof ImageDimensions) {
+                ++$unknownDimensions;
+                continue;
+            }
+
+            if (!$dryRun) {
+                $media->setWidth($dimensions->width);
+                $media->setHeight($dimensions->height);
+            }
+
+            ++$updated;
+        }
+
+        if (!$dryRun && $updated > 0) {
+            $this->entityManager->flush();
+        }
+
+        return new MediaDimensionsBackfillResult($updated, $missingFile, $unknownDimensions);
+    }
+}
+
+final readonly class MediaDimensionsBackfillResult
+{
+    public function __construct(
+        public int $updated,
+        public int $missingFile,
+        public int $unknownDimensions,
+    ) {
+    }
+}

--- a/src/Content/Application/Media/MediaImageFigureHtmlBuilder.php
+++ b/src/Content/Application/Media/MediaImageFigureHtmlBuilder.php
@@ -6,9 +6,15 @@ namespace App\Content\Application\Media;
 
 final readonly class MediaImageFigureHtmlBuilder
 {
-    public function build(string $url, string $alt, string $size = 'lg', string $float = 'none'): string
-    {
-        $size = \in_array($size, ['sm', 'md', 'lg'], true) ? $size : 'lg';
+    public function build(
+        string $url,
+        string $alt,
+        string $size = 'auto',
+        string $float = 'none',
+        ?int $width = null,
+        ?int $height = null,
+    ): string {
+        $size = \in_array($size, ['auto', 'sm', 'md', 'lg'], true) ? $size : 'auto';
         $float = \in_array($float, ['none', 'left', 'right'], true) ? $float : 'none';
 
         $classes = ['card', 'card-sm', 'page-content-image', 'page-content-image--size-'.$size, 'mb-0'];
@@ -22,13 +28,24 @@ final readonly class MediaImageFigureHtmlBuilder
         $classAttr = htmlspecialchars(implode(' ', $classes), ENT_QUOTES | ENT_HTML5);
         $urlEsc = htmlspecialchars($url, ENT_QUOTES | ENT_HTML5);
         $altEsc = htmlspecialchars($alt, ENT_QUOTES | ENT_HTML5);
+        $dimensionAttrs = $this->buildDimensionAttributes($width, $height);
 
         return sprintf(
-            '<figure class="%s"><a href="%s" data-fslightbox="content-gallery" class="d-block page-content-image__link"><img class="card-img-top" src="%s" alt="%s" loading="lazy"></a></figure>',
+            '<figure class="%s"><a href="%s" data-fslightbox="content-gallery" class="d-block page-content-image__link"><img class="card-img-top" src="%s" alt="%s"%s loading="lazy"></a></figure>',
             $classAttr,
             $urlEsc,
             $urlEsc,
             $altEsc,
+            $dimensionAttrs,
         );
+    }
+
+    private function buildDimensionAttributes(?int $width, ?int $height): string
+    {
+        if (null === $width || $width <= 0 || null === $height || $height <= 0) {
+            return '';
+        }
+
+        return sprintf(' width="%d" height="%d"', $width, $height);
     }
 }

--- a/src/Content/Application/Media/MediaSnippetGenerator.php
+++ b/src/Content/Application/Media/MediaSnippetGenerator.php
@@ -39,7 +39,7 @@ final readonly class MediaSnippetGenerator
 
     public function generateImageFigureHtml(
         Media $media,
-        string $size = 'lg',
+        string $size = 'auto',
         string $float = 'none',
     ): string {
         return $this->imageFigureHtmlBuilder->build(
@@ -47,6 +47,8 @@ final readonly class MediaSnippetGenerator
             $this->resolveAltText($media),
             $size,
             $float,
+            $media->getWidth(),
+            $media->getHeight(),
         );
     }
 

--- a/src/Content/Application/Page/DTO/PageImageContentFinding.php
+++ b/src/Content/Application/Page/DTO/PageImageContentFinding.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page\DTO;
+
+final readonly class PageImageContentFinding
+{
+    public function __construct(
+        public int $pageId,
+        public string $pageTitle,
+        public string $pageSlug,
+        public int $blockIndex,
+        public string $blockType,
+        public ?int $mediaId,
+        public ?string $filename,
+        public ?int $imageWidth,
+        public ?int $imageHeight,
+        public string $currentSize,
+        public string $float,
+        public string $status,
+        public string $recommendation,
+    ) {
+    }
+}

--- a/src/Content/Application/Page/DTO/PageImagePresentation.php
+++ b/src/Content/Application/Page/DTO/PageImagePresentation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page\DTO;
+
+final readonly class PageImagePresentation
+{
+    /**
+     * @param list<string> $figureClasses
+     */
+    public function __construct(
+        public array $figureClasses,
+        public ?int $imgWidth = null,
+        public ?int $imgHeight = null,
+    ) {
+    }
+
+    public function figureClassString(): string
+    {
+        return implode(' ', $this->figureClasses);
+    }
+}

--- a/src/Content/Application/Page/PageContentBlockDataNormalizer.php
+++ b/src/Content/Application/Page/PageContentBlockDataNormalizer.php
@@ -12,7 +12,7 @@ final readonly class PageContentBlockDataNormalizer
     private const array ALLOWED_FIELDS_BY_TYPE = [
         PageContentBlockType::Richtext->value => ['html'],
         PageContentBlockType::Image->value => [
-            'mediaId', 'src', 'alt', 'caption', 'size', 'float',
+            'mediaId', 'src', 'alt', 'caption', 'size', 'float', 'width', 'height',
         ],
         PageContentBlockType::Cta->value => [
             'headline', 'buttonLabel', 'buttonUrl', 'mediaId', 'linkType', 'openInNewTab',
@@ -123,7 +123,7 @@ final readonly class PageContentBlockDataNormalizer
     private function normalizeImageSize(array $data): string
     {
         $size = $data['size'] ?? null;
-        if (is_string($size) && in_array($size, ['sm', 'md', 'lg'], true)) {
+        if (is_string($size) && in_array($size, ['auto', 'sm', 'md', 'lg'], true)) {
             return $size;
         }
 
@@ -132,7 +132,8 @@ final readonly class PageContentBlockDataNormalizer
         return match ($preset) {
             'sm' => 'sm',
             'md' => 'md',
-            default => 'lg',
+            'lg' => 'lg',
+            default => 'auto',
         };
     }
 

--- a/src/Content/Application/Page/PageContentMediaResolver.php
+++ b/src/Content/Application/Page/PageContentMediaResolver.php
@@ -78,6 +78,15 @@ final readonly class PageContentMediaResolver
             $data['alt'] = $this->defaultAltFromMedia($media);
         }
 
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+        if (null !== $width && $width > 0) {
+            $data['width'] = $width;
+        }
+        if (null !== $height && $height > 0) {
+            $data['height'] = $height;
+        }
+
         return $data;
     }
 

--- a/src/Content/Application/Page/PageContentValidator.php
+++ b/src/Content/Application/Page/PageContentValidator.php
@@ -40,7 +40,7 @@ final readonly class PageContentValidator
     private const array HIGHLIGHT_ICON_MODES = ['auto', 'custom', 'none'];
 
     /** @var list<string> */
-    private const array IMAGE_SIZES = ['sm', 'md', 'lg'];
+    private const array IMAGE_SIZES = ['auto', 'sm', 'md', 'lg'];
 
     /** @var list<string> */
     private const array IMAGE_FLOATS = ['none', 'left', 'right'];
@@ -169,12 +169,13 @@ final readonly class PageContentValidator
      */
     private function resolveLegacyImageSize(array $data): string
     {
-        $preset = (string) ($data['widthPreset'] ?? 'lg');
+        $preset = (string) ($data['widthPreset'] ?? '');
 
         return match ($preset) {
             'sm' => 'sm',
             'md' => 'md',
-            default => 'lg',
+            'lg' => 'lg',
+            default => 'auto',
         };
     }
 

--- a/src/Content/Application/Page/PageImageBlockPresenter.php
+++ b/src/Content/Application/Page/PageImageBlockPresenter.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Application\Page\DTO\PageImagePresentation;
+
+final readonly class PageImageBlockPresenter
+{
+    /** @var list<string> */
+    private const array ALLOWED_SIZES = ['auto', 'sm', 'md', 'lg'];
+
+    /** @var list<string> */
+    private const array ALLOWED_FLOATS = ['none', 'left', 'right'];
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function present(array $data): PageImagePresentation
+    {
+        $size = $this->normalizeSize($data);
+        $float = $this->normalizeFloat($data);
+
+        $classes = ['card', 'card-sm', 'page-content-image', 'page-content-image--size-'.$size, 'mb-0'];
+
+        if ('left' === $float) {
+            $classes = [...$classes, 'page-content-image--float-left', 'float-start', 'me-3', 'mb-3'];
+        } elseif ('right' === $float) {
+            $classes = [...$classes, 'page-content-image--float-right', 'float-end', 'ms-3', 'mb-3'];
+        }
+
+        $imgWidth = $this->extractPositiveInt($data['width'] ?? null);
+        $imgHeight = $this->extractPositiveInt($data['height'] ?? null);
+
+        return new PageImagePresentation($classes, $imgWidth, $imgHeight);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function normalizeSize(array $data): string
+    {
+        $size = $data['size'] ?? null;
+        if (is_string($size) && in_array($size, self::ALLOWED_SIZES, true)) {
+            return $size;
+        }
+
+        $preset = (string) ($data['widthPreset'] ?? '');
+
+        return match ($preset) {
+            'sm' => 'sm',
+            'md' => 'md',
+            'lg' => 'lg',
+            default => 'auto',
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function normalizeFloat(array $data): string
+    {
+        $float = (string) ($data['float'] ?? 'none');
+
+        return in_array($float, self::ALLOWED_FLOATS, true) ? $float : 'none';
+    }
+
+    private function extractPositiveInt(mixed $value): ?int
+    {
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+
+            return $int > 0 ? $int : null;
+        }
+
+        return null;
+    }
+}

--- a/src/Content/Application/Page/PageImageContentAnalyzer.php
+++ b/src/Content/Application/Page/PageImageContentAnalyzer.php
@@ -1,0 +1,384 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Application\Page\DTO\PageImageContentFinding;
+use App\Content\Domain\Entity\Media;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\MediaType;
+use App\Content\Domain\ValueObject\ImageDimensions;
+use App\Content\Infrastructure\Media\LocalMediaFileLocator;
+use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
+use App\Content\Infrastructure\Repository\MediaRepository;
+use App\Content\Infrastructure\Repository\PageRepository;
+
+final readonly class PageImageContentAnalyzer
+{
+    /** @var list<string> */
+    private const array HTML_BLOCK_TYPES = ['richtext', 'highlight', 'accordion'];
+
+    public function __construct(
+        private PageRepository $pageRepository,
+        private MediaRepository $mediaRepository,
+        private LocalMediaFileLocator $fileLocator,
+        private MediaDimensionsExtractor $dimensionsExtractor,
+        private int $contentWidthEstimate,
+    ) {
+    }
+
+    /**
+     * @return list<PageImageContentFinding>
+     */
+    public function analyze(?int $pageId = null): array
+    {
+        $pages = null === $pageId
+            ? $this->pageRepository->findAll()
+            : array_filter([$this->pageRepository->find($pageId)]);
+
+        $findings = [];
+
+        foreach ($pages as $page) {
+            if (!$page instanceof Page) {
+                continue;
+            }
+
+            foreach ($page->getContent() as $index => $block) {
+                $type = $block['type'];
+                $data = $block['data'];
+
+                if ('image' === $type) {
+                    $findings[] = $this->analyzeImageBlock($page, $index, $type, $data);
+                    continue;
+                }
+
+                if (!in_array($type, self::HTML_BLOCK_TYPES, true)) {
+                    continue;
+                }
+
+                if ('accordion' === $type) {
+                    $items = is_array($data['items'] ?? null) ? $data['items'] : [];
+                    foreach ($items as $itemIndex => $item) {
+                        if (!is_array($item) || !is_string($item['html'] ?? null)) {
+                            continue;
+                        }
+
+                        foreach ($this->analyzeHtmlImages($page, $index, $type.' item '.($itemIndex + 1), $item['html']) as $finding) {
+                            $findings[] = $finding;
+                        }
+                    }
+                    continue;
+                }
+
+                $html = $data['html'] ?? null;
+                if (!is_string($html) || '' === $html) {
+                    continue;
+                }
+
+                foreach ($this->analyzeHtmlImages($page, $index, $type, $html) as $finding) {
+                    $findings[] = $finding;
+                }
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function analyzeImageBlock(Page $page, int $blockIndex, string $blockType, array $data): PageImageContentFinding
+    {
+        $size = $this->resolveSize($data);
+        $float = (string) ($data['float'] ?? 'none');
+        $mediaContext = $this->resolveMediaContext($data);
+
+        return $this->buildFinding(
+            $page,
+            $blockIndex,
+            $blockType,
+            $size,
+            $float,
+            $mediaContext['mediaId'],
+            $mediaContext['filename'],
+            $mediaContext['imageWidth'],
+            $mediaContext['imageHeight'],
+            $mediaContext['status'],
+        );
+    }
+
+    /**
+     * @return list<PageImageContentFinding>
+     */
+    private function analyzeHtmlImages(Page $page, int $blockIndex, string $blockType, string $html): array
+    {
+        $findings = [];
+
+        if (false !== preg_match_all('/page-content-image--size-([a-z]+)/', $html, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $matchIndex => $match) {
+                $size = $match[1];
+                $mediaContext = $this->resolveMediaContextFromHtml($html);
+                $findings[] = $this->buildFinding(
+                    $page,
+                    $blockIndex,
+                    $blockType.' snippet '.($matchIndex + 1),
+                    $size,
+                    $this->resolveFloatFromHtml($html),
+                    $mediaContext['mediaId'],
+                    $mediaContext['filename'],
+                    $mediaContext['imageWidth'],
+                    $mediaContext['imageHeight'],
+                    $mediaContext['status'],
+                );
+            }
+        }
+
+        if (false !== preg_match_all('/<img[^>]+src="(\/uploads\/media\/[^"]+)"[^>]*>/i', $html, $imgMatches, PREG_SET_ORDER)) {
+            foreach ($imgMatches as $matchIndex => $match) {
+                if ($this->htmlContainsPageContentImageClass($html)) {
+                    continue;
+                }
+
+                $src = $match[1];
+                $mediaContext = $this->resolveMediaContext(['src' => $src]);
+                $findings[] = $this->buildFinding(
+                    $page,
+                    $blockIndex,
+                    $blockType.' inline img '.($matchIndex + 1),
+                    'auto',
+                    'none',
+                    $mediaContext['mediaId'],
+                    $mediaContext['filename'],
+                    $mediaContext['imageWidth'],
+                    $mediaContext['imageHeight'],
+                    $mediaContext['status'],
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    private function htmlContainsPageContentImageClass(string $html): bool
+    {
+        return str_contains($html, 'page-content-image--size-');
+    }
+
+    private function resolveFloatFromHtml(string $html): string
+    {
+        if (str_contains($html, 'page-content-image--float-left')) {
+            return 'left';
+        }
+
+        if (str_contains($html, 'page-content-image--float-right')) {
+            return 'right';
+        }
+
+        return 'none';
+    }
+
+    /**
+     * @return array{mediaId: ?int, filename: ?string, imageWidth: ?int, imageHeight: ?int, status: string}
+     */
+    private function resolveMediaContextFromHtml(string $html): array
+    {
+        if (preg_match('/src="(\/uploads\/media\/[^"]+)"/', $html, $match)) {
+            return $this->resolveMediaContext(['src' => $match[1]]);
+        }
+
+        return [
+            'mediaId' => null,
+            'filename' => null,
+            'imageWidth' => null,
+            'imageHeight' => null,
+            'status' => 'missing_src',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array{mediaId: ?int, filename: ?string, imageWidth: ?int, imageHeight: ?int, status: string}
+     */
+    private function resolveMediaContext(array $data): array
+    {
+        $media = $this->resolveMedia($data);
+        if ($media instanceof Media) {
+            $absolutePath = $this->fileLocator->resolveAbsolutePath($media);
+            if (null === $absolutePath || !is_file($absolutePath)) {
+                return [
+                    'mediaId' => $media->getId(),
+                    'filename' => $media->getFilename(),
+                    'imageWidth' => $media->getWidth(),
+                    'imageHeight' => $media->getHeight(),
+                    'status' => 'missing_file',
+                ];
+            }
+
+            $width = $media->getWidth();
+            $height = $media->getHeight();
+            if (null === $width || null === $height) {
+                $dimensions = $this->dimensionsExtractor->extract($absolutePath);
+                if ($dimensions instanceof ImageDimensions) {
+                    $width = $dimensions->width;
+                    $height = $dimensions->height;
+                }
+            }
+
+            return [
+                'mediaId' => $media->getId(),
+                'filename' => $media->getFilename(),
+                'imageWidth' => $width,
+                'imageHeight' => $height,
+                'status' => (null === $width || null === $height) ? 'dimensions_unknown' : 'ok',
+            ];
+        }
+
+        $src = trim((string) ($data['src'] ?? ''));
+        if ('' === $src) {
+            return [
+                'mediaId' => null,
+                'filename' => null,
+                'imageWidth' => null,
+                'imageHeight' => null,
+                'status' => 'missing_src',
+            ];
+        }
+
+        $filename = $this->fileLocator->resolveFilenameFromPublicSrc($src);
+        if (null === $filename) {
+            return [
+                'mediaId' => null,
+                'filename' => null,
+                'imageWidth' => null,
+                'imageHeight' => null,
+                'status' => 'external_src',
+            ];
+        }
+
+        $absolutePath = $this->fileLocator->resolveAbsolutePathFromFilename($filename);
+        if (!is_file($absolutePath)) {
+            return [
+                'mediaId' => null,
+                'filename' => $filename,
+                'imageWidth' => null,
+                'imageHeight' => null,
+                'status' => 'missing_file',
+            ];
+        }
+
+        $dimensions = $this->dimensionsExtractor->extract($absolutePath);
+
+        return [
+            'mediaId' => null,
+            'filename' => $filename,
+            'imageWidth' => $dimensions?->width,
+            'imageHeight' => $dimensions?->height,
+            'status' => $dimensions instanceof ImageDimensions ? 'ok' : 'dimensions_unknown',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function resolveMedia(array $data): ?Media
+    {
+        $mediaId = $data['mediaId'] ?? null;
+        if (is_int($mediaId) && $mediaId > 0) {
+            $media = $this->mediaRepository->findOneById($mediaId);
+
+            return $media instanceof Media && MediaType::IMAGE === $media->getType() ? $media : null;
+        }
+
+        if (is_string($mediaId) && ctype_digit($mediaId)) {
+            $media = $this->mediaRepository->findOneById((int) $mediaId);
+
+            return $media instanceof Media && MediaType::IMAGE === $media->getType() ? $media : null;
+        }
+
+        $src = trim((string) ($data['src'] ?? ''));
+        $filename = $this->fileLocator->resolveFilenameFromPublicSrc($src);
+        if (null === $filename) {
+            return null;
+        }
+
+        $media = $this->mediaRepository->findOneBy(['filename' => $filename, 'type' => MediaType::IMAGE]);
+
+        return $media instanceof Media ? $media : null;
+    }
+
+    private function buildFinding(
+        Page $page,
+        int $blockIndex,
+        string $blockType,
+        string $size,
+        string $float,
+        ?int $mediaId,
+        ?string $filename,
+        ?int $imageWidth,
+        ?int $imageHeight,
+        string $status,
+    ): PageImageContentFinding {
+        return new PageImageContentFinding(
+            pageId: (int) $page->getId(),
+            pageTitle: $page->getTitle() ?? '',
+            pageSlug: $page->getSlug() ?? '',
+            blockIndex: $blockIndex,
+            blockType: $blockType,
+            mediaId: $mediaId,
+            filename: $filename,
+            imageWidth: $imageWidth,
+            imageHeight: $imageHeight,
+            currentSize: $size,
+            float: $float,
+            status: $status,
+            recommendation: $this->buildRecommendation($size, $float, $imageWidth, $status),
+        );
+    }
+
+    private function buildRecommendation(string $size, string $float, ?int $imageWidth, string $status): string
+    {
+        if ('missing_file' === $status) {
+            return 'Sync media files locally';
+        }
+
+        if ('dimensions_unknown' === $status) {
+            return 'Backfill image dimensions';
+        }
+
+        if ('lg' === $size && 'none' === $float && null !== $imageWidth && $imageWidth < $this->contentWidthEstimate) {
+            return 'Migrate size lg to auto';
+        }
+
+        if ('lg' === $size && str_contains($status, 'richtext')) {
+            return 'Replace --size-lg with --size-auto in HTML snippet';
+        }
+
+        if ('auto' === $size || in_array($size, ['sm', 'md'], true)) {
+            return 'No change';
+        }
+
+        return 'Review layout';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function resolveSize(array $data): string
+    {
+        $size = $data['size'] ?? null;
+        if (is_string($size) && in_array($size, ['auto', 'sm', 'md', 'lg'], true)) {
+            return $size;
+        }
+
+        $preset = (string) ($data['widthPreset'] ?? '');
+
+        return match ($preset) {
+            'sm' => 'sm',
+            'md' => 'md',
+            'lg' => 'lg',
+            default => 'auto',
+        };
+    }
+}

--- a/src/Content/Application/Page/PageImageContentMigrationService.php
+++ b/src/Content/Application/Page/PageImageContentMigrationService.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Infrastructure\Repository\PageRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class PageImageContentMigrationService
+{
+    public function __construct(
+        private PageRepository $pageRepository,
+        private PageImageContentAnalyzer $analyzer,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function migrateSizes(bool $dryRun, ?int $pageId = null): PageImageContentMigrationResult
+    {
+        $findings = $this->analyzer->analyze($pageId);
+        $candidatePageIds = [];
+
+        foreach ($findings as $finding) {
+            if ('Migrate size lg to auto' !== $finding->recommendation || 'image' !== $finding->blockType) {
+                continue;
+            }
+
+            $candidatePageIds[$finding->pageId] = true;
+        }
+
+        $updatedBlocks = 0;
+
+        foreach (array_keys($candidatePageIds) as $candidatePageId) {
+            $page = $this->pageRepository->find($candidatePageId);
+            if (!$page instanceof Page) {
+                continue;
+            }
+
+            $content = $page->getContent();
+            $changed = false;
+
+            foreach ($content as $index => $block) {
+                if ('image' !== $block['type']) {
+                    continue;
+                }
+
+                $data = $block['data'];
+                $size = (string) ($data['size'] ?? 'auto');
+                $float = (string) ($data['float'] ?? 'none');
+
+                if ('lg' !== $size || 'none' !== $float) {
+                    continue;
+                }
+
+                $data['size'] = 'auto';
+                $block['data'] = $data;
+                $content[$index] = $block;
+                $changed = true;
+                ++$updatedBlocks;
+            }
+
+            if ($changed && !$dryRun) {
+                $page->setContent($content);
+            }
+        }
+
+        if (!$dryRun && $updatedBlocks > 0) {
+            $this->entityManager->flush();
+        }
+
+        return new PageImageContentMigrationResult($updatedBlocks, count($candidatePageIds));
+    }
+
+    public function fixRichtextSnippets(bool $dryRun, ?int $pageId = null): PageImageContentMigrationResult
+    {
+        $pages = null === $pageId
+            ? $this->pageRepository->findAll()
+            : array_filter([$this->pageRepository->find($pageId)]);
+
+        $updatedBlocks = 0;
+        $updatedPages = 0;
+
+        foreach ($pages as $page) {
+            if (!$page instanceof Page) {
+                continue;
+            }
+
+            $content = $page->getContent();
+            $changed = false;
+
+            foreach ($content as $index => $block) {
+                $type = $block['type'];
+                $data = $block['data'];
+
+                if ('accordion' === $type) {
+                    $items = is_array($data['items'] ?? null) ? $data['items'] : [];
+                    foreach ($items as $itemIndex => $item) {
+                        if (!is_array($item) || !is_string($item['html'] ?? null)) {
+                            continue;
+                        }
+
+                        $updatedHtml = $this->replaceSnippetSizeClass($item['html']);
+                        if ($updatedHtml !== $item['html']) {
+                            $items[$itemIndex]['html'] = $updatedHtml;
+                            $changed = true;
+                            ++$updatedBlocks;
+                        }
+                    }
+
+                    if ($changed) {
+                        $data['items'] = $items;
+                        $block['data'] = $data;
+                        $content[$index] = $block;
+                    }
+
+                    continue;
+                }
+
+                if (!in_array($type, ['richtext', 'highlight'], true) || !is_string($data['html'] ?? null)) {
+                    continue;
+                }
+
+                $updatedHtml = $this->replaceSnippetSizeClass($data['html']);
+                if ($updatedHtml === $data['html']) {
+                    continue;
+                }
+
+                $data['html'] = $updatedHtml;
+                $block['data'] = $data;
+                $content[$index] = $block;
+                $changed = true;
+                ++$updatedBlocks;
+            }
+
+            if ($changed) {
+                ++$updatedPages;
+                if (!$dryRun) {
+                    $page->setContent($content);
+                }
+            }
+        }
+
+        if (!$dryRun && $updatedBlocks > 0) {
+            $this->entityManager->flush();
+        }
+
+        return new PageImageContentMigrationResult($updatedBlocks, $updatedPages);
+    }
+
+    private function replaceSnippetSizeClass(string $html): string
+    {
+        return str_replace('page-content-image--size-lg', 'page-content-image--size-auto', $html);
+    }
+}
+
+final readonly class PageImageContentMigrationResult
+{
+    public function __construct(
+        public int $updatedBlocks,
+        public int $updatedPages,
+    ) {
+    }
+}

--- a/src/Content/Domain/Entity/Media.php
+++ b/src/Content/Domain/Entity/Media.php
@@ -46,6 +46,12 @@ class Media implements \Stringable
     #[ORM\Column(nullable: true)]
     private ?int $size = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?int $width = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $height = null;
+
     #[ORM\Column(nullable: true, enumType: MediaType::class)]
     private ?MediaType $type = null;
 
@@ -145,6 +151,30 @@ class Media implements \Stringable
     public function setSize(?int $size): self
     {
         $this->size = $size;
+
+        return $this;
+    }
+
+    public function getWidth(): ?int
+    {
+        return $this->width;
+    }
+
+    public function setWidth(?int $width): self
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function getHeight(): ?int
+    {
+        return $this->height;
+    }
+
+    public function setHeight(?int $height): self
+    {
+        $this->height = $height;
 
         return $this;
     }

--- a/src/Content/Domain/ValueObject/ImageDimensions.php
+++ b/src/Content/Domain/ValueObject/ImageDimensions.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Domain\ValueObject;
+
+final readonly class ImageDimensions
+{
+    public function __construct(
+        public int $width,
+        public int $height,
+    ) {
+    }
+}

--- a/src/Content/Infrastructure/Doctrine/MediaUploadListener.php
+++ b/src/Content/Infrastructure/Doctrine/MediaUploadListener.php
@@ -6,6 +6,8 @@ namespace App\Content\Infrastructure\Doctrine;
 
 use App\Content\Application\Media\MediaTypeResolver;
 use App\Content\Domain\Entity\Media;
+use App\Content\Domain\Enum\MediaType;
+use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Vich\UploaderBundle\Event\Event;
 
@@ -14,6 +16,7 @@ final readonly class MediaUploadListener
 {
     public function __construct(
         private MediaTypeResolver $mediaTypeResolver,
+        private MediaDimensionsExtractor $dimensionsExtractor,
     ) {
     }
 
@@ -26,5 +29,29 @@ final readonly class MediaUploadListener
         }
 
         $this->mediaTypeResolver->applyTo($object);
+        $this->applyDimensions($object);
+    }
+
+    private function applyDimensions(Media $media): void
+    {
+        if (MediaType::IMAGE !== $media->getType()) {
+            $media->setWidth(null);
+            $media->setHeight(null);
+
+            return;
+        }
+
+        $file = $media->getFile();
+        if (!$file instanceof \Symfony\Component\HttpFoundation\File\File) {
+            return;
+        }
+
+        $dimensions = $this->dimensionsExtractor->extract($file->getPathname());
+        if (!$dimensions instanceof \App\Content\Domain\ValueObject\ImageDimensions) {
+            return;
+        }
+
+        $media->setWidth($dimensions->width);
+        $media->setHeight($dimensions->height);
     }
 }

--- a/src/Content/Infrastructure/Media/LocalMediaFileLocator.php
+++ b/src/Content/Infrastructure/Media/LocalMediaFileLocator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Infrastructure\Media;
+
+use App\Content\Domain\Entity\Media;
+
+final readonly class LocalMediaFileLocator
+{
+    /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
+    public function __construct(
+        private string $uploadDir,
+    ) {
+    }
+
+    public function resolveAbsolutePath(Media $media): ?string
+    {
+        $filename = $media->getFilename();
+        if (null === $filename || '' === $filename) {
+            return null;
+        }
+
+        return rtrim($this->uploadDir, '/').'/'.$filename;
+    }
+
+    public function resolveAbsolutePathFromFilename(string $filename): string
+    {
+        return rtrim($this->uploadDir, '/').'/'.ltrim($filename, '/');
+    }
+
+    public function resolveFilenameFromPublicSrc(string $src): ?string
+    {
+        $prefix = '/uploads/media/';
+        if (!str_starts_with($src, $prefix)) {
+            return null;
+        }
+
+        $filename = substr($src, strlen($prefix));
+
+        return '' !== $filename ? $filename : null;
+    }
+}

--- a/src/Content/Infrastructure/Media/MediaDimensionsExtractor.php
+++ b/src/Content/Infrastructure/Media/MediaDimensionsExtractor.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Infrastructure\Media;
+
+use App\Content\Domain\ValueObject\ImageDimensions;
+
+final readonly class MediaDimensionsExtractor
+{
+    public function extract(string $absolutePath): ?ImageDimensions
+    {
+        if (!is_file($absolutePath) || !is_readable($absolutePath)) {
+            return null;
+        }
+
+        $size = @getimagesize($absolutePath);
+        if (!is_array($size)) {
+            return null;
+        }
+
+        $width = $size[0];
+        $height = $size[1];
+
+        if ($width <= 0 || $height <= 0) {
+            return null;
+        }
+
+        return new ImageDimensions($width, $height);
+    }
+}

--- a/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
+++ b/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\UI\Console\Command;
+
+use App\Content\Application\Media\MediaDimensionsBackfillService;
+use App\Content\Application\Page\PageImageContentAnalyzer;
+use App\Content\Application\Page\PageImageContentMigrationService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:content:analyze-page-images',
+    description: 'Analyze page image references, backfill media dimensions, and optionally migrate layout sizes.',
+)]
+final class AnalyzePageImagesCommand extends Command
+{
+    public function __construct(
+        private readonly PageImageContentAnalyzer $analyzer,
+        private readonly MediaDimensionsBackfillService $dimensionsBackfillService,
+        private readonly PageImageContentMigrationService $migrationService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report findings without writing changes (default)')
+            ->addOption('apply', null, InputOption::VALUE_NONE, 'Apply selected write operations')
+            ->addOption('backfill-dimensions', null, InputOption::VALUE_NONE, 'Backfill missing media width/height from local files')
+            ->addOption('migrate-size', null, InputOption::VALUE_NONE, 'Migrate image blocks from size lg to auto when recommended')
+            ->addOption('fix-richtext-snippets', null, InputOption::VALUE_NONE, 'Replace --size-lg with --size-auto in HTML snippets')
+            ->addOption('page-id', null, InputOption::VALUE_REQUIRED, 'Analyze or migrate a single page');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = !$input->getOption('apply');
+        $pageId = $this->parsePageId($input->getOption('page-id'));
+
+        $io->title('Analyze page images');
+
+        if ($dryRun) {
+            $io->note('Dry run: no database or content changes will be written. Use --apply to persist changes.');
+        }
+
+        $findings = $this->analyzer->analyze($pageId);
+
+        if ([] === $findings) {
+            $io->success('No image references found in pages.');
+        } else {
+            $io->section(sprintf('Found %d image reference(s)', count($findings)));
+            $io->table(
+                ['Page', 'Block', 'Media', 'File', 'Width', 'Size', 'Status', 'Recommendation'],
+                array_map(
+                    static fn ($finding): array => [
+                        sprintf('#%d %s', $finding->pageId, $finding->pageTitle),
+                        sprintf('%d (%s)', $finding->blockIndex + 1, $finding->blockType),
+                        null !== $finding->mediaId ? (string) $finding->mediaId : '-',
+                        $finding->filename ?? '-',
+                        null !== $finding->imageWidth ? (string) $finding->imageWidth : '-',
+                        $finding->currentSize,
+                        $finding->status,
+                        $finding->recommendation,
+                    ],
+                    $findings,
+                ),
+            );
+        }
+
+        if ($input->getOption('backfill-dimensions')) {
+            $result = $this->dimensionsBackfillService->backfill($dryRun);
+            $io->section('Media dimension backfill');
+            $io->table(
+                ['Metric', 'Count'],
+                [
+                    ['Updated media records', (string) $result->updated],
+                    ['Missing local files', (string) $result->missingFile],
+                    ['Unknown dimensions', (string) $result->unknownDimensions],
+                ],
+            );
+        }
+
+        if ($input->getOption('migrate-size')) {
+            $result = $this->migrationService->migrateSizes($dryRun, $pageId);
+            $io->section('Image block size migration');
+            $io->writeln(sprintf('Updated image blocks: %d', $result->updatedBlocks));
+            $io->writeln(sprintf('Affected pages: %d', $result->updatedPages));
+        }
+
+        if ($input->getOption('fix-richtext-snippets')) {
+            $result = $this->migrationService->fixRichtextSnippets($dryRun, $pageId);
+            $io->section('Richtext snippet migration');
+            $io->writeln(sprintf('Updated HTML blocks: %d', $result->updatedBlocks));
+            $io->writeln(sprintf('Affected pages: %d', $result->updatedPages));
+        }
+
+        if ($dryRun && ($input->getOption('backfill-dimensions') || $input->getOption('migrate-size') || $input->getOption('fix-richtext-snippets'))) {
+            $io->success('Dry run finished. Re-run with --apply to persist changes.');
+        } else {
+            $io->success('Analysis finished.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function parsePageId(mixed $value): ?int
+    {
+        if (!is_string($value) || !ctype_digit($value)) {
+            return null;
+        }
+
+        $pageId = (int) $value;
+
+        return $pageId > 0 ? $pageId : null;
+    }
+}

--- a/src/Content/UI/Twig/PageExtension.php
+++ b/src/Content/UI/Twig/PageExtension.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Content\UI\Twig;
 
+use App\Content\Application\Page\DTO\PageImagePresentation;
 use App\Content\Application\Page\DTO\PageNavigationLink;
+use App\Content\Application\Page\PageImageBlockPresenter;
 use App\Content\Application\Page\PageNavigationProvider;
 use App\Content\Domain\Entity\Page;
 use App\Content\Domain\Enum\PageContentBlockType;
@@ -16,6 +18,7 @@ final class PageExtension extends AbstractExtension
 {
     public function __construct(
         private readonly PageNavigationProvider $pageNavigationProvider,
+        private readonly PageImageBlockPresenter $pageImageBlockPresenter,
     ) {
     }
 
@@ -28,7 +31,16 @@ final class PageExtension extends AbstractExtension
             new TwigFunction('page_nav_header_items', $this->pageNavHeaderItems(...)),
             new TwigFunction('page_nav_footer_items', $this->pageNavFooterItems(...)),
             new TwigFunction('page_content_block_types', $this->pageContentBlockTypes(...)),
+            new TwigFunction('page_image_presentation', $this->pageImagePresentation(...)),
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function pageImagePresentation(array $data): PageImagePresentation
+    {
+        return $this->pageImageBlockPresenter->present($data);
     }
 
     public function pageByKey(string $key): ?Page

--- a/src/Content/UI/Twig/templates/page/blocks/image.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/image.html.twig
@@ -1,23 +1,15 @@
-{% set size = block.data.size|default('lg') %}
-{% if size not in ['sm', 'md', 'lg'] %}
-    {% set size = 'lg' %}
-{% endif %}
-{% set float = block.data.float|default('none') %}
-{% set figureClasses = ['card', 'card-sm', 'page-content-image', 'page-content-image--size-' ~ size, 'mb-0'] %}
-
-{% if float == 'left' %}
-    {% set figureClasses = figureClasses|merge(['page-content-image--float-left', 'float-start', 'me-3', 'mb-3']) %}
-{% elseif float == 'right' %}
-    {% set figureClasses = figureClasses|merge(['page-content-image--float-right', 'float-end', 'ms-3', 'mb-3']) %}
-{% endif %}
-
-<figure class="{{ figureClasses|join(' ') }}">
+{% set presentation = page_image_presentation(block.data) %}
+<figure class="{{ presentation.figureClassString }}">
     <a href="{{ block.data.src|default('') }}"
        data-fslightbox="content-gallery"
        class="d-block page-content-image__link">
         <img class="card-img-top"
              src="{{ block.data.src|default('') }}"
              alt="{{ block.data.alt|default('') }}"
+             {% if presentation.imgWidth and presentation.imgHeight %}
+                 width="{{ presentation.imgWidth }}"
+                 height="{{ presentation.imgHeight }}"
+             {% endif %}
              loading="lazy">
     </a>
     {% if block.data.caption|default('') is not empty %}

--- a/tests/Content/Functional/Command/AnalyzePageImagesCommandTest.php
+++ b/tests/Content/Functional/Command/AnalyzePageImagesCommandTest.php
@@ -83,6 +83,111 @@ final class AnalyzePageImagesCommandTest extends KernelTestCase
         self::assertSame(1, $reloaded->getHeight());
     }
 
+    public function testReportsNoImageReferencesWhenPagesHaveNoImages(): void
+    {
+        self::bootKernel();
+
+        PageFactory::createOne([
+            'slug' => 'command-no-images',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => '<p>Only text</p>'],
+                ],
+            ],
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No image references found in pages.', $tester->getDisplay());
+    }
+
+    public function testFixRichtextSnippetsDryRunReportsPendingSnippetChanges(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'command-fix-snippets',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([
+            '--fix-richtext-snippets' => true,
+            '--page-id' => (string) $page->getId(),
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Richtext snippet migration', $display);
+        self::assertStringContainsString('Updated HTML blocks: 1', $display);
+        self::assertStringContainsString('Dry run finished. Re-run with --apply to persist changes.', $display);
+        self::assertStringContainsString(
+            'page-content-image--size-lg',
+            $page->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testApplyFixRichtextSnippetsPersistsChanges(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'command-fix-snippets-apply',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([
+            '--apply' => true,
+            '--fix-richtext-snippets' => true,
+            '--page-id' => (string) $pageId,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Analysis finished.', $tester->getDisplay());
+
+        $reloaded = PageFactory::repository()->find($pageId);
+        self::assertNotNull($reloaded);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $reloaded->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testInvalidPageIdOptionIsIgnored(): void
+    {
+        self::bootKernel();
+        $this->seedPageWithAutoImage();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--page-id' => 'not-a-number']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Found 1 image reference(s)', $tester->getDisplay());
+    }
+
     public function testMigrateSizeDryRunReportsPendingChanges(): void
     {
         self::bootKernel();

--- a/tests/Content/Functional/Command/AnalyzePageImagesCommandTest.php
+++ b/tests/Content/Functional/Command/AnalyzePageImagesCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Functional\Command;
+
+use App\Content\Infrastructure\Factory\MediaFactory;
+use App\Content\Infrastructure\Factory\PageFactory;
+use App\Content\UI\Console\Command\AnalyzePageImagesCommand;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class AnalyzePageImagesCommandTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDryRunShowsFindingsWithoutWritingChanges(): void
+    {
+        self::bootKernel();
+        $this->seedPageWithAutoImage();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Analyze page images', $display);
+        self::assertStringContainsString('Dry run: no database or content changes will be written.', $display);
+        self::assertStringContainsString('Found 1 image reference(s)', $display);
+        self::assertStringContainsString('No change', $display);
+        self::assertStringContainsString('Analysis finished.', $display);
+    }
+
+    public function testApplyWithBackfillDimensionsPersistsMediaMetadata(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'command-backfill.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        PageFactory::createOne([
+            'slug' => 'command-backfill-page',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/command-backfill.png',
+                        'alt' => 'Backfill',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([
+            '--apply' => true,
+            '--backfill-dimensions' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Media dimension backfill', $display);
+        self::assertStringContainsString('Updated media records', $display);
+        self::assertStringContainsString('Analysis finished.', $display);
+        self::assertStringNotContainsString('Dry run finished.', $display);
+
+        $reloaded = MediaFactory::repository()->find($media->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(1, $reloaded->getWidth());
+        self::assertSame(1, $reloaded->getHeight());
+    }
+
+    public function testMigrateSizeDryRunReportsPendingChanges(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'command-migrate.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'command-migrate-page',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/command-migrate.png',
+                        'alt' => 'Migrate',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([
+            '--migrate-size' => true,
+            '--page-id' => (string) $page->getId(),
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Image block size migration', $display);
+        self::assertStringContainsString('Updated image blocks: 1', $display);
+        self::assertStringContainsString('Dry run finished. Re-run with --apply to persist changes.', $display);
+        self::assertSame('lg', $page->getContent()[0]['data']['size']);
+    }
+
+    private function seedPageWithAutoImage(): void
+    {
+        $media = MediaFactory::createOne([
+            'filename' => 'command-auto.png',
+            'width' => 320,
+            'height' => 200,
+        ])->_real();
+
+        PageFactory::createOne([
+            'slug' => 'command-auto-page',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/command-auto.png',
+                        'alt' => 'Auto',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $command = self::getContainer()->get(AnalyzePageImagesCommand::class);
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -146,6 +146,36 @@ final class PageControllerTest extends WebTestCase
         self::assertSelectorExists('.page-content-accordion .accordion-button');
     }
 
+    public function testImageBlockWithAutoSizeRendersNaturalWidthClass(): void
+    {
+        $client = self::createClient();
+
+        PageFactory::createOne([
+            'title' => 'Auto Image',
+            'slug' => 'auto-image',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [
+                [
+                    'type' => 'image',
+                    'data' => [
+                        'src' => '/uploads/demo.jpg',
+                        'alt' => 'Demo',
+                        'size' => 'auto',
+                        'width' => 320,
+                        'height' => 200,
+                    ],
+                ],
+            ],
+        ]);
+
+        $client->request(Request::METHOD_GET, '/auto-image');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.page-content-image--size-auto');
+        self::assertSelectorExists('img[width="320"][height="200"]');
+    }
+
     public function testSidebarShowsOnlyPublicPagesForGuest(): void
     {
         $client = self::createClient();

--- a/tests/Content/Integration/Media/MediaDimensionsBackfillServiceTest.php
+++ b/tests/Content/Integration/Media/MediaDimensionsBackfillServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Media;
+
+use App\Content\Application\Media\MediaDimensionsBackfillService;
+use App\Content\Infrastructure\Factory\MediaFactory;
+use App\Content\Infrastructure\Repository\MediaRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class MediaDimensionsBackfillServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDryRunReportsUpdatableMediaWithoutPersisting(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'backfill-dry-run.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        $result = $this->backfillService()->backfill(true);
+
+        self::assertGreaterThanOrEqual(1, $result->updated);
+        self::assertNull($this->reloadMedia((int) $media->getId())->getWidth());
+        self::assertNull($this->reloadMedia((int) $media->getId())->getHeight());
+    }
+
+    public function testApplyBackfillsDimensionsFromLocalFile(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'backfill-apply.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        $result = $this->backfillService()->backfill(false);
+
+        self::assertGreaterThanOrEqual(1, $result->updated);
+
+        $reloaded = $this->reloadMedia((int) $media->getId());
+        self::assertSame(1, $reloaded->getWidth());
+        self::assertSame(1, $reloaded->getHeight());
+    }
+
+    public function testSkipsMediaThatAlreadyHasDimensions(): void
+    {
+        self::bootKernel();
+
+        MediaFactory::createOne([
+            'filename' => 'already-sized.png',
+            'width' => 120,
+            'height' => 80,
+        ]);
+
+        $result = $this->backfillService()->backfill(false);
+
+        self::assertSame(0, $result->updated);
+        self::assertSame(0, $result->unknownDimensions);
+    }
+
+    private function reloadMedia(int $mediaId): \App\Content\Domain\Entity\Media
+    {
+        $media = self::getContainer()->get(MediaRepository::class)->find($mediaId);
+        self::assertNotNull($media);
+
+        return $media;
+    }
+
+    private function backfillService(): MediaDimensionsBackfillService
+    {
+        return self::getContainer()->get(MediaDimensionsBackfillService::class);
+    }
+}

--- a/tests/Content/Integration/Media/MediaDimensionsBackfillServiceTest.php
+++ b/tests/Content/Integration/Media/MediaDimensionsBackfillServiceTest.php
@@ -68,6 +68,50 @@ final class MediaDimensionsBackfillServiceTest extends KernelTestCase
         self::assertSame(0, $result->unknownDimensions);
     }
 
+    public function testCountsMissingLocalFiles(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'backfill-missing-file.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        $path = $projectDir.'/public/uploads/media/backfill-missing-file.png';
+        if (is_file($path)) {
+            unlink($path);
+        }
+
+        $result = $this->backfillService()->backfill(true);
+
+        self::assertGreaterThanOrEqual(1, $result->missingFile);
+        self::assertNull($this->reloadMedia((int) $media->getId())->getWidth());
+    }
+
+    public function testCountsUnknownDimensionsForUnreadableImageFile(): void
+    {
+        self::bootKernel();
+
+        MediaFactory::createOne([
+            'filename' => 'backfill-unknown-dims.png',
+            'width' => null,
+            'height' => null,
+        ]);
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        file_put_contents(
+            $projectDir.'/public/uploads/media/backfill-unknown-dims.png',
+            'not-an-image',
+        );
+
+        $result = $this->backfillService()->backfill(true);
+
+        self::assertGreaterThanOrEqual(1, $result->unknownDimensions);
+        self::assertSame(0, $result->updated);
+    }
+
     private function reloadMedia(int $mediaId): \App\Content\Domain\Entity\Media
     {
         $media = self::getContainer()->get(MediaRepository::class)->find($mediaId);

--- a/tests/Content/Integration/Media/MediaUploadListenerTest.php
+++ b/tests/Content/Integration/Media/MediaUploadListenerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Media;
+
+use App\Content\Domain\Entity\Media;
+use App\Content\Infrastructure\Doctrine\MediaUploadListener;
+use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\File;
+use Vich\UploaderBundle\Event\Event;
+use Vich\UploaderBundle\Mapping\PropertyMapping;
+
+final class MediaUploadListenerTest extends TestCase
+{
+    public function testPostUploadSetsImageDimensions(): void
+    {
+        $path = $this->createPng(150, 90);
+        $media = new Media();
+        $media->setFile(new File($path));
+        $media->setMimeType('image/png');
+
+        $listener = new MediaUploadListener(
+            new \App\Content\Application\Media\MediaTypeResolver(),
+            new MediaDimensionsExtractor(),
+        );
+
+        $listener->onPostUpload(new Event($media, new PropertyMapping('file', 'filename')));
+
+        self::assertSame(150, $media->getWidth());
+        self::assertSame(90, $media->getHeight());
+    }
+
+    private function createPng(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($image);
+
+        $path = sys_get_temp_dir().'/upload-listener-'.uniqid().'.png';
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return $path;
+    }
+}

--- a/tests/Content/Integration/Media/MediaUploadListenerTest.php
+++ b/tests/Content/Integration/Media/MediaUploadListenerTest.php
@@ -21,15 +21,69 @@ final class MediaUploadListenerTest extends TestCase
         $media->setFile(new File($path));
         $media->setMimeType('image/png');
 
-        $listener = new MediaUploadListener(
-            new \App\Content\Application\Media\MediaTypeResolver(),
-            new MediaDimensionsExtractor(),
-        );
-
-        $listener->onPostUpload(new Event($media, new PropertyMapping('file', 'filename')));
+        $this->listener()->onPostUpload($this->event($media));
 
         self::assertSame(150, $media->getWidth());
         self::assertSame(90, $media->getHeight());
+    }
+
+    public function testIgnoresNonMediaUploadObjects(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->listener()->onPostUpload($this->event(new \stdClass()));
+    }
+
+    public function testClearsDimensionsForNonImageUploads(): void
+    {
+        $media = new Media();
+        $media->setMimeType('application/pdf');
+        $media->setWidth(100);
+        $media->setHeight(100);
+
+        $this->listener()->onPostUpload($this->event($media));
+
+        self::assertNull($media->getWidth());
+        self::assertNull($media->getHeight());
+    }
+
+    public function testSkipsDimensionsWhenFileIsUnreadable(): void
+    {
+        $path = sys_get_temp_dir().'/upload-listener-invalid-'.uniqid().'.png';
+        file_put_contents($path, 'not-an-image');
+
+        $media = new Media();
+        $media->setFile(new File($path));
+        $media->setMimeType('image/png');
+
+        $this->listener()->onPostUpload($this->event($media));
+
+        self::assertNull($media->getWidth());
+        self::assertNull($media->getHeight());
+    }
+
+    public function testSkipsDimensionsWhenUploadFileIsMissing(): void
+    {
+        $media = new Media();
+        $media->setMimeType('image/png');
+
+        $this->listener()->onPostUpload($this->event($media));
+
+        self::assertNull($media->getWidth());
+        self::assertNull($media->getHeight());
+    }
+
+    private function listener(): MediaUploadListener
+    {
+        return new MediaUploadListener(
+            new \App\Content\Application\Media\MediaTypeResolver(),
+            new MediaDimensionsExtractor(),
+        );
+    }
+
+    private function event(object $object): Event
+    {
+        return new Event($object, new PropertyMapping('file', 'filename'));
     }
 
     private function createPng(int $width, int $height): string

--- a/tests/Content/Integration/Page/PageContentMediaResolverTest.php
+++ b/tests/Content/Integration/Page/PageContentMediaResolverTest.php
@@ -22,6 +22,8 @@ final class PageContentMediaResolverTest extends KernelTestCase
         $media = MediaFactory::createOne([
             'filename' => 'resolved.png',
             'altText' => 'From media',
+            'width' => 640,
+            'height' => 480,
         ])->_real();
 
         $sut = self::getContainer()->get(PageContentMediaResolver::class);
@@ -38,6 +40,8 @@ final class PageContentMediaResolverTest extends KernelTestCase
 
         self::assertSame('/uploads/media/resolved.png', $resolved[0]['data']['src']);
         self::assertSame('From media', $resolved[0]['data']['alt']);
+        self::assertSame(640, $resolved[0]['data']['width']);
+        self::assertSame(480, $resolved[0]['data']['height']);
     }
 
     public function testCtaMediaBlockResolvesPdfUrlAndOpensInNewTab(): void

--- a/tests/Content/Integration/Page/PageImageContentAnalyzerTest.php
+++ b/tests/Content/Integration/Page/PageImageContentAnalyzerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PageImageContentAnalyzer;
+use App\Content\Infrastructure\Factory\MediaFactory;
+use App\Content\Infrastructure\Factory\PageFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Path;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageImageContentAnalyzerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testRecommendsMigratingSmallFullWidthImageToAuto(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'small-image.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-small-lg',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/small-image.png',
+                        'alt' => 'Small',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('Migrate size lg to auto', $findings[0]->recommendation);
+        self::assertSame('ok', $findings[0]->status);
+        self::assertSame(605, $findings[0]->imageWidth);
+    }
+
+    public function testAutoSizeImageNeedsNoChange(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'auto-image.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-auto',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/auto-image.png',
+                        'alt' => 'Auto',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('No change', $findings[0]->recommendation);
+    }
+
+    public function testMissingLocalFileIsReported(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'missing-on-disk.png',
+            'width' => 400,
+            'height' => 300,
+        ])->_real();
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        $path = Path::join($projectDir, 'public', 'uploads', 'media', 'missing-on-disk.png');
+        if (is_file($path)) {
+            unlink($path);
+        }
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-missing-file',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/missing-on-disk.png',
+                        'alt' => 'Missing',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_file', $findings[0]->status);
+        self::assertSame('Sync media files locally', $findings[0]->recommendation);
+    }
+
+    public function testDetectsRichtextSnippetWithLegacyLargeSizeClass(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-richtext-snippet',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/snippet.png" alt="Snippet"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('richtext', $findings[0]->blockType);
+        self::assertSame('lg', $findings[0]->currentSize);
+    }
+
+    private function analyzer(): PageImageContentAnalyzer
+    {
+        return self::getContainer()->get(PageImageContentAnalyzer::class);
+    }
+}

--- a/tests/Content/Integration/Page/PageImageContentAnalyzerTest.php
+++ b/tests/Content/Integration/Page/PageImageContentAnalyzerTest.php
@@ -149,6 +149,610 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
         self::assertSame('lg', $findings[0]->currentSize);
     }
 
+    public function testAnalyzeAllPagesWhenNoPageIdFilter(): void
+    {
+        self::bootKernel();
+
+        $this->createImagePage('analyzer-all-1');
+        $this->createImagePage('analyzer-all-2');
+
+        $findings = $this->analyzer()->analyze();
+
+        self::assertGreaterThanOrEqual(2, count($findings));
+    }
+
+    public function testReturnsEmptyFindingsForUnknownPageId(): void
+    {
+        self::bootKernel();
+
+        self::assertSame([], $this->analyzer()->analyze(999_999));
+    }
+
+    public function testDetectsHighlightBlockWithFloatedSnippet(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne(['filename' => 'highlight-float.png'])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-highlight',
+            'content' => [
+                [
+                    'type' => 'highlight',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<figure class="page-content-image page-content-image--size-md page-content-image--float-right"><img src="/uploads/media/%s" alt="Highlight"></figure>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('highlight', $findings[0]->blockType);
+        self::assertSame('right', $findings[0]->float);
+        self::assertSame('md', $findings[0]->currentSize);
+        self::assertSame('No change', $findings[0]->recommendation);
+    }
+
+    public function testDetectsAccordionItemWithImageSnippet(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-accordion',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            [
+                                'title' => 'FAQ',
+                                'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/accordion.png" alt="Accordion"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('accordion item 1', $findings[0]->blockType);
+    }
+
+    public function testDetectsInlineImageWithoutFigureClasses(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne(['filename' => 'inline-only.png'])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-inline-img',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<p>Text <img src="/uploads/media/%s" alt="Inline"></p>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('inline img', $findings[0]->blockType);
+        self::assertSame('auto', $findings[0]->currentSize);
+    }
+
+    public function testReportsDimensionsUnknownWhenDatabaseMetadataMissing(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'dims-unknown.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-dims-unknown',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/dims-unknown.png',
+                        'alt' => 'Unknown dims',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('ok', $findings[0]->status);
+        self::assertSame(1, $findings[0]->imageWidth);
+        self::assertSame(1, $findings[0]->imageHeight);
+    }
+
+    public function testReportsExternalSrcForNonMediaPath(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-external-src',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'src' => 'https://example.com/photo.png',
+                        'alt' => 'External',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('external_src', $findings[0]->status);
+    }
+
+    public function testReportsMissingSrcWhenImageBlockHasNoMediaOrSrc(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-missing-src',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'alt' => 'No source',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_src', $findings[0]->status);
+    }
+
+    public function testResolvesMediaByStringMediaId(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'string-media-id.png',
+            'width' => 320,
+            'height' => 200,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-string-media-id',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => (string) $media->getId(),
+                        'src' => '/uploads/media/string-media-id.png',
+                        'alt' => 'String id',
+                        'size' => 'sm',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame($media->getId(), $findings[0]->mediaId);
+        self::assertSame('No change', $findings[0]->recommendation);
+    }
+
+    public function testResolvesLegacyWidthPresetToSize(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'legacy-preset.png',
+            'width' => 400,
+            'height' => 300,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-legacy-preset',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/legacy-preset.png',
+                        'alt' => 'Preset',
+                        'widthPreset' => 'md',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('md', $findings[0]->currentSize);
+    }
+
+    public function testResolvesSmallAndLargeLegacyWidthPresets(): void
+    {
+        self::bootKernel();
+
+        $small = MediaFactory::createOne([
+            'filename' => 'preset-sm.png',
+            'width' => 200,
+            'height' => 100,
+        ])->_real();
+        $large = MediaFactory::createOne([
+            'filename' => 'preset-lg.png',
+            'width' => 900,
+            'height' => 600,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-preset-sm-lg',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $small->getId(),
+                        'src' => '/uploads/media/preset-sm.png',
+                        'alt' => 'Small preset',
+                        'widthPreset' => 'sm',
+                        'float' => 'none',
+                    ],
+                ],
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $large->getId(),
+                        'src' => '/uploads/media/preset-lg.png',
+                        'alt' => 'Large preset',
+                        'widthPreset' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(2, $findings);
+        self::assertSame('sm', $findings[0]->currentSize);
+        self::assertSame('lg', $findings[1]->currentSize);
+        self::assertSame('No change', $findings[0]->recommendation);
+        self::assertSame('Review layout', $findings[1]->recommendation);
+    }
+
+    public function testLargeFullWidthImageRecommendsReviewLayout(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'wide-image.png',
+            'width' => 1200,
+            'height' => 800,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-wide-lg',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/wide-image.png',
+                        'alt' => 'Wide',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('Review layout', $findings[0]->recommendation);
+    }
+
+    public function testUnknownSnippetSizeRecommendsReviewLayout(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne(['filename' => 'xl-snippet.png'])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-unknown-snippet-size',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<figure class="page-content-image page-content-image--size-xl"><img src="/uploads/media/%s" alt="XL"></figure>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('xl', $findings[0]->currentSize);
+        self::assertSame('Review layout', $findings[0]->recommendation);
+    }
+
+    public function testSnippetWithoutSrcReportsMissingSrc(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-snippet-no-src',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_src', $findings[0]->status);
+    }
+
+    public function testDetectsFloatedLeftSnippetInHtml(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-float-left-snippet',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-sm page-content-image--float-left"><img src="/uploads/media/float-left.png" alt="Left"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('left', $findings[0]->float);
+    }
+
+    public function testResolvesMediaBySrcFilenameWhenMediaIdMissing(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'src-lookup.png',
+            'width' => 200,
+            'height' => 100,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-src-lookup',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'src' => '/uploads/media/src-lookup.png',
+                        'alt' => 'Lookup',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame($media->getId(), $findings[0]->mediaId);
+    }
+
+    public function testResolvesSrcOnlyImageWhenNoMediaRecordExists(): void
+    {
+        self::bootKernel();
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        $filename = 'orphan-src-only.png';
+        $path = Path::join($projectDir, 'public', 'uploads', 'media', $filename);
+        if (!is_file($path)) {
+            file_put_contents($path, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', true));
+        }
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-orphan-src',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'src' => '/uploads/media/'.$filename,
+                        'alt' => 'Orphan',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertNull($findings[0]->mediaId);
+        self::assertSame($filename, $findings[0]->filename);
+        self::assertSame('ok', $findings[0]->status);
+        self::assertSame(1, $findings[0]->imageWidth);
+    }
+
+    public function testSkipsAccordionItemsWithoutHtml(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-accordion-invalid-item',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            ['title' => 'No html'],
+                            [
+                                'title' => 'With snippet',
+                                'html' => '<figure class="page-content-image page-content-image--size-md"><img src="/uploads/media/acc-valid.png" alt="Valid"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('accordion item 2', $findings[0]->blockType);
+    }
+
+    public function testSkipsHtmlBlocksWithEmptyContent(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-empty-html',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => ''],
+                ],
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'Title only'],
+                ],
+            ],
+        ])->_real();
+
+        self::assertSame([], $this->analyzer()->analyze($page->getId()));
+    }
+
+    public function testUnreadableLocalFileReportsDimensionsUnknown(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'unreadable-dims.png',
+            'width' => null,
+            'height' => null,
+        ])->_real();
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        $path = Path::join($projectDir, 'public', 'uploads', 'media', 'unreadable-dims.png');
+        file_put_contents($path, 'not-an-image');
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-unreadable-file',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/unreadable-dims.png',
+                        'alt' => 'Unreadable',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('dimensions_unknown', $findings[0]->status);
+        self::assertSame('Backfill image dimensions', $findings[0]->recommendation);
+    }
+
+    private function createImagePage(string $slug): void
+    {
+        $media = MediaFactory::createOne([
+            'filename' => $slug.'.png',
+            'width' => 100,
+            'height' => 100,
+        ])->_real();
+
+        PageFactory::createOne([
+            'slug' => $slug,
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/'.$slug.'.png',
+                        'alt' => 'Image',
+                        'size' => 'auto',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     private function analyzer(): PageImageContentAnalyzer
     {
         return self::getContainer()->get(PageImageContentAnalyzer::class);

--- a/tests/Content/Integration/Page/PageImageContentMigrationServiceTest.php
+++ b/tests/Content/Integration/Page/PageImageContentMigrationServiceTest.php
@@ -76,6 +76,308 @@ final class PageImageContentMigrationServiceTest extends KernelTestCase
         );
     }
 
+    public function testMigrateSizesWithoutPageFilterUpdatesAllCandidates(): void
+    {
+        self::bootKernel();
+
+        $page = $this->createPageWithLargeImageBlock();
+        $pageId = (int) $page->getId();
+
+        $result = $this->migrationService()->migrateSizes(false);
+
+        self::assertGreaterThanOrEqual(1, $result->updatedBlocks);
+        self::assertSame('auto', $this->reloadPage($pageId)->getContent()[0]['data']['size']);
+    }
+
+    public function testFixRichtextSnippetsDryRunDoesNotPersist(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-richtext-dry-run',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(true, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertStringContainsString(
+            'page-content-image--size-lg',
+            $this->reloadPage($pageId)->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testFixHighlightSnippetsReplacesLegacySizeClass(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-highlight',
+            'content' => [
+                [
+                    'type' => 'highlight',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $this->reloadPage($pageId)->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testFixAccordionSnippetsReplacesLegacySizeClass(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-accordion',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            [
+                                'title' => 'Item',
+                                'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $this->reloadPage($pageId)->getContent()[0]['data']['items'][0]['html'],
+        );
+    }
+
+    public function testFixRichtextSnippetsWithoutPageFilterUpdatesAllPages(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-all-pages',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(false);
+
+        self::assertGreaterThanOrEqual(1, $result->updatedBlocks);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $this->reloadPage($pageId)->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testFixRichtextSnippetsSkipsBlocksWithoutHtmlChanges(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-no-snippet-change',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-auto"></figure>',
+                    ],
+                ],
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => ''],
+                ],
+            ],
+        ])->_real();
+
+        $result = $this->migrationService()->fixRichtextSnippets(false, (int) $page->getId());
+
+        self::assertSame(0, $result->updatedBlocks);
+        self::assertSame(0, $result->updatedPages);
+    }
+
+    public function testMigrateSizesSkipsNonImageBlocks(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'migrate-with-headline.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-headline-and-image',
+            'content' => [
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'Title'],
+                ],
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/migrate-with-headline.png',
+                        'alt' => 'Image',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->migrateSizes(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertSame('auto', $this->reloadPage($pageId)->getContent()[1]['data']['size']);
+    }
+
+    public function testMigrateSizesSkipsNonLargeImageBlocksOnCandidatePage(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'migrate-candidate-mix.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-lg-and-md',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/migrate-candidate-mix.png',
+                        'alt' => 'Large candidate',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/migrate-candidate-mix.png',
+                        'alt' => 'Medium sibling',
+                        'size' => 'md',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->migrateSizes(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertSame('auto', $this->reloadPage($pageId)->getContent()[0]['data']['size']);
+        self::assertSame('md', $this->reloadPage($pageId)->getContent()[1]['data']['size']);
+    }
+
+    public function testFixRichtextSnippetsReturnsEmptyForUnknownPageId(): void
+    {
+        self::bootKernel();
+
+        $result = $this->migrationService()->fixRichtextSnippets(false, 999_999);
+
+        self::assertSame(0, $result->updatedBlocks);
+        self::assertSame(0, $result->updatedPages);
+    }
+
+    public function testFixAccordionSnippetsSkipsInvalidItems(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-accordion-invalid',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            ['title' => 'Broken'],
+                            [
+                                'title' => 'Valid',
+                                'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $this->reloadPage($pageId)->getContent()[0]['data']['items'][1]['html'],
+        );
+    }
+
+    public function testFixRichtextSnippetsSkipsBlocksWithoutHtmlField(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-highlight-no-html',
+            'content' => [
+                [
+                    'type' => 'highlight',
+                    'enabled' => true,
+                    'data' => ['variant' => 'info'],
+                ],
+            ],
+        ])->_real();
+
+        $result = $this->migrationService()->fixRichtextSnippets(false, (int) $page->getId());
+
+        self::assertSame(0, $result->updatedBlocks);
+    }
+
     public function testSkipsFloatedLargeImagesDuringSizeMigration(): void
     {
         self::bootKernel();

--- a/tests/Content/Integration/Page/PageImageContentMigrationServiceTest.php
+++ b/tests/Content/Integration/Page/PageImageContentMigrationServiceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PageImageContentMigrationService;
+use App\Content\Infrastructure\Factory\MediaFactory;
+use App\Content\Infrastructure\Factory\PageFactory;
+use App\Content\Infrastructure\Repository\PageRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class PageImageContentMigrationServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDryRunDoesNotPersistSizeMigration(): void
+    {
+        self::bootKernel();
+
+        $page = $this->createPageWithLargeImageBlock();
+        $pageId = (int) $page->getId();
+
+        $result = $this->migrationService()->migrateSizes(true, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertSame(1, $result->updatedPages);
+        self::assertSame('lg', $this->reloadPage($pageId)->getContent()[0]['data']['size']);
+    }
+
+    public function testApplyMigratesLargeImageBlocksToAuto(): void
+    {
+        self::bootKernel();
+
+        $page = $this->createPageWithLargeImageBlock();
+        $pageId = (int) $page->getId();
+
+        $result = $this->migrationService()->migrateSizes(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertSame('auto', $this->reloadPage($pageId)->getContent()[0]['data']['size']);
+    }
+
+    public function testFixRichtextSnippetsReplacesLegacySizeClass(): void
+    {
+        self::bootKernel();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-richtext',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->fixRichtextSnippets(false, $pageId);
+
+        self::assertSame(1, $result->updatedBlocks);
+        self::assertSame(1, $result->updatedPages);
+        self::assertStringContainsString(
+            'page-content-image--size-auto',
+            $this->reloadPage($pageId)->getContent()[0]['data']['html'],
+        );
+        self::assertStringNotContainsString(
+            'page-content-image--size-lg',
+            $this->reloadPage($pageId)->getContent()[0]['data']['html'],
+        );
+    }
+
+    public function testSkipsFloatedLargeImagesDuringSizeMigration(): void
+    {
+        self::bootKernel();
+
+        $media = MediaFactory::createOne([
+            'filename' => 'floated.png',
+            'width' => 400,
+            'height' => 300,
+        ])->_real();
+
+        $page = PageFactory::createOne([
+            'slug' => 'migration-floated-lg',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/floated.png',
+                        'alt' => 'Floated',
+                        'size' => 'lg',
+                        'float' => 'left',
+                    ],
+                ],
+            ],
+        ])->_real();
+
+        $pageId = (int) $page->getId();
+        $result = $this->migrationService()->migrateSizes(false, $pageId);
+
+        self::assertSame(0, $result->updatedBlocks);
+        self::assertSame('lg', $this->reloadPage($pageId)->getContent()[0]['data']['size']);
+    }
+
+    private function createPageWithLargeImageBlock(): \App\Content\Domain\Entity\Page
+    {
+        $media = MediaFactory::createOne([
+            'filename' => 'migrate-me.png',
+            'width' => 605,
+            'height' => 400,
+        ])->_real();
+
+        return PageFactory::createOne([
+            'slug' => 'migration-lg-image',
+            'content' => [
+                [
+                    'type' => 'image',
+                    'enabled' => true,
+                    'data' => [
+                        'mediaId' => $media->getId(),
+                        'src' => '/uploads/media/migrate-me.png',
+                        'alt' => 'Migrate me',
+                        'size' => 'lg',
+                        'float' => 'none',
+                    ],
+                ],
+            ],
+        ])->_real();
+    }
+
+    private function reloadPage(int $pageId): \App\Content\Domain\Entity\Page
+    {
+        $page = self::getContainer()->get(PageRepository::class)->find($pageId);
+        self::assertNotNull($page);
+
+        return $page;
+    }
+
+    private function migrationService(): PageImageContentMigrationService
+    {
+        return self::getContainer()->get(PageImageContentMigrationService::class);
+    }
+}

--- a/tests/Content/Integration/Twig/PageExtensionTest.php
+++ b/tests/Content/Integration/Twig/PageExtensionTest.php
@@ -77,6 +77,15 @@ final class PageExtensionTest extends KernelTestCase
         self::assertStringNotContainsString('/privacy-slug', $html);
     }
 
+    public function testPageImagePresentationFunctionReturnsAutoSizeByDefault(): void
+    {
+        $html = $this->twig->createTemplate(
+            '{% set presentation = page_image_presentation({src: "/uploads/media/x.png", alt: "Alt"}) %}{{ presentation.figureClassString }}'
+        )->render();
+
+        self::assertStringContainsString('page-content-image--size-auto', $html);
+    }
+
     public function testPageNavHeaderItemsOnlyListsAvailablePages(): void
     {
         PageFactory::createOne([

--- a/tests/Content/Unit/Media/LocalMediaFileLocatorTest.php
+++ b/tests/Content/Unit/Media/LocalMediaFileLocatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Media;
+
+use App\Content\Domain\Entity\Media;
+use App\Content\Infrastructure\Media\LocalMediaFileLocator;
+use PHPUnit\Framework\TestCase;
+
+final class LocalMediaFileLocatorTest extends TestCase
+{
+    private const string UPLOAD_DIR = '/var/project/public/uploads/media';
+
+    public function testResolveAbsolutePathFromMediaFilename(): void
+    {
+        $media = new Media();
+        $media->setFilename('photo.png');
+
+        self::assertSame(
+            self::UPLOAD_DIR.'/photo.png',
+            $this->locator()->resolveAbsolutePath($media),
+        );
+    }
+
+    public function testResolveAbsolutePathReturnsNullWhenFilenameMissing(): void
+    {
+        self::assertNull($this->locator()->resolveAbsolutePath(new Media()));
+    }
+
+    public function testResolveFilenameFromPublicSrc(): void
+    {
+        self::assertSame(
+            'photo.png',
+            $this->locator()->resolveFilenameFromPublicSrc('/uploads/media/photo.png'),
+        );
+    }
+
+    public function testResolveFilenameFromPublicSrcReturnsNullForExternalPath(): void
+    {
+        self::assertNull($this->locator()->resolveFilenameFromPublicSrc('https://example.org/photo.png'));
+    }
+
+    private function locator(): LocalMediaFileLocator
+    {
+        return new LocalMediaFileLocator(self::UPLOAD_DIR);
+    }
+}

--- a/tests/Content/Unit/Media/MediaDimensionsExtractorTest.php
+++ b/tests/Content/Unit/Media/MediaDimensionsExtractorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Media;
+
+use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class MediaDimensionsExtractorTest extends TestCase
+{
+    public function testExtractsDimensionsFromValidPng(): void
+    {
+        $path = $this->createPng(120, 80);
+
+        $dimensions = $this->extractor()->extract($path);
+
+        self::assertNotNull($dimensions);
+        self::assertSame(120, $dimensions->width);
+        self::assertSame(80, $dimensions->height);
+    }
+
+    public function testReturnsNullForMissingFile(): void
+    {
+        self::assertNull($this->extractor()->extract('/tmp/does-not-exist-'.uniqid().'.png'));
+    }
+
+    public function testReturnsNullForInvalidFile(): void
+    {
+        $path = sys_get_temp_dir().'/invalid-image-'.uniqid().'.png';
+        file_put_contents($path, 'not-an-image');
+
+        self::assertNull($this->extractor()->extract($path));
+    }
+
+    private function extractor(): MediaDimensionsExtractor
+    {
+        return new MediaDimensionsExtractor();
+    }
+
+    private function createPng(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        self::assertNotFalse($image);
+
+        $path = sys_get_temp_dir().'/extractor-test-'.uniqid().'.png';
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return $path;
+    }
+}

--- a/tests/Content/Unit/Media/MediaDimensionsExtractorTest.php
+++ b/tests/Content/Unit/Media/MediaDimensionsExtractorTest.php
@@ -33,6 +33,19 @@ final class MediaDimensionsExtractorTest extends TestCase
         self::assertNull($this->extractor()->extract($path));
     }
 
+    public function testReturnsNullForUnreadableFile(): void
+    {
+        $path = $this->createPng(10, 10);
+        chmod($path, 0000);
+
+        try {
+            self::assertNull($this->extractor()->extract($path));
+        } finally {
+            chmod($path, 0644);
+            unlink($path);
+        }
+    }
+
     private function extractor(): MediaDimensionsExtractor
     {
         return new MediaDimensionsExtractor();

--- a/tests/Content/Unit/Media/MediaImageFigureHtmlBuilderTest.php
+++ b/tests/Content/Unit/Media/MediaImageFigureHtmlBuilderTest.php
@@ -9,11 +9,11 @@ use PHPUnit\Framework\TestCase;
 
 final class MediaImageFigureHtmlBuilderTest extends TestCase
 {
-    public function testBuildsFullWidthFigureByDefault(): void
+    public function testBuildsNaturalSizeFigureByDefault(): void
     {
         $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo');
 
-        self::assertStringContainsString('<figure class="card card-sm page-content-image page-content-image--size-lg mb-0">', $html);
+        self::assertStringContainsString('<figure class="card card-sm page-content-image page-content-image--size-auto mb-0">', $html);
         self::assertStringContainsString('data-fslightbox="content-gallery"', $html);
         self::assertStringContainsString('<img class="card-img-top" src="/uploads/media/photo.webp" alt="A photo" loading="lazy">', $html);
     }
@@ -31,9 +31,17 @@ final class MediaImageFigureHtmlBuilderTest extends TestCase
     {
         $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo', 'xl', 'center');
 
-        self::assertStringContainsString('page-content-image--size-lg', $html);
+        self::assertStringContainsString('page-content-image--size-auto', $html);
         self::assertStringNotContainsString('float-start', $html);
         self::assertStringNotContainsString('float-end', $html);
+    }
+
+    public function testBuildsDimensionAttributesWhenProvided(): void
+    {
+        $html = $this->builder()->build('/uploads/media/photo.webp', 'A photo', 'auto', 'none', 320, 200);
+
+        self::assertStringContainsString('width="320"', $html);
+        self::assertStringContainsString('height="200"', $html);
     }
 
     private function builder(): MediaImageFigureHtmlBuilder

--- a/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
+++ b/tests/Content/Unit/Page/PageContentBlockDataNormalizerTest.php
@@ -32,7 +32,7 @@ final class PageContentBlockDataNormalizerTest extends TestCase
                 'data' => [
                     'alt' => 'Alt text',
                     'src' => '/uploads/media/x.png',
-                    'size' => 'lg',
+                    'size' => 'auto',
                     'float' => 'none',
                 ],
             ],
@@ -229,6 +229,45 @@ final class PageContentBlockDataNormalizerTest extends TestCase
         ]);
 
         self::assertSame('md', $normalized[0]['data']['size']);
+    }
+
+    public function testNormalizesLegacyWidthPresetLgToSize(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'lg',
+                ],
+            ],
+        ]);
+
+        self::assertSame('lg', $normalized[0]['data']['size']);
+    }
+
+    public function testPreservesImageWidthAndHeightFields(): void
+    {
+        $sut = new PageContentBlockDataNormalizer();
+
+        $normalized = $sut->normalize([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/uploads/media/photo.png',
+                    'alt' => 'Alt',
+                    'size' => 'auto',
+                    'width' => 640,
+                    'height' => 480,
+                ],
+            ],
+        ]);
+
+        self::assertSame(640, $normalized[0]['data']['width']);
+        self::assertSame(480, $normalized[0]['data']['height']);
     }
 
     public function testNormalizesAccordionItemsToEmptyListWhenInvalid(): void

--- a/tests/Content/Unit/Page/PageContentValidatorTest.php
+++ b/tests/Content/Unit/Page/PageContentValidatorTest.php
@@ -102,6 +102,43 @@ final class PageContentValidatorTest extends TestCase
         self::assertSame([], $errors);
     }
 
+    public function testImageWithoutExplicitSizeDefaultsToAutoViaLegacyPreset(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'float' => 'none',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testImageWithUnknownWidthPresetDefaultsToAuto(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'full',
+                    'float' => 'none',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
     public function testHighlightCustomIconRequiresIconName(): void
     {
         $validator = new PageContentValidator($this->translator());
@@ -271,6 +308,25 @@ final class PageContentValidatorTest extends TestCase
                     'src' => '/img.jpg',
                     'alt' => 'Alt',
                     'widthPreset' => 'sm',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
+    public function testImageAcceptsLegacyLargeWidthPresetForSize(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'widthPreset' => 'lg',
+                    'float' => 'none',
                 ],
             ],
         ]);

--- a/tests/Content/Unit/Page/PageContentValidatorTest.php
+++ b/tests/Content/Unit/Page/PageContentValidatorTest.php
@@ -83,6 +83,25 @@ final class PageContentValidatorTest extends TestCase
         self::assertStringContainsString('non-full-width', implode(' ', $errors));
     }
 
+    public function testAutoImageSizeIsValid(): void
+    {
+        $validator = new PageContentValidator($this->translator());
+
+        $errors = $validator->validate([
+            [
+                'type' => 'image',
+                'data' => [
+                    'src' => '/img.jpg',
+                    'alt' => 'Alt',
+                    'size' => 'auto',
+                    'float' => 'none',
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $errors);
+    }
+
     public function testHighlightCustomIconRequiresIconName(): void
     {
         $validator = new PageContentValidator($this->translator());

--- a/tests/Content/Unit/Page/PageImageBlockPresenterTest.php
+++ b/tests/Content/Unit/Page/PageImageBlockPresenterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Page;
+
+use App\Content\Application\Page\PageImageBlockPresenter;
+use PHPUnit\Framework\TestCase;
+
+final class PageImageBlockPresenterTest extends TestCase
+{
+    public function testAutoSizeUsesNaturalWidthClasses(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'size' => 'auto',
+            'width' => 400,
+            'height' => 300,
+        ]);
+
+        self::assertContains('page-content-image--size-auto', $presentation->figureClasses);
+        self::assertSame(400, $presentation->imgWidth);
+        self::assertSame(300, $presentation->imgHeight);
+    }
+
+    public function testDefaultsMissingSizeToAuto(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+        ]);
+
+        self::assertContains('page-content-image--size-auto', $presentation->figureClasses);
+    }
+
+    public function testLargeSizeKeepsFullWidthClass(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'size' => 'lg',
+        ]);
+
+        self::assertContains('page-content-image--size-lg', $presentation->figureClasses);
+    }
+
+    public function testMediumFloatedImageKeepsFloatClasses(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'size' => 'md',
+            'float' => 'left',
+        ]);
+
+        self::assertContains('page-content-image--size-md', $presentation->figureClasses);
+        self::assertContains('page-content-image--float-left', $presentation->figureClasses);
+        self::assertContains('float-start', $presentation->figureClasses);
+    }
+
+    public function testMissingDimensionsAreIgnored(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'size' => 'auto',
+        ]);
+
+        self::assertNull($presentation->imgWidth);
+        self::assertNull($presentation->imgHeight);
+    }
+
+    private function presenter(): PageImageBlockPresenter
+    {
+        return new PageImageBlockPresenter();
+    }
+}

--- a/tests/Content/Unit/Page/PageImageBlockPresenterTest.php
+++ b/tests/Content/Unit/Page/PageImageBlockPresenterTest.php
@@ -71,6 +71,77 @@ final class PageImageBlockPresenterTest extends TestCase
         self::assertNull($presentation->imgHeight);
     }
 
+    public function testLegacyWidthPresetMapsToSizeClass(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'widthPreset' => 'md',
+        ]);
+
+        self::assertContains('page-content-image--size-md', $presentation->figureClasses);
+    }
+
+    public function testLegacySmallWidthPresetMapsToSizeClass(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'widthPreset' => 'sm',
+        ]);
+
+        self::assertContains('page-content-image--size-sm', $presentation->figureClasses);
+    }
+
+    public function testLegacyLargeWidthPresetMapsToSizeClass(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'widthPreset' => 'lg',
+        ]);
+
+        self::assertContains('page-content-image--size-lg', $presentation->figureClasses);
+    }
+
+    public function testRightFloatAddsEndClasses(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'size' => 'sm',
+            'float' => 'right',
+        ]);
+
+        self::assertContains('page-content-image--float-right', $presentation->figureClasses);
+        self::assertContains('float-end', $presentation->figureClasses);
+    }
+
+    public function testInvalidFloatDefaultsToNone(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'float' => 'center',
+        ]);
+
+        self::assertNotContains('page-content-image--float-left', $presentation->figureClasses);
+        self::assertNotContains('page-content-image--float-right', $presentation->figureClasses);
+    }
+
+    public function testStringDimensionsAreParsed(): void
+    {
+        $presentation = $this->presenter()->present([
+            'src' => '/uploads/media/photo.png',
+            'alt' => 'Photo',
+            'width' => '640',
+            'height' => '480',
+        ]);
+
+        self::assertSame(640, $presentation->imgWidth);
+        self::assertSame(480, $presentation->imgHeight);
+    }
+
     private function presenter(): PageImageBlockPresenter
     {
         return new PageImageBlockPresenter();

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -4019,6 +4019,10 @@
         <source>label.image_size</source>
         <target>Image size</target>
       </trans-unit>
+      <trans-unit id="page0026bf0" resname="label.image_size.auto">
+        <source>label.image_size.auto</source>
+        <target>Natural size</target>
+      </trans-unit>
       <trans-unit id="page0026bf" resname="label.image_size.sm">
         <source>label.image_size.sm</source>
         <target>Small</target>
@@ -4033,7 +4037,7 @@
       </trans-unit>
       <trans-unit id="page0026bi" resname="help.page.image_size">
         <source>help.page.image_size</source>
-        <target>Relative to the content card width, not the full page.</target>
+        <target>Natural size keeps the original image width (up to the content column). Small, medium, and large force a relative width inside the content card.</target>
       </trans-unit>
       <trans-unit id="page0026bj" resname="label.move_block_up">
         <source>label.move_block_up</source>
@@ -4341,7 +4345,7 @@
       </trans-unit>
       <trans-unit id="media016c1" resname="help.media.image_layout.size">
         <source>help.media.image_layout.size</source>
-        <target>Size: replace page-content-image--size-lg with --size-sm (33%) or --size-md (66%).</target>
+        <target>Size: default is --size-auto (natural width). Use --size-sm (33%), --size-md (66%), or --size-lg (full width).</target>
       </trans-unit>
       <trans-unit id="media016c2" resname="help.media.image_layout.float">
         <source>help.media.image_layout.float</source>


### PR DESCRIPTION
### Summary

- Added support for rendering page images using their natural width
- Improved image presentation within CMS/content pages
- Reduced unnecessary scaling and layout distortion for embedded images
- Updated page rendering and media-related templates where needed
- Improved consistency between uploaded media and frontend display
- Added or updated tests covering image rendering behavior

### Motivation

- Improve visual quality of embedded images
- Allow content authors to present media closer to its intended appearance
- Reduce layout issues caused by aggressive resizing or fixed-width rendering
- Enhance the overall reading and content consumption experience

### Notes for Reviewers

- Verify images render correctly across different page layouts
- Check responsive behavior on smaller screen sizes
- Ensure existing content continues to render as expected
- Review interactions with lightbox, media snippets, and other CMS media features
- Confirm tests cover natural-width rendering and fallback behavior