### PR TITLE
feat: Deduplicate statistics (including projections) and improve rebuild consistency

### DIFF
--- a/src/Statistics/Application/Projection/AllocationProjectionDeduplicator.php
+++ b/src/Statistics/Application/Projection/AllocationProjectionDeduplicator.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Projection;
+
+use App\Statistics\Application\Projection\Dto\DeduplicationReport;
+use App\Statistics\Application\Projection\Dto\DeduplicationResult;
+use App\Statistics\Application\Projection\Dto\DeduplicationStrategySummary;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Removes duplicate allocations that inflate allocation_stats_projection counts.
+ *
+ * Duplicate detection:
+ * - ENR strategy: same hospital_id + case_id_hash + event fingerprint (IVENA enr alone is
+ *   not unique per hospital — numbers reset or repeat across years; only rows with identical
+ *   case event data are treated as re-import duplicates).
+ * - Fingerprint strategy: same hospital_id + content fingerprint when case_id_hash IS NULL.
+ *
+ * Keeper per group (documented business rule):
+ * 1. Newest import (import.created_at DESC, import.id DESC) — latest IVENA export wins.
+ * 2. Most complete row (optional fields: notes, assessment, secondary indication, occasion, infection).
+ * 3. Lowest allocation.id as stable tiebreaker.
+ */
+final readonly class AllocationProjectionDeduplicator
+{
+    public const string PHASE_ANALYZE_ENR = 'analyze_enr';
+    public const string PHASE_ANALYZE_FINGERPRINT = 'analyze_fingerprint';
+    public const string PHASE_ANALYZE_ORPHANS = 'analyze_orphans';
+    public const string PHASE_DELETE_BATCH = 'delete_batch';
+    public const string PHASE_DELETE_ORPHANS = 'delete_orphans';
+
+    private const int BATCH_SIZE = 500;
+    private const int SAMPLE_LIMIT = 5;
+    private const string STRATEGY_ENR = 'enr';
+    private const string STRATEGY_FINGERPRINT = 'fingerprint';
+
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function analyze(?DeduplicationProgressCallback $progress = null): DeduplicationReport
+    {
+        $this->notify($progress, self::PHASE_ANALYZE_ENR, 0, 2, 'Scanning ENR duplicates…');
+        $enr = $this->analyzeStrategy(self::STRATEGY_ENR);
+        $this->notify(
+            $progress,
+            self::PHASE_ANALYZE_ENR,
+            1,
+            2,
+            sprintf('Found %d duplicate rows in %d groups', $enr->duplicateRows, $enr->duplicateGroups),
+        );
+        $this->notify($progress, self::PHASE_ANALYZE_ENR, 2, 2, 'ENR analysis complete');
+
+        $this->notify($progress, self::PHASE_ANALYZE_FINGERPRINT, 0, 2, 'Scanning fingerprint duplicates…');
+        $fingerprint = $this->analyzeStrategy(self::STRATEGY_FINGERPRINT);
+        $this->notify(
+            $progress,
+            self::PHASE_ANALYZE_FINGERPRINT,
+            1,
+            2,
+            sprintf('Found %d duplicate rows in %d groups', $fingerprint->duplicateRows, $fingerprint->duplicateGroups),
+        );
+        $this->notify($progress, self::PHASE_ANALYZE_FINGERPRINT, 2, 2, 'Fingerprint analysis complete');
+
+        $this->notify($progress, self::PHASE_ANALYZE_ORPHANS, 0, 1, 'Scanning orphan projection rows…');
+        $orphanCount = $this->countOrphanProjections();
+        $this->notify($progress, self::PHASE_ANALYZE_ORPHANS, 1, 1, sprintf('Found %d orphan projection rows', $orphanCount));
+
+        $report = new DeduplicationReport(
+            $enr,
+            $fingerprint,
+            $orphanCount,
+            $this->countEnrHashGroupsSpanningMultipleYears(),
+        );
+
+        $this->logger->info('projection.deduplicate.analyzed', [
+            'enr_duplicate_rows' => $enr->duplicateRows,
+            'enr_duplicate_groups' => $enr->duplicateGroups,
+            'fingerprint_duplicate_rows' => $fingerprint->duplicateRows,
+            'fingerprint_duplicate_groups' => $fingerprint->duplicateGroups,
+            'orphan_projection_rows' => $orphanCount,
+            'enr_hash_groups_spanning_multiple_years' => $report->enrHashGroupsSpanningMultipleYears,
+        ]);
+
+        return $report;
+    }
+
+    public function execute(?DeduplicationProgressCallback $progress = null): DeduplicationResult
+    {
+        $report = $this->analyze($progress);
+
+        $duplicateIds = $this->fetchDuplicateAllocationIds();
+        $totalDuplicates = \count($duplicateIds);
+
+        $deletedProjections = 0;
+        $deletedAllocations = 0;
+        $deletedAssessments = 0;
+
+        if ($totalDuplicates > 0) {
+            $batchCount = (int) ceil($totalDuplicates / self::BATCH_SIZE);
+            $batchIndex = 0;
+
+            $this->connection->beginTransaction();
+
+            try {
+                foreach (array_chunk($duplicateIds, self::BATCH_SIZE) as $batch) {
+                    ++$batchIndex;
+                    $this->notify(
+                        $progress,
+                        self::PHASE_DELETE_BATCH,
+                        $batchIndex,
+                        $batchCount,
+                        sprintf('Batch %d/%d (projections, allocations, assessments)', $batchIndex, $batchCount),
+                    );
+
+                    $assessmentIds = $this->fetchAssessmentIdsForAllocations($batch);
+                    $deletedProjections += $this->deleteByIds('allocation_stats_projection', 'id', $batch);
+                    $deletedAllocations += $this->deleteByIds('allocation', 'id', $batch);
+                    if ([] !== $assessmentIds) {
+                        $deletedAssessments += $this->deleteByIds('assessment', 'id', $assessmentIds);
+                    }
+                }
+
+                $this->notify($progress, self::PHASE_DELETE_ORPHANS, 0, 1, 'Removing orphan projection rows…');
+                $deletedOrphans = $this->deleteOrphanProjections();
+                $this->notify($progress, self::PHASE_DELETE_ORPHANS, 1, 1, sprintf('Removed %d orphan rows', $deletedOrphans));
+
+                $this->connection->commit();
+            } catch (\Throwable $e) {
+                $this->connection->rollBack();
+
+                $this->logger->error('projection.deduplicate.failed', [
+                    'exception' => $e::class,
+                    'message' => $e->getMessage(),
+                ]);
+
+                throw $e;
+            }
+        } else {
+            $this->notify($progress, self::PHASE_DELETE_ORPHANS, 0, 1, 'Removing orphan projection rows…');
+            $this->connection->beginTransaction();
+
+            try {
+                $deletedOrphans = $this->deleteOrphanProjections();
+                $this->notify($progress, self::PHASE_DELETE_ORPHANS, 1, 1, sprintf('Removed %d orphan rows', $deletedOrphans));
+                $this->connection->commit();
+            } catch (\Throwable $e) {
+                $this->connection->rollBack();
+
+                $this->logger->error('projection.deduplicate.failed', [
+                    'exception' => $e::class,
+                    'message' => $e->getMessage(),
+                ]);
+
+                throw $e;
+            }
+        }
+
+        $result = new DeduplicationResult(
+            $report,
+            $deletedProjections,
+            $deletedAllocations,
+            $deletedAssessments,
+            $deletedOrphans,
+        );
+
+        $this->logger->info('projection.deduplicate.deleted', [
+            'deleted_projections' => $deletedProjections,
+            'deleted_allocations' => $deletedAllocations,
+            'deleted_assessments' => $deletedAssessments,
+            'deleted_orphan_projections' => $deletedOrphans,
+        ]);
+
+        return $result;
+    }
+
+    private function analyzeStrategy(string $strategy): DeduplicationStrategySummary
+    {
+        $duplicateRows = $this->countDuplicateRows($strategy);
+        $duplicateGroups = $this->countDuplicateGroups($strategy);
+        $sampleIds = $this->fetchSampleDuplicateIds($strategy);
+
+        return new DeduplicationStrategySummary(
+            $strategy,
+            $duplicateGroups,
+            $duplicateRows,
+            $sampleIds,
+        );
+    }
+
+    private function countDuplicateRows(string $strategy): int
+    {
+        return (int) $this->connection->fetchOne(
+            sprintf('SELECT COUNT(*) FROM (%s) duplicates', $this->duplicateRowsSubquery($strategy)),
+        );
+    }
+
+    private function countDuplicateGroups(string $strategy): int
+    {
+        $partitionExpr = $this->partitionKeyExpression($strategy);
+
+        return (int) $this->connection->fetchOne(
+            <<<SQL
+SELECT COUNT(*) FROM (
+    SELECT 1
+    FROM allocation a
+    INNER JOIN import i ON i.id = a.import_id
+    WHERE {$this->strategyWhereClause($strategy)}
+    GROUP BY {$partitionExpr}
+    HAVING COUNT(*) > 1
+) grouped
+SQL
+        );
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function fetchSampleDuplicateIds(string $strategy): array
+    {
+        /** @var list<int|string> $rows */
+        $rows = $this->connection->fetchFirstColumn(
+            sprintf(
+                'SELECT id FROM (%s) duplicates ORDER BY id ASC LIMIT %d',
+                $this->duplicateRowsSubquery($strategy),
+                self::SAMPLE_LIMIT,
+            ),
+        );
+
+        return array_map(static fn (int|string $id): int => (int) $id, $rows);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function fetchDuplicateAllocationIds(): array
+    {
+        $sql = sprintf(
+            <<<'SQL'
+SELECT id FROM (
+    %s
+    UNION ALL
+    %s
+) all_duplicates
+ORDER BY id ASC
+SQL,
+            $this->duplicateRowsSubquery(self::STRATEGY_ENR),
+            $this->duplicateRowsSubquery(self::STRATEGY_FINGERPRINT),
+        );
+
+        /** @var list<int|string> $rows */
+        $rows = $this->connection->fetchFirstColumn($sql);
+
+        return array_map(static fn (int|string $id): int => (int) $id, $rows);
+    }
+
+    private function duplicateRowsSubquery(string $strategy): string
+    {
+        $partitionExpr = $this->partitionKeyExpression($strategy);
+        $where = $this->strategyWhereClause($strategy);
+
+        return <<<SQL
+SELECT ranked.id
+FROM (
+    SELECT
+        a.id,
+        ROW_NUMBER() OVER (
+            PARTITION BY {$partitionExpr}
+            ORDER BY
+                i.created_at DESC,
+                i.id DESC,
+                (
+                    CASE WHEN a.notes IS NOT NULL AND a.notes <> '' THEN 1 ELSE 0 END
+                    + CASE WHEN a.assessment_id IS NOT NULL THEN 1 ELSE 0 END
+                    + CASE WHEN a.secondary_indication_raw_id IS NOT NULL THEN 1 ELSE 0 END
+                    + CASE WHEN a.occasion_id IS NOT NULL THEN 1 ELSE 0 END
+                    + CASE WHEN a.infection_id IS NOT NULL THEN 1 ELSE 0 END
+                ) DESC,
+                a.id ASC
+        ) AS rn
+    FROM allocation a
+    INNER JOIN import i ON i.id = a.import_id
+    WHERE {$where}
+) ranked
+WHERE ranked.rn > 1
+SQL;
+    }
+
+    private function strategyWhereClause(string $strategy): string
+    {
+        return self::STRATEGY_ENR === $strategy
+            ? 'a.case_id_hash IS NOT NULL'
+            : 'a.case_id_hash IS NULL';
+    }
+
+    private function partitionKeyExpression(string $strategy): string
+    {
+        if (self::STRATEGY_ENR === $strategy) {
+            return 'a.hospital_id, a.case_id_hash, '.$this->eventFingerprintExpression('a');
+        }
+
+        return $this->eventFingerprintExpression('a');
+    }
+
+    /**
+     * Stable identity of the underlying IVENA case event (independent of import / surrogate id).
+     */
+    private function eventFingerprintExpression(string $alias): string
+    {
+        return <<<SQL
+md5(concat_ws(
+    '|',
+    {$alias}.hospital_id::text,
+    {$alias}.created_at::text,
+    {$alias}.arrival_at::text,
+    {$alias}.age::text,
+    {$alias}.gender::text,
+    {$alias}.urgency::text,
+    {$alias}.speciality_id::text,
+    {$alias}.department_id::text,
+    {$alias}.assignment_id::text,
+    {$alias}.dispatch_area_id::text,
+    {$alias}.indication_raw_id::text
+))
+SQL;
+    }
+
+    /**
+     * Groups sharing hospital + ENR hash across multiple calendar years (informational; not deduplicated).
+     */
+    private function countEnrHashGroupsSpanningMultipleYears(): int
+    {
+        return (int) $this->connection->fetchOne(
+            <<<'SQL'
+SELECT COUNT(*) FROM (
+    SELECT 1
+    FROM allocation a
+    WHERE a.case_id_hash IS NOT NULL
+    GROUP BY a.hospital_id, a.case_id_hash
+    HAVING COUNT(DISTINCT EXTRACT(YEAR FROM a.created_at)) > 1
+) spanning_years
+SQL
+        );
+    }
+
+    private function countOrphanProjections(): int
+    {
+        return (int) $this->connection->fetchOne(
+            <<<'SQL'
+SELECT COUNT(*)
+FROM allocation_stats_projection p
+WHERE NOT EXISTS (
+    SELECT 1 FROM allocation a WHERE a.id = p.id
+)
+SQL
+        );
+    }
+
+    private function deleteOrphanProjections(): int
+    {
+        $deleted = $this->connection->executeStatement(
+            <<<'SQL'
+DELETE FROM allocation_stats_projection p
+WHERE NOT EXISTS (
+    SELECT 1 FROM allocation a WHERE a.id = p.id
+)
+SQL
+        );
+
+        $this->logger->info('projection.deduplicate.orphans_removed', ['rows' => $deleted]);
+
+        return $deleted;
+    }
+
+    /**
+     * @param list<int> $allocationIds
+     *
+     * @return list<int>
+     */
+    private function fetchAssessmentIdsForAllocations(array $allocationIds): array
+    {
+        if ([] === $allocationIds) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, \count($allocationIds), '?'));
+
+        /** @var list<int|string> $rows */
+        $rows = $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT assessment_id FROM allocation WHERE id IN ('.$placeholders.') AND assessment_id IS NOT NULL',
+            $allocationIds,
+        );
+
+        return array_map(static fn (int|string $id): int => (int) $id, $rows);
+    }
+
+    /**
+     * @param list<int> $ids
+     */
+    private function deleteByIds(string $table, string $column, array $ids): int
+    {
+        if ([] === $ids) {
+            return 0;
+        }
+
+        $placeholders = implode(', ', array_fill(0, \count($ids), '?'));
+
+        return $this->connection->executeStatement(
+            sprintf('DELETE FROM %s WHERE %s IN (%s)', $table, $column, $placeholders),
+            $ids,
+        );
+    }
+
+    private function notify(
+        ?DeduplicationProgressCallback $progress,
+        string $phase,
+        int $current,
+        int $max,
+        string $message,
+    ): void {
+        $progress?->onProgress($phase, $current, $max, $message);
+    }
+}

--- a/src/Statistics/Application/Projection/DeduplicationProgressCallback.php
+++ b/src/Statistics/Application/Projection/DeduplicationProgressCallback.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Projection;
+
+interface DeduplicationProgressCallback
+{
+    public function onProgress(string $phase, int $current, int $max, string $message): void;
+}

--- a/src/Statistics/Application/Projection/Dto/DeduplicationReport.php
+++ b/src/Statistics/Application/Projection/Dto/DeduplicationReport.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Projection\Dto;
+
+final readonly class DeduplicationReport
+{
+    public function __construct(
+        public DeduplicationStrategySummary $enr,
+        public DeduplicationStrategySummary $fingerprint,
+        public int $orphanProjectionRows,
+        public int $enrHashGroupsSpanningMultipleYears = 0,
+    ) {
+    }
+
+    public function totalDuplicateRows(): int
+    {
+        return $this->enr->duplicateRows + $this->fingerprint->duplicateRows;
+    }
+}

--- a/src/Statistics/Application/Projection/Dto/DeduplicationResult.php
+++ b/src/Statistics/Application/Projection/Dto/DeduplicationResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Projection\Dto;
+
+final readonly class DeduplicationResult
+{
+    public function __construct(
+        public DeduplicationReport $report,
+        public int $deletedProjections,
+        public int $deletedAllocations,
+        public int $deletedAssessments,
+        public int $deletedOrphanProjections,
+    ) {
+    }
+
+    public function totalDeletedRows(): int
+    {
+        return $this->deletedProjections
+            + $this->deletedAllocations
+            + $this->deletedAssessments
+            + $this->deletedOrphanProjections;
+    }
+}

--- a/src/Statistics/Application/Projection/Dto/DeduplicationStrategySummary.php
+++ b/src/Statistics/Application/Projection/Dto/DeduplicationStrategySummary.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Projection\Dto;
+
+final readonly class DeduplicationStrategySummary
+{
+    /**
+     * @param list<int> $sampleAllocationIds
+     */
+    public function __construct(
+        public string $strategy,
+        public int $duplicateGroups,
+        public int $duplicateRows,
+        public array $sampleAllocationIds,
+    ) {
+    }
+}

--- a/src/Statistics/UI/Console/Command/DeduplicateProjectionCommand.php
+++ b/src/Statistics/UI/Console/Command/DeduplicateProjectionCommand.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Console\Command;
+
+use App\Statistics\Application\Projection\AllocationProjectionDeduplicator;
+use App\Statistics\Application\Projection\DeduplicationProgressCallback;
+use App\Statistics\Application\Projection\Dto\DeduplicationReport;
+use App\Statistics\Application\Projection\Dto\DeduplicationStrategySummary;
+use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:projection:deduplicate',
+    description: 'Detect and remove duplicate allocation_stats_projection rows caused by duplicate allocations.',
+)]
+final class DeduplicateProjectionCommand extends Command
+{
+    private const int PROGRESS_BAR_THRESHOLD = 100;
+
+    public function __construct(
+        private readonly AllocationProjectionDeduplicator $deduplicator,
+        private readonly MaterializedViewRefresher $materializedViewRefresher,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report duplicates without deleting (default)')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Delete duplicates, remove orphan projections, and refresh materialized views');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $execute = (bool) $input->getOption('execute');
+        $dryRun = !$execute || (bool) $input->getOption('dry-run');
+
+        $io->title('Deduplicate allocation_stats_projection');
+
+        if ($dryRun) {
+            $io->note('Dry run: no rows will be deleted.');
+        }
+
+        $startedAt = microtime(true);
+        $progress = new ConsoleDeduplicationProgress($output, $io, self::PROGRESS_BAR_THRESHOLD);
+
+        try {
+            if ($dryRun) {
+                $report = $this->deduplicator->analyze($progress);
+                $this->renderReport($io, $report);
+                $io->success('Dry run finished. Re-run with --execute to apply changes.');
+
+                return Command::SUCCESS;
+            }
+
+            $result = $this->deduplicator->execute($progress);
+            $this->renderReport($io, $result->report);
+
+            $io->section('Refreshing materialized views');
+            $failed = false;
+            foreach ($this->materializedViewRefresher->refresh([StatisticsMaterializedViewGroups::OVERVIEW]) as $refreshResult) {
+                if ($refreshResult['success']) {
+                    $io->writeln(sprintf(' <info>✓</info> %s', $refreshResult['view']));
+                } else {
+                    $failed = true;
+                    $io->writeln(sprintf(' <error>✗</error> %s — %s', $refreshResult['view'], $refreshResult['message']));
+                }
+            }
+
+            if ($failed) {
+                $io->warning('Deduplication completed but some materialized view refreshes failed.');
+
+                return Command::FAILURE;
+            }
+
+            $remainingAllocations = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM allocation');
+            $durationSeconds = microtime(true) - $startedAt;
+
+            $io->success(sprintf(
+                'Deduplication finished in %.2fs. Removed %d projection row(s), %d allocation(s), %d assessment(s), %d orphan projection row(s). Remaining allocations: %d.',
+                $durationSeconds,
+                $result->deletedProjections,
+                $result->deletedAllocations,
+                $result->deletedAssessments,
+                $result->deletedOrphanProjections,
+                $remainingAllocations,
+            ));
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $io->error(sprintf('Deduplication failed: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function renderReport(SymfonyStyle $io, DeduplicationReport $report): void
+    {
+        $io->section('Duplicate summary');
+
+        $io->table(
+            ['Strategy', 'Groups', 'Duplicate rows', 'Sample allocation IDs'],
+            [
+                $this->strategyTableRow($report->enr),
+                $this->strategyTableRow($report->fingerprint),
+            ],
+        );
+
+        $io->writeln(sprintf('Orphan projection rows: <info>%d</info>', $report->orphanProjectionRows));
+        if ($report->enrHashGroupsSpanningMultipleYears > 0) {
+            $io->writeln(sprintf(
+                'ENR hash groups spanning multiple years (excluded from naive ENR-only match): <comment>%d</comment>',
+                $report->enrHashGroupsSpanningMultipleYears,
+            ));
+        }
+        $io->writeln(sprintf(
+            'Total duplicate allocation rows to remove: <info>%d</info>',
+            $report->totalDuplicateRows(),
+        ));
+    }
+
+    /**
+     * @return array{0: string, 1: int|string, 2: int|string, 3: string}
+     */
+    private function strategyTableRow(DeduplicationStrategySummary $summary): array
+    {
+        $sample = [] === $summary->sampleAllocationIds
+            ? '—'
+            : implode(', ', array_map(static fn (int $id): string => (string) $id, $summary->sampleAllocationIds));
+
+        return [$summary->strategy, $summary->duplicateGroups, $summary->duplicateRows, $sample];
+    }
+}
+
+/**
+ * @internal console adapter for deduplication progress events
+ */
+final class ConsoleDeduplicationProgress implements DeduplicationProgressCallback
+{
+    private ?ProgressBar $progressBar = null;
+
+    private string $currentPhase = '';
+
+    public function __construct(
+        private readonly OutputInterface $output,
+        private readonly SymfonyStyle $io,
+        private readonly int $progressBarThreshold,
+    ) {
+    }
+
+    #[\Override]
+    public function onProgress(string $phase, int $current, int $max, string $message): void
+    {
+        if ($phase !== $this->currentPhase) {
+            $this->finishProgressBar();
+            $this->currentPhase = $phase;
+            $this->renderPhaseHeader($phase);
+        }
+
+        if ($this->shouldUseProgressBar($phase, $max)) {
+            if (!$this->progressBar instanceof ProgressBar) {
+                $this->progressBar = new ProgressBar($this->output, max(1, $max));
+                $this->progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% — %message%');
+                $this->progressBar->setMessage($message);
+                $this->progressBar->start();
+            }
+
+            $this->progressBar->setProgress($current);
+            $this->progressBar->setMessage($message);
+
+            if ($current >= $max) {
+                $this->finishProgressBar();
+            }
+
+            return;
+        }
+
+        $this->io->writeln(sprintf('  %s', $message));
+    }
+
+    private function shouldUseProgressBar(string $phase, int $max): bool
+    {
+        if ($max <= 1 && AllocationProjectionDeduplicator::PHASE_DELETE_BATCH !== $phase) {
+            return false;
+        }
+
+        if ($this->output->isVerbose()) {
+            return true;
+        }
+
+        return AllocationProjectionDeduplicator::PHASE_DELETE_BATCH === $phase
+            || $max >= $this->progressBarThreshold;
+    }
+
+    private function renderPhaseHeader(string $phase): void
+    {
+        $title = match ($phase) {
+            AllocationProjectionDeduplicator::PHASE_ANALYZE_ENR => 'Analyzing ENR duplicates',
+            AllocationProjectionDeduplicator::PHASE_ANALYZE_FINGERPRINT => 'Analyzing fingerprint duplicates',
+            AllocationProjectionDeduplicator::PHASE_ANALYZE_ORPHANS => 'Analyzing orphan projection rows',
+            AllocationProjectionDeduplicator::PHASE_DELETE_BATCH => 'Deleting duplicates',
+            AllocationProjectionDeduplicator::PHASE_DELETE_ORPHANS => 'Removing orphan projection rows',
+            default => $phase,
+        };
+
+        $this->io->section($title);
+    }
+
+    private function finishProgressBar(): void
+    {
+        if (!$this->progressBar instanceof ProgressBar) {
+            return;
+        }
+
+        $this->progressBar->finish();
+        $this->output->writeln('');
+        $this->progressBar = null;
+    }
+}

--- a/tests/Statistics/Functional/Command/DeduplicateProjectionCommandTest.php
+++ b/tests/Statistics/Functional/Command/DeduplicateProjectionCommandTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Functional\Command;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssessmentFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\UI\Console\Command\DeduplicateProjectionCommand;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class DeduplicateProjectionCommandTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testDryRunReportsEnrDuplicateWithoutDeleting(): void
+    {
+        self::bootKernel();
+        $this->seedEnrDuplicateFixture();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Dry run: no rows will be deleted.', $display);
+        self::assertStringContainsString('Analyzing ENR duplicates', $display);
+        self::assertStringContainsString('enr', $display);
+        self::assertStringContainsString('Dry run finished. Re-run with --execute to apply changes.', $display);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+        self::assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation_stats_projection'));
+    }
+
+    public function testExecuteRemovesEnrDuplicateAndKeepsNewestImport(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedEnrDuplicateFixture();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--execute' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Deleting duplicates', $display);
+        self::assertStringContainsString('Refreshing materialized views', $display);
+        self::assertStringContainsString('Deduplication finished', $display);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation_stats_projection'));
+
+        $keptId = (int) $connection->fetchOne('SELECT id FROM allocation');
+        self::assertSame($fixture['newerAllocationId'], $keptId);
+        self::assertSame(
+            0,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation WHERE id = :id', ['id' => $fixture['olderAllocationId']]),
+        );
+    }
+
+    public function testSameEnrDifferentEventIsNotTreatedAsDuplicate(): void
+    {
+        self::bootKernel();
+        $this->seedEnrReuseAcrossYearsFixture();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('enr', $display);
+        self::assertStringContainsString('spanning multiple years', $display);
+        self::assertMatchesRegularExpression('/enr\s+\d+\s+0/', preg_replace('/\s+/', ' ', $display) ?? '');
+    }
+
+    public function testExecuteDeletesAssessmentLinkedToRemovedDuplicate(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedEnrDuplicateFixture(withAssessmentOnOlderDuplicate: true);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(1, (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM assessment WHERE id = :id',
+            ['id' => $fixture['olderAssessmentId']],
+        ));
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--execute' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame(0, (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM assessment WHERE id = :id',
+            ['id' => $fixture['olderAssessmentId']],
+        ));
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+    }
+
+    public function testExecuteRemovesFingerprintDuplicate(): void
+    {
+        self::bootKernel();
+        $fixture = $this->seedFingerprintDuplicateFixture();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--execute' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Analyzing fingerprint duplicates', $tester->getDisplay());
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+        self::assertSame($fixture['newerAllocationId'], (int) $connection->fetchOne('SELECT id FROM allocation'));
+    }
+
+    public function testExecuteRemovesOrphanProjectionRow(): void
+    {
+        self::bootKernel();
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        $connection->executeStatement(
+            'INSERT INTO allocation_stats_projection (id, import_id, hospital_id, state_id, dispatch_area_id, speciality_id, department_id, occasion_id, assignment_id, infection_id, indication_normalized_id, created_at, arrival_at, created_year, created_quarter, created_month, created_week, created_day, created_weekday, created_hour, day_time_bucket_code, shift_bucket_code, transport_time_minutes, age, gender_code, urgency_code, transport_type_code, requires_resus, requires_cathlab, is_cpr, is_ventilated, is_work_accident, is_with_physician) VALUES (888888, 1, 1, 1, 1, 1, 1, NULL, 1, NULL, NULL, NOW(), NOW(), 2025, 1, 1, 1, 1, 1, 8, 2, 2, 10, 30, 1, 1, 1, false, false, false, false, false, false)',
+        );
+
+        self::assertSame(1, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation_stats_projection WHERE id = 888888'));
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--execute' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Removing orphan projection rows', $tester->getDisplay());
+        self::assertSame(0, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation_stats_projection WHERE id = 888888'));
+    }
+
+    public function testDefaultRunIsDryRun(): void
+    {
+        self::bootKernel();
+        $this->seedEnrDuplicateFixture();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dry run finished', $tester->getDisplay());
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM allocation'));
+    }
+
+    public function testNoDuplicatesSucceedsWithZeroRemovals(): void
+    {
+        self::bootKernel();
+        $seed = $this->seedReferenceGraph();
+        $import = ImportFactory::createOne([
+            'name' => 'Unique Import',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+        ]);
+        $allocation = AllocationFactory::createOne($this->allocationDefaults(
+            $seed,
+            $import,
+            25,
+            '2025-05-01 08:00:00',
+            '2025-05-01 08:30:00',
+        ));
+        $this->rebuildProjectionForImport((int) $import->getId());
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--execute' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = preg_replace('/\s+/', ' ', $tester->getDisplay()) ?? '';
+        self::assertStringContainsString('Deduplication finished', $display);
+        self::assertStringContainsString('Remaining allocations: 1', $display);
+        self::assertSame((int) $allocation->getId(), (int) self::getContainer()->get(Connection::class)->fetchOne('SELECT id FROM allocation'));
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $command = self::getContainer()->get(DeduplicateProjectionCommand::class);
+
+        return new CommandTester($command);
+    }
+
+    /**
+     * @return array{olderAllocationId: int, newerAllocationId: int, olderAssessmentId?: int}
+     */
+    private function seedEnrDuplicateFixture(bool $withAssessmentOnOlderDuplicate = false): array
+    {
+        $seed = $this->seedReferenceGraph();
+        /** @var CaseIdHasher $hasher */
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        $caseIdHash = $hasher->hashFrom('123456789');
+
+        $olderImport = ImportFactory::createOne([
+            'name' => 'ENR Duplicate Import Old',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2024-01-01 10:00:00'),
+        ]);
+        $newerImport = ImportFactory::createOne([
+            'name' => 'ENR Duplicate Import New',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2025-06-01 10:00:00'),
+        ]);
+
+        $defaults = $this->allocationDefaults($seed, $olderImport, 30, '2025-03-01 08:00:00', '2025-03-01 08:30:00');
+        $defaults['caseIdHash'] = $caseIdHash;
+        if ($withAssessmentOnOlderDuplicate) {
+            $defaults['assessment'] = AssessmentFactory::createOne();
+        }
+        $olderAllocation = AllocationFactory::createOne($defaults);
+
+        $newerDefaults = $this->allocationDefaults($seed, $newerImport, 30, '2025-03-01 08:00:00', '2025-03-01 08:30:00');
+        $newerDefaults['caseIdHash'] = $caseIdHash;
+        $newerAllocation = AllocationFactory::createOne($newerDefaults);
+
+        $this->rebuildProjectionForImport((int) $olderImport->getId());
+        $this->rebuildProjectionForImport((int) $newerImport->getId());
+
+        $result = [
+            'olderAllocationId' => (int) $olderAllocation->getId(),
+            'newerAllocationId' => (int) $newerAllocation->getId(),
+        ];
+
+        if ($withAssessmentOnOlderDuplicate) {
+            /** @var Connection $connection */
+            $connection = self::getContainer()->get(Connection::class);
+            $result['olderAssessmentId'] = (int) $connection->fetchOne(
+                'SELECT assessment_id FROM allocation WHERE id = :id',
+                ['id' => $result['olderAllocationId']],
+            );
+        }
+
+        return $result;
+    }
+
+    private function seedEnrReuseAcrossYearsFixture(): void
+    {
+        $seed = $this->seedReferenceGraph();
+        /** @var CaseIdHasher $hasher */
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        $caseIdHash = $hasher->hashFrom('555001');
+
+        $import2024 = ImportFactory::createOne([
+            'name' => 'ENR Reuse Import 2024',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2024-06-01 10:00:00'),
+        ]);
+        $import2025 = ImportFactory::createOne([
+            'name' => 'ENR Reuse Import 2025',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2025-06-01 10:00:00'),
+        ]);
+
+        $defaults2024 = $this->allocationDefaults($seed, $import2024, 45, '2024-03-15 08:00:00', '2024-03-15 08:40:00');
+        $defaults2024['caseIdHash'] = $caseIdHash;
+        AllocationFactory::createOne($defaults2024);
+
+        $defaults2025 = $this->allocationDefaults($seed, $import2025, 52, '2025-03-15 08:00:00', '2025-03-15 08:40:00');
+        $defaults2025['caseIdHash'] = $caseIdHash;
+        AllocationFactory::createOne($defaults2025);
+
+        $this->rebuildProjectionForImport((int) $import2024->getId());
+        $this->rebuildProjectionForImport((int) $import2025->getId());
+    }
+
+    /**
+     * @return array{newerAllocationId: int}
+     */
+    private function seedFingerprintDuplicateFixture(): array
+    {
+        $seed = $this->seedReferenceGraph();
+
+        $olderImport = ImportFactory::createOne([
+            'name' => 'Fingerprint Duplicate Import Old',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2024-02-01 10:00:00'),
+        ]);
+        $newerImport = ImportFactory::createOne([
+            'name' => 'Fingerprint Duplicate Import New',
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2025-07-01 10:00:00'),
+        ]);
+
+        $shared = $this->allocationDefaults($seed, $olderImport, 35, '2025-04-10 09:00:00', '2025-04-10 09:45:00');
+        $shared['caseIdHash'] = null;
+        AllocationFactory::createOne($shared);
+
+        $newerDefaults = $this->allocationDefaults($seed, $newerImport, 35, '2025-04-10 09:00:00', '2025-04-10 09:45:00');
+        $newerDefaults['caseIdHash'] = null;
+        $newerAllocation = AllocationFactory::createOne($newerDefaults);
+
+        $this->rebuildProjectionForImport((int) $olderImport->getId());
+        $this->rebuildProjectionForImport((int) $newerImport->getId());
+
+        return ['newerAllocationId' => (int) $newerAllocation->getId()];
+    }
+
+    private function rebuildProjectionForImport(int $importId): void
+    {
+        /** @var AllocationStatsProjectionRebuildInterface $rebuilder */
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($importId);
+    }
+
+    /**
+     * @return array{
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     hospital: object,
+     *     indicationNormalized: object,
+     *     indicationRaw: object,
+     *     speciality: object,
+     *     department: object,
+     *     assignment: object
+     * }
+     */
+    private function seedReferenceGraph(): array
+    {
+        $user = UserFactory::createOne(['username' => 'dedup-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DedupState-'.bin2hex(random_bytes(3))]);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'DedupDispatch-'.bin2hex(random_bytes(3)), 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'DedupHospital-'.bin2hex(random_bytes(3)),
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        $speciality = SpecialityFactory::createOne(['name' => 'DedupSpeciality-'.bin2hex(random_bytes(3))]);
+        $department = DepartmentFactory::createOne(['name' => 'DedupDepartment-'.bin2hex(random_bytes(3))]);
+        $assignment = AssignmentFactory::createOne(['name' => 'DedupAssignment-'.bin2hex(random_bytes(3))]);
+        OccasionFactory::createOne(['name' => 'DedupOccasion-'.bin2hex(random_bytes(3))]);
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'DedupRawIndication', 'code' => 700002]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'DedupNormalizedIndication']);
+
+        return [
+            'user' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'hospital' => $hospital,
+            'speciality' => $speciality,
+            'department' => $department,
+            'assignment' => $assignment,
+            'indicationNormalized' => $indicationNormalized,
+            'indicationRaw' => $indicationRaw,
+        ];
+    }
+
+    /**
+     * @param array{
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     hospital: object,
+     *     indicationNormalized: object,
+     *     indicationRaw: object,
+     *     speciality: object,
+     *     department: object,
+     *     assignment: object
+     * } $seed
+     *
+     * @return array<string, mixed>
+     */
+    private function allocationDefaults(
+        array $seed,
+        object $import,
+        int $age,
+        string $createdAt,
+        string $arrivalAt,
+    ): array {
+        return [
+            'import' => $import,
+            'hospital' => $seed['hospital'],
+            'state' => $seed['state'],
+            'dispatchArea' => $seed['dispatchArea'],
+            'speciality' => $seed['speciality'],
+            'department' => $seed['department'],
+            'assignment' => $seed['assignment'],
+            'indicationRaw' => $seed['indicationRaw'],
+            'indicationNormalized' => $seed['indicationNormalized'],
+            'createdAt' => new \DateTimeImmutable($createdAt),
+            'arrivalAt' => new \DateTimeImmutable($arrivalAt),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => $age,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'occasion' => null,
+            'infection' => null,
+            'departmentWasClosed' => false,
+        ];
+    }
+}


### PR DESCRIPTION
### Summary

- Added deduplication logic for statistics projection data
- Prevented duplicate projection records from being created during imports or rebuilds
- Improved projection generation and synchronization behavior
- Added safeguards to ensure projection data remains consistent over time
- Updated related services, queries, or rebuild workflows where necessary
- Added or updated tests covering duplicate handling and projection integrity

### Motivation

- Ensure projection data remains accurate and reliable
- Prevent inflated statistics caused by duplicated projection entries
- Improve consistency between import processing, rebuilds, and analytical queries
- Strengthen the foundation for dashboards, analytics, benchmarking, and KPI calculations
- Reduce operational issues caused by inconsistent projection data

### Notes for Reviewers

- Verify duplicate projection records are prevented or cleaned up correctly
- Check rebuild and re-import workflows for idempotent behavior
- Ensure existing statistics remain unchanged except for corrected duplicate handling
- Review any unique constraints, cleanup logic, or migration changes introduced by this PR
- Confirm tests cover duplicate creation scenarios, rebuilds, and edge cases.

This is a sub issue of #95. 