### PR TITLE
feat: Add hospital access grants and delegated access management

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -55,3 +55,7 @@ For flow details: [Import-workflow.md](Import-workflow.md) and [Statistics-proje
 - `app:allocation:backfill-indications`
 - `app:seed:projection`
 - `app:install`
+
+## Clinic-specific access grants
+
+Hospital owners can grant other `ROLE_PARTICIPANT` users clinic-scoped permissions via `HospitalAccessGrant` (entity) and `HospitalPermissionAccess` (resolver). Permissions are stored as a bitmask (`VIEW`, `STATISTICS`, `BENCHMARKING`, `IMPORT`, `EXPORT`). Owners retain full control; admins retain global access. Benchmarking requires statistics permissions.

--- a/migrations/Version20260615111834.php
+++ b/migrations/Version20260615111834.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260615111834 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add hospital_access_grant table for clinic-specific user permissions';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE hospital_access_grant (id SERIAL NOT NULL, hospital_id INT NOT NULL, user_id INT NOT NULL, created_by_id INT NOT NULL, updated_by_id INT DEFAULT NULL, permissions INT NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_HOSPITAL_ACCESS_GRANT_HOSPITAL ON hospital_access_grant (hospital_id)');
+        $this->addSql('CREATE INDEX IDX_HOSPITAL_ACCESS_GRANT_USER ON hospital_access_grant (user_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_hospital_access_grant_hospital_user ON hospital_access_grant (hospital_id, user_id)');
+        $this->addSql('ALTER TABLE hospital_access_grant ADD CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_HOSPITAL FOREIGN KEY (hospital_id) REFERENCES hospital (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE hospital_access_grant ADD CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_USER FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE hospital_access_grant ADD CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_CREATED_BY FOREIGN KEY (created_by_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE hospital_access_grant ADD CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_UPDATED_BY FOREIGN KEY (updated_by_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE hospital_access_grant DROP CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_HOSPITAL');
+        $this->addSql('ALTER TABLE hospital_access_grant DROP CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_USER');
+        $this->addSql('ALTER TABLE hospital_access_grant DROP CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_CREATED_BY');
+        $this->addSql('ALTER TABLE hospital_access_grant DROP CONSTRAINT FK_HOSPITAL_ACCESS_GRANT_UPDATED_BY');
+        $this->addSql('DROP TABLE hospital_access_grant');
+    }
+}

--- a/src/Allocation/Application/Service/HospitalPermissionAccess.php
+++ b/src/Allocation/Application/Service/HospitalPermissionAccess.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Service;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository;
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
+
+final readonly class HospitalPermissionAccess
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private HospitalRepository $hospitalRepository,
+        private HospitalAccessGrantRepository $hospitalAccessGrantRepository,
+    ) {
+    }
+
+    public function hasPermission(User $user, int $hospitalId, HospitalPermission $permission): bool
+    {
+        if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
+            return true;
+        }
+
+        $hospital = $this->hospitalRepository->findById($hospitalId);
+        if (!$hospital instanceof Hospital) {
+            return false;
+        }
+
+        if ($this->isOwner($user, $hospital)) {
+            return true;
+        }
+
+        $grant = $this->hospitalAccessGrantRepository->findForUserAndHospital($user, $hospital);
+        if (!$grant instanceof \App\Allocation\Domain\Entity\HospitalAccessGrant) {
+            return false;
+        }
+
+        return HospitalPermissionMask::has($grant->getPermissions(), $permission);
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function resolveHospitalIdsWithPermission(User $user, HospitalPermission $permission): array
+    {
+        /** @var list<int|string> $rawIds */
+        $rawIds = $this->hospitalRepository
+            ->getQueryBuilderForHospitalsWithPermission($user, $permission)
+            ->select('h.id')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(static fn (int|string $id): int => (int) $id, $rawIds);
+    }
+
+    public function isOwner(User $user, Hospital $hospital): bool
+    {
+        $owner = $hospital->getOwner();
+
+        return $owner instanceof User && $owner->getId() === $user->getId();
+    }
+
+    public function canEditHospital(User $user, Hospital $hospital): bool
+    {
+        if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
+            return true;
+        }
+
+        return $this->isOwner($user, $hospital);
+    }
+
+    public function canManageAccessGrants(User $user, Hospital $hospital): bool
+    {
+        return $this->canEditHospital($user, $hospital);
+    }
+}

--- a/src/Allocation/Domain/Entity/Hospital.php
+++ b/src/Allocation/Domain/Entity/Hospital.php
@@ -11,6 +11,8 @@ use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Shared\Domain\Traits\Blamable;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[Audit\Audited]
@@ -70,6 +72,12 @@ class Hospital implements \Stringable
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $updatedAt = null;
 
+    /**
+     * @var Collection<int, HospitalAccessGrant>
+     */
+    #[ORM\OneToMany(targetEntity: HospitalAccessGrant::class, mappedBy: 'hospital', orphanRemoval: true)]
+    private Collection $accessGrants;
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false)]
@@ -83,6 +91,7 @@ class Hospital implements \Stringable
     {
         $this->createdAt = new \DateTimeImmutable('now');
         $this->address = new Address();
+        $this->accessGrants = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -254,6 +263,31 @@ class Hospital implements \Stringable
     public function setUpdatedAt(?\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, HospitalAccessGrant>
+     */
+    public function getAccessGrants(): Collection
+    {
+        return $this->accessGrants;
+    }
+
+    public function addAccessGrant(HospitalAccessGrant $accessGrant): static
+    {
+        if (!$this->accessGrants->contains($accessGrant)) {
+            $this->accessGrants->add($accessGrant);
+            $accessGrant->setHospital($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAccessGrant(HospitalAccessGrant $accessGrant): static
+    {
+        $this->accessGrants->removeElement($accessGrant);
 
         return $this;
     }

--- a/src/Allocation/Domain/Entity/HospitalAccessGrant.php
+++ b/src/Allocation/Domain/Entity/HospitalAccessGrant.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Domain\Entity;
+
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository;
+use App\Shared\Domain\Traits\Blamable;
+use App\Shared\Infrastructure\Audit\Attribute as Audit;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Mapping as ORM;
+
+#[Audit\Audited]
+#[ORM\Entity(repositoryClass: HospitalAccessGrantRepository::class)]
+#[ORM\Table(name: 'hospital_access_grant')]
+#[ORM\UniqueConstraint(name: 'uniq_hospital_access_grant_hospital_user', fields: ['hospital', 'user'])]
+#[ORM\HasLifecycleCallbacks]
+class HospitalAccessGrant
+{
+    use Blamable;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'accessGrants')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Hospital $hospital = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\Column]
+    private int $permissions = 0;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    protected ?User $createdBy = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    protected ?User $updatedBy = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable('now');
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getHospital(): ?Hospital
+    {
+        return $this->hospital;
+    }
+
+    public function setHospital(Hospital $hospital): static
+    {
+        $this->hospital = $hospital;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getPermissions(): int
+    {
+        return $this->permissions;
+    }
+
+    public function setPermissions(int $permissions): static
+    {
+        $normalized = HospitalPermissionMask::normalize($permissions);
+        if (!HospitalPermissionMask::isValid($normalized)) {
+            throw new \InvalidArgumentException('Invalid hospital permission mask.');
+        }
+
+        $this->permissions = $normalized;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PreUpdate]
+    public function updateTimestamps(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable('now');
+    }
+}

--- a/src/Allocation/Domain/Enum/HospitalPermission.php
+++ b/src/Allocation/Domain/Enum/HospitalPermission.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Domain\Enum;
+
+enum HospitalPermission: int
+{
+    case View = 1;
+    case Statistics = 2;
+    case Import = 4;
+    case Export = 8;
+    case Benchmarking = 16;
+
+    /**
+     * @return list<self>
+     */
+    public static function assignableCases(): array
+    {
+        return [
+            self::View,
+            self::Statistics,
+            self::Benchmarking,
+            self::Import,
+            self::Export,
+        ];
+    }
+}

--- a/src/Allocation/Domain/HospitalPermissionMask.php
+++ b/src/Allocation/Domain/HospitalPermissionMask.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Domain;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+
+final class HospitalPermissionMask
+{
+    public const int ALL = 31;
+
+    public static function has(int $mask, HospitalPermission $permission): bool
+    {
+        $required = self::requiredBits($permission);
+
+        return ($mask & $required) === $required;
+    }
+
+    public static function normalize(int $mask): int
+    {
+        $normalized = 0;
+
+        foreach (HospitalPermission::assignableCases() as $permission) {
+            if (($mask & $permission->value) !== 0) {
+                $normalized |= self::requiredBits($permission);
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param list<HospitalPermission> $permissions
+     */
+    public static function fromPermissions(array $permissions): int
+    {
+        $mask = 0;
+        foreach ($permissions as $permission) {
+            $mask |= $permission->value;
+        }
+
+        return self::normalize($mask);
+    }
+
+    public static function requiredBits(HospitalPermission $permission): int
+    {
+        return match ($permission) {
+            HospitalPermission::View => HospitalPermission::View->value,
+            HospitalPermission::Statistics => HospitalPermission::View->value | HospitalPermission::Statistics->value,
+            HospitalPermission::Import => HospitalPermission::View->value | HospitalPermission::Import->value,
+            HospitalPermission::Export => HospitalPermission::View->value | HospitalPermission::Export->value,
+            HospitalPermission::Benchmarking => HospitalPermission::View->value
+                | HospitalPermission::Statistics->value
+                | HospitalPermission::Benchmarking->value,
+        };
+    }
+
+    public static function isValid(int $mask): bool
+    {
+        if (($mask & ~self::ALL) !== 0) {
+            return false;
+        }
+
+        if (self::has($mask, HospitalPermission::Benchmarking) && !self::has($mask, HospitalPermission::Statistics)) {
+            return false;
+        }
+
+        return self::normalize($mask) === $mask;
+    }
+}

--- a/src/Allocation/Infrastructure/Factory/HospitalAccessGrantFactory.php
+++ b/src/Allocation/Infrastructure/Factory/HospitalAccessGrantFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Factory;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\User\Domain\Factory\UserFactory;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<HospitalAccessGrant>
+ */
+final class HospitalAccessGrantFactory extends PersistentProxyObjectFactory
+{
+    #[\Override]
+    public static function class(): string
+    {
+        return HospitalAccessGrant::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function defaults(): array
+    {
+        return [
+            'hospital' => HospitalFactory::new(),
+            'user' => UserFactory::new(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]),
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Statistics,
+            ]),
+            'createdBy' => UserFactory::new(),
+        ];
+    }
+
+    /** @psalm-suppress MoreSpecificReturnType */
+    #[\Override]
+    protected function initialize(): static
+    {
+        /** @var static $factory */
+        $factory = $this->afterInstantiate(static function (HospitalAccessGrant $grant): void {
+            $hospital = $grant->getHospital();
+            if ($hospital instanceof Hospital) {
+                $hospital->addAccessGrant($grant);
+            }
+        });
+
+        return $factory;
+    }
+}

--- a/src/Allocation/Infrastructure/Repository/HospitalAccessGrantRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalAccessGrantRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Repository;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\User\Domain\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<HospitalAccessGrant>
+ */
+final class HospitalAccessGrantRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, HospitalAccessGrant::class);
+    }
+
+    /**
+     * @return list<HospitalAccessGrant>
+     */
+    public function findForHospital(Hospital $hospital): array
+    {
+        /** @var list<HospitalAccessGrant> $grants */
+        $grants = $this->createQueryBuilder('g')
+            ->innerJoin('g.user', 'u')
+            ->addSelect('u')
+            ->andWhere('g.hospital = :hospital')
+            ->setParameter('hospital', $hospital)
+            ->orderBy('u.username', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $grants;
+    }
+
+    public function findForUserAndHospital(User $user, Hospital $hospital): ?HospitalAccessGrant
+    {
+        $userId = $user->getId();
+        $hospitalId = $hospital->getId();
+        if (null === $userId || null === $hospitalId) {
+            return null;
+        }
+
+        $grant = $this->createQueryBuilder('g')
+            ->andWhere('IDENTITY(g.user) = :userId')
+            ->andWhere('IDENTITY(g.hospital) = :hospitalId')
+            ->setParameter('userId', $userId)
+            ->setParameter('hospitalId', $hospitalId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $grant instanceof HospitalAccessGrant ? $grant : null;
+    }
+
+    public function existsForUserAndHospital(User $user, Hospital $hospital): bool
+    {
+        return $this->findForUserAndHospital($user, $hospital) instanceof HospitalAccessGrant;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function findHospitalIdsForUserWithPermission(User $user, HospitalPermission $permission): array
+    {
+        $userId = $user->getId();
+        if (null === $userId) {
+            return [];
+        }
+
+        /** @var list<array{hospitalId: int|string, permissions: int|string}> $rows */
+        $rows = $this->createQueryBuilder('g')
+            ->select('IDENTITY(g.hospital) AS hospitalId', 'g.permissions')
+            ->andWhere('IDENTITY(g.user) = :userId')
+            ->setParameter('userId', $userId)
+            ->getQuery()
+            ->getArrayResult();
+
+        $ids = [];
+        foreach ($rows as $row) {
+            $mask = (int) $row['permissions'];
+            if (HospitalPermissionMask::has($mask, $permission)) {
+                $ids[] = (int) $row['hospitalId'];
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -9,11 +9,13 @@ use App\Allocation\Domain\Entity\DispatchArea;
 use App\Allocation\Domain\Entity\Hospital;
 use App\Allocation\Domain\Entity\State;
 use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\UI\Http\DTO\HospitalQueryParametersDTO;
 use App\Shared\Infrastructure\Pagination\Paginator;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -24,8 +26,10 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class HospitalRepository extends ServiceEntityRepository implements HospitalLookupInterface
 {
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly HospitalAccessGrantRepository $hospitalAccessGrantRepository,
+    ) {
         parent::__construct($registry, Hospital::class);
     }
 
@@ -74,17 +78,34 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
 
     public function getQueryBuilderForAccessibleHospitals(User $user): QueryBuilder
     {
+        return $this->getQueryBuilderForHospitalsWithPermission($user, HospitalPermission::View);
+    }
+
+    public function getQueryBuilderForHospitalsWithPermission(User $user, HospitalPermission $permission): QueryBuilder
+    {
         $qb = $this->createQueryBuilder('h')
             ->orderBy('h.name', 'ASC');
 
-        if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+        if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
             return $qb;
         }
 
+        $grantHospitalIds = $this->hospitalAccessGrantRepository->findHospitalIdsForUserWithPermission($user, $permission);
+        $userId = $user->getId();
+        if (null === $userId) {
+            return $qb->andWhere('1 = 0');
+        }
+
+        if ([] === $grantHospitalIds) {
+            return $qb
+                ->andWhere('IDENTITY(h.owner) = :userId')
+                ->setParameter('userId', $userId);
+        }
+
         return $qb
-            ->innerJoin('h.owner', 'o')
-            ->andWhere('o = :user')
-            ->setParameter('user', $user->getId());
+            ->andWhere('IDENTITY(h.owner) = :userId OR h.id IN (:grantHospitalIds)')
+            ->setParameter('userId', $userId)
+            ->setParameter('grantHospitalIds', $grantHospitalIds);
     }
 
     /**
@@ -92,20 +113,17 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
      */
     public function countAccessibleHospitals(User $user): int
     {
-        if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+        if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
             return (int) $this->createQueryBuilder('h')
                 ->select('COUNT(h.id)')
                 ->getQuery()
                 ->getSingleScalarResult();
         }
 
-        return (int) $this->createQueryBuilder('h')
-            ->select('COUNT(h.id)')
-            ->innerJoin('h.owner', 'o')
-            ->andWhere('o = :user')
-            ->setParameter('user', $user->getId())
+        return \count($this->getQueryBuilderForHospitalsWithPermission($user, HospitalPermission::Statistics)
+            ->select('h.id')
             ->getQuery()
-            ->getSingleScalarResult();
+            ->getSingleColumnResult());
     }
 
     /**
@@ -217,9 +235,9 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
     /**
      * @return list<array{id: int, name: string}>
      */
-    public function findAccessibleParticipatingHospitalSummaries(User $user): array
+    public function findAccessibleParticipatingHospitalSummaries(User $user, HospitalPermission $permission = HospitalPermission::Statistics): array
     {
-        $rows = $this->getQueryBuilderForAccessibleHospitals($user)
+        $rows = $this->getQueryBuilderForHospitalsWithPermission($user, $permission)
             ->andWhere('h.isParticipating = true')
             ->select('h.id AS id', 'h.name AS name')
             ->getQuery()

--- a/src/Allocation/Infrastructure/Security/Voter/HospitalVoter.php
+++ b/src/Allocation/Infrastructure/Security/Voter/HospitalVoter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Allocation\Infrastructure\Security\Voter;
 
+use App\Allocation\Application\Service\HospitalPermissionAccess;
 use App\Allocation\Domain\Entity\Hospital;
 use App\Import\Application\Service\ImportListAccess;
 use App\User\Domain\Entity\User;
@@ -19,9 +20,12 @@ final class HospitalVoter extends Voter
 
     public const string EDIT = 'EDIT';
 
+    public const string MANAGE_ACCESS_GRANTS = 'MANAGE_ACCESS_GRANTS';
+
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private readonly ImportListAccess $importListAccess,
+        private readonly HospitalPermissionAccess $hospitalPermissionAccess,
     ) {
     }
 
@@ -35,7 +39,7 @@ final class HospitalVoter extends Voter
     protected function supports(string $attribute, mixed $subject): bool
     {
         return $subject instanceof Hospital
-            && \in_array($attribute, [self::ACCESS, self::EDIT], true);
+            && \in_array($attribute, [self::ACCESS, self::EDIT, self::MANAGE_ACCESS_GRANTS], true);
     }
 
     #[\Override]
@@ -53,7 +57,8 @@ final class HospitalVoter extends Voter
 
         return match ($attribute) {
             self::ACCESS => $this->importListAccess->canAccessHospital($user, $hospitalId),
-            self::EDIT => $subject->getOwner()?->getId() === $user->getId(),
+            self::EDIT => $this->hospitalPermissionAccess->canEditHospital($user, $subject),
+            self::MANAGE_ACCESS_GRANTS => $this->hospitalPermissionAccess->canManageAccessGrants($user, $subject),
             default => false,
         };
     }

--- a/src/Allocation/UI/Form/HospitalAccessGrantType.php
+++ b/src/Allocation/UI/Form/HospitalAccessGrantType.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form;
+
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\UI\Form\Transformer\UserToIdTransformer;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @extends AbstractType<HospitalAccessGrant>
+ */
+final class HospitalAccessGrantType extends AbstractType
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private readonly UserRepository $userRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $isCreate = (bool) $options['is_create'];
+
+        if ($isCreate) {
+            /** @var list<array{id: int, label: string}> $eligibleUserChoices */
+            $eligibleUserChoices = $options['eligible_user_choices'];
+            $allowedUserIds = array_map(
+                static fn (array $row): int => $row['id'],
+                $eligibleUserChoices,
+            );
+
+            $builder
+                ->add('user_label', TextType::class, [
+                    'mapped' => false,
+                    'required' => false,
+                    'label' => 'label.hospital_access_grant.search_user',
+                    'attr' => [
+                        'placeholder' => 'label.hospital_access_grant.search_user_placeholder',
+                        'autocomplete' => 'off',
+                        'data-controller' => 'datalist-chooser',
+                    ],
+                ])
+                ->add('user', HiddenType::class, [
+                    'constraints' => [new Assert\NotNull()],
+                ]);
+
+            $builder->get('user')->addModelTransformer(
+                new UserToIdTransformer($this->userRepository, $allowedUserIds),
+            );
+        }
+
+        $builder
+            ->add('permissionChoices', EnumType::class, [
+                'class' => HospitalPermission::class,
+                'choices' => HospitalPermission::assignableCases(),
+                'multiple' => true,
+                'expanded' => true,
+                'mapped' => false,
+                'label' => 'label.hospital_access_grant.permissions',
+                'choice_label' => static fn (HospitalPermission $permission): string => 'label.hospital_permission.'.$permission->name,
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'label.btn.save',
+            ]);
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $data = $event->getData();
+            if (!\is_array($data)) {
+                return;
+            }
+
+            /** @var list<int|string> $choices */
+            $choices = $data['permissionChoices'] ?? [];
+            $statisticsValue = (string) HospitalPermission::Statistics->value;
+            $benchmarkingValue = (string) HospitalPermission::Benchmarking->value;
+
+            if (\in_array($benchmarkingValue, $choices, true) && !\in_array($statisticsValue, $choices, true)) {
+                $choices[] = $statisticsValue;
+            }
+
+            if (!\in_array($statisticsValue, $choices, true)) {
+                $choices = array_values(array_filter(
+                    $choices,
+                    static fn (int|string $choice): bool => (string) $choice !== $benchmarkingValue,
+                ));
+            }
+
+            $data['permissionChoices'] = $choices;
+            $event->setData($data);
+        });
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event): void {
+            $grant = $event->getData();
+            if (!$grant instanceof HospitalAccessGrant) {
+                return;
+            }
+
+            $choices = [];
+            foreach (HospitalPermission::assignableCases() as $permission) {
+                if (($grant->getPermissions() & $permission->value) !== 0) {
+                    $choices[] = $permission;
+                }
+            }
+
+            $event->getForm()->get('permissionChoices')->setData($choices);
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $grant = $event->getData();
+            if (!$grant instanceof HospitalAccessGrant) {
+                return;
+            }
+
+            /** @var list<HospitalPermission> $choices */
+            $choices = $event->getForm()->get('permissionChoices')->getData() ?? [];
+            if ([] === $choices) {
+                throw new \InvalidArgumentException('At least one permission is required.');
+            }
+
+            $grant->setPermissions(HospitalPermissionMask::fromPermissions($choices));
+        });
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => HospitalAccessGrant::class,
+            'is_create' => false,
+            'eligible_user_choices' => [],
+        ]);
+
+        $resolver->setAllowedTypes('eligible_user_choices', 'array');
+    }
+}

--- a/src/Allocation/UI/Form/Transformer/UserToIdTransformer.php
+++ b/src/Allocation/UI/Form/Transformer/UserToIdTransformer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form\Transformer;
+
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @implements DataTransformerInterface<User|null, string>
+ */
+final readonly class UserToIdTransformer implements DataTransformerInterface
+{
+    /**
+     * @param list<int> $allowedUserIds
+     */
+    public function __construct(
+        private UserRepository $userRepository,
+        private array $allowedUserIds,
+    ) {
+    }
+
+    #[\Override]
+    public function transform(mixed $value): string
+    {
+        if ($value instanceof User) {
+            return (string) $value->getId();
+        }
+
+        return '';
+    }
+
+    #[\Override]
+    public function reverseTransform(mixed $value): ?User
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $userId = (int) $value;
+        if (!\in_array($userId, $this->allowedUserIds, true)) {
+            return null;
+        }
+
+        $user = $this->userRepository->find($userId);
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Hospitals/DeleteHospitalAccessGrantController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/DeleteHospitalAccessGrantController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Hospitals;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Infrastructure\Security\Voter\HospitalVoter;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class DeleteHospitalAccessGrantController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[Route('/hospitals/{id}/edit/access/{grantId}/delete', name: 'app_hospitals_edit_access_grant_delete', requirements: ['grantId' => '\d+'], methods: ['POST'])]
+    #[Route('/hospitals/{id}/access-grants/{grantId}/delete', name: 'app_hospitals_access_grants_delete', requirements: ['grantId' => '\d+'], methods: ['POST'])]
+    public function __invoke(Request $request, Hospital $hospital, int $grantId): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        $this->denyAccessUnlessGranted(HospitalVoter::MANAGE_ACCESS_GRANTS, $hospital);
+
+        if (!$this->isCsrfTokenValid('delete_access_grant_'.$grantId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        $grant = $this->entityManager->getRepository(HospitalAccessGrant::class)->find($grantId);
+        if (!$grant instanceof HospitalAccessGrant || $grant->getHospital()?->getId() !== $hospital->getId()) {
+            throw $this->createNotFoundException('Access grant not found.');
+        }
+
+        $this->entityManager->remove($grant);
+        $this->auditContext->beginIntent('hospital.access_grant.deleted', [
+            'hospital_id' => $hospital->getId(),
+            'grant_id' => $grantId,
+        ]);
+        try {
+            $this->entityManager->flush();
+        } finally {
+            $this->auditContext->endIntent();
+        }
+
+        $this->addFlash('success', 'flash.hospital_access_grant.deleted');
+
+        return $this->redirectToRoute('app_hospitals_edit_access', ['id' => $hospital->getId()]);
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Hospitals/EditHospitalAccessGrantController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/EditHospitalAccessGrantController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Hospitals;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Infrastructure\Security\Voter\HospitalVoter;
+use App\Allocation\UI\Form\HospitalAccessGrantType;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class EditHospitalAccessGrantController extends AbstractController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[Route('/hospitals/{id}/edit/access/{grantId}', name: 'app_hospitals_edit_access_grant', requirements: ['grantId' => '\d+'], methods: ['GET', 'POST'])]
+    public function __invoke(Request $request, Hospital $hospital, int $grantId): Response
+    {
+        $this->denyAccessUnlessGranted(HospitalVoter::MANAGE_ACCESS_GRANTS, $hospital);
+
+        $grant = $this->findGrantForHospital($hospital, $grantId);
+
+        $form = $this->createForm(HospitalAccessGrantType::class, $grant, [
+            'is_create' => false,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $user = $this->getUser();
+            if ($user instanceof User) {
+                $grant->setUpdatedBy($user);
+            }
+
+            $this->auditContext->beginIntent('hospital.access_grant.updated', [
+                'hospital_id' => $hospital->getId(),
+                'grant_id' => $grantId,
+            ]);
+            try {
+                $this->entityManager->flush();
+            } finally {
+                $this->auditContext->endIntent();
+            }
+
+            $this->addFlash('success', 'flash.hospital_access_grant.updated');
+
+            return $this->redirectToRoute('app_hospitals_edit_access', ['id' => $hospital->getId()]);
+        }
+
+        return $this->render('@Allocation/hospitals/access/edit.html.twig', [
+            'hospital' => $hospital,
+            'grant' => $grant,
+            'form' => $form,
+        ]);
+    }
+
+    private function findGrantForHospital(Hospital $hospital, int $grantId): HospitalAccessGrant
+    {
+        foreach ($hospital->getAccessGrants() as $grant) {
+            if ($grant->getId() === $grantId) {
+                return $grant;
+            }
+        }
+
+        $grant = $this->entityManager->getRepository(HospitalAccessGrant::class)->find($grantId);
+        if (!$grant instanceof HospitalAccessGrant || $grant->getHospital()?->getId() !== $hospital->getId()) {
+            throw $this->createNotFoundException('Access grant not found.');
+        }
+
+        return $grant;
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Hospitals/ListHospitalAccessGrantsController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/ListHospitalAccessGrantsController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Hospitals;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository;
+use App\Allocation\Infrastructure\Security\Voter\HospitalVoter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class ListHospitalAccessGrantsController extends AbstractController
+{
+    public function __construct(
+        private readonly HospitalAccessGrantRepository $hospitalAccessGrantRepository,
+    ) {
+    }
+
+    #[Route('/hospitals/{id}/edit/access', name: 'app_hospitals_edit_access', methods: ['GET'])]
+    public function __invoke(Hospital $hospital): Response
+    {
+        $this->denyAccessUnlessGranted(HospitalVoter::MANAGE_ACCESS_GRANTS, $hospital);
+
+        $grants = $this->hospitalAccessGrantRepository->findForHospital($hospital);
+
+        return $this->render('@Allocation/hospitals/access/index.html.twig', [
+            'hospital' => $hospital,
+            'grants' => $grants,
+            'assignablePermissions' => HospitalPermission::assignableCases(),
+        ]);
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Hospitals/NewHospitalAccessGrantController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/NewHospitalAccessGrantController.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Hospitals;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository;
+use App\Allocation\Infrastructure\Security\Voter\HospitalVoter;
+use App\Allocation\UI\Form\HospitalAccessGrantType;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class NewHospitalAccessGrantController extends AbstractController
+{
+    public function __construct(
+        private readonly HospitalAccessGrantRepository $hospitalAccessGrantRepository,
+        private readonly UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[Route('/hospitals/{id}/edit/access/new', name: 'app_hospitals_edit_access_new', methods: ['GET', 'POST'])]
+    public function __invoke(Request $request, Hospital $hospital): Response
+    {
+        $this->denyAccessUnlessGranted(HospitalVoter::MANAGE_ACCESS_GRANTS, $hospital);
+
+        $grants = $this->hospitalAccessGrantRepository->findForHospital($hospital);
+        $userDatalist = $this->userRepository->findGrantEligibleUserDatalist(
+            $hospital,
+            $this->resolveGrantedUserIds($grants),
+        );
+
+        $grant = new HospitalAccessGrant()
+            ->setHospital($hospital);
+
+        $user = $this->getUser();
+        if ($user instanceof User) {
+            $grant->setCreatedBy($user);
+        }
+
+        $form = $this->createForm(HospitalAccessGrantType::class, $grant, [
+            'is_create' => true,
+            'eligible_user_choices' => $userDatalist,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $selectedUser = $grant->getUser();
+            if (!$selectedUser instanceof User) {
+                throw $this->createAccessDeniedException('User is required.');
+            }
+
+            if ($this->hospitalAccessGrantRepository->existsForUserAndHospital($selectedUser, $hospital)) {
+                $this->addFlash('error', 'flash.hospital_access_grant.duplicate');
+
+                return $this->redirectToRoute('app_hospitals_edit_access_new', ['id' => $hospital->getId()]);
+            }
+
+            $this->entityManager->persist($grant);
+            $this->auditContext->beginIntent('hospital.access_grant.created', ['hospital_id' => $hospital->getId()]);
+            try {
+                $this->entityManager->flush();
+            } finally {
+                $this->auditContext->endIntent();
+            }
+
+            $this->addFlash('success', 'flash.hospital_access_grant.created');
+
+            return $this->redirectToRoute('app_hospitals_edit_access', ['id' => $hospital->getId()]);
+        }
+
+        return $this->render('@Allocation/hospitals/access/new.html.twig', [
+            'hospital' => $hospital,
+            'userDatalist' => $userDatalist,
+            'form' => $form,
+        ]);
+    }
+
+    /**
+     * @param list<HospitalAccessGrant> $grants
+     *
+     * @return list<int>
+     */
+    private function resolveGrantedUserIds(array $grants): array
+    {
+        $ids = [];
+        foreach ($grants as $grant) {
+            $userId = $grant->getUser()?->getId();
+            if (null !== $userId) {
+                $ids[] = $userId;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Hospitals/RedirectLegacyHospitalAccessGrantController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/RedirectLegacyHospitalAccessGrantController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Hospitals;
+
+use App\Allocation\Domain\Entity\Hospital;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+final class RedirectLegacyHospitalAccessGrantController extends AbstractController
+{
+    #[Route('/hospitals/{id}/access-grants', name: 'app_hospitals_access_grants', methods: ['GET'])]
+    public function list(Hospital $hospital): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        return $this->redirectToRoute('app_hospitals_edit_access', ['id' => $hospital->getId()], Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    #[Route('/hospitals/{id}/access-grants/new', name: 'app_hospitals_access_grants_new', methods: ['GET'])]
+    public function create(Hospital $hospital): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        return $this->redirectToRoute('app_hospitals_edit_access_new', ['id' => $hospital->getId()], Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    #[Route('/hospitals/{id}/access-grants/{grantId}/edit', name: 'app_hospitals_access_grants_edit', methods: ['GET'])]
+    public function edit(Hospital $hospital, int $grantId): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        return $this->redirectToRoute('app_hospitals_edit_access_grant', [
+            'id' => $hospital->getId(),
+            'grantId' => $grantId,
+        ], Response::HTTP_MOVED_PERMANENTLY);
+    }
+}

--- a/src/Allocation/UI/Twig/templates/hospitals/_access_grants_matrix.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/_access_grants_matrix.html.twig
@@ -1,0 +1,170 @@
+<style>
+    .access-grants-matrix-table {
+        width: 100%;
+        table-layout: fixed;
+        border-collapse: separate;
+        border-spacing: 0;
+    }
+
+    .access-grants-matrix-table thead th {
+        background: var(--tblr-bg-surface, #fff);
+        border-bottom: 1px solid var(--tblr-border-color, rgba(98, 105, 118, 0.16));
+        padding: 0;
+        vertical-align: bottom;
+        text-transform: none;
+        font-weight: 600;
+    }
+
+    .access-grants-matrix-table thead .access-grants-matrix__user-th {
+        padding: 0 0.75rem 0.65rem;
+        font-size: 0.75rem;
+        color: var(--tblr-secondary, #667382);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .access-grants-matrix-table thead .access-grants-matrix__permission-th {
+        height: 7rem;
+        overflow: hidden;
+    }
+
+    .access-grants-matrix-table .access-grants-matrix__permission-head {
+        position: relative;
+        height: 6.75rem;
+        width: 100%;
+    }
+
+    .access-grants-matrix-table thead .access-grants-matrix__permission-label {
+        position: absolute;
+        left: 0.85rem;
+        bottom: 0.6rem;
+        transform: rotate(-45deg);
+        transform-origin: left bottom;
+        white-space: nowrap;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.1;
+        color: var(--tblr-secondary, #667382);
+        letter-spacing: 0.01em;
+        text-transform: none;
+    }
+
+    .access-grants-matrix-table tbody td {
+        vertical-align: middle;
+        border-bottom: 1px solid var(--tblr-border-color, rgba(98, 105, 118, 0.16));
+    }
+
+    .access-grants-matrix-table tbody .access-grants-matrix__user-td {
+        padding: 0.85rem 0.75rem;
+        font-weight: 500;
+        max-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .access-grants-matrix-table tbody .access-grants-matrix__permission-td {
+        text-align: left;
+        padding: 0.85rem 0.35rem 0.85rem 0.85rem;
+    }
+
+    .access-grants-matrix-table tbody .access-grants-matrix__actions-td {
+        padding-right: 0.75rem;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    .access-grants-matrix-table .access-grants-matrix__user-col {
+        width: 30%;
+    }
+
+    .access-grants-matrix-table .access-grants-matrix__perm-col {
+        width: 12%;
+    }
+
+    .access-grants-matrix-table .access-grants-matrix__actions-col {
+        width: 10%;
+    }
+
+    .access-grants-matrix-table .access-grants-matrix__actions-list {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: flex-end;
+        gap: 0.25rem;
+    }
+</style>
+
+<div class="table-responsive">
+    <table class="table table-vcenter card-table access-grants-matrix-table">
+        <colgroup>
+            <col class="access-grants-matrix__user-col">
+            <col class="access-grants-matrix__perm-col" span="{{ assignablePermissions|length }}">
+            <col class="access-grants-matrix__actions-col">
+        </colgroup>
+        <thead>
+        <tr>
+            <th class="access-grants-matrix__user-th" scope="col">{{ 'label.username'|trans }}</th>
+            {% for permission in assignablePermissions %}
+                {% set permissionLabel = ('label.hospital_permission.' ~ permission.name)|trans %}
+                <th class="access-grants-matrix__permission-th" scope="col" title="{{ permissionLabel }}">
+                    <div class="access-grants-matrix__permission-head">
+                        <span class="access-grants-matrix__permission-label">{{ permissionLabel }}</span>
+                    </div>
+                </th>
+            {% endfor %}
+            <th class="access-grants-matrix__actions-th" scope="col" aria-hidden="true"></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for grant in grants %}
+            <tr>
+                <td class="access-grants-matrix__user-td" title="{{ grant.user.username }}">{{ grant.user.username }}</td>
+                {% for permission in assignablePermissions %}
+                    {% set granted = (grant.permissions b-and permission.value) != 0 %}
+                    <td class="access-grants-matrix__permission-td">
+                        {% if granted %}
+                            <span class="text-success" aria-label="{{ ('label.hospital_access_grants.matrix.granted'|trans({username: grant.user.username, permission: ('label.hospital_permission.' ~ permission.name)|trans})) }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                    <path d="M5 12l5 5l10 -10" />
+                                </svg>
+                            </span>
+                        {% else %}
+                            <span class="text-danger" aria-label="{{ ('label.hospital_access_grants.matrix.denied'|trans({username: grant.user.username, permission: ('label.hospital_permission.' ~ permission.name)|trans})) }}">
+                                <twig:ux:icon name="tabler:x" width="20" height="20" aria-hidden="true" />
+                            </span>
+                        {% endif %}
+                    </td>
+                {% endfor %}
+                <td class="access-grants-matrix__actions-td">
+                    <div class="access-grants-matrix__actions-list">
+                        <a
+                            class="btn btn-icon btn-outline-primary"
+                            href="{{ path('app_hospitals_edit_access_grant', {id: hospital.id, grantId: grant.id}) }}"
+                            title="{{ 'label.edit'|trans }}"
+                            aria-label="{{ 'label.edit'|trans }}"
+                        >
+                            <twig:ux:icon name="tabler:edit" width="1em" height="1em" />
+                        </a>
+                        <form method="post" action="{{ path('app_hospitals_edit_access_grant_delete', {id: hospital.id, grantId: grant.id}) }}" class="d-inline" onsubmit="return confirm('{{ 'confirm.hospital_access_grant.delete'|trans|e('js') }}');">
+                            <input type="hidden" name="_token" value="{{ csrf_token('delete_access_grant_' ~ grant.id) }}">
+                            <button
+                                type="submit"
+                                class="btn btn-icon btn-outline-danger"
+                                title="{{ 'label.delete'|trans }}"
+                                aria-label="{{ 'label.delete'|trans }}"
+                            >
+                                <twig:ux:icon name="tabler:trash" width="1em" height="1em" />
+                            </button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+        {% else %}
+            <tr>
+                <td colspan="{{ assignablePermissions|length + 2 }}" class="text-center text-muted py-4">{{ 'help.hospital_access_grants.empty'|trans }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/src/Allocation/UI/Twig/templates/hospitals/_edit_shell.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/_edit_shell.html.twig
@@ -1,0 +1,49 @@
+<div class="page-body">
+    <div class="container-xl">
+        <div class="card">
+            <div class="row g-0">
+                <div class="col-12 col-md-3 border-end">
+                    <div class="card-body">
+                        <h4 class="subheader">{{ 'title.hospital.edit'|trans }}</h4>
+                        <div class="list-group list-group-transparent">
+                            <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeSection == 'general' ? 'active' }}" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
+                                {{ 'label.hospital.general_information'|trans }}
+                            </a>
+                            <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeSection == 'address' ? 'active' }}" href="{{ path('app_hospitals_edit_address', {id: hospital.id}) }}">
+                                {{ 'label.hospital.address_information'|trans }}
+                            </a>
+                        </div>
+
+                        {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\HospitalVoter::MANAGE_ACCESS_GRANTS'), hospital) %}
+                            <h4 class="subheader mt-4">{{ 'label.hospital.manage_access'|trans }}</h4>
+                            <div class="list-group list-group-transparent">
+                                <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeAccessSubsection|default('') == 'overview' ? 'active' }}" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">
+                                    {{ 'label.hospital.access_grants.overview'|trans }}
+                                </a>
+                                <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeAccessSubsection|default('') == 'new' ? 'active' }}" href="{{ path('app_hospitals_edit_access_new', {id: hospital.id}) }}">
+                                    {{ 'label.hospital_access_grants.add'|trans }}
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="col-12 col-md-9">
+                    {% block edit_main %}
+                        <div class="card-header d-flex align-items-center justify-content-between">
+                            <h3 class="card-title mb-0">{% block edit_card_title %}{% endblock %}</h3>
+                            <div class="ms-auto">{% block edit_card_actions %}{% endblock %}</div>
+                        </div>
+                        <div class="card-body">
+                            {% block edit_content %}{% endblock %}
+                        </div>
+                        {% if block('edit_footer') is defined and block('edit_footer')|trim is not empty %}
+                            <div class="card-footer d-flex justify-content-end gap-2">
+                                {% block edit_footer %}{% endblock %}
+                            </div>
+                        {% endif %}
+                    {% endblock %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Allocation/UI/Twig/templates/hospitals/_hospital_edit_page_header.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/_hospital_edit_page_header.html.twig
@@ -1,0 +1,18 @@
+<div class="container-xl">
+    <twig:Breadcrumbs
+        :items="[
+            { label: 'title.hospitals.my', path: path('app_hospitals_index') },
+            { label: hospital.name, path: path('app_explore_hospital_show', {id: hospital.id}) },
+            { label: 'title.hospital.edit' }
+        ]"
+    />
+
+    <div class="page-header d-print-none">
+        <div class="row g-2 align-items-center">
+            <div class="col">
+                <h2 class="page-title">{{ 'title.hospital.edit'|trans }}</h2>
+                <div class="text-secondary mt-1">{{ hospital.name }}</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Allocation/UI/Twig/templates/hospitals/access/edit.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/access/edit.html.twig
@@ -1,0 +1,30 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.hospital.edit'|trans }} - {{ hospital.name }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    {{ include('@Allocation/hospitals/_hospital_edit_page_header.html.twig') }}
+{% endblock %}
+
+{% block page_body %}
+    {% embed '@Allocation/hospitals/_edit_shell.html.twig' with {
+        hospital: hospital,
+        activeSection: '',
+        activeAccessSubsection: 'overview',
+    } %}
+        {% block edit_main %}
+            {{ form_start(form) }}
+            <div class="card-header">
+                <h3 class="card-title">{{ 'title.hospital_access_grants.edit'|trans }} · {{ grant.user.username }}</h3>
+            </div>
+            <div class="card-body">
+                {{ form_row(form.permissionChoices) }}
+            </div>
+            <div class="card-footer d-flex justify-content-end gap-2">
+                <a class="btn btn-link" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">{{ 'btn.cancel'|trans }}</a>
+                {{ form_widget(form.submit) }}
+            </div>
+            {{ form_end(form) }}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
@@ -1,0 +1,30 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.hospital.edit'|trans }} - {{ hospital.name }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    {{ include('@Allocation/hospitals/_hospital_edit_page_header.html.twig') }}
+{% endblock %}
+
+{% block page_body %}
+    {% embed '@Allocation/hospitals/_edit_shell.html.twig' with {
+        hospital: hospital,
+        activeSection: '',
+        activeAccessSubsection: 'overview',
+    } %}
+        {% block edit_card_title %}{{ 'label.hospital.access_grants.overview'|trans }}{% endblock %}
+        {% block edit_card_actions %}
+            <a class="btn btn-primary" href="{{ path('app_hospitals_edit_access_new', {id: hospital.id}) }}">{{ 'label.hospital_access_grants.add'|trans }}</a>
+        {% endblock %}
+        {% block edit_content %}
+            {{ include('@Allocation/hospitals/_access_grants_matrix.html.twig', {
+                grants: grants,
+                assignablePermissions: assignablePermissions,
+                hospital: hospital,
+            }) }}
+        {% endblock %}
+        {% block edit_footer %}
+            <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">{{ 'label.hospital.back_to_profile'|trans }}</a>
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/src/Allocation/UI/Twig/templates/hospitals/access/new.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/access/new.html.twig
@@ -1,0 +1,48 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.hospital.edit'|trans }} - {{ hospital.name }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    {{ include('@Allocation/hospitals/_hospital_edit_page_header.html.twig') }}
+{% endblock %}
+
+{% block page_body %}
+    {% embed '@Allocation/hospitals/_edit_shell.html.twig' with {
+        hospital: hospital,
+        activeSection: '',
+        activeAccessSubsection: 'new',
+    } %}
+        {% block edit_main %}
+            {{ form_start(form) }}
+            <div class="card-header">
+                <h3 class="card-title">{{ 'title.hospital_access_grants.new'|trans }}</h3>
+            </div>
+            <div class="card-body">
+                {% set listId = form.user_label.vars.id ~ '-datalist' %}
+                {% set hiddenSelector = '#' ~ form.user.vars.id %}
+
+                {{ form_row(form.user_label, {
+                    attr: form.user_label.vars.attr|merge({
+                        list: listId,
+                        'data-datalist-chooser-list-id-value': listId,
+                        'data-datalist-chooser-hidden-selector-value': hiddenSelector,
+                    }),
+                }) }}
+
+                <datalist id="{{ listId }}">
+                    {% for row in userDatalist %}
+                        <option value="{{ row.label }}" data-id="{{ row.id }}"></option>
+                    {% endfor %}
+                </datalist>
+
+                {{ form_widget(form.user) }}
+                {{ form_row(form.permissionChoices) }}
+            </div>
+            <div class="card-footer d-flex justify-content-end gap-2">
+                <a class="btn btn-link" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">{{ 'btn.cancel'|trans }}</a>
+                {{ form_widget(form.submit) }}
+            </div>
+            {{ form_end(form) }}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/src/Allocation/UI/Twig/templates/hospitals/edit_owned.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/edit_owned.html.twig
@@ -3,81 +3,45 @@
 {% block title %}{{ 'title.hospital.edit'|trans }} - {{ hospital.name }} - {{ parent() }}{% endblock %}
 
 {% block page_header %}
-    <div class="container-xl">
-        <twig:Breadcrumbs
-            :items="[
-                { label: 'title.hospitals.my', path: path('app_hospitals_index') },
-                { label: hospital.name, path: path('app_explore_hospital_show', {id: hospital.id}) },
-                { label: 'title.hospital.edit' }
-            ]"
-        />
-
-        <div class="page-header d-print-none">
-            <div class="row g-2 align-items-center">
-                <div class="col">
-                    <h2 class="page-title">{{ 'title.hospital.edit'|trans }}</h2>
-                    <div class="text-secondary mt-1">{{ hospital.name }}</div>
-                </div>
-            </div>
-        </div>
-    </div>
+    {{ include('@Allocation/hospitals/_hospital_edit_page_header.html.twig') }}
 {% endblock %}
 
 {% block page_body %}
-    <div class="page-body">
-        <div class="container-xl">
-            <div class="card">
-                <div class="row g-0">
-                    <div class="col-12 col-md-3 border-end">
-                        <div class="card-body">
-                            <h4 class="subheader">{{ 'title.hospital.edit'|trans }}</h4>
-                            <div class="list-group list-group-transparent">
-                                <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeSection == 'general' ? 'active' }}" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
-                                    {{ 'label.hospital.general_information'|trans }}
-                                </a>
-                                <a class="list-group-item list-group-item-action d-flex align-items-center {{ activeSection == 'address' ? 'active' }}" href="{{ path('app_hospitals_edit_address', {id: hospital.id}) }}">
-                                    {{ 'label.hospital.address_information'|trans }}
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 col-md-9">
-                        {{ form_start(form) }}
-                        <div class="card-header">
-                            <h3 class="card-title">{{ 'title.hospital.edit'|trans }}</h3>
-                        </div>
-                        <div class="card-body">
-                            {% if activeSection == 'address' %}
-                                <h4 id="address-information" class="subheader mb-3">{{ 'label.hospital.address_information'|trans }}</h4>
-                                <div class="row g-3">
-                                    <div class="col-md-8">{{ form_row(form.address.street) }}</div>
-                                    <div class="col-md-4">{{ form_row(form.address.postalCode) }}</div>
-                                    <div class="col-md-6">{{ form_row(form.address.city) }}</div>
-                                    <div class="col-md-3">{{ form_row(form.address.state) }}</div>
-                                    <div class="col-md-3">{{ form_row(form.address.country) }}</div>
-                                </div>
-                            {% else %}
-                                <h4 id="general-information" class="subheader mb-3">{{ 'label.hospital.general_information'|trans }}</h4>
-                                <div class="row g-3 mb-4">
-                                    <div class="col-md-6">{{ form_row(form.name) }}</div>
-                                    <div class="col-md-3">{{ form_row(form.location) }}</div>
-                                    <div class="col-md-3">{{ form_row(form.tier) }}</div>
-                                    <div class="col-md-6">{{ form_row(form.dispatchArea) }}</div>
-                                    <div class="col-md-6">{{ form_row(form.state) }}</div>
-                                    <div class="col-md-4">{{ form_row(form.size) }}</div>
-                                    <div class="col-md-4">{{ form_row(form.beds) }}</div>
-                                    <div class="col-md-4 d-flex align-items-end">{{ form_row(form.isParticipating) }}</div>
-                                </div>
-                            {% endif %}
-                        </div>
-                        <div class="card-footer d-flex justify-content-end gap-2">
-                            <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">{{ 'label.hospital.back_to_profile'|trans }}</a>
-                            <button type="submit" class="btn btn-primary">{{ 'btn.save.changes'|trans }}</button>
-                        </div>
-                        {{ form_end(form) }}
-                    </div>
-                </div>
+    {% embed '@Allocation/hospitals/_edit_shell.html.twig' with {hospital: hospital, activeSection: activeSection} %}
+        {% block edit_main %}
+            {{ form_start(form) }}
+            <div class="card-header">
+                <h3 class="card-title">{{ 'title.hospital.edit'|trans }}</h3>
             </div>
-        </div>
-    </div>
+            <div class="card-body">
+                {% if activeSection == 'address' %}
+                    <h4 id="address-information" class="subheader mb-3">{{ 'label.hospital.address_information'|trans }}</h4>
+                    <div class="row g-3">
+                        <div class="col-md-8">{{ form_row(form.address.street) }}</div>
+                        <div class="col-md-4">{{ form_row(form.address.postalCode) }}</div>
+                        <div class="col-md-6">{{ form_row(form.address.city) }}</div>
+                        <div class="col-md-3">{{ form_row(form.address.state) }}</div>
+                        <div class="col-md-3">{{ form_row(form.address.country) }}</div>
+                    </div>
+                {% else %}
+                    <h4 id="general-information" class="subheader mb-3">{{ 'label.hospital.general_information'|trans }}</h4>
+                    <div class="row g-3 mb-4">
+                        <div class="col-md-6">{{ form_row(form.name) }}</div>
+                        <div class="col-md-3">{{ form_row(form.location) }}</div>
+                        <div class="col-md-3">{{ form_row(form.tier) }}</div>
+                        <div class="col-md-6">{{ form_row(form.dispatchArea) }}</div>
+                        <div class="col-md-6">{{ form_row(form.state) }}</div>
+                        <div class="col-md-4">{{ form_row(form.size) }}</div>
+                        <div class="col-md-4">{{ form_row(form.beds) }}</div>
+                        <div class="col-md-4 d-flex align-items-end">{{ form_row(form.isParticipating) }}</div>
+                    </div>
+                {% endif %}
+            </div>
+            <div class="card-footer d-flex justify-content-end gap-2">
+                <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">{{ 'label.hospital.back_to_profile'|trans }}</a>
+                <button type="submit" class="btn btn-primary">{{ 'btn.save.changes'|trans }}</button>
+            </div>
+            {{ form_end(form) }}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}

--- a/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
@@ -52,7 +52,12 @@
                             <td>{{ badges.render('hospital_location', hospital.location.value) }}</td>
                             <td>{% if hospital.tier %}{{ badges.render('hospital_tier', hospital.tier.value) }}{% endif %}</td>
                             <td>{{ badges.render('hospital_size', hospital.size.value, hospital.beds) }}</td>
-                            <td>
+                            <td class="text-nowrap">
+                                {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\HospitalVoter::MANAGE_ACCESS_GRANTS'), hospital) %}
+                                    <a class="btn btn-sm btn-outline-secondary me-1" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">
+                                        {{ 'label.hospital_access_grants.manage'|trans }}
+                                    </a>
+                                {% endif %}
                                 <a class="btn btn-sm btn-outline-primary" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
                                     {{ 'label.edit'|trans }}
                                 </a>

--- a/src/Allocation/UI/Twig/templates/hospitals/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/show.html.twig
@@ -43,7 +43,7 @@
             </div>
             <div class="col-auto ms-auto">
                 <div class="btn-list">
-                    {% if is_granted('ROLE_PARTICIPANT') and app.user and hospital.owner and hospital.owner.id == app.user.id %}
+                    {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\HospitalVoter::EDIT'), hospital) %}
                         <span class="d-none d-sm-inline">
                             <a class="btn btn-primary" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
                                 <twig:ux:icon name="tabler:edit" width="1em" height="1em" />&nbsp;

--- a/src/Import/Application/Service/ImportListAccess.php
+++ b/src/Import/Application/Service/ImportListAccess.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
+use App\Allocation\Application\Service\HospitalPermissionAccess;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\User\Domain\Entity\User;
 
@@ -12,6 +14,7 @@ final readonly class ImportListAccess
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private HospitalRepository $hospitalRepository,
+        private HospitalPermissionAccess $hospitalPermissionAccess,
     ) {
     }
 
@@ -20,24 +23,17 @@ final readonly class ImportListAccess
      */
     public function resolveAccessibleHospitalIds(User $user): array
     {
-        /** @var list<int|string> $rawIds */
-        $rawIds = $this->hospitalRepository
-            ->getQueryBuilderForAccessibleHospitals($user)
-            ->select('h.id')
-            ->getQuery()
-            ->getSingleColumnResult();
-
-        return array_map(static fn (int|string $id): int => (int) $id, $rawIds);
+        return $this->hospitalPermissionAccess->resolveHospitalIdsWithPermission($user, HospitalPermission::Import);
     }
 
     public function canAccessHospital(User $user, int $hospitalId): bool
     {
-        return \in_array($hospitalId, $this->resolveAccessibleHospitalIds($user), true);
+        return $this->hospitalPermissionAccess->hasPermission($user, $hospitalId, HospitalPermission::View);
     }
 
     public function canAccessImportHospital(User $user, int $hospitalId): bool
     {
-        return $this->canAccessHospital($user, $hospitalId);
+        return $this->hospitalPermissionAccess->hasPermission($user, $hospitalId, HospitalPermission::Import);
     }
 
     public function sanitizeHospitalId(User $user, ?int $hospitalId): ?int

--- a/src/Import/Infrastructure/Security/Voter/ImportVoter.php
+++ b/src/Import/Infrastructure/Security/Voter/ImportVoter.php
@@ -7,6 +7,7 @@ namespace App\Import\Infrastructure\Security\Voter;
 use App\Import\Application\Service\ImportListAccess;
 use App\Import\Domain\Entity\Import;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -45,8 +46,9 @@ final class ImportVoter extends Voter
             return false;
         }
 
+        $hospitalId = $subject->getHospital()?->getId();
+
         if (self::VIEW === $attribute) {
-            $hospitalId = $subject->getHospital()?->getId();
             if (null === $hospitalId) {
                 return false;
             }
@@ -54,11 +56,10 @@ final class ImportVoter extends Voter
             return $this->importListAccess->canAccessImportHospital($user, $hospitalId);
         }
 
-        if (\in_array('ROLE_ADMIN', $user->getRoles(), true)) {
+        if (\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
             return true;
         }
 
-        $hospitalId = $subject->getHospital()?->getId();
         if (null !== $hospitalId && $this->importListAccess->canAccessImportHospital($user, $hospitalId)) {
             return true;
         }

--- a/src/Import/UI/Form/ImportCreateType.php
+++ b/src/Import/UI/Form/ImportCreateType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Import\UI\Form;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Import\Domain\Entity\Import;
 use App\User\Domain\Entity\User;
@@ -53,7 +54,7 @@ final class ImportCreateType extends AbstractType
                 'class' => Hospital::class,
                 'choice_label' => 'name',
                 'placeholder' => 'label.import.selectHospital',
-                'query_builder' => fn (): QueryBuilder => $this->hospitalRepository->getQueryBuilderForAccessibleHospitals($user),
+                'query_builder' => fn (): QueryBuilder => $this->hospitalRepository->getQueryBuilderForHospitalsWithPermission($user, HospitalPermission::Import),
                 'constraints' => [new Assert\NotNull()],
             ])
             ->add('file', FileType::class, [

--- a/src/Import/UI/Http/Controller/NewImportController.php
+++ b/src/Import/UI/Http/Controller/NewImportController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Import\UI\Http\Controller;
 
+use App\Allocation\Application\Service\HospitalPermissionAccess;
 use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Import\Application\Message\ImportAllocationsMessage;
 use App\Import\Application\Service\FileChecksumCalculator;
 use App\Import\Application\Service\FileUploader;
@@ -13,6 +15,7 @@ use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
 use App\Import\UI\Form\ImportCreateType;
 use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -32,6 +35,7 @@ final class NewImportController extends AbstractController
         private readonly FileChecksumCalculator $checksumCalculator,
         private readonly FileUploader $fileUploader,
         private readonly AuditContext $auditContext,
+        private readonly HospitalPermissionAccess $hospitalPermissionAccess,
     ) {
     }
 
@@ -48,6 +52,12 @@ final class NewImportController extends AbstractController
 
         /** @var Hospital $hospital */
         $hospital = $form->get('hospital')->getData();
+        $user = $this->getUser();
+        $hospitalId = $hospital->getId();
+        if (!$user instanceof User || null === $hospitalId || !$this->hospitalPermissionAccess->hasPermission($user, $hospitalId, HospitalPermission::Import)) {
+            throw $this->createAccessDeniedException();
+        }
+
         $name = (string) $form->get('name')->getData();
 
         /** @var UploadedFile $file */

--- a/src/Statistics/Application/ComparisonScopeResolver.php
+++ b/src/Statistics/Application/ComparisonScopeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application;
 
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Statistics\Application\Cohort\HospitalCohortKey;
 use App\Statistics\Application\Cohort\HospitalCohortResolver;
 use App\Statistics\Application\Contract\HospitalAccessInterface;
@@ -26,26 +27,33 @@ final readonly class ComparisonScopeResolver
     ) {
     }
 
-    public function resolve(Request $request, ?User $user, StatisticsFilter $primaryFilter): StatisticsFilter
-    {
+    public function resolve(
+        Request $request,
+        ?User $user,
+        StatisticsFilter $primaryFilter,
+        HospitalPermission $hospitalPermission = HospitalPermission::Statistics,
+    ): StatisticsFilter {
         $input = $this->comparisonFilterInputFactory->fromQuery(
             $request->query,
             $primaryFilter,
-            $this->defaultComparisonCohort($primaryFilter, $user),
+            $this->defaultComparisonCohort($primaryFilter, $user, $hospitalPermission),
         );
 
         return $this->statisticsFilterFactory->createFromInput($input, $user);
     }
 
-    private function defaultComparisonCohort(StatisticsFilter $primaryFilter, ?User $user): string
-    {
+    private function defaultComparisonCohort(
+        StatisticsFilter $primaryFilter,
+        ?User $user,
+        HospitalPermission $hospitalPermission,
+    ): string {
         if (StatisticsFilterScope::HospitalCohort === $primaryFilter->scope && $primaryFilter->cohortType instanceof HospitalCohortKey) {
             return $primaryFilter->cohortType->value();
         }
 
         $hospitalIds = match ($primaryFilter->scope) {
             StatisticsFilterScope::Hospital => null !== $primaryFilter->hospitalId ? [$primaryFilter->hospitalId] : [],
-            StatisticsFilterScope::MyHospitals => $this->accessibleHospitalIds($user),
+            StatisticsFilterScope::MyHospitals => $this->accessibleHospitalIds($user, $hospitalPermission),
             StatisticsFilterScope::State => null !== $primaryFilter->stateId
                 ? $this->projectionScopeQuery->distinctHospitalIdsForState($primaryFilter->stateId)
                 : [],
@@ -85,9 +93,21 @@ final readonly class ComparisonScopeResolver
     /**
      * @return list<int>
      */
-    private function accessibleHospitalIds(?User $user): array
+    private function accessibleHospitalIds(?User $user, HospitalPermission $hospitalPermission): array
     {
-        if (!$user instanceof User || !$this->hospitalAccess->canUseMyHospitalsScope($user)) {
+        if (!$user instanceof User) {
+            return [];
+        }
+
+        if (HospitalPermission::Benchmarking === $hospitalPermission) {
+            if (!$this->hospitalAccess->canUseBenchmarkingScope($user)) {
+                return [];
+            }
+
+            return $this->hospitalAccess->benchmarkingHospitalIds($user);
+        }
+
+        if (!$this->hospitalAccess->canUseMyHospitalsScope($user)) {
             return [];
         }
 

--- a/src/Statistics/Application/Contract/HospitalAccessInterface.php
+++ b/src/Statistics/Application/Contract/HospitalAccessInterface.php
@@ -12,6 +12,8 @@ interface HospitalAccessInterface
 
     public function canUseMyHospitalsScope(User $user): bool;
 
+    public function canUseBenchmarkingScope(User $user): bool;
+
     public function canSelectHospitalScope(User $user, int $hospitalId): bool;
 
     public function countAccessibleHospitals(User $user): int;
@@ -20,4 +22,9 @@ interface HospitalAccessInterface
      * @return list<int>
      */
     public function accessibleHospitalIds(User $user): array;
+
+    /**
+     * @return list<int>
+     */
+    public function benchmarkingHospitalIds(User $user): array;
 }

--- a/src/Statistics/Benchmarking/Application/BenchmarkDefaultResolver.php
+++ b/src/Statistics/Benchmarking/Application/BenchmarkDefaultResolver.php
@@ -27,7 +27,7 @@ final readonly class BenchmarkDefaultResolver
             return null;
         }
 
-        if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
+        if ($user instanceof User && $this->hospitalAccess->canUseBenchmarkingScope($user)) {
             return [
                 'query' => [
                     'scope' => StatisticsFilterScope::MyHospitals->value,

--- a/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPageViewModelFactory.php
+++ b/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPageViewModelFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\Benchmarking\UI\Http\Controller;
 
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Allocation\Infrastructure\Repository\StateRepository;
@@ -67,8 +68,8 @@ final readonly class BenchmarkComparisonPageViewModelFactory
 
         $accessibleHospitals = [];
         $hospitalUrls = [];
-        if ($user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)) {
-            $accessibleHospitals = $this->hospitalRepository->findAccessibleParticipatingHospitalSummaries($user);
+        if ($user instanceof User && $this->hospitalAccess->canUseBenchmarkingScope($user)) {
+            $accessibleHospitals = $this->hospitalRepository->findAccessibleParticipatingHospitalSummaries($user, HospitalPermission::Benchmarking);
             foreach ($accessibleHospitals as $row) {
                 $hospitalUrls[$row['id']] = $this->statisticsNavigationUrlBuilder->build(
                     $request,
@@ -183,7 +184,7 @@ final readonly class BenchmarkComparisonPageViewModelFactory
         );
 
         $myHospitalsDual = $user instanceof User
-            && $this->hospitalAccess->canUseMyHospitalsScope($user)
+            && $this->hospitalAccess->canUseBenchmarkingScope($user)
             && \count($accessibleHospitals) > 1
             && (StatisticsFilterScope::MyHospitals === $filter->scope || StatisticsFilterScope::Hospital === $filter->scope);
         $stateDual = StatisticsFilterScope::State === $filter->scope && [] !== $eligibleStateRows;
@@ -426,7 +427,7 @@ final readonly class BenchmarkComparisonPageViewModelFactory
         }
 
         if ($user instanceof User
-            && $this->hospitalAccess->canUseMyHospitalsScope($user)
+            && $this->hospitalAccess->canUseBenchmarkingScope($user)
             && \count($accessibleHospitals) > 1
             && (StatisticsFilterScope::MyHospitals === $filter->scope || StatisticsFilterScope::Hospital === $filter->scope)
         ) {

--- a/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkingController.php
+++ b/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkingController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\Benchmarking\UI\Http\Controller;
 
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Statistics\Application\ComparisonScopeResolver;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\StatisticsContextFactory;
@@ -63,7 +64,7 @@ final class BenchmarkingController extends AbstractController
             return $this->redirectToRoute('app_stats_benchmarking', $publicRedirect['query']);
         }
 
-        $comparisonFilter = $this->comparisonScopeResolver->resolve($request, $user, $filter);
+        $comparisonFilter = $this->comparisonScopeResolver->resolve($request, $user, $filter, HospitalPermission::Benchmarking);
         $context = $this->statisticsContextFactory->create(
             $user,
             $filter,

--- a/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
+++ b/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Statistics\Infrastructure\Adapter;
 
+use App\Allocation\Application\Service\HospitalPermissionAccess;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\User\Domain\Entity\User;
@@ -13,6 +15,7 @@ final readonly class DoctrineHospitalAccess implements HospitalAccessInterface
 {
     public function __construct(
         private HospitalRepository $hospitalRepository,
+        private HospitalPermissionAccess $hospitalPermissionAccess,
     ) {
     }
 
@@ -37,6 +40,20 @@ final readonly class DoctrineHospitalAccess implements HospitalAccessInterface
     }
 
     #[\Override]
+    public function canUseBenchmarkingScope(User $user): bool
+    {
+        if ($this->isAdminHospitalScopeUser($user)) {
+            return true;
+        }
+
+        if (!\in_array(UserRole::PARTICIPANT, $user->getRoles(), true)) {
+            return false;
+        }
+
+        return \count($this->benchmarkingHospitalIds($user)) > 0;
+    }
+
+    #[\Override]
     public function canSelectHospitalScope(User $user, int $hospitalId): bool
     {
         return \in_array($hospitalId, $this->accessibleHospitalIds($user), true);
@@ -45,19 +62,22 @@ final readonly class DoctrineHospitalAccess implements HospitalAccessInterface
     #[\Override]
     public function countAccessibleHospitals(User $user): int
     {
-        return $this->hospitalRepository->countAccessibleHospitals($user);
+        if ($this->isAdminHospitalScopeUser($user)) {
+            return $this->hospitalRepository->countAccessibleHospitals($user);
+        }
+
+        return \count($this->accessibleHospitalIds($user));
     }
 
     #[\Override]
     public function accessibleHospitalIds(User $user): array
     {
-        /** @var list<int|string> $rawIds */
-        $rawIds = $this->hospitalRepository
-            ->getQueryBuilderForAccessibleHospitals($user)
-            ->select('h.id')
-            ->getQuery()
-            ->getSingleColumnResult();
+        return $this->hospitalPermissionAccess->resolveHospitalIdsWithPermission($user, HospitalPermission::Statistics);
+    }
 
-        return array_map(static fn (int|string $id): int => (int) $id, $rawIds);
+    #[\Override]
+    public function benchmarkingHospitalIds(User $user): array
+    {
+        return $this->hospitalPermissionAccess->resolveHospitalIdsWithPermission($user, HospitalPermission::Benchmarking);
     }
 }

--- a/src/User/Infrastructure/Repository/UserRepository.php
+++ b/src/User/Infrastructure/Repository/UserRepository.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Repository;
 
+use App\Allocation\Domain\Entity\Hospital;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -57,6 +59,47 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
         }
 
         return $matched;
+    }
+
+    /**
+     * @param list<int> $excludeUserIds
+     *
+     * @return list<array{id: int, label: string}>
+     */
+    public function findGrantEligibleUserDatalist(Hospital $hospital, array $excludeUserIds = []): array
+    {
+        $excludeLookup = array_fill_keys($excludeUserIds, true);
+        $ownerId = $hospital->getOwner()?->getId();
+        if (null !== $ownerId) {
+            $excludeLookup[$ownerId] = true;
+        }
+
+        $users = $this->findEnabledVerifiedUsersWithRoles([UserRole::PARTICIPANT]);
+        $choices = [];
+
+        foreach ($users as $user) {
+            $userId = $user->getId();
+            if (null === $userId || isset($excludeLookup[$userId])) {
+                continue;
+            }
+
+            $username = $user->getUsername();
+            if (null === $username || '' === $username) {
+                continue;
+            }
+
+            $choices[] = [
+                'id' => $userId,
+                'label' => $username,
+            ];
+        }
+
+        usort(
+            $choices,
+            static fn (array $a, array $b): int => strcasecmp($a['label'], $b['label']),
+        );
+
+        return $choices;
     }
 
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void

--- a/tests/Allocation/Functional/Controller/Hospitals/ParticipantHospitalsControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Hospitals/ParticipantHospitalsControllerTest.php
@@ -104,6 +104,31 @@ final class ParticipantHospitalsControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(403);
     }
 
+    public function testAdminCanEditForeignHospital(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $createdBy = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $client->loginUser($admin->_real());
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit');
+        self::assertResponseIsSuccessful();
+
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/address');
+        self::assertResponseIsSuccessful();
+    }
+
     public function testOwnerParticipantCanEditHospitalGeneralData(): void
     {
         $client = self::createClient();
@@ -126,6 +151,7 @@ final class ParticipantHospitalsControllerTest extends WebTestCase
         $client->loginUser($owner->_real());
         $crawler = $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit');
         self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Manage access', (string) $client->getResponse()->getContent());
 
         $form = $crawler->selectButton('Save changes')->form([
             'hospital_participant_edit[name]' => 'Hospital After Edit',

--- a/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
-final class ShowHospitalController extends WebTestCase
+final class ShowHospitalControllerTest extends WebTestCase
 {
     use Factories;
     use InteractsWithAuthenticatedUser;
@@ -26,7 +26,6 @@ final class ShowHospitalController extends WebTestCase
 
     public function testShowDisplaysHospitalDetails(): void
     {
-        // Arrange
         $client = $this->createClientAsParticipant();
 
         $owner = UserFactory::createOne(['username' => 'owner-user']);
@@ -56,10 +55,8 @@ final class ShowHospitalController extends WebTestCase
             'createdAt' => new \DateTimeImmutable('2025-01-02 03:04:05'),
         ]);
 
-        // Act
         $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
 
-        // Assert
         self::assertResponseIsSuccessful();
 
         self::assertSelectorTextContains('#hospital-name', 'St. Test Hospital');
@@ -72,6 +69,40 @@ final class ShowHospitalController extends WebTestCase
         self::assertSelectorTextContains('#hospital-beds', '321');
         self::assertSelectorTextContains('#hospital-location', HospitalLocation::cases()[0]->value);
         self::assertSelectorTextContains('#hospital-tier', HospitalTier::cases()[0]->value);
+        self::assertSelectorNotExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
+    }
+
+    public function testOwnerSeesEditButtonOnOwnHospitalShowPage(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'owner-user']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Owned Clinic']);
+
+        $client->loginUser($owner->_real());
+        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
+    }
+
+    public function testAdminSeesEditButtonOnForeignHospitalShowPage(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Foreign Clinic']);
+
+        $client->loginUser($admin->_real());
+        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
     }
 
     public function testShowRejectsPostMethod(): void

--- a/tests/Allocation/Functional/Security/HospitalAccessGrantAccessTest.php
+++ b/tests/Allocation/Functional/Security/HospitalAccessGrantAccessTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Functional\Security;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class HospitalAccessGrantAccessTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+    use ResetDatabase;
+
+    public function testOwnerCanViewAccessGrantMatrix(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-candidate']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $client->loginUser($owner->_real());
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access');
+
+        self::assertResponseIsSuccessful();
+        $content = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('User permissions', $content);
+        self::assertStringContainsString('Access Statistics', $content);
+        self::assertStringContainsString('access-grants-matrix__permission-label', $content);
+        self::assertStringContainsString('Manage access', $content);
+        self::assertStringContainsString('/hospitals/'.$hospital->getId().'/edit/access', $content);
+        self::assertStringContainsString('Grant access', $content);
+        self::assertStringNotContainsString('<datalist', $content);
+    }
+
+    public function testOwnerCanCreateAccessGrantViaHiddenUserId(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $candidate = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-candidate']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $client->loginUser($owner->_real());
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access/new');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('datalist-chooser', (string) $client->getResponse()->getContent());
+
+        $form = $crawler->filter('form')->form([
+            'hospital_access_grant[user]' => (string) $candidate->getId(),
+            'hospital_access_grant[permissionChoices]' => [(string) HospitalPermission::View->value],
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+        $grant = $repository->findForUserAndHospital($candidate->_real(), $hospital->_real());
+
+        self::assertNotNull($grant);
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::View));
+    }
+
+    public function testAdminCanCreateAccessGrantViaHiddenUserId(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $candidate = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'admin-grant-candidate']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $client->loginUser($admin->_real());
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->form([
+            'hospital_access_grant[user]' => (string) $candidate->getId(),
+            'hospital_access_grant[permissionChoices]' => [(string) HospitalPermission::View->value],
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+        $grant = $repository->findForUserAndHospital($candidate->_real(), $hospital->_real());
+
+        self::assertNotNull($grant);
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::View));
+    }
+
+    public function testOwnerCanEditAccessGrantPermissions(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-edit-user']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $grant = HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $client->loginUser($owner->_real());
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/hospitals/'.$hospital->getId().'/edit/access/'.$grant->getId(),
+        );
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('grant-edit-user', (string) $client->getResponse()->getContent());
+
+        $form = $crawler->filter('form')->form([
+            'hospital_access_grant[permissionChoices]' => [
+                (string) HospitalPermission::View->value,
+                (string) HospitalPermission::Statistics->value,
+            ],
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+        $updatedGrant = $repository->findForUserAndHospital($grantee->_real(), $hospital->_real());
+
+        self::assertNotNull($updatedGrant);
+        self::assertTrue(HospitalPermissionMask::has($updatedGrant->getPermissions(), HospitalPermission::Statistics));
+    }
+
+    public function testAdminCanEditAccessGrantPermissions(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'admin-edit-grantee']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $grant = HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $client->loginUser($admin->_real());
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/hospitals/'.$hospital->getId().'/edit/access/'.$grant->getId(),
+        );
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->form([
+            'hospital_access_grant[permissionChoices]' => [
+                (string) HospitalPermission::View->value,
+                (string) HospitalPermission::Statistics->value,
+            ],
+        ]);
+
+        $client->submit($form);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+        $updatedGrant = $repository->findForUserAndHospital($grantee->_real(), $hospital->_real());
+
+        self::assertNotNull($updatedGrant);
+        self::assertTrue(HospitalPermissionMask::has($updatedGrant->getPermissions(), HospitalPermission::Statistics));
+    }
+
+    public function testOwnerCanDeleteAccessGrant(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-delete-user']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $grant = HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $client->loginUser($owner->_real());
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access');
+        self::assertResponseIsSuccessful();
+
+        $deleteForm = $crawler->filter('form[action$="/edit/access/'.$grant->getId().'/delete"]')->form();
+        $client->submit($deleteForm);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+
+        self::assertNull($repository->findForUserAndHospital($grantee->_real(), $hospital->_real()));
+    }
+
+    public function testAdminCanDeleteAccessGrant(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'admin-delete-grantee']);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $grant = HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $client->loginUser($admin->_real());
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access');
+        self::assertResponseIsSuccessful();
+
+        $deleteForm = $crawler->filter('form[action$="/edit/access/'.$grant->getId().'/delete"]')->form();
+        $client->submit($deleteForm);
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access');
+
+        /** @var HospitalAccessGrantRepository $repository */
+        $repository = self::getContainer()->get(HospitalAccessGrantRepository::class);
+
+        self::assertNull($repository->findForUserAndHospital($grantee->_real(), $hospital->_real()));
+    }
+
+    public function testLegacyAccessGrantsUrlRedirectsToEditAccess(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $client->loginUser($owner->_real());
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/access-grants');
+
+        self::assertResponseRedirects('/hospitals/'.$hospital->getId().'/edit/access', Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    public function testNonOwnerCannotManageAccessGrants(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        $client->loginUser($intruder->_real());
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanViewAccessGrantMatrix(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+
+        $client->loginUser($admin->_real());
+        $client->request(Request::METHOD_GET, '/hospitals/'.$hospital->getId().'/edit/access');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('User permissions', (string) $client->getResponse()->getContent());
+    }
+
+    public function testGranteeWithStatisticsButWithoutBenchmarkingCannotUseBenchmarkingScope(): void
+    {
+        $client = self::createClient();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::Statistics]),
+            'createdBy' => $owner,
+        ]);
+
+        $access = $client->getContainer()->get(HospitalAccessInterface::class);
+
+        self::assertTrue($access->canUseMyHospitalsScope($grantee->_real()));
+        self::assertFalse($access->canUseBenchmarkingScope($grantee->_real()));
+    }
+}

--- a/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
+++ b/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
@@ -6,7 +6,10 @@ declare(strict_types=1);
 namespace App\Tests\Allocation\Integration\Repository;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
@@ -126,5 +129,35 @@ final class HospitalRepositoryQueryTest extends KernelTestCase
         $ids = array_column($summaries, 'id');
 
         self::assertSame([(int) $participating->getId()], $ids);
+    }
+
+    public function testGrantedUserSeesHospitalWithMatchingPermission(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'owner-'.bin2hex(random_bytes(6))]);
+        $grantee = UserFactory::createOne(['username' => 'grantee-'.bin2hex(random_bytes(6)), 'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $other = UserFactory::createOne(['username' => 'other-'.bin2hex(random_bytes(6))]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        $grantedHospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Granted Hospital']);
+        HospitalFactory::createOne(['owner' => $other, 'name' => 'Foreign Hospital']);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $grantedHospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $result = $this->repo
+            ->getQueryBuilderForHospitalsWithPermission($grantee->_real(), HospitalPermission::View)
+            ->getQuery()
+            ->getResult();
+
+        $ids = array_map(static fn (Hospital $hospital): ?int => $hospital->getId(), $result);
+
+        self::assertContains($grantedHospital->getId(), $ids);
+        self::assertCount(1, $ids);
     }
 }

--- a/tests/Allocation/Unit/Application/Service/HospitalPermissionAccessTest.php
+++ b/tests/Allocation/Unit/Application/Service/HospitalPermissionAccessTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Application\Service;
+
+use App\Allocation\Application\Service\HospitalPermissionAccess;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class HospitalPermissionAccessTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private HospitalPermissionAccess $access;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->access = self::getContainer()->get(HospitalPermissionAccess::class);
+    }
+
+    public function testOwnerHasAllPermissions(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        self::assertTrue($this->access->hasPermission($owner->_real(), (int) $hospital->getId(), HospitalPermission::Import));
+        self::assertTrue($this->access->hasPermission($owner->_real(), (int) $hospital->getId(), HospitalPermission::Benchmarking));
+        self::assertTrue($this->access->canManageAccessGrants($owner->_real(), $hospital->_real()));
+    }
+
+    public function testGrantUserHasOnlyAssignedPermissions(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Statistics,
+            ]),
+            'createdBy' => $owner,
+        ]);
+
+        $hospitalId = (int) $hospital->getId();
+
+        self::assertTrue($this->access->hasPermission($grantee->_real(), $hospitalId, HospitalPermission::Statistics));
+        self::assertFalse($this->access->hasPermission($grantee->_real(), $hospitalId, HospitalPermission::Benchmarking));
+        self::assertFalse($this->access->hasPermission($grantee->_real(), $hospitalId, HospitalPermission::Import));
+        self::assertFalse($this->access->canManageAccessGrants($grantee->_real(), $hospital->_real()));
+    }
+
+    public function testResolveHospitalIdsWithImportPermission(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+        $foreign = $this->createHospitalForOwner(UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]));
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::Import]),
+            'createdBy' => $owner,
+        ]);
+
+        $ids = $this->access->resolveHospitalIdsWithPermission($grantee->_real(), HospitalPermission::Import);
+
+        self::assertSame([(int) $hospital->getId()], $ids);
+        self::assertNotContains((int) $foreign->getId(), $ids);
+    }
+
+    public function testAdminCanEditAndManageAccessGrantsForForeignHospital(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        self::assertTrue($this->access->canEditHospital($admin->_real(), $hospital->_real()));
+        self::assertTrue($this->access->canManageAccessGrants($admin->_real(), $hospital->_real()));
+    }
+
+    private function createHospitalForOwner(object $owner): object
+    {
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        return HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => UserFactory::createOne(),
+        ]);
+    }
+}

--- a/tests/Allocation/Unit/Domain/HospitalPermissionMaskTest.php
+++ b/tests/Allocation/Unit/Domain/HospitalPermissionMaskTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Domain;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use PHPUnit\Framework\TestCase;
+
+final class HospitalPermissionMaskTest extends TestCase
+{
+    public function testBenchmarkingImpliesStatisticsAndView(): void
+    {
+        $mask = HospitalPermissionMask::fromPermissions([HospitalPermission::Benchmarking]);
+
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Benchmarking));
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Statistics));
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::View));
+        self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Import));
+    }
+
+    public function testStatisticsDoesNotImplyBenchmarking(): void
+    {
+        $mask = HospitalPermissionMask::fromPermissions([HospitalPermission::Statistics]);
+
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Statistics));
+        self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Benchmarking));
+    }
+
+    public function testBenchmarkingWithoutStatisticsIsInvalid(): void
+    {
+        $raw = HospitalPermission::Benchmarking->value;
+
+        self::assertFalse(HospitalPermissionMask::isValid($raw));
+    }
+}

--- a/tests/Allocation/Unit/Infrastructure/Security/HospitalVoterTest.php
+++ b/tests/Allocation/Unit/Infrastructure/Security/HospitalVoterTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Allocation\Unit\Infrastructure\Security;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Allocation\Infrastructure\Security\Voter\HospitalVoter;
@@ -77,13 +80,13 @@ final class HospitalVoterTest extends KernelTestCase
         );
     }
 
-    public function testEditDeniedForNonOwnerEvenWhenAdmin(): void
+    public function testEditGrantedForAdmin(): void
     {
         [, $hospital] = $this->createOwnedHospital();
         $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
 
         self::assertSame(
-            Voter::ACCESS_DENIED,
+            Voter::ACCESS_GRANTED,
             $this->voter->vote($this->createToken($admin->_real()), $hospital->_real(), [HospitalVoter::EDIT]),
         );
     }
@@ -109,6 +112,57 @@ final class HospitalVoterTest extends KernelTestCase
         self::assertSame(
             Voter::ACCESS_DENIED,
             $this->voter->vote($this->createToken($owner->_real()), $hospital, [HospitalVoter::ACCESS]),
+        );
+    }
+
+    public function testManageAccessGrantsGrantedForOwner(): void
+    {
+        [$owner, $hospital] = $this->createOwnedHospital();
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($owner), $hospital->_real(), [HospitalVoter::MANAGE_ACCESS_GRANTS]),
+        );
+    }
+
+    public function testManageAccessGrantsDeniedForNonOwner(): void
+    {
+        [, $hospital] = $this->createOwnedHospital();
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($intruder->_real()), $hospital->_real(), [HospitalVoter::MANAGE_ACCESS_GRANTS]),
+        );
+    }
+
+    public function testManageAccessGrantsGrantedForAdmin(): void
+    {
+        [, $hospital] = $this->createOwnedHospital();
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($admin->_real()), $hospital->_real(), [HospitalVoter::MANAGE_ACCESS_GRANTS]),
+        );
+    }
+
+    public function testAccessGrantedForUserWithViewGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($grantee->_real()), $hospital->_real(), [HospitalVoter::ACCESS]),
         );
     }
 

--- a/tests/Import/Unit/Infrastructure/Security/ImportVoterTest.php
+++ b/tests/Import/Unit/Infrastructure/Security/ImportVoterTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Import\Unit\Infrastructure\Security;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Domain\Entity\Import;
@@ -127,6 +130,44 @@ final class ImportVoterTest extends KernelTestCase
         self::assertSame(
             Voter::ACCESS_DENIED,
             $this->voter->vote($this->createToken($intruder->_real()), $import->_real(), [ImportVoter::DELETE]),
+        );
+    }
+
+    public function testViewGrantedForUserWithImportGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $import->getHospital(),
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::Import]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($grantee->_real()), $import->_real(), [ImportVoter::VIEW]),
+        );
+    }
+
+    public function testViewDeniedForUserWithOnlyViewGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $import->getHospital(),
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($grantee->_real()), $import->_real(), [ImportVoter::VIEW]),
         );
     }
 

--- a/tests/Statistics/Unit/Application/ComparisonScopeResolverDefaultComparisonCohortTest.php
+++ b/tests/Statistics/Unit/Application/ComparisonScopeResolverDefaultComparisonCohortTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Statistics\Unit\Application;
 
 use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Statistics\Application\Cohort\HospitalCohortKey;
 use App\Statistics\Application\ComparisonScopeResolver;
@@ -89,7 +90,7 @@ final class ComparisonScopeResolverDefaultComparisonCohortTest extends KernelTes
         $resolver = self::getContainer()->get(ComparisonScopeResolver::class);
         $method = new \ReflectionMethod(ComparisonScopeResolver::class, 'defaultComparisonCohort');
 
-        return $method->invoke($resolver, $primaryFilter, null);
+        return $method->invoke($resolver, $primaryFilter, null, HospitalPermission::Statistics);
     }
 
     /**

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkDefaultResolverTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkDefaultResolverTest.php
@@ -16,7 +16,7 @@ final class BenchmarkDefaultResolverTest extends TestCase
     public function testRedirectsToPublicScopesForUserWithoutHospitalAccess(): void
     {
         $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
-        $hospitalAccess->method('canUseMyHospitalsScope')->willReturn(false);
+        $hospitalAccess->method('canUseBenchmarkingScope')->willReturn(false);
 
         $resolver = new BenchmarkDefaultResolver($hospitalAccess);
         $payload = $resolver->maybeRedirectPayload(new Request(), $this->createMock(User::class));
@@ -31,7 +31,7 @@ final class BenchmarkDefaultResolverTest extends TestCase
     public function testRedirectsToMyHospitalsAndHospitalCohortForParticipant(): void
     {
         $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
-        $hospitalAccess->method('canUseMyHospitalsScope')->willReturn(true);
+        $hospitalAccess->method('canUseBenchmarkingScope')->willReturn(true);
 
         $resolver = new BenchmarkDefaultResolver($hospitalAccess);
         $payload = $resolver->maybeRedirectPayload(

--- a/tests/User/Unit/Infrastructure/Repository/UserRepositoryGrantDatalistTest.php
+++ b/tests/User/Unit/Infrastructure/Repository/UserRepositoryGrantDatalistTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Unit\Infrastructure\Repository;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class UserRepositoryGrantDatalistTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private UserRepository $repository;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->repository = self::getContainer()->get(UserRepository::class);
+    }
+
+    public function testDatalistExcludesOwnerAndExistingGrantUsers(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'owner-user']);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grantee-user']);
+        $available = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'available-user']);
+        UserFactory::createOne(['roles' => ['ROLE_USER'], 'username' => 'plain-user']);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        $datalist = $this->repository->findGrantEligibleUserDatalist(
+            $hospital->_real(),
+            [(int) $grantee->getId()],
+        );
+
+        $labels = array_column($datalist, 'label');
+        $ids = array_column($datalist, 'id');
+
+        self::assertContains('available-user', $labels);
+        self::assertNotContains('owner-user', $labels);
+        self::assertNotContains('grantee-user', $labels);
+        self::assertNotContains('plain-user', $labels);
+        self::assertContains((int) $available->getId(), $ids);
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -61,6 +61,10 @@
         <source>btn.save.changes</source>
         <target>Save changes</target>
       </trans-unit>
+      <trans-unit id="hag20" resname="label.btn.save">
+        <source>label.btn.save</source>
+        <target>Save</target>
+      </trans-unit>
       <trans-unit id="qLSIn.8" resname="cookie.banner.accept_all">
         <source>cookie.banner.accept_all</source>
         <target>Allow All Cookies</target>
@@ -6274,6 +6278,110 @@
       <trans-unit id="statsHp98" resname="stats.hospital_population.allocation.cross_table_share_hint">
         <source>stats.hospital_population.allocation.cross_table_share_hint</source>
         <target>The percentage shows this cell's share of all allocations and highlights where the data is concentrated.</target>
+      </trans-unit>
+      <trans-unit id="hag01" resname="title.hospital_access_grants">
+        <source>title.hospital_access_grants</source>
+        <target>Access grants</target>
+      </trans-unit>
+      <trans-unit id="hag02" resname="title.hospital_access_grants.list">
+        <source>title.hospital_access_grants.list</source>
+        <target>User permissions</target>
+      </trans-unit>
+      <trans-unit id="hag03" resname="title.hospital_access_grants.new">
+        <source>title.hospital_access_grants.new</source>
+        <target>Grant access</target>
+      </trans-unit>
+      <trans-unit id="hag04" resname="title.hospital_access_grants.edit">
+        <source>title.hospital_access_grants.edit</source>
+        <target>Edit access grant</target>
+      </trans-unit>
+      <trans-unit id="hag05" resname="label.hospital_access_grants.manage">
+        <source>label.hospital_access_grants.manage</source>
+        <target>Manage access</target>
+      </trans-unit>
+      <trans-unit id="hag05a" resname="label.hospital.manage_access">
+        <source>label.hospital.manage_access</source>
+        <target>Manage access</target>
+      </trans-unit>
+      <trans-unit id="hag05d" resname="label.hospital.access_grants.overview">
+        <source>label.hospital.access_grants.overview</source>
+        <target>User permissions</target>
+      </trans-unit>
+      <trans-unit id="hag05b" resname="label.hospital_access_grants.add">
+        <source>label.hospital_access_grants.add</source>
+        <target>Grant access</target>
+      </trans-unit>
+      <trans-unit id="hag05c" resname="label.hospital_access_grants.matrix.granted">
+        <source>label.hospital_access_grants.matrix.granted</source>
+        <target>{username} has {permission}</target>
+      </trans-unit>
+      <trans-unit id="hag05e" resname="label.hospital_access_grants.matrix.denied">
+        <source>label.hospital_access_grants.matrix.denied</source>
+        <target>{username} does not have {permission}</target>
+      </trans-unit>
+      <trans-unit id="hag06" resname="label.hospital_access_grant.permissions">
+        <source>label.hospital_access_grant.permissions</source>
+        <target>Permissions</target>
+      </trans-unit>
+      <trans-unit id="hag07" resname="label.hospital_access_grant.select_user">
+        <source>label.hospital_access_grant.select_user</source>
+        <target>Select user</target>
+      </trans-unit>
+      <trans-unit id="hag19a" resname="label.hospital_access_grant.search_user">
+        <source>label.hospital_access_grant.search_user</source>
+        <target>Search participant by username</target>
+      </trans-unit>
+      <trans-unit id="hag19b" resname="label.hospital_access_grant.search_user_placeholder">
+        <source>label.hospital_access_grant.search_user_placeholder</source>
+        <target>Search by username</target>
+      </trans-unit>
+      <trans-unit id="hag08" resname="label.hospital_permission.View">
+        <source>label.hospital_permission.View</source>
+        <target>View Details</target>
+      </trans-unit>
+      <trans-unit id="hag09" resname="label.hospital_permission.Statistics">
+        <source>label.hospital_permission.Statistics</source>
+        <target>Access Statistics</target>
+      </trans-unit>
+      <trans-unit id="hag10" resname="label.hospital_permission.Benchmarking">
+        <source>label.hospital_permission.Benchmarking</source>
+        <target>Access Benchmarks</target>
+      </trans-unit>
+      <trans-unit id="hag11" resname="label.hospital_permission.Import">
+        <source>label.hospital_permission.Import</source>
+        <target>Access Imports</target>
+      </trans-unit>
+      <trans-unit id="hag12" resname="label.hospital_permission.Export">
+        <source>label.hospital_permission.Export</source>
+        <target>Access Exports</target>
+      </trans-unit>
+      <trans-unit id="hag13" resname="help.hospital_access_grants.empty">
+        <source>help.hospital_access_grants.empty</source>
+        <target>No users have been granted access yet.</target>
+      </trans-unit>
+      <trans-unit id="hag14" resname="confirm.hospital_access_grant.delete">
+        <source>confirm.hospital_access_grant.delete</source>
+        <target>Remove this access grant?</target>
+      </trans-unit>
+      <trans-unit id="hag15" resname="flash.hospital_access_grant.created">
+        <source>flash.hospital_access_grant.created</source>
+        <target>Access grant created.</target>
+      </trans-unit>
+      <trans-unit id="hag16" resname="flash.hospital_access_grant.updated">
+        <source>flash.hospital_access_grant.updated</source>
+        <target>Access grant updated.</target>
+      </trans-unit>
+      <trans-unit id="hag17" resname="flash.hospital_access_grant.deleted">
+        <source>flash.hospital_access_grant.deleted</source>
+        <target>Access grant removed.</target>
+      </trans-unit>
+      <trans-unit id="hag18" resname="flash.hospital_access_grant.duplicate">
+        <source>flash.hospital_access_grant.duplicate</source>
+        <target>This user already has an access grant for this clinic.</target>
+      </trans-unit>
+      <trans-unit id="hag19" resname="label.delete">
+        <source>label.delete</source>
+        <target>Delete</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
### Summary

- Added support for **hospital access grants**
- Introduced a dedicated mechanism for assigning hospital-specific access rights to users
- Decoupled hospital visibility from global role assignments
- Added management workflows for granting and revoking hospital access
- Integrated access grants into existing hospital-scoped permissions and queries
- Updated security, filtering, and visibility checks to respect granted hospital access
- Added or updated tests covering grant assignment, revocation, and access enforcement

### Motivation

- Provide more granular control over hospital-specific data access
- Allow users to access only the hospitals relevant to their responsibilities
- Reduce reliance on broad global permissions
- Improve security and maintainability of hospital-scoped access control
- Establish a foundation for future delegation and organizational access management features

### Notes for Reviewers

- Verify hospital access grants are applied consistently across the application
- Check interaction between grants and existing user roles/permissions
- Ensure hospital-scoped statistics, imports, and allocation views respect granted access
- Review grant assignment and revocation workflows for correctness
- Confirm users without grants cannot access restricted hospital data
- Ensure tests cover grant inheritance, revocation, and edge-case permission scenarios

Closes #184 