### PR TITLE
feat(notifications): Add administrative email notifications

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -112,6 +112,12 @@ services:
     App\User\Infrastructure\Security\FeedbackRecipientEmailResolver:
         alias: App\User\Infrastructure\Security\FeedbackRecipientResolver
 
+    App\User\Infrastructure\Security\NotificationRecipientEmailResolver:
+        alias: App\User\Infrastructure\Security\NotificationRecipientResolver
+
+    App\Shared\Application\Notification\AdminNotificationSenderInterface:
+        alias: App\Shared\Infrastructure\Mail\AdminNotificationSender
+
     App\Import\Infrastructure\Adapter\SplCsvRejectWriter:
         arguments:
             $rejectsBaseDir: '%app.rejects_base_dir%'

--- a/src/Admin/Application/Service/AdminUserUrlGenerator.php
+++ b/src/Admin/Application/Service/AdminUserUrlGenerator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use App\Admin\UI\Http\Controller\User\UserCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class AdminUserUrlGenerator
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function detailUrl(int $userId): string
+    {
+        $relativeUrl = $this->adminUrlGenerator
+            ->setController(UserCrudController::class)
+            ->setAction(Action::DETAIL)
+            ->setEntityId($userId)
+            ->generateUrl();
+
+        $query = parse_url($relativeUrl, PHP_URL_QUERY);
+        $params = [];
+        if (\is_string($query) && '' !== $query) {
+            parse_str($query, $params);
+        }
+
+        return $this->urlGenerator->generate(
+            'app_admin_dashboard',
+            $params,
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+    }
+}

--- a/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
+++ b/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class GrantParticipantUrlGenerator
+{
+    private const int EXPIRATION_SECONDS = 604800;
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private UriSigner $uriSigner,
+    ) {
+    }
+
+    public function generate(int $userId): string
+    {
+        $url = $this->urlGenerator->generate(
+            'app_admin_user_grant_participant',
+            ['id' => $userId],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $expires = time() + self::EXPIRATION_SECONDS;
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $this->uriSigner->sign($url.$separator.'expires='.$expires);
+    }
+}

--- a/src/Admin/UI/Http/Controller/User/GrantParticipantController.php
+++ b/src/Admin/UI/Http/Controller/User/GrantParticipantController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\User;
+
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+final class GrantParticipantController extends AbstractController
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UriSigner $uriSigner,
+        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[Route('/admin/users/{id}/grant-participant', name: 'app_admin_user_grant_participant', requirements: ['id' => '\d+'])]
+    public function __invoke(int $id, Request $request): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        if (!$this->uriSigner->check($request->getUri())) {
+            throw $this->createAccessDeniedException('Invalid or expired link.');
+        }
+
+        $expires = $request->query->get('expires');
+        if (!\is_string($expires) || !ctype_digit($expires) || (int) $expires < time()) {
+            throw $this->createAccessDeniedException('Invalid or expired link.');
+        }
+
+        $user = $this->entityManager->getRepository(User::class)->find($id);
+        if (!$user instanceof User) {
+            throw $this->createNotFoundException('User not found.');
+        }
+
+        $roles = array_values(array_filter(
+            $user->getRoles(),
+            static fn (string $role): bool => UserRole::USER !== $role,
+        ));
+        if (!\in_array(UserRole::PARTICIPANT, $roles, true)) {
+            $roles[] = UserRole::PARTICIPANT;
+            $user->setRoles($roles);
+
+            $this->auditContext->beginIntent('user.admin.grant_participant', ['user_id' => $id]);
+            try {
+                $this->entityManager->flush();
+            } finally {
+                $this->auditContext->endIntent();
+            }
+
+            $this->addFlash('success', 'flash.admin.user.grant_participant.success');
+        } else {
+            $this->addFlash('info', 'flash.admin.user.grant_participant.already');
+        }
+
+        return $this->redirect(
+            $this->adminUrlGenerator
+                ->setController(UserCrudController::class)
+                ->setAction(Action::DETAIL)
+                ->setEntityId($id)
+                ->generateUrl(),
+        );
+    }
+}

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -103,6 +103,7 @@ final class UserCrudController extends AbstractCrudController
                 'Participant' => UserRole::PARTICIPANT,
                 'User' => UserRole::USER,
                 'Receives Feedback' => UserRole::FEEDBACK_RECIPIENT,
+                'Receives notifications' => UserRole::RECEIVES_NOTIFICATION,
             ])
             ->allowMultipleChoices()
             ->renderAsBadges([
@@ -110,6 +111,7 @@ final class UserCrudController extends AbstractCrudController
                 UserRole::PARTICIPANT => 'warning',
                 UserRole::USER => 'primary',
                 UserRole::FEEDBACK_RECIPIENT => 'success',
+                UserRole::RECEIVES_NOTIFICATION => 'info',
             ]);
         yield TextField::new('password')
             ->setFormType(PasswordType::class)

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -45,7 +45,7 @@ final class UserFixtures extends Fixture
     public static function getUserData(): array
     {
         return [
-            ['admin', 'password', ['ROLE_ADMIN', 'ROLE_FEEDBACK_RECIPIENT', 'ROLE_USER'], 'admin@test.local', true],
+            ['admin', 'password', ['ROLE_ADMIN', 'ROLE_FEEDBACK_RECIPIENT', 'ROLE_RECEIVES_NOTIFICATION', 'ROLE_USER'], 'admin@test.local', true],
             ['foo', 'bar', ['ROLE_USER'], 'foo@bar.local', true],
         ];
     }

--- a/src/Import/Application/Event/ImportFailed.php
+++ b/src/Import/Application/Event/ImportFailed.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Event;
+
+final class ImportFailed
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        public int $importId,
+        public ?string $reason = null,
+    ) {
+    }
+}

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -9,6 +9,7 @@ use App\Import\Application\Contracts\RejectWriterInterface;
 use App\Import\Application\Contracts\RowReaderInterface;
 use App\Import\Application\DTO\ImportSummary;
 use App\Import\Application\Event\ImportCompleted;
+use App\Import\Application\Event\ImportFailed;
 use App\Import\Application\Factory\AllocationImporterFactory;
 use App\Import\Application\Factory\RejectWriterFactory;
 use App\Import\Application\Factory\RowReaderFactory;
@@ -57,13 +58,16 @@ final readonly class ImportAllocationsMessageHandler
         $filePath = $import->getFilePath();
         if (null === $filePath) {
             $this->markFailed($import, 'Import has no file path');
+            $this->dispatchImportOutcome($message->importId, 'Import has no file path');
 
             return;
         }
 
         $filePath = $this->resolvePath($filePath);
         if (!\is_file($filePath)) {
-            $this->markFailed($import, 'CSV not found: '.$filePath);
+            $reason = 'CSV not found: '.$filePath;
+            $this->markFailed($import, $reason);
+            $this->dispatchImportOutcome($message->importId, $reason);
 
             return;
         }
@@ -83,15 +87,18 @@ final readonly class ImportAllocationsMessageHandler
 
             try {
                 $this->run($import, $reader, $writer);
-
-                $this->dispatcher->dispatch(new ImportCompleted($message->importId));
             } catch (\Throwable $e) {
                 $this->importLogger->critical('import.failed', [
                     'id' => $import->getId(),
                     'ex' => $e::class,
                     'msg' => $e->getMessage(),
                 ]);
+                $this->dispatchImportOutcome($message->importId, $e->getMessage());
+
+                return;
             }
+
+            $this->dispatchImportOutcome($message->importId);
         } finally {
             $this->auditContext->popSuppressedEntityAudit();
         }
@@ -149,6 +156,48 @@ final readonly class ImportAllocationsMessageHandler
             'id' => $import->getId(),
             'reason' => $reason,
         ]);
+    }
+
+    private function dispatchImportOutcome(int $importId, ?string $failureReason = null): void
+    {
+        $this->em->clear();
+        $import = $this->importRepository->find($importId);
+        if (!$import instanceof Import) {
+            return;
+        }
+
+        $status = $import->getStatus();
+        if (ImportStatus::FAILED === $status) {
+            $this->dispatcher->dispatch(new ImportFailed(
+                $importId,
+                $failureReason ?? $this->resolveFailureReason($import),
+            ));
+
+            return;
+        }
+
+        if ($status?->isFinal() ?? false) {
+            $this->dispatcher->dispatch(new ImportCompleted($importId));
+        }
+    }
+
+    private function resolveFailureReason(Import $import): string
+    {
+        $rowCount = $import->getRowCount() ?? 0;
+        if (0 === $rowCount) {
+            return 'Import file contained no rows.';
+        }
+
+        $rejected = $import->getRowsRejected() ?? 0;
+        if ($rejected > 0) {
+            return sprintf(
+                'Import exceeded the maximum allowed rejection ratio (%d of %d rows rejected).',
+                $rejected,
+                $rowCount,
+            );
+        }
+
+        return 'Import processing failed.';
     }
 
     /** @param array<string, mixed> $metadata */

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -160,11 +160,12 @@ final readonly class ImportAllocationsMessageHandler
 
     private function dispatchImportOutcome(int $importId, ?string $failureReason = null): void
     {
-        $this->em->clear();
         $import = $this->importRepository->find($importId);
         if (!$import instanceof Import) {
             return;
         }
+
+        $this->em->refresh($import);
 
         $status = $import->getStatus();
         if (ImportStatus::FAILED === $status) {

--- a/src/Import/Infrastructure/EventSubscriber/ImportFailedNotificationSubscriber.php
+++ b/src/Import/Infrastructure/EventSubscriber/ImportFailedNotificationSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\EventSubscriber;
+
+use App\Import\Application\Event\ImportFailed;
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationSenderInterface;
+use App\Shared\Application\Notification\AdminNotificationType;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[AsEventListener(event: ImportFailed::class, method: 'onImportFailed')]
+final readonly class ImportFailedNotificationSubscriber
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private ImportRepository $importRepository,
+        private AdminNotificationSenderInterface $adminNotificationSender,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function onImportFailed(ImportFailed $event): void
+    {
+        $import = $this->importRepository->find($event->importId);
+        if (!$import instanceof Import) {
+            return;
+        }
+
+        $importId = $import->getId();
+        if (null === $importId) {
+            return;
+        }
+
+        $hospital = $import->getHospital();
+
+        $status = $import->getStatus();
+
+        $this->adminNotificationSender->send(new AdminNotification(
+            type: AdminNotificationType::ImportFailed,
+            templateContext: [
+                'importName' => $import->getName() ?? '—',
+                'hospitalName' => $hospital instanceof \App\Allocation\Domain\Entity\Hospital ? (string) $hospital : '—',
+                'status' => $status instanceof \App\Import\Domain\Enum\ImportStatus ? $status->value : '—',
+                'rowCount' => $import->getRowCount(),
+                'runTimeMs' => $import->getRunTime(),
+                'reason' => $event->reason,
+                'importDetailUrl' => $this->urlGenerator->generate(
+                    'app_import_show',
+                    ['id' => $importId],
+                    UrlGeneratorInterface::ABSOLUTE_URL,
+                ),
+            ],
+            referenceId: (string) $importId,
+        ));
+    }
+}

--- a/src/Shared/Application/Notification/AdminNotification.php
+++ b/src/Shared/Application/Notification/AdminNotification.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Notification;
+
+final readonly class AdminNotification
+{
+    /**
+     * @param array<string, mixed> $templateContext
+     */
+    public function __construct(
+        public AdminNotificationType $type,
+        public array $templateContext,
+        public ?string $referenceId = null,
+    ) {
+    }
+}

--- a/src/Shared/Application/Notification/AdminNotificationSenderInterface.php
+++ b/src/Shared/Application/Notification/AdminNotificationSenderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Notification;
+
+interface AdminNotificationSenderInterface
+{
+    public function send(AdminNotification $notification): void;
+}

--- a/src/Shared/Application/Notification/AdminNotificationType.php
+++ b/src/Shared/Application/Notification/AdminNotificationType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Notification;
+
+enum AdminNotificationType: string
+{
+    case UserRegistered = 'user_registered';
+    case ImportFailed = 'import_failed';
+
+    public function subjectTranslationKey(): string
+    {
+        return match ($this) {
+            self::UserRegistered => 'admin_notification.email.subject.user_registered',
+            self::ImportFailed => 'admin_notification.email.subject.import_failed',
+        };
+    }
+}

--- a/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
+++ b/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mail;
+
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationSenderInterface;
+use App\Shared\Application\Notification\AdminNotificationType;
+use App\User\Infrastructure\Security\NotificationRecipientEmailResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/** @psalm-suppress UnusedClass */
+final readonly class AdminNotificationSender implements AdminNotificationSenderInterface
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private MailerInterface $mailer,
+        private MailConfig $mailConfig,
+        private NotificationRecipientEmailResolver $notificationRecipientResolver,
+        private TranslatorInterface $translator,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    #[\Override]
+    public function send(AdminNotification $notification): void
+    {
+        $recipients = $this->notificationRecipientResolver->resolveRecipientEmails();
+        if ([] === $recipients) {
+            $this->logger->info('admin_notification.skipped', [
+                'reason' => 'no_notification_recipients',
+                'type' => $notification->type->value,
+                'reference_id' => $notification->referenceId,
+            ]);
+
+            return;
+        }
+
+        $email = $this->createTemplatedEmail()
+            ->to(...$recipients)
+            ->subject($this->buildSubject($notification->type))
+            ->htmlTemplate($this->resolveTemplate($notification->type))
+            ->context($notification->templateContext);
+
+        $this->mailer->send($email);
+    }
+
+    private function buildSubject(AdminNotificationType $type): string
+    {
+        $label = $this->translator->trans($type->subjectTranslationKey());
+
+        return sprintf('[%s] %s', $this->mailConfig->appName, $label);
+    }
+
+    private function resolveTemplate(AdminNotificationType $type): string
+    {
+        return match ($type) {
+            AdminNotificationType::UserRegistered => '@Shared/email/admin_notification/user_registered.html.twig',
+            AdminNotificationType::ImportFailed => '@Shared/email/admin_notification/import_failed.html.twig',
+        };
+    }
+
+    private function createTemplatedEmail(): TemplatedEmail
+    {
+        $email = new TemplatedEmail()
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName));
+
+        $replyTo = $this->mailConfig->replyTo();
+        if (null !== $replyTo) {
+            $email->replyTo($replyTo);
+        }
+
+        return $email;
+    }
+}

--- a/src/Shared/UI/Twig/templates/email/admin_notification/import_failed.html.twig
+++ b/src/Shared/UI/Twig/templates/email/admin_notification/import_failed.html.twig
@@ -1,0 +1,71 @@
+{%- set fg = '#4b5563' -%}
+{%- set fgHeading = '#111827' -%}
+{%- set link = '#066FD1' -%}
+{%- set boxBg = '#ffffff' -%}
+{%- set pageBg = '#f9fafb' -%}
+{%- set quoteBg = '#fafafa' -%}
+{%- set border = '#e8ebee' -%}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="color-scheme" content="light dark"/>
+    <meta name="supported-color-schemes" content="light dark"/>
+    <title>{{ 'admin_notification.email.import_failed.title'|trans }}</title>
+</head>
+<body style="margin:0;padding:0;background-color:{{ pageBg }};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.6;color:{{ fg }};-webkit-font-smoothing:antialiased;">
+<center role="presentation" style="width:100%;background-color:{{ pageBg }};">
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto;max-width:560px;width:100%;border-collapse:collapse;">
+        <tr>
+            <td style="padding:40px 16px;">
+                <div style="background:{{ boxBg }};border:1px solid {{ border }};border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,0.05);">
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                        <tr>
+                            <td align="center" style="padding:40px 32px 0;">
+                                <h1 style="margin:0;text-align:center;font-size:26px;line-height:1.26;color:{{ fgHeading }};font-weight:600;">
+                                    {{ 'admin_notification.email.import_failed.heading'|trans }}
+                                </h1>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:32px;">
+                                <p style="margin:0 0 16px;">{{ 'admin_notification.email.import_failed.intro'|trans }}</p>
+                                <div style="font-size:13px;line-height:1.5;color:{{ fg }};margin-bottom:24px;">
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.import_name'|trans }}:</strong>
+                                    {{ importName }}<br/>
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.hospital'|trans }}:</strong>
+                                    {{ hospitalName }}<br/>
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.status'|trans }}:</strong>
+                                    {{ status }}<br/>
+                                    {% if rowCount is not null %}
+                                        <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.rows'|trans }}:</strong>
+                                        {{ rowCount }}<br/>
+                                    {% endif %}
+                                    {% if runTimeMs is not null %}
+                                        <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.runtime'|trans }}:</strong>
+                                        {{ runTimeMs }} ms<br/>
+                                    {% endif %}
+                                </div>
+                                {% if reason %}
+                                    <div style="background-color:{{ quoteBg }};border-radius:8px;padding:14px 16px;margin-bottom:24px;">
+                                        <div style="font-weight:600;color:{{ fgHeading }};margin-bottom:8px;">{{ 'admin_notification.email.label.error'|trans }}</div>
+                                        <p style="margin:0;font-size:14px;line-height:1.6;white-space:pre-wrap;word-break:break-word;">{{ reason|e('html') }}</p>
+                                    </div>
+                                {% endif %}
+                                <a href="{{ importDetailUrl }}" style="display:inline-block;background-color:{{ link }};color:#ffffff;text-decoration:none;font-weight:500;font-size:15px;border-radius:4px;padding:12px 24px;">
+                                    {{ 'admin_notification.email.import_failed.action.view'|trans }}
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <div style="text-align:center;margin-top:20px;font-size:12px;color:#8491a1;">
+                    {{ 'email.footer.transactional'|trans({app: app_title}) }}
+                </div>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/src/Shared/UI/Twig/templates/email/admin_notification/user_registered.html.twig
+++ b/src/Shared/UI/Twig/templates/email/admin_notification/user_registered.html.twig
@@ -1,0 +1,70 @@
+{%- set fg = '#4b5563' -%}
+{%- set fgHeading = '#111827' -%}
+{%- set link = '#066FD1' -%}
+{%- set boxBg = '#ffffff' -%}
+{%- set pageBg = '#f9fafb' -%}
+{%- set quoteBg = '#fafafa' -%}
+{%- set border = '#e8ebee' -%}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="color-scheme" content="light dark"/>
+    <meta name="supported-color-schemes" content="light dark"/>
+    <title>{{ 'admin_notification.email.user_registered.title'|trans }}</title>
+</head>
+<body style="margin:0;padding:0;background-color:{{ pageBg }};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:15px;line-height:1.6;color:{{ fg }};-webkit-font-smoothing:antialiased;">
+<center role="presentation" style="width:100%;background-color:{{ pageBg }};">
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto;max-width:560px;width:100%;border-collapse:collapse;">
+        <tr>
+            <td style="padding:40px 16px;">
+                <div style="background:{{ boxBg }};border:1px solid {{ border }};border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,0.05);">
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                        <tr>
+                            <td align="center" style="padding:40px 32px 0;">
+                                <h1 style="margin:0;text-align:center;font-size:26px;line-height:1.26;color:{{ fgHeading }};font-weight:600;">
+                                    {{ 'admin_notification.email.user_registered.heading'|trans }}
+                                </h1>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:32px;">
+                                <p style="margin:0 0 16px;">{{ 'admin_notification.email.user_registered.intro'|trans }}</p>
+                                <div style="font-size:13px;line-height:1.5;color:{{ fg }};margin-bottom:24px;">
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.username'|trans }}:</strong>
+                                    {{ username }}<br/>
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.email'|trans }}:</strong>
+                                    {{ userEmail }}<br/>
+                                    <strong style="font-weight:600;color:{{ fgHeading }};">{{ 'admin_notification.email.label.registered_at'|trans }}:</strong>
+                                    {{ registeredAt|date('d.m.Y H:i', 'Europe/Berlin') }}
+                                </div>
+                                <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                                    <tr>
+                                        <td style="padding-bottom:12px;">
+                                            <a href="{{ userManagementUrl }}" style="display:inline-block;background-color:{{ link }};color:#ffffff;text-decoration:none;font-weight:500;font-size:15px;border-radius:4px;padding:12px 24px;">
+                                                {{ 'admin_notification.email.user_registered.action.manage'|trans }}
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <a href="{{ grantParticipantUrl }}" style="display:inline-block;background-color:#16a34a;color:#ffffff;text-decoration:none;font-weight:500;font-size:15px;border-radius:4px;padding:12px 24px;">
+                                                {{ 'admin_notification.email.user_registered.action.grant_participant'|trans }}
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <div style="text-align:center;margin-top:20px;font-size:12px;color:#8491a1;">
+                    {{ 'email.footer.transactional'|trans({app: app_title}) }}
+                </div>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/src/User/Application/Event/UserRegistered.php
+++ b/src/User/Application/Event/UserRegistered.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Event;
+
+final class UserRegistered
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        public int $userId,
+    ) {
+    }
+}

--- a/src/User/Domain/Factory/UserFactory.php
+++ b/src/User/Domain/Factory/UserFactory.php
@@ -76,4 +76,10 @@ final class UserFactory extends PersistentProxyObjectFactory
     {
         return $this->with(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_FEEDBACK_RECIPIENT']]);
     }
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function asNotificationRecipient(): self
+    {
+        return $this->with(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_RECEIVES_NOTIFICATION']]);
+    }
 }

--- a/src/User/Domain/Security/UserRole.php
+++ b/src/User/Domain/Security/UserRole.php
@@ -13,4 +13,6 @@ final class UserRole
     public const string ADMIN = 'ROLE_ADMIN';
 
     public const string FEEDBACK_RECIPIENT = 'ROLE_FEEDBACK_RECIPIENT';
+
+    public const string RECEIVES_NOTIFICATION = 'ROLE_RECEIVES_NOTIFICATION';
 }

--- a/src/User/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriber.php
+++ b/src/User/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\EventSubscriber;
+
+use App\Admin\Application\Service\AdminUserUrlGenerator;
+use App\Admin\Application\Service\GrantParticipantUrlGenerator;
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationSenderInterface;
+use App\Shared\Application\Notification\AdminNotificationType;
+use App\User\Application\Event\UserRegistered;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: UserRegistered::class, method: 'onUserRegistered')]
+final readonly class UserRegisteredNotificationSubscriber
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private UserRepository $userRepository,
+        private AdminUserUrlGenerator $adminUserUrlGenerator,
+        private GrantParticipantUrlGenerator $grantParticipantUrlGenerator,
+        private AdminNotificationSenderInterface $adminNotificationSender,
+    ) {
+    }
+
+    public function onUserRegistered(UserRegistered $event): void
+    {
+        $user = $this->userRepository->find($event->userId);
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $userId = $user->getId();
+        if (null === $userId) {
+            return;
+        }
+
+        $this->adminNotificationSender->send(new AdminNotification(
+            type: AdminNotificationType::UserRegistered,
+            templateContext: [
+                'username' => $user->getUserIdentifier(),
+                'userEmail' => $user->getEmail() ?? '—',
+                'registeredAt' => new \DateTimeImmutable(),
+                'userManagementUrl' => $this->adminUserUrlGenerator->detailUrl($userId),
+                'grantParticipantUrl' => $this->grantParticipantUrlGenerator->generate($userId),
+            ],
+            referenceId: (string) $userId,
+        ));
+    }
+}

--- a/src/User/Infrastructure/Repository/UserRepository.php
+++ b/src/User/Infrastructure/Repository/UserRepository.php
@@ -28,6 +28,37 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
     /**
      * Used to upgrade (rehash) the user's password automatically over time.
      */
+    /**
+     * @param list<string> $requiredRoles
+     *
+     * @return list<User>
+     */
+    public function findEnabledVerifiedUsersWithRoles(array $requiredRoles): array
+    {
+        /** @var list<User> $candidates */
+        $candidates = $this->createQueryBuilder('u')
+            ->where('u.isEnabled = true')
+            ->andWhere('u.isVerified = true')
+            ->andWhere('u.email IS NOT NULL')
+            ->andWhere("u.email != ''")
+            ->getQuery()
+            ->getResult();
+
+        $matched = [];
+        foreach ($candidates as $user) {
+            $roles = $user->getRoles();
+            foreach ($requiredRoles as $requiredRole) {
+                if (!\in_array($requiredRole, $roles, true)) {
+                    continue 2;
+                }
+            }
+
+            $matched[] = $user;
+        }
+
+        return $matched;
+    }
+
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
         if (!$user instanceof User) {

--- a/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Security;
+
+interface NotificationRecipientEmailResolver
+{
+    /**
+     * @return list<string>
+     */
+    public function resolveRecipientEmails(): array;
+}

--- a/src/User/Infrastructure/Security/NotificationRecipientResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use App\User\Infrastructure\Repository\UserRepository;
 
 /** @psalm-suppress UnusedClass */
-final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmailResolver
+final readonly class NotificationRecipientResolver implements NotificationRecipientEmailResolver
 {
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
@@ -24,11 +25,21 @@ final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmail
     {
         $candidates = $this->userRepository->findEnabledVerifiedUsersWithRoles([
             UserRole::ADMIN,
-            UserRole::FEEDBACK_RECIPIENT,
+            UserRole::RECEIVES_NOTIFICATION,
         ]);
 
+        return $this->extractUniqueEmails($candidates);
+    }
+
+    /**
+     * @param list<User> $users
+     *
+     * @return list<string>
+     */
+    private function extractUniqueEmails(array $users): array
+    {
         $emails = [];
-        foreach ($candidates as $user) {
+        foreach ($users as $user) {
             $email = $user->getEmail();
             if (null === $email || '' === trim($email)) {
                 continue;

--- a/src/User/UI/Http/Controller/RegistrationController.php
+++ b/src/User/UI/Http/Controller/RegistrationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Application\Event\UserRegistered;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\EmailVerifier;
 use App\User\UI\Form\RegistrationFormType;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
 final class RegistrationController extends AbstractController
@@ -25,6 +27,7 @@ final class RegistrationController extends AbstractController
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly EmailVerifier $emailVerifier,
         private readonly AuditContext $auditContext,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -60,6 +63,11 @@ final class RegistrationController extends AbstractController
                 $this->entityManager->flush();
             } finally {
                 $this->auditContext->endIntent();
+            }
+
+            $userId = $user->getId();
+            if (null !== $userId) {
+                $this->eventDispatcher->dispatch(new UserRegistered($userId));
             }
 
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user);

--- a/tests/Admin/Functional/Controller/GrantParticipantControllerTest.php
+++ b/tests/Admin/Functional/Controller/GrantParticipantControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Admin\Application\Service\GrantParticipantUrlGenerator;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class GrantParticipantControllerTest extends WebTestCase
+{
+    use Factories;
+    use HasBrowser;
+    use ResetDatabase;
+
+    public function testAdminCanGrantParticipantRoleViaSignedUrl(): void
+    {
+        $admin = UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => 'grant-admin-'.bin2hex(random_bytes(4)),
+            ]);
+        $target = UserFactory::createOne([
+            'username' => 'grant-target-'.bin2hex(random_bytes(4)),
+            'roles' => [UserRole::USER],
+        ]);
+
+        /** @var GrantParticipantUrlGenerator $urlGenerator */
+        $urlGenerator = self::getContainer()->get(GrantParticipantUrlGenerator::class);
+        $url = $urlGenerator->generate((int) $target->getId());
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit($url)
+            ->assertSuccessful()
+        ;
+
+        $target->_refresh();
+        self::assertContains(UserRole::PARTICIPANT, $target->getRoles());
+    }
+
+    public function testGrantParticipantIsIdempotent(): void
+    {
+        $admin = UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => 'grant-admin-idem-'.bin2hex(random_bytes(4)),
+            ]);
+        $target = UserFactory::createOne([
+            'username' => 'grant-target-idem-'.bin2hex(random_bytes(4)),
+            'roles' => [UserRole::USER, UserRole::PARTICIPANT],
+        ]);
+
+        /** @var GrantParticipantUrlGenerator $urlGenerator */
+        $urlGenerator = self::getContainer()->get(GrantParticipantUrlGenerator::class);
+        $url = $urlGenerator->generate((int) $target->getId());
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit($url)
+            ->assertSuccessful()
+        ;
+
+        $target->_refresh();
+        self::assertContains(UserRole::PARTICIPANT, $target->getRoles());
+    }
+
+    public function testInvalidSignedUrlIsRejected(): void
+    {
+        $admin = UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => 'grant-admin-invalid-'.bin2hex(random_bytes(4)),
+            ]);
+        $target = UserFactory::createOne([
+            'username' => 'grant-target-invalid-'.bin2hex(random_bytes(4)),
+        ]);
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit('/admin/users/'.$target->getId().'/grant-participant')
+            ->assertStatus(403)
+        ;
+    }
+
+    public function testExpiredSignedUrlIsRejected(): void
+    {
+        $admin = UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => 'grant-admin-expired-'.bin2hex(random_bytes(4)),
+            ]);
+        $target = UserFactory::createOne([
+            'username' => 'grant-target-expired-'.bin2hex(random_bytes(4)),
+        ]);
+
+        /** @var UrlGeneratorInterface $urlGenerator */
+        $urlGenerator = self::getContainer()->get(UrlGeneratorInterface::class);
+        /** @var UriSigner $uriSigner */
+        $uriSigner = self::getContainer()->get(UriSigner::class);
+
+        $url = $urlGenerator->generate(
+            'app_admin_user_grant_participant',
+            ['id' => $target->getId()],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+        $expiredUrl = $uriSigner->sign($url.'?expires='.(time() - 60));
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit($expiredUrl)
+            ->assertStatus(403)
+        ;
+    }
+}

--- a/tests/Import/Integration/Infrastructure/EventSubscriber/ImportFailedNotificationSubscriberTest.php
+++ b/tests/Import/Integration/Infrastructure/EventSubscriber/ImportFailedNotificationSubscriberTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Infrastructure\EventSubscriber;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Application\Event\ImportFailed;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\EventSubscriber\ImportFailedNotificationSubscriber;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationSenderInterface;
+use App\Shared\Application\Notification\AdminNotificationType;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class ImportFailedNotificationSubscriberTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testOnImportFailedSendsNotification(): void
+    {
+        $user = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'Notify Area', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Notify Hospital',
+            'owner' => $user,
+            'createdBy' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+        $import = ImportFactory::createOne([
+            'name' => 'Broken allocation import',
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::FAILED,
+            'rowCount' => 42,
+            'runTime' => 1500,
+        ]);
+        $importId = (int) $import->getId();
+
+        $sender = $this->createMock(AdminNotificationSenderInterface::class);
+        $sender->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (AdminNotification $notification) use ($importId): bool {
+                self::assertSame(AdminNotificationType::ImportFailed, $notification->type);
+                self::assertSame('Broken allocation import', $notification->templateContext['importName'] ?? null);
+                self::assertSame('Notify Hospital', $notification->templateContext['hospitalName'] ?? null);
+                self::assertSame(ImportStatus::FAILED->value, $notification->templateContext['status'] ?? null);
+                self::assertSame(42, $notification->templateContext['rowCount'] ?? null);
+                self::assertSame(1500, $notification->templateContext['runTimeMs'] ?? null);
+                self::assertSame('CSV file missing', $notification->templateContext['reason'] ?? null);
+                self::assertIsString($notification->templateContext['importDetailUrl'] ?? null);
+                self::assertSame((string) $importId, $notification->referenceId);
+
+                return true;
+            }));
+
+        $subscriber = new ImportFailedNotificationSubscriber(
+            self::getContainer()->get(ImportRepository::class),
+            $sender,
+            self::getContainer()->get(UrlGeneratorInterface::class),
+        );
+
+        $subscriber->onImportFailed(new ImportFailed($importId, 'CSV file missing'));
+    }
+}

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
@@ -14,9 +14,11 @@ use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
 use App\Allocation\Infrastructure\Factory\InfectionFactory;
 use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Application\Event\ImportCompleted;
+use App\Import\Application\Event\ImportFailed;
 use App\Import\Application\Message\ImportAllocationsMessage;
 use App\Import\Application\MessageHandler\ImportAllocationsMessageHandler;
 use App\Import\Domain\Entity\Import;
@@ -71,6 +73,8 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         OccasionFactory::createOne(['name' => 'Häuslicher Einsatz']);
         OccasionFactory::createOne(['name' => 'Öffentlicher Raum']);
         OccasionFactory::createOne(['name' => 'Sonstiger Einsatz']);
+
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
 
         InfectionFactory::createOne(['name' => 'Noro']);
         InfectionFactory::createOne(['name' => 'V.a. COVID']);
@@ -274,50 +278,111 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         $id = (int) $import->getId();
         self::assertGreaterThan(0, $id);
 
+        $failedIds = [];
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addListener(ImportFailed::class, function (object $event) use (&$failedIds): void {
+            if ($event instanceof ImportFailed) {
+                $failedIds[] = $event->importId;
+            }
+        });
+
         $this->handler->__invoke(new ImportAllocationsMessage($id));
+
+        self::assertSame([$id], $failedIds);
 
         $fresh = $this->imports->find($id);
         self::assertNotNull($fresh);
         self::assertSame(ImportStatus::FAILED, $fresh->getStatus());
     }
 
-    public function testInvokeDispatchesImportCompletedAfterSuccessfulFileImport(): void
+    public function testDispatchImportOutcomeDispatchesImportCompletedForFinalImportStatus(): void
     {
-        ['id' => $id, 'csvPath' => $csvPath] = $this->arrangeSingleRowSuccessfulCsvImport();
-
-        $allocationAuditsBeforeInvoke = $this->countAuditEntriesForEntityClass(Allocation::class);
+        $import = $this->createPersistedImport(ImportStatus::PARTIAL, rowCount: 3, rowsPassed: 2, rowsRejected: 1);
 
         $dispatchedIds = [];
+        $failedIds = [];
         $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $dispatcher->addListener(ImportCompleted::class, function (object $event) use (&$dispatchedIds): void {
             if ($event instanceof ImportCompleted) {
                 $dispatchedIds[] = $event->importId;
             }
         });
-
-        try {
-            $this->handler->__invoke(new ImportAllocationsMessage($id));
-        } finally {
-            if (is_file($csvPath)) {
-                @unlink($csvPath);
+        $dispatcher->addListener(ImportFailed::class, function (object $event) use (&$failedIds): void {
+            if ($event instanceof ImportFailed) {
+                $failedIds[] = $event->importId;
             }
-        }
+        });
 
-        self::assertSame([$id], $dispatchedIds);
+        $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'dispatchImportOutcome');
+        $reflection->invoke($this->handler, (int) $import->getId());
 
-        self::assertSame(
-            $allocationAuditsBeforeInvoke,
-            $this->countAuditEntriesForEntityClass(Allocation::class),
-            'Import via __invoke must suppress per-row Allocation audit entries',
-        );
-        self::assertTrue(
-            $this->importEntityHasAuditIntent($id, 'import.run.finished'),
-            'Expected Import audit metadata to include import.run.finished intent for this import id',
-        );
+        self::assertSame([], $failedIds);
+        self::assertSame([(int) $import->getId()], $dispatchedIds);
+    }
 
-        $fresh = $this->imports->find($id);
-        self::assertNotNull($fresh);
-        self::assertNotSame(ImportStatus::FAILED, $fresh->getStatus());
+    public function testDispatchImportOutcomeDispatchesImportFailedForFailedImportStatus(): void
+    {
+        $import = $this->createPersistedImport(ImportStatus::FAILED);
+
+        $dispatchedIds = [];
+        $failedIds = [];
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addListener(ImportCompleted::class, function (object $event) use (&$dispatchedIds): void {
+            if ($event instanceof ImportCompleted) {
+                $dispatchedIds[] = $event->importId;
+            }
+        });
+        $dispatcher->addListener(ImportFailed::class, function (object $event) use (&$failedIds): void {
+            if ($event instanceof ImportFailed) {
+                $failedIds[] = $event->importId;
+            }
+        });
+
+        $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'dispatchImportOutcome');
+        $reflection->invoke($this->handler, (int) $import->getId(), 'CSV not found');
+
+        self::assertSame([], $dispatchedIds);
+        self::assertSame([(int) $import->getId()], $failedIds);
+    }
+
+    private function createPersistedImport(
+        ImportStatus $status,
+        int $rowCount = 0,
+        int $rowsPassed = 0,
+        int $rowsRejected = 0,
+    ): Import {
+        $owner = UserFactory::createOne(['username' => 'import-status-'.bin2hex(random_bytes(6))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'StatusEvt'.bin2hex(random_bytes(4)), 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Status Hospital '.bin2hex(random_bytes(4)),
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
+        $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
+
+        $import = new Import()
+            ->setName('Dispatch status IT')
+            ->setHospital($hospitalRef)
+            ->setCreatedBy($userRef)
+            ->setType(ImportType::ALLOCATION)
+            ->setStatus($status)
+            ->setFilePath('/tmp/unused.csv')
+            ->setFileExtension('csv')
+            ->setFileMimeType('text/csv')
+            ->setFileSize(0)
+            ->setRunCount(1)
+            ->setRunTime(10)
+            ->setRowCount($rowCount)
+            ->setRowsPassed($rowsPassed)
+            ->setRowsRejected($rowsRejected);
+
+        $this->em->persist($import);
+        $this->em->flush();
+
+        return $import;
     }
 
     public function testReimportWithAssessmentSucceedsAfterCleanup(): void
@@ -400,13 +465,17 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
      */
     private function arrangeSingleRowSuccessfulCsvImport(bool $withAssessment = false): array
     {
+        if ($withAssessment) {
+            return $this->arrangeAssessmentCsvImport();
+        }
+
         $suffix = bin2hex(random_bytes(5));
 
         $owner = UserFactory::createOne(['username' => 'import-csv-'.$suffix]);
         $state = StateFactory::createOne();
         $dispatch = DispatchAreaFactory::createOne(['name' => 'CsvDisp'.$suffix, 'state' => $state]);
         $hospital = HospitalFactory::createOne([
-            'name' => 'CsvHospital'.$suffix,
+            'name' => 'Testkrankenhaus Musterstadt',
             'state' => $state,
             'dispatchArea' => $dispatch,
         ]);
@@ -423,13 +492,15 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         OccasionFactory::createOne(['name' => 'Öffentlicher Raum']);
         OccasionFactory::createOne(['name' => 'Sonstiger Einsatz']);
 
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+
         InfectionFactory::createOne(['name' => 'Noro']);
         InfectionFactory::createOne(['name' => 'V.a. COVID']);
 
         IndicationRawFactory::createOne([
-            'name' => 'Evt Indication '.$suffix,
-            'code' => 456,
-            'hash' => bin2hex(random_bytes(16)),
+            'name' => 'Test Indication',
+            'code' => 123,
+            'hash' => '070f5e78cc3ce4b3c3378aeaa0a304a4',
         ]);
 
         $header = [
@@ -441,17 +512,98 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
             'PZC und Text',
         ];
 
-        if ($withAssessment) {
-            $header = array_merge($header, ['Airway', 'Breathing', 'Circulation', 'Disability']);
-        }
+        $row = ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741', 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', '123 Test Indication'];
 
-        $pzcCol = '456741';
-        $pzTextCol = '456 Evt Indication '.$suffix;
+        $rows = [$row];
 
-        $row = ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', $pzcCol, 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', $pzTextCol];
-        if ($withAssessment) {
-            $row = array_merge($row, ['A-Frei', 'B-Spontan', 'C-Stabil', 'D-Wach']);
+        $csvPath = sys_get_temp_dir().'/ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv';
+        $fh = fopen($csvPath, 'wb');
+        self::assertNotFalse($fh);
+        $delimiter = ';';
+        $enclosure = '"';
+        $escape = '\\';
+        fputcsv($fh, $header, $delimiter, $enclosure, $escape);
+        foreach ($rows as $csvRow) {
+            fputcsv($fh, $csvRow, $delimiter, $enclosure, $escape);
         }
+        fclose($fh);
+
+        $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
+        $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
+
+        $import = new Import()
+            ->setName('Handler invoke IT '.$suffix)
+            ->setHospital($hospitalRef)
+            ->setCreatedBy($userRef)
+            ->setType(ImportType::ALLOCATION)
+            ->setStatus(ImportStatus::PENDING)
+            ->setFilePath($csvPath)
+            ->setFileExtension('csv')
+            ->setFileMimeType('text/csv')
+            ->setFileSize((int) filesize($csvPath))
+            ->setRunCount(0)
+            ->setRunTime(0)
+            ->setRowCount(0);
+
+        $this->em->persist($import);
+        $this->em->flush();
+
+        return ['id' => (int) $import->getId(), 'csvPath' => $csvPath];
+    }
+
+    /**
+     * @return array{id: int, csvPath: string}
+     */
+    private function arrangeAssessmentCsvImport(): array
+    {
+        $suffix = bin2hex(random_bytes(5));
+
+        $owner = UserFactory::createOne(['username' => 'import-csv-'.$suffix]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'CsvDisp'.$suffix, 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Testkrankenhaus Musterstadt',
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+
+        AssignmentFactory::createOne(['name' => 'Patient']);
+        AssignmentFactory::createOne(['name' => 'RD']);
+        AssignmentFactory::createOne(['name' => 'ZLST']);
+
+        OccasionFactory::createOne(['name' => 'aus Arztpraxis']);
+        OccasionFactory::createOne(['name' => 'Häuslicher Einsatz']);
+        OccasionFactory::createOne(['name' => 'Öffentlicher Raum']);
+        OccasionFactory::createOne(['name' => 'Sonstiger Einsatz']);
+
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+
+        InfectionFactory::createOne(['name' => 'Noro']);
+        InfectionFactory::createOne(['name' => 'V.a. COVID']);
+
+        IndicationRawFactory::createOne([
+            'name' => 'Test Indication',
+            'code' => 123,
+            'hash' => '070f5e78cc3ce4b3c3378aeaa0a304a4',
+        ]);
+
+        $header = [
+            'Versorgungsbereich', 'KHS-Versorgungsgebiet', 'Krankenhaus', 'Krankenhaus-Kurzname',
+            'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
+            'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
+            'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC', 'Fachgebiet', 'Fachbereich', 'Fachbereich war abgemeldet?', 'Anlass', 'Grund', 'Ansteckungsfähig',
+            'PZC und Text',
+            'Airway', 'Breathing', 'Circulation', 'Disability',
+        ];
+
+        $pzcCol = '123741';
+        $pzTextCol = '123 Test Indication';
+
+        $row = ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', $pzcCol, 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', $pzTextCol, 'A-Frei', 'B-Spontan', 'C-Stabil', 'D-Wach'];
 
         $rows = [$row];
 

--- a/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Infrastructure\Mail;
+
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationType;
+use App\Shared\Infrastructure\Mail\AdminNotificationSender;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use App\User\Infrastructure\Security\NotificationRecipientEmailResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AdminNotificationSenderTest extends TestCase
+{
+    public function testSendUsesResolvedRecipientsAndTemplate(): void
+    {
+        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientEmails')->willReturn([
+            'admin-a@example.test',
+            'admin-b@example.test',
+        ]);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('New user registration');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(
+                    ['admin-a@example.test', 'admin-b@example.test'],
+                    array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
+                );
+                self::assertSame('[Test App] New user registration', $email->getSubject());
+                self::assertSame('@Shared/email/admin_notification/user_registered.html.twig', $email->getHtmlTemplate());
+                self::assertSame('new-user', $email->getContext()['username'] ?? null);
+
+                return true;
+            }));
+
+        $this->createSender($mailer, $recipientResolver, $translator)->send(new AdminNotification(
+            type: AdminNotificationType::UserRegistered,
+            templateContext: ['username' => 'new-user'],
+        ));
+    }
+
+    public function testSendUsesImportFailedTemplate(): void
+    {
+        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientEmails')->willReturn(['admin@example.test']);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('Import failed');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(['admin@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getTo(),
+                ));
+                self::assertSame('[Test App] Import failed', $email->getSubject());
+                self::assertSame('@Shared/email/admin_notification/import_failed.html.twig', $email->getHtmlTemplate());
+                self::assertSame('Broken import', $email->getContext()['importName'] ?? null);
+                self::assertSame('Missing header row', $email->getContext()['reason'] ?? null);
+
+                return true;
+            }));
+
+        $this->createSender($mailer, $recipientResolver, $translator)->send(new AdminNotification(
+            type: AdminNotificationType::ImportFailed,
+            templateContext: [
+                'importName' => 'Broken import',
+                'reason' => 'Missing header row',
+            ],
+            referenceId: '99',
+        ));
+    }
+
+    public function testSendSkipsWhenNoRecipients(): void
+    {
+        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientEmails')->willReturn([]);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(
+                'admin_notification.skipped',
+                self::callback(static fn (array $context): bool => 'no_notification_recipients' === ($context['reason'] ?? null)),
+            );
+
+        $this->createSender($mailer, $recipientResolver, logger: $logger)->send(new AdminNotification(
+            type: AdminNotificationType::ImportFailed,
+            templateContext: ['importName' => 'Broken import'],
+            referenceId: '42',
+        ));
+    }
+
+    private function createSender(
+        MailerInterface $mailer,
+        NotificationRecipientEmailResolver $recipientResolver,
+        ?TranslatorInterface $translator = null,
+        ?LoggerInterface $logger = null,
+    ): AdminNotificationSender {
+        return new AdminNotificationSender(
+            $mailer,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'Test App',
+                appName: 'Test App',
+                replyTo: '',
+            ),
+            $recipientResolver,
+            $translator ?? $this->createMock(TranslatorInterface::class),
+            $logger ?? $this->createMock(LoggerInterface::class),
+        );
+    }
+}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -9,7 +9,10 @@ use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Factory\PageFactory;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Mime\Email;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Test\Factories;
@@ -20,7 +23,65 @@ final class RegistrationControllerTest extends WebTestCase
     use CookieConsentTestHelper;
     use Factories;
     use HasBrowser;
+    use MailerAssertionsTrait;
     use ResetDatabase;
+
+    public function testRegistrationSendsAdminNotificationToNotificationRecipients(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $recipientEmail = sprintf('admin-notify-%s@example.test', $suffix);
+        UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => sprintf('admin-notify-%s', $suffix),
+                'email' => $recipientEmail,
+            ]);
+
+        $username = sprintf('register-admin-mail-%s', $suffix);
+        $email = sprintf('register-admin-mail-%s@example.test', $suffix);
+
+        $previousFollowRedirects = $_SERVER['BROWSER_FOLLOW_REDIRECTS'] ?? null;
+        $_SERVER['BROWSER_FOLLOW_REDIRECTS'] = '0';
+
+        try {
+            $this->browser()
+                ->disableReboot()
+                ->visit('/register')
+                ->fillField('Username', $username)
+                ->fillField('Email', $email)
+                ->fillField('Plain password', 'super-secret-password')
+                ->checkField('registration_form[acceptTerms]')
+                ->click('Register')
+                ->assertStatus(302)
+            ;
+        } finally {
+            if (null === $previousFollowRedirects) {
+                unset($_SERVER['BROWSER_FOLLOW_REDIRECTS']);
+            } else {
+                $_SERVER['BROWSER_FOLLOW_REDIRECTS'] = $previousFollowRedirects;
+            }
+        }
+
+        self::assertQueuedEmailCount(2);
+
+        $adminNotification = null;
+        foreach (self::getMailerMessages() as $message) {
+            if (!$message instanceof Email) {
+                continue;
+            }
+
+            if (!str_contains((string) $message->getSubject(), 'New user registration')) {
+                continue;
+            }
+
+            self::assertEmailAddressContains($message, 'to', $recipientEmail);
+            $adminNotification = $message;
+            break;
+        }
+
+        self::assertInstanceOf(TemplatedEmail::class, $adminNotification);
+        self::assertEmailSubjectContains($adminNotification, 'New user registration');
+    }
 
     public function testUserCanRegisterButIsNotAutoLoggedInWithoutConsentDecision(): void
     {

--- a/tests/User/Integration/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriberTest.php
+++ b/tests/User/Integration/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriberTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\Infrastructure\EventSubscriber;
+
+use App\Shared\Application\Notification\AdminNotification;
+use App\Shared\Application\Notification\AdminNotificationSenderInterface;
+use App\Shared\Application\Notification\AdminNotificationType;
+use App\User\Application\Event\UserRegistered;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\EventSubscriber\UserRegisteredNotificationSubscriber;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class UserRegisteredNotificationSubscriberTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testOnUserRegisteredSendsNotification(): void
+    {
+        $user = UserFactory::createOne([
+            'username' => 'notify-me',
+            'email' => 'notify-me@example.test',
+        ]);
+        $userId = (int) $user->getId();
+
+        $sender = $this->createMock(AdminNotificationSenderInterface::class);
+        $sender->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (AdminNotification $notification): bool {
+                self::assertSame(AdminNotificationType::UserRegistered, $notification->type);
+                self::assertSame('notify-me', $notification->templateContext['username'] ?? null);
+                self::assertSame('notify-me@example.test', $notification->templateContext['userEmail'] ?? null);
+                self::assertIsString($notification->templateContext['userManagementUrl'] ?? null);
+                self::assertIsString($notification->templateContext['grantParticipantUrl'] ?? null);
+
+                return true;
+            }));
+
+        $subscriber = new UserRegisteredNotificationSubscriber(
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(\App\Admin\Application\Service\AdminUserUrlGenerator::class),
+            self::getContainer()->get(\App\Admin\Application\Service\GrantParticipantUrlGenerator::class),
+            $sender,
+        );
+
+        $subscriber->onUserRegistered(new UserRegistered($userId));
+    }
+}

--- a/tests/User/Integration/Infrastructure/Security/NotificationRecipientResolverTest.php
+++ b/tests/User/Integration/Infrastructure/Security/NotificationRecipientResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\Infrastructure\Security;
+
+use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
+use App\User\Infrastructure\Security\NotificationRecipientResolver;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class NotificationRecipientResolverTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testResolvesEnabledVerifiedAdminWithNotificationRole(): void
+    {
+        UserFactory::new([
+            'email' => 'notify@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::RECEIVES_NOTIFICATION],
+            'isEnabled' => true,
+            'isVerified' => true,
+        ])->create();
+
+        UserFactory::new([
+            'email' => 'admin-only@example.test',
+            'roles' => [UserRole::ADMIN],
+            'isEnabled' => true,
+            'isVerified' => true,
+        ])->create();
+
+        UserFactory::new([
+            'email' => 'disabled@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::RECEIVES_NOTIFICATION],
+            'isEnabled' => false,
+            'isVerified' => true,
+        ])->create();
+
+        $resolver = self::getContainer()->get(NotificationRecipientResolver::class);
+
+        self::assertSame(['notify@example.test'], $resolver->resolveRecipientEmails());
+    }
+
+    public function testDeduplicatesEmails(): void
+    {
+        UserFactory::new([
+            'email' => 'DUPLICATE@example.test',
+            'roles' => [UserRole::ADMIN, UserRole::RECEIVES_NOTIFICATION],
+        ])->create();
+
+        $resolver = self::getContainer()->get(NotificationRecipientResolver::class);
+
+        self::assertSame(['duplicate@example.test'], $resolver->resolveRecipientEmails());
+    }
+
+    public function testReturnsEmptyListWhenNoMatchingUsers(): void
+    {
+        UserFactory::new([
+            'email' => 'user@example.test',
+            'roles' => [UserRole::USER],
+        ])->create();
+
+        $resolver = self::getContainer()->get(NotificationRecipientResolver::class);
+
+        self::assertSame([], $resolver->resolveRecipientEmails());
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -4191,6 +4191,94 @@
         <source>email.footer.transactional</source>
         <target>This is an automated message from {app}.</target>
       </trans-unit>
+      <trans-unit id="an.subjUserReg" resname="admin_notification.email.subject.user_registered">
+        <source>admin_notification.email.subject.user_registered</source>
+        <target>New user registration</target>
+      </trans-unit>
+      <trans-unit id="an.subjImportFail" resname="admin_notification.email.subject.import_failed">
+        <source>admin_notification.email.subject.import_failed</source>
+        <target>Import failed</target>
+      </trans-unit>
+      <trans-unit id="an.urTitle" resname="admin_notification.email.user_registered.title">
+        <source>admin_notification.email.user_registered.title</source>
+        <target>New user registration</target>
+      </trans-unit>
+      <trans-unit id="an.urHeading" resname="admin_notification.email.user_registered.heading">
+        <source>admin_notification.email.user_registered.heading</source>
+        <target>New user registered</target>
+      </trans-unit>
+      <trans-unit id="an.urIntro" resname="admin_notification.email.user_registered.intro">
+        <source>admin_notification.email.user_registered.intro</source>
+        <target>A new user has registered and may need participant permissions before they can fully use the platform.</target>
+      </trans-unit>
+      <trans-unit id="an.urManage" resname="admin_notification.email.user_registered.action.manage">
+        <source>admin_notification.email.user_registered.action.manage</source>
+        <target>Manage user</target>
+      </trans-unit>
+      <trans-unit id="an.urGrant" resname="admin_notification.email.user_registered.action.grant_participant">
+        <source>admin_notification.email.user_registered.action.grant_participant</source>
+        <target>Grant participant role</target>
+      </trans-unit>
+      <trans-unit id="an.ifTitle" resname="admin_notification.email.import_failed.title">
+        <source>admin_notification.email.import_failed.title</source>
+        <target>Import failed</target>
+      </trans-unit>
+      <trans-unit id="an.ifHeading" resname="admin_notification.email.import_failed.heading">
+        <source>admin_notification.email.import_failed.heading</source>
+        <target>Import failed</target>
+      </trans-unit>
+      <trans-unit id="an.ifIntro" resname="admin_notification.email.import_failed.intro">
+        <source>admin_notification.email.import_failed.intro</source>
+        <target>An import has failed and may require investigation.</target>
+      </trans-unit>
+      <trans-unit id="an.ifView" resname="admin_notification.email.import_failed.action.view">
+        <source>admin_notification.email.import_failed.action.view</source>
+        <target>View import details</target>
+      </trans-unit>
+      <trans-unit id="an.lblUsername" resname="admin_notification.email.label.username">
+        <source>admin_notification.email.label.username</source>
+        <target>Username</target>
+      </trans-unit>
+      <trans-unit id="an.lblEmail" resname="admin_notification.email.label.email">
+        <source>admin_notification.email.label.email</source>
+        <target>Email</target>
+      </trans-unit>
+      <trans-unit id="an.lblRegisteredAt" resname="admin_notification.email.label.registered_at">
+        <source>admin_notification.email.label.registered_at</source>
+        <target>Registered at</target>
+      </trans-unit>
+      <trans-unit id="an.lblImportName" resname="admin_notification.email.label.import_name">
+        <source>admin_notification.email.label.import_name</source>
+        <target>Import</target>
+      </trans-unit>
+      <trans-unit id="an.lblHospital" resname="admin_notification.email.label.hospital">
+        <source>admin_notification.email.label.hospital</source>
+        <target>Hospital</target>
+      </trans-unit>
+      <trans-unit id="an.lblStatus" resname="admin_notification.email.label.status">
+        <source>admin_notification.email.label.status</source>
+        <target>Status</target>
+      </trans-unit>
+      <trans-unit id="an.lblRows" resname="admin_notification.email.label.rows">
+        <source>admin_notification.email.label.rows</source>
+        <target>Rows processed</target>
+      </trans-unit>
+      <trans-unit id="an.lblRuntime" resname="admin_notification.email.label.runtime">
+        <source>admin_notification.email.label.runtime</source>
+        <target>Runtime</target>
+      </trans-unit>
+      <trans-unit id="an.lblError" resname="admin_notification.email.label.error">
+        <source>admin_notification.email.label.error</source>
+        <target>Error details</target>
+      </trans-unit>
+      <trans-unit id="flash.grantParticipantOk" resname="flash.admin.user.grant_participant.success">
+        <source>flash.admin.user.grant_participant.success</source>
+        <target>Participant role has been granted.</target>
+      </trans-unit>
+      <trans-unit id="flash.grantParticipantAlready" resname="flash.admin.user.grant_participant.already">
+        <source>flash.admin.user.grant_participant.already</source>
+        <target>This user already has the participant role.</target>
+      </trans-unit>
       <trans-unit id="em.footerContactPrefix" resname="email.footer.contact_prefix">
         <source>email.footer.contact_prefix</source>
         <target>If you have questions, reply to this email or write to </target>


### PR DESCRIPTION
…mports

Introduce ROLE_RECEIVES_NOTIFICATION, a reusable notification sender, and event subscribers so verified admins are emailed when users register or imports fail.### Summary

- Added support for **administrative email notifications**
- Introduced notification handling for relevant administrative and operational events
- Integrated notifications with the existing transactional mail infrastructure
- Added configurable recipients and notification delivery settings
- Implemented reusable notification templates and email rendering support
- Added or updated tests covering notification generation and delivery behavior

### Motivation

- Keep administrators informed about important system events
- Improve operational awareness without requiring constant dashboard monitoring
- Leverage the existing transactional mail infrastructure for consistent communication
- Establish a foundation for future operational and system notifications
- Improve responsiveness to important events occurring within the platform

### Notes for Reviewers

- Verify notification triggering conditions and recipient handling
- Check email rendering and template consistency
- Ensure notifications are sent only for the intended events
- Review configuration and environment handling for notification recipients
- Confirm tests cover notification generation, delivery, and edge cases

Closes #185