### PR TITLE
feat(import): Add duplicate detection during import processing

### DIFF
--- a/migrations/Version20260616120816.php
+++ b/migrations/Version20260616120816.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260616120816 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add deduplication statistics columns to import table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import ADD rows_deduplicated INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE import ADD rows_deduplicated_discarded INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE import ADD rows_deduplicated_replaced INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import DROP rows_deduplicated_replaced');
+        $this->addSql('ALTER TABLE import DROP rows_deduplicated_discarded');
+        $this->addSql('ALTER TABLE import DROP rows_deduplicated');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
@@ -100,6 +100,12 @@ final class ImportCrudController extends AbstractCrudController
             ->onlyOnDetail();
         yield IntegerField::new('rowsRejected', 'Rows rejected')
             ->onlyOnDetail();
+        yield IntegerField::new('rowsDeduplicated', 'Rows deduplicated')
+            ->onlyOnDetail();
+        yield IntegerField::new('rowsDeduplicatedDiscarded', 'Rows deduplicated (Discarded)')
+            ->onlyOnDetail();
+        yield IntegerField::new('rowsDeduplicatedReplaced', 'Rows deduplicated (Replaced)')
+            ->onlyOnDetail();
         yield IntegerField::new('runCount', 'Run count')
             ->onlyOnDetail();
         yield IntegerField::new('runTime', 'Runtime (ms)')

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -14,6 +14,7 @@ use App\Import\Application\Factory\AllocationImporterFactory;
 use App\Import\Application\Factory\RejectWriterFactory;
 use App\Import\Application\Factory\RowReaderFactory;
 use App\Import\Application\Message\ImportAllocationsMessage;
+use App\Import\Application\Service\ImportAllocationDeduplicationService;
 use App\Import\Application\Service\ImportPreviousRunCleanupService;
 use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
@@ -40,6 +41,7 @@ final readonly class ImportAllocationsMessageHandler
         private LoggerInterface $importLogger,
         private EventDispatcherInterface $dispatcher,
         private ImportPreviousRunCleanupService $previousRunCleanupService,
+        private ImportAllocationDeduplicationService $deduplicationService,
         private AuditContext $auditContext,
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
@@ -108,6 +110,7 @@ final readonly class ImportAllocationsMessageHandler
     public function run(Import $import, RowReaderInterface $reader, RejectWriterInterface $writer): ImportSummary
     {
         $started = \microtime(true);
+        $summary = ImportSummary::empty();
 
         try {
             $importer = $this->importFactory->create($reader, $writer);
@@ -125,6 +128,10 @@ final readonly class ImportAllocationsMessageHandler
                 $fresh->setRejectFilePath(\str_replace('\\', '/', $rel));
             }
 
+            $dedupResult = $this->deduplicationService->deduplicateForImport($fresh);
+            $this->deduplicationService->applyDeduplicationStats($fresh, $dedupResult);
+            $summary = $this->deduplicationService->adjustSummary($summary, $dedupResult);
+
             $runtimeMs = (int) \round((\microtime(true) - $started) * 1000.0);
 
             ImportEvaluation::apply($fresh, $summary, $runtimeMs);
@@ -135,7 +142,12 @@ final readonly class ImportAllocationsMessageHandler
         } catch (\Throwable $e) {
             $runtimeMs = (int) \round((\microtime(true) - $started) * 1000.0);
 
-            $import->markAsFailed($runtimeMs);
+            $import->markAsFailed(
+                $runtimeMs,
+                $summary->total,
+                $summary->ok,
+                $summary->rejected,
+            );
             $this->flushWithImportIntent('import.run.failed', $import, ['reason' => $e->getMessage()]);
 
             $this->importLogger->error('import.failed.precondition', [

--- a/src/Import/Application/Service/ImportAllocationDeduplicationService.php
+++ b/src/Import/Application/Service/ImportAllocationDeduplicationService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Application\DTO\ImportSummary;
+use App\Import\Domain\Entity\Import;
+use App\Statistics\Application\Projection\AllocationProjectionDeduplicator;
+use App\Statistics\Application\Projection\Dto\DeduplicationResult;
+use Psr\Log\LoggerInterface;
+
+final readonly class ImportAllocationDeduplicationService
+{
+    public function __construct(
+        private AllocationProjectionDeduplicator $deduplicator,
+        private LoggerInterface $importLogger,
+    ) {
+    }
+
+    public function deduplicateForImport(Import $import): DeduplicationResult
+    {
+        $importId = $import->getId();
+        $hospital = $import->getHospital();
+        $hospitalId = $hospital?->getId();
+
+        if (null === $importId || null === $hospitalId) {
+            throw new \InvalidArgumentException('Import must be persisted with a hospital before deduplication.');
+        }
+
+        $result = $this->deduplicator->executeForHospital($hospitalId, $importId);
+
+        $this->importLogger->info('import.deduplicate.finished', [
+            'import_id' => $importId,
+            'hospital_id' => $hospitalId,
+            'rows_deduplicated' => $result->totalDeletedAllocations(),
+            'rows_deduplicated_discarded' => $result->deletedFromCurrentImport,
+            'rows_deduplicated_replaced' => $result->deletedFromOtherImports,
+        ]);
+
+        return $result;
+    }
+
+    public function adjustSummary(ImportSummary $summary, DeduplicationResult $result): ImportSummary
+    {
+        return new ImportSummary(
+            $summary->total,
+            max(0, $summary->ok - $result->deletedFromCurrentImport),
+            $summary->rejected,
+        );
+    }
+
+    public function applyDeduplicationStats(Import $import, DeduplicationResult $result): void
+    {
+        $import
+            ->setRowsDeduplicated($result->totalDeletedAllocations())
+            ->setRowsDeduplicatedDiscarded($result->deletedFromCurrentImport)
+            ->setRowsDeduplicatedReplaced($result->deletedFromOtherImports);
+    }
+}

--- a/src/Import/Domain/DTO/ImportRateBadge.php
+++ b/src/Import/Domain/DTO/ImportRateBadge.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\DTO;
+
+final readonly class ImportRateBadge
+{
+    public function __construct(
+        public string $color,
+        public string $icon,
+    ) {
+    }
+}

--- a/src/Import/Domain/Entity/Import.php
+++ b/src/Import/Domain/Entity/Import.php
@@ -62,6 +62,15 @@ class Import implements \Stringable
     #[ORM\Column(nullable: true)]
     private ?int $rowsRejected = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?int $rowsDeduplicated = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $rowsDeduplicatedDiscarded = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $rowsDeduplicatedReplaced = null;
+
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $rejectFilePath = null;
 
@@ -245,6 +254,42 @@ class Import implements \Stringable
         return $this;
     }
 
+    public function getRowsDeduplicated(): ?int
+    {
+        return $this->rowsDeduplicated;
+    }
+
+    public function setRowsDeduplicated(?int $rowsDeduplicated): static
+    {
+        $this->rowsDeduplicated = $rowsDeduplicated;
+
+        return $this;
+    }
+
+    public function getRowsDeduplicatedDiscarded(): ?int
+    {
+        return $this->rowsDeduplicatedDiscarded;
+    }
+
+    public function setRowsDeduplicatedDiscarded(?int $rowsDeduplicatedDiscarded): static
+    {
+        $this->rowsDeduplicatedDiscarded = $rowsDeduplicatedDiscarded;
+
+        return $this;
+    }
+
+    public function getRowsDeduplicatedReplaced(): ?int
+    {
+        return $this->rowsDeduplicatedReplaced;
+    }
+
+    public function setRowsDeduplicatedReplaced(?int $rowsDeduplicatedReplaced): static
+    {
+        $this->rowsDeduplicatedReplaced = $rowsDeduplicatedReplaced;
+
+        return $this;
+    }
+
     public function getRejectFilePath(): ?string
     {
         return $this->rejectFilePath;
@@ -300,6 +345,9 @@ class Import implements \Stringable
             ->setRowCount(0)
             ->setRowsPassed(0)
             ->setRowsRejected(0)
+            ->setRowsDeduplicated(0)
+            ->setRowsDeduplicatedDiscarded(0)
+            ->setRowsDeduplicatedReplaced(0)
             ->setRejectFilePath(null)
             ->setRunTime(0);
     }
@@ -331,10 +379,13 @@ class Import implements \Stringable
             ->setRunTime($runtimeMs);
     }
 
-    public function markAsFailed(int $runtimeMs): void
+    public function markAsFailed(int $runtimeMs, int $total = 0, int $ok = 0, int $rejected = 0): void
     {
         $this
             ->setStatus(ImportStatus::FAILED)
+            ->setRowCount($total)
+            ->setRowsPassed($ok)
+            ->setRowsRejected($rejected)
             ->incrementRunCount()
             ->setRunTime($runtimeMs);
     }

--- a/src/Import/Domain/Service/ImportDuplicationRatePresentation.php
+++ b/src/Import/Domain/Service/ImportDuplicationRatePresentation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Service;
+
+use App\Import\Domain\DTO\ImportRateBadge;
+
+final class ImportDuplicationRatePresentation
+{
+    public const float LOW_MAX_RATIO = 0.10;
+
+    public const float ELEVATED_MAX_RATIO = 0.35;
+
+    public const float HIGH_MIN_RATIO = 0.50;
+
+    public static function forPercent(float $percent): ImportRateBadge
+    {
+        $ratio = $percent / 100.0;
+
+        if ($ratio < self::LOW_MAX_RATIO) {
+            return new ImportRateBadge('azure', 'tabler:copy');
+        }
+
+        if ($ratio < self::ELEVATED_MAX_RATIO) {
+            return new ImportRateBadge('yellow', 'tabler:circle-half');
+        }
+
+        if ($ratio < self::HIGH_MIN_RATIO) {
+            return new ImportRateBadge('orange', 'tabler:alert-triangle');
+        }
+
+        return new ImportRateBadge('red', 'tabler:alert-triangle');
+    }
+}

--- a/src/Import/Domain/Service/ImportEvaluation.php
+++ b/src/Import/Domain/Service/ImportEvaluation.php
@@ -16,7 +16,12 @@ final class ImportEvaluation
     public static function apply(Import $import, ImportSummary $summary, int $runtimeMs): void
     {
         if (0 === $summary->total) {
-            $import->markAsFailed($runtimeMs);
+            $import->markAsFailed(
+                runtimeMs: $runtimeMs,
+                total: $summary->total,
+                ok: $summary->ok,
+                rejected: $summary->rejected,
+            );
 
             return;
         }
@@ -35,7 +40,12 @@ final class ImportEvaluation
         }
 
         if ($ratio >= self::FAILED_MIN_RATIO) {
-            $import->markAsFailed($runtimeMs);
+            $import->markAsFailed(
+                runtimeMs: $runtimeMs,
+                total: $summary->total,
+                ok: $summary->ok,
+                rejected: $summary->rejected,
+            );
 
             return;
         }

--- a/src/Import/Domain/Service/ImportRejectionRatePresentation.php
+++ b/src/Import/Domain/Service/ImportRejectionRatePresentation.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Service;
+
+use App\Import\Domain\DTO\ImportRateBadge;
+
+final class ImportRejectionRatePresentation
+{
+    public static function forPercent(float $percent): ImportRateBadge
+    {
+        $ratio = $percent / 100.0;
+
+        if ($ratio < ImportEvaluation::COMPLETE_MAX_RATIO) {
+            return new ImportRateBadge('green', 'tabler:circle-check');
+        }
+
+        if ($ratio < ImportEvaluation::FAILED_MIN_RATIO) {
+            return new ImportRateBadge('yellow', 'tabler:circle-half');
+        }
+
+        return new ImportRateBadge('red', 'tabler:alert-triangle');
+    }
+}

--- a/src/Import/UI/Twig/ImportTwigExtension.php
+++ b/src/Import/UI/Twig/ImportTwigExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Twig;
+
+use App\Import\Domain\Service\ImportDuplicationRatePresentation;
+use App\Import\Domain\Service\ImportRejectionRatePresentation;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ImportTwigExtension extends AbstractExtension
+{
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('import_rate_badge', $this->importRateBadge(...)),
+        ];
+    }
+
+    /**
+     * @return array{color: string, icon: string}
+     */
+    public function importRateBadge(float $percent, string $kind): array
+    {
+        $badge = match ($kind) {
+            'rejection' => ImportRejectionRatePresentation::forPercent($percent),
+            'duplication' => ImportDuplicationRatePresentation::forPercent($percent),
+            default => throw new \InvalidArgumentException(sprintf('Unknown import rate kind "%s".', $kind)),
+        };
+
+        return [
+            'color' => $badge->color,
+            'icon' => $badge->icon,
+        ];
+    }
+}

--- a/src/Import/UI/Twig/templates/show.html.twig
+++ b/src/Import/UI/Twig/templates/show.html.twig
@@ -163,23 +163,53 @@
                                 <div class="datagrid-item">
                                     <div class="datagrid-title">{{ 'import.field.rowsPassed'|trans }}</div>
                                     <div class="datagrid-content">
-                                        {{ import.rowsPassed }}
+                                        {{ import.rowsPassed ?? 0 }}
                                     </div>
                                 </div>
                                 <div class="datagrid-item">
                                     <div class="datagrid-title">{{ 'import.field.rowsRejected'|trans }}</div>
                                     <div class="datagrid-content">
-                                        {{ import.rowsRejected }}
+                                        {{ import.rowsRejected ?? 0 }}
                                     </div>
                                 </div>
                                 <div class="datagrid-item">
                                     <div class="datagrid-title">{{ 'import.field.rejectionRate'|trans }}</div>
                                     <div class="datagrid-content">
                                         {% if import.rowCount > 0 %}
-                                            {{ (import.rowsRejected / import.rowCount * 100)|number_format(2, ',', '.') }}%
+                                            {% set rejectionRate = (import.rowsRejected ?? 0) / import.rowCount * 100 %}
+                                            {{ macros.import_rate(rejectionRate, 'rejection') }}
                                         {% endif %}
                                     </div>
                                 </div>
+                                <div class="datagrid-item">
+                                    <div class="datagrid-title">{{ 'import.field.rowsDeduplicated'|trans }}</div>
+                                    <div class="datagrid-content">
+                                        {{ import.rowsDeduplicated ?? 0 }}
+                                    </div>
+                                </div>
+                                {% if (import.rowsDeduplicated ?? 0) > 0 %}
+                                <div class="datagrid-item">
+                                    <div class="datagrid-title">{{ 'import.field.rowsDeduplicatedDiscarded'|trans }}</div>
+                                    <div class="datagrid-content">
+                                        {{ import.rowsDeduplicatedDiscarded ?? 0 }}
+                                    </div>
+                                </div>
+                                <div class="datagrid-item">
+                                    <div class="datagrid-title">{{ 'import.field.rowsDeduplicatedReplaced'|trans }}</div>
+                                    <div class="datagrid-content">
+                                        {{ import.rowsDeduplicatedReplaced ?? 0 }}
+                                    </div>
+                                </div>
+                                <div class="datagrid-item">
+                                    <div class="datagrid-title">{{ 'import.field.duplicationRate'|trans }}</div>
+                                    <div class="datagrid-content">
+                                        {% if import.rowCount > 0 %}
+                                            {% set duplicationRate = (import.rowsDeduplicated ?? 0) / import.rowCount * 100 %}
+                                            {{ macros.import_rate(duplicationRate, 'duplication') }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                {% endif %}
                             </div>
                         </twig:Card>
                     </div>

--- a/src/Shared/UI/Twig/templates/_macros/status.html.twig
+++ b/src/Shared/UI/Twig/templates/_macros/status.html.twig
@@ -20,3 +20,11 @@
         {{ status }}
     </span>
 {% endmacro %}
+
+{% macro import_rate(percent, kind) %}
+    {% set badge = import_rate_badge(percent, kind) %}
+    <span class="status status-{{ badge.color }}">
+        {{ ux_icon(badge.icon, {width: 12, height: 12}) }}
+        {{ percent|number_format(2, ',', '.') }}%
+    </span>
+{% endmacro %}

--- a/src/Statistics/Application/Projection/AllocationProjectionDeduplicator.php
+++ b/src/Statistics/Application/Projection/AllocationProjectionDeduplicator.php
@@ -45,8 +45,31 @@ final readonly class AllocationProjectionDeduplicator
 
     public function analyze(?DeduplicationProgressCallback $progress = null): DeduplicationReport
     {
+        return $this->analyzeScoped($progress, null);
+    }
+
+    public function analyzeForHospital(int $hospitalId, ?DeduplicationProgressCallback $progress = null): DeduplicationReport
+    {
+        return $this->analyzeScoped($progress, $hospitalId);
+    }
+
+    public function execute(?DeduplicationProgressCallback $progress = null): DeduplicationResult
+    {
+        return $this->executeScoped($progress, null, null);
+    }
+
+    public function executeForHospital(
+        int $hospitalId,
+        int $triggeringImportId,
+        ?DeduplicationProgressCallback $progress = null,
+    ): DeduplicationResult {
+        return $this->executeScoped($progress, $hospitalId, $triggeringImportId);
+    }
+
+    private function analyzeScoped(?DeduplicationProgressCallback $progress, ?int $hospitalId): DeduplicationReport
+    {
         $this->notify($progress, self::PHASE_ANALYZE_ENR, 0, 2, 'Scanning ENR duplicates…');
-        $enr = $this->analyzeStrategy(self::STRATEGY_ENR);
+        $enr = $this->analyzeStrategy(self::STRATEGY_ENR, $hospitalId);
         $this->notify(
             $progress,
             self::PHASE_ANALYZE_ENR,
@@ -57,7 +80,7 @@ final readonly class AllocationProjectionDeduplicator
         $this->notify($progress, self::PHASE_ANALYZE_ENR, 2, 2, 'ENR analysis complete');
 
         $this->notify($progress, self::PHASE_ANALYZE_FINGERPRINT, 0, 2, 'Scanning fingerprint duplicates…');
-        $fingerprint = $this->analyzeStrategy(self::STRATEGY_FINGERPRINT);
+        $fingerprint = $this->analyzeStrategy(self::STRATEGY_FINGERPRINT, $hospitalId);
         $this->notify(
             $progress,
             self::PHASE_ANALYZE_FINGERPRINT,
@@ -75,10 +98,11 @@ final readonly class AllocationProjectionDeduplicator
             $enr,
             $fingerprint,
             $orphanCount,
-            $this->countEnrHashGroupsSpanningMultipleYears(),
+            $this->countEnrHashGroupsSpanningMultipleYears($hospitalId),
         );
 
         $this->logger->info('projection.deduplicate.analyzed', [
+            'hospital_id' => $hospitalId,
             'enr_duplicate_rows' => $enr->duplicateRows,
             'enr_duplicate_groups' => $enr->duplicateGroups,
             'fingerprint_duplicate_rows' => $fingerprint->duplicateRows,
@@ -90,12 +114,16 @@ final readonly class AllocationProjectionDeduplicator
         return $report;
     }
 
-    public function execute(?DeduplicationProgressCallback $progress = null): DeduplicationResult
-    {
-        $report = $this->analyze($progress);
+    private function executeScoped(
+        ?DeduplicationProgressCallback $progress,
+        ?int $hospitalId,
+        ?int $triggeringImportId,
+    ): DeduplicationResult {
+        $report = $this->analyzeScoped($progress, $hospitalId);
 
-        $duplicateIds = $this->fetchDuplicateAllocationIds();
+        $duplicateIds = $this->fetchDuplicateAllocationIds($hospitalId);
         $totalDuplicates = \count($duplicateIds);
+        $attribution = $this->attributeDuplicateIdsByImport($duplicateIds, $triggeringImportId);
 
         $deletedProjections = 0;
         $deletedAllocations = 0;
@@ -135,6 +163,8 @@ final readonly class AllocationProjectionDeduplicator
                 $this->connection->rollBack();
 
                 $this->logger->error('projection.deduplicate.failed', [
+                    'hospital_id' => $hospitalId,
+                    'triggering_import_id' => $triggeringImportId,
                     'exception' => $e::class,
                     'message' => $e->getMessage(),
                 ]);
@@ -153,6 +183,8 @@ final readonly class AllocationProjectionDeduplicator
                 $this->connection->rollBack();
 
                 $this->logger->error('projection.deduplicate.failed', [
+                    'hospital_id' => $hospitalId,
+                    'triggering_import_id' => $triggeringImportId,
                     'exception' => $e::class,
                     'message' => $e->getMessage(),
                 ]);
@@ -167,23 +199,29 @@ final readonly class AllocationProjectionDeduplicator
             $deletedAllocations,
             $deletedAssessments,
             $deletedOrphans,
+            $attribution['fromCurrent'],
+            $attribution['fromOther'],
         );
 
         $this->logger->info('projection.deduplicate.deleted', [
+            'hospital_id' => $hospitalId,
+            'triggering_import_id' => $triggeringImportId,
             'deleted_projections' => $deletedProjections,
             'deleted_allocations' => $deletedAllocations,
             'deleted_assessments' => $deletedAssessments,
             'deleted_orphan_projections' => $deletedOrphans,
+            'deleted_from_current_import' => $attribution['fromCurrent'],
+            'deleted_from_other_imports' => $attribution['fromOther'],
         ]);
 
         return $result;
     }
 
-    private function analyzeStrategy(string $strategy): DeduplicationStrategySummary
+    private function analyzeStrategy(string $strategy, ?int $hospitalId): DeduplicationStrategySummary
     {
-        $duplicateRows = $this->countDuplicateRows($strategy);
-        $duplicateGroups = $this->countDuplicateGroups($strategy);
-        $sampleIds = $this->fetchSampleDuplicateIds($strategy);
+        $duplicateRows = $this->countDuplicateRows($strategy, $hospitalId);
+        $duplicateGroups = $this->countDuplicateGroups($strategy, $hospitalId);
+        $sampleIds = $this->fetchSampleDuplicateIds($strategy, $hospitalId);
 
         return new DeduplicationStrategySummary(
             $strategy,
@@ -193,16 +231,17 @@ final readonly class AllocationProjectionDeduplicator
         );
     }
 
-    private function countDuplicateRows(string $strategy): int
+    private function countDuplicateRows(string $strategy, ?int $hospitalId): int
     {
         return (int) $this->connection->fetchOne(
-            sprintf('SELECT COUNT(*) FROM (%s) duplicates', $this->duplicateRowsSubquery($strategy)),
+            sprintf('SELECT COUNT(*) FROM (%s) duplicates', $this->duplicateRowsSubquery($strategy, $hospitalId)),
         );
     }
 
-    private function countDuplicateGroups(string $strategy): int
+    private function countDuplicateGroups(string $strategy, ?int $hospitalId): int
     {
         $partitionExpr = $this->partitionKeyExpression($strategy);
+        $where = $this->allocationFilterClause($strategy, $hospitalId);
 
         return (int) $this->connection->fetchOne(
             <<<SQL
@@ -210,7 +249,7 @@ SELECT COUNT(*) FROM (
     SELECT 1
     FROM allocation a
     INNER JOIN import i ON i.id = a.import_id
-    WHERE {$this->strategyWhereClause($strategy)}
+    WHERE {$where}
     GROUP BY {$partitionExpr}
     HAVING COUNT(*) > 1
 ) grouped
@@ -221,13 +260,13 @@ SQL
     /**
      * @return list<int>
      */
-    private function fetchSampleDuplicateIds(string $strategy): array
+    private function fetchSampleDuplicateIds(string $strategy, ?int $hospitalId): array
     {
         /** @var list<int|string> $rows */
         $rows = $this->connection->fetchFirstColumn(
             sprintf(
                 'SELECT id FROM (%s) duplicates ORDER BY id ASC LIMIT %d',
-                $this->duplicateRowsSubquery($strategy),
+                $this->duplicateRowsSubquery($strategy, $hospitalId),
                 self::SAMPLE_LIMIT,
             ),
         );
@@ -238,7 +277,7 @@ SQL
     /**
      * @return list<int>
      */
-    private function fetchDuplicateAllocationIds(): array
+    private function fetchDuplicateAllocationIds(?int $hospitalId): array
     {
         $sql = sprintf(
             <<<'SQL'
@@ -249,8 +288,8 @@ SELECT id FROM (
 ) all_duplicates
 ORDER BY id ASC
 SQL,
-            $this->duplicateRowsSubquery(self::STRATEGY_ENR),
-            $this->duplicateRowsSubquery(self::STRATEGY_FINGERPRINT),
+            $this->duplicateRowsSubquery(self::STRATEGY_ENR, $hospitalId),
+            $this->duplicateRowsSubquery(self::STRATEGY_FINGERPRINT, $hospitalId),
         );
 
         /** @var list<int|string> $rows */
@@ -259,10 +298,34 @@ SQL,
         return array_map(static fn (int|string $id): int => (int) $id, $rows);
     }
 
-    private function duplicateRowsSubquery(string $strategy): string
+    /**
+     * @param list<int> $duplicateIds
+     *
+     * @return array{fromCurrent: int, fromOther: int}
+     */
+    private function attributeDuplicateIdsByImport(array $duplicateIds, ?int $triggeringImportId): array
+    {
+        if ([] === $duplicateIds || null === $triggeringImportId) {
+            return ['fromCurrent' => 0, 'fromOther' => 0];
+        }
+
+        $placeholders = implode(', ', array_fill(0, \count($duplicateIds), '?'));
+
+        $fromCurrent = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM allocation WHERE id IN ('.$placeholders.') AND import_id = ?',
+            [...$duplicateIds, $triggeringImportId],
+        );
+
+        return [
+            'fromCurrent' => $fromCurrent,
+            'fromOther' => \count($duplicateIds) - $fromCurrent,
+        ];
+    }
+
+    private function duplicateRowsSubquery(string $strategy, ?int $hospitalId): string
     {
         $partitionExpr = $this->partitionKeyExpression($strategy);
-        $where = $this->strategyWhereClause($strategy);
+        $where = $this->allocationFilterClause($strategy, $hospitalId);
 
         return <<<SQL
 SELECT ranked.id
@@ -289,6 +352,17 @@ FROM (
 ) ranked
 WHERE ranked.rn > 1
 SQL;
+    }
+
+    private function allocationFilterClause(string $strategy, ?int $hospitalId): string
+    {
+        $clauses = [$this->strategyWhereClause($strategy)];
+
+        if (null !== $hospitalId) {
+            $clauses[] = 'a.hospital_id = '.$hospitalId;
+        }
+
+        return implode(' AND ', $clauses);
     }
 
     private function strategyWhereClause(string $strategy): string
@@ -333,14 +407,18 @@ SQL;
     /**
      * Groups sharing hospital + ENR hash across multiple calendar years (informational; not deduplicated).
      */
-    private function countEnrHashGroupsSpanningMultipleYears(): int
+    private function countEnrHashGroupsSpanningMultipleYears(?int $hospitalId): int
     {
+        $hospitalFilter = null !== $hospitalId
+            ? ' AND a.hospital_id = '.$hospitalId
+            : '';
+
         return (int) $this->connection->fetchOne(
-            <<<'SQL'
+            <<<SQL
 SELECT COUNT(*) FROM (
     SELECT 1
     FROM allocation a
-    WHERE a.case_id_hash IS NOT NULL
+    WHERE a.case_id_hash IS NOT NULL{$hospitalFilter}
     GROUP BY a.hospital_id, a.case_id_hash
     HAVING COUNT(DISTINCT EXTRACT(YEAR FROM a.created_at)) > 1
 ) spanning_years

--- a/src/Statistics/Application/Projection/Dto/DeduplicationResult.php
+++ b/src/Statistics/Application/Projection/Dto/DeduplicationResult.php
@@ -12,7 +12,14 @@ final readonly class DeduplicationResult
         public int $deletedAllocations,
         public int $deletedAssessments,
         public int $deletedOrphanProjections,
+        public int $deletedFromCurrentImport = 0,
+        public int $deletedFromOtherImports = 0,
     ) {
+    }
+
+    public function totalDeletedAllocations(): int
+    {
+        return $this->deletedAllocations;
     }
 
     public function totalDeletedRows(): int

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTest.php
@@ -7,6 +7,10 @@ namespace App\Tests\Import\Integration\MessageHandler;
 
 use App\Allocation\Domain\Entity\Allocation;
 use App\Allocation\Domain\Entity\Assessment;
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
@@ -24,11 +28,13 @@ use App\Import\Application\MessageHandler\ImportAllocationsMessageHandler;
 use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
 use App\Import\Infrastructure\Repository\ImportRepository;
 use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
 use App\Tests\Import\Doubles\Service\Adapter\InMemoryRejectWriter;
 use App\Tests\Import\Doubles\Service\Adapter\InMemoryRowReader;
 use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -139,6 +145,89 @@ final class ImportAllocationsMessageHandlerTest extends KernelTestCase
         $firstReject = $rejectWriter->all()[0];
         self::assertArrayHasKey('messages', $firstReject);
         self::assertNotEmpty($firstReject['messages']);
+    }
+
+    public function testRunDeduplicatesOverlappingAllocationsAndRecordsStats(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'import-dedup-'.bin2hex(random_bytes(6))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Test', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Testkrankenhaus Musterstadt',
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $speciality = SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        $department = DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        $assignment = AssignmentFactory::createOne(['name' => 'Patient']);
+        OccasionFactory::createOne(['name' => 'aus Arztpraxis']);
+        InfectionFactory::createOne(['name' => 'Noro']);
+        $indicationRaw = IndicationRawFactory::createOne([
+            'name' => 'Test Indication',
+            'code' => 123,
+            'hash' => '070f5e78cc3ce4b3c3378aeaa0a304a4',
+        ]);
+
+        $olderImport = ImportFactory::createOne([
+            'name' => 'Older overlapping import',
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+            'createdAt' => new \DateTimeImmutable('2024-01-01 10:00:00'),
+        ]);
+
+        AllocationFactory::createOne([
+            'import' => $olderImport,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+            'speciality' => $speciality,
+            'department' => $department,
+            'assignment' => $assignment,
+            'indicationRaw' => $indicationRaw,
+            'caseIdHash' => null,
+            'gender' => AllocationGender::FEMALE,
+            'age' => 74,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'createdAt' => new \DateTimeImmutable('2025-01-07 10:19:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-01-07 13:14:00'),
+        ]);
+
+        $header = [
+            'Versorgungsbereich', 'KHS-Versorgungsgebiet', 'Krankenhaus', 'Krankenhaus-Kurzname',
+            'Datum', 'Uhrzeit', 'Datum (Eintreffzeit)', 'Uhrzeit (Eintreffzeit)',
+            'Geschlecht', 'Alter', 'Schockraum', 'Herzkatheter', 'Reanimation', 'Beatmet',
+            'Schwanger', 'Arztbegleitet', 'Transportmittel', 'Datum (Erstellungsdatum)', 'Uhrzeit (Erstellungsdatum)',
+            'PZC', 'Fachgebiet', 'Fachbereich', 'Fachbereich war abgemeldet?', 'Anlass', 'Grund', 'Ansteckungsfähig',
+            'PZC und Text',
+        ];
+
+        $rows = [
+            ['Leitstelle Test', '1', $hospital->getName(), 'KH Test', '07.01.2025', '10:19', '07.01.2025', '13:14', 'W', '74', 'S+', 'H+', 'R+', 'B-', '', 'N-', 'Boden', '07.01.2025', '10:19', '123741', 'Innere Medizin', 'Kardiologie', 'Ja', 'aus Arztpraxis', 'Patient', 'Noro', '123 Test Indication'],
+        ];
+
+        $import = $this->createInMemoryImport($owner, $hospital);
+        $reader = new InMemoryRowReader($header, $rows);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $this->handler->run($import, $reader, $rejectWriter);
+
+        $fresh = $this->imports->find($import->getId());
+        self::assertNotNull($fresh);
+        self::assertSame(ImportStatus::COMPLETED, $fresh->getStatus());
+        self::assertSame(1, $fresh->getRowsPassed());
+        self::assertSame(0, $fresh->getRowsRejected());
+        self::assertSame(1, $fresh->getRowsDeduplicated());
+        self::assertSame(0, $fresh->getRowsDeduplicatedDiscarded());
+        self::assertSame(1, $fresh->getRowsDeduplicatedReplaced());
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        self::assertSame(1, (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM allocation WHERE hospital_id = :hospitalId',
+            ['hospitalId' => $hospital->getId()],
+        ));
     }
 
     public function testImportWithPlaceholderAbcdColumnsDoesNotPersistAssessmentOrAudit(): void

--- a/tests/Import/Unit/Application/Service/ImportAllocationDeduplicationServiceTest.php
+++ b/tests/Import/Unit/Application/Service/ImportAllocationDeduplicationServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Import\Application\DTO\ImportSummary;
+use App\Import\Application\Service\ImportAllocationDeduplicationService;
+use App\Import\Domain\Entity\Import;
+use App\Statistics\Application\Projection\AllocationProjectionDeduplicator;
+use App\Statistics\Application\Projection\Dto\DeduplicationReport;
+use App\Statistics\Application\Projection\Dto\DeduplicationResult;
+use App\Statistics\Application\Projection\Dto\DeduplicationStrategySummary;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class ImportAllocationDeduplicationServiceTest extends TestCase
+{
+    public function testDeduplicateForImportRequiresPersistedImportWithHospital(): void
+    {
+        $service = $this->createService();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Import must be persisted with a hospital before deduplication.');
+
+        $service->deduplicateForImport(new Import());
+    }
+
+    public function testDeduplicateForImportRequiresHospitalWhenImportHasId(): void
+    {
+        $import = $this->createStub(Import::class);
+        $import->method('getId')->willReturn(42);
+        $import->method('getHospital')->willReturn(null);
+
+        $service = $this->createService();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Import must be persisted with a hospital before deduplication.');
+
+        $service->deduplicateForImport($import);
+    }
+
+    #[DataProvider('adjustSummaryProvider')]
+    public function testAdjustSummaryReducesPassedRowsFromCurrentImportDeletionsOnly(
+        ImportSummary $summary,
+        DeduplicationResult $result,
+        ImportSummary $expected,
+    ): void {
+        $adjusted = $this->createService()->adjustSummary($summary, $result);
+
+        self::assertSame($expected->total, $adjusted->total);
+        self::assertSame($expected->ok, $adjusted->ok);
+        self::assertSame($expected->rejected, $adjusted->rejected);
+    }
+
+    public function testApplyDeduplicationStatsWritesAllDeduplicationCounters(): void
+    {
+        $import = new Import();
+        $result = $this->createDeduplicationResult(
+            deletedAllocations: 5,
+            deletedFromCurrentImport: 2,
+            deletedFromOtherImports: 3,
+        );
+
+        $service = $this->createService();
+
+        $service->applyDeduplicationStats($import, $result);
+
+        self::assertSame(5, $import->getRowsDeduplicated());
+        self::assertSame(2, $import->getRowsDeduplicatedDiscarded());
+        self::assertSame(3, $import->getRowsDeduplicatedReplaced());
+    }
+
+    /**
+     * @return iterable<string, array{ImportSummary, DeduplicationResult, ImportSummary}>
+     */
+    public static function adjustSummaryProvider(): iterable
+    {
+        yield 'no current-import deletions' => [
+            new ImportSummary(total: 10, ok: 8, rejected: 2),
+            self::createDeduplicationResultStatic(deletedFromCurrentImport: 0),
+            new ImportSummary(total: 10, ok: 8, rejected: 2),
+        ];
+
+        yield 'subtracts current-import deletions from passed rows' => [
+            new ImportSummary(total: 10, ok: 8, rejected: 2),
+            self::createDeduplicationResultStatic(deletedFromCurrentImport: 3),
+            new ImportSummary(total: 10, ok: 5, rejected: 2),
+        ];
+
+        yield 'clamps passed rows at zero' => [
+            new ImportSummary(total: 10, ok: 2, rejected: 8),
+            self::createDeduplicationResultStatic(deletedFromCurrentImport: 5),
+            new ImportSummary(total: 10, ok: 0, rejected: 8),
+        ];
+    }
+
+    private function createService(): ImportAllocationDeduplicationService
+    {
+        $logger = $this->createStub(LoggerInterface::class);
+
+        return new ImportAllocationDeduplicationService(
+            new AllocationProjectionDeduplicator(
+                $this->createStub(\Doctrine\DBAL\Connection::class),
+                $logger,
+            ),
+            $logger,
+        );
+    }
+
+    private function createDeduplicationResult(
+        int $deletedAllocations = 0,
+        int $deletedFromCurrentImport = 0,
+        int $deletedFromOtherImports = 0,
+    ): DeduplicationResult {
+        return self::createDeduplicationResultStatic(
+            deletedAllocations: $deletedAllocations,
+            deletedFromCurrentImport: $deletedFromCurrentImport,
+            deletedFromOtherImports: $deletedFromOtherImports,
+        );
+    }
+
+    private static function createDeduplicationResultStatic(
+        int $deletedAllocations = 0,
+        int $deletedFromCurrentImport = 0,
+        int $deletedFromOtherImports = 0,
+    ): DeduplicationResult {
+        $emptyStrategy = new DeduplicationStrategySummary('test', 0, 0, []);
+
+        return new DeduplicationResult(
+            report: new DeduplicationReport(
+                enr: $emptyStrategy,
+                fingerprint: $emptyStrategy,
+                orphanProjectionRows: 0,
+            ),
+            deletedProjections: 0,
+            deletedAllocations: $deletedAllocations,
+            deletedAssessments: 0,
+            deletedOrphanProjections: 0,
+            deletedFromCurrentImport: $deletedFromCurrentImport,
+            deletedFromOtherImports: $deletedFromOtherImports,
+        );
+    }
+}

--- a/tests/Import/Unit/Domain/Service/ImportDuplicationRatePresentationTest.php
+++ b/tests/Import/Unit/Domain/Service/ImportDuplicationRatePresentationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Domain\Service;
+
+use App\Import\Domain\Service\ImportDuplicationRatePresentation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ImportDuplicationRatePresentationTest extends TestCase
+{
+    #[DataProvider('duplicationRateProvider')]
+    public function testForPercent(float $percent, string $expectedColor, string $expectedIcon): void
+    {
+        $badge = ImportDuplicationRatePresentation::forPercent($percent);
+
+        self::assertSame($expectedColor, $badge->color);
+        self::assertSame($expectedIcon, $badge->icon);
+    }
+
+    /**
+     * @return iterable<string, array{float, string, string}>
+     */
+    public static function duplicationRateProvider(): iterable
+    {
+        yield 'below low threshold' => [9.99, 'azure', 'tabler:copy'];
+        yield 'at low threshold' => [10.0, 'yellow', 'tabler:circle-half'];
+        yield 'below elevated threshold' => [34.99, 'yellow', 'tabler:circle-half'];
+        yield 'at elevated threshold' => [35.0, 'orange', 'tabler:alert-triangle'];
+        yield 'below high threshold' => [49.99, 'orange', 'tabler:alert-triangle'];
+        yield 'at high threshold' => [50.0, 'red', 'tabler:alert-triangle'];
+    }
+}

--- a/tests/Import/Unit/Domain/Service/ImportEvaluationTest.php
+++ b/tests/Import/Unit/Domain/Service/ImportEvaluationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Domain\Service;
+
+use App\Import\Application\DTO\ImportSummary;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Service\ImportEvaluation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ImportEvaluationTest extends TestCase
+{
+    #[DataProvider('completedSummaryProvider')]
+    public function testCompletedWhenRejectionRateIsBelowCompleteThreshold(ImportSummary $summary): void
+    {
+        $import = new Import();
+
+        ImportEvaluation::apply($import, $summary, 1200);
+
+        self::assertSame(ImportStatus::COMPLETED, $import->getStatus());
+        self::assertSame($summary->total, $import->getRowCount());
+        self::assertSame($summary->ok, $import->getRowsPassed());
+        self::assertSame($summary->rejected, $import->getRowsRejected());
+        self::assertSame(1, $import->getRunCount());
+        self::assertSame(1200, $import->getRunTime());
+    }
+
+    #[DataProvider('partialSummaryProvider')]
+    public function testPartialWhenRejectionRateIsBetweenCompleteAndFailedThreshold(ImportSummary $summary): void
+    {
+        $import = new Import();
+
+        ImportEvaluation::apply($import, $summary, 800);
+
+        self::assertSame(ImportStatus::PARTIAL, $import->getStatus());
+        self::assertSame($summary->total, $import->getRowCount());
+        self::assertSame($summary->ok, $import->getRowsPassed());
+        self::assertSame($summary->rejected, $import->getRowsRejected());
+        self::assertSame(1, $import->getRunCount());
+        self::assertSame(800, $import->getRunTime());
+    }
+
+    public function testFailedDueToHighRejectionRatePersistsRowStatistics(): void
+    {
+        $import = new Import();
+
+        ImportEvaluation::apply($import, new ImportSummary(total: 713, ok: 231, rejected: 482), 2909);
+
+        self::assertSame(ImportStatus::FAILED, $import->getStatus());
+        self::assertSame(713, $import->getRowCount());
+        self::assertSame(231, $import->getRowsPassed());
+        self::assertSame(482, $import->getRowsRejected());
+        self::assertSame(1, $import->getRunCount());
+        self::assertSame(2909, $import->getRunTime());
+    }
+
+    public function testFailedDueToEmptyFilePersistsZeroRowStatistics(): void
+    {
+        $import = new Import();
+
+        ImportEvaluation::apply($import, ImportSummary::empty(), 100);
+
+        self::assertSame(ImportStatus::FAILED, $import->getStatus());
+        self::assertSame(0, $import->getRowCount());
+        self::assertSame(0, $import->getRowsPassed());
+        self::assertSame(0, $import->getRowsRejected());
+    }
+
+    /**
+     * @return iterable<string, array{ImportSummary}>
+     */
+    public static function completedSummaryProvider(): iterable
+    {
+        yield 'no rejects' => [new ImportSummary(total: 100, ok: 100, rejected: 0)];
+        yield 'below complete threshold' => [new ImportSummary(total: 100, ok: 96, rejected: 4)];
+    }
+
+    /**
+     * @return iterable<string, array{ImportSummary}>
+     */
+    public static function partialSummaryProvider(): iterable
+    {
+        yield 'at complete threshold' => [new ImportSummary(total: 100, ok: 95, rejected: 5)];
+        yield 'below failed threshold' => [new ImportSummary(total: 100, ok: 70, rejected: 30)];
+        yield 'just below failed threshold' => [new ImportSummary(total: 1000, ok: 651, rejected: 349)];
+    }
+}

--- a/tests/Import/Unit/Domain/Service/ImportRejectionRatePresentationTest.php
+++ b/tests/Import/Unit/Domain/Service/ImportRejectionRatePresentationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Domain\Service;
+
+use App\Import\Domain\Service\ImportRejectionRatePresentation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ImportRejectionRatePresentationTest extends TestCase
+{
+    #[DataProvider('rejectionRateProvider')]
+    public function testForPercent(float $percent, string $expectedColor, string $expectedIcon): void
+    {
+        $badge = ImportRejectionRatePresentation::forPercent($percent);
+
+        self::assertSame($expectedColor, $badge->color);
+        self::assertSame($expectedIcon, $badge->icon);
+    }
+
+    /**
+     * @return iterable<string, array{float, string, string}>
+     */
+    public static function rejectionRateProvider(): iterable
+    {
+        yield 'below complete threshold' => [4.99, 'green', 'tabler:circle-check'];
+        yield 'at complete threshold' => [5.0, 'yellow', 'tabler:circle-half'];
+        yield 'below failed threshold' => [34.99, 'yellow', 'tabler:circle-half'];
+        yield 'at failed threshold' => [35.0, 'red', 'tabler:alert-triangle'];
+    }
+}

--- a/tests/Import/Unit/UI/Twig/ImportTwigExtensionTest.php
+++ b/tests/Import/Unit/UI/Twig/ImportTwigExtensionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\UI\Twig;
+
+use App\Import\UI\Twig\ImportTwigExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ImportTwigExtensionTest extends TestCase
+{
+    private ImportTwigExtension $extension;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->extension = new ImportTwigExtension();
+    }
+
+    #[DataProvider('rejectionBadgeProvider')]
+    public function testImportRateBadgeForRejection(float $percent, string $expectedColor, string $expectedIcon): void
+    {
+        $badge = $this->extension->importRateBadge($percent, 'rejection');
+
+        self::assertSame($expectedColor, $badge['color']);
+        self::assertSame($expectedIcon, $badge['icon']);
+    }
+
+    #[DataProvider('duplicationBadgeProvider')]
+    public function testImportRateBadgeForDuplication(float $percent, string $expectedColor, string $expectedIcon): void
+    {
+        $badge = $this->extension->importRateBadge($percent, 'duplication');
+
+        self::assertSame($expectedColor, $badge['color']);
+        self::assertSame($expectedIcon, $badge['icon']);
+    }
+
+    public function testImportRateBadgeRejectsUnknownKind(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown import rate kind "unknown".');
+
+        $this->extension->importRateBadge(12.5, 'unknown');
+    }
+
+    /**
+     * @return iterable<string, array{float, string, string}>
+     */
+    public static function rejectionBadgeProvider(): iterable
+    {
+        yield 'completed tier' => [4.99, 'green', 'tabler:circle-check'];
+        yield 'partial tier' => [20.0, 'yellow', 'tabler:circle-half'];
+        yield 'failed tier' => [35.0, 'red', 'tabler:alert-triangle'];
+    }
+
+    /**
+     * @return iterable<string, array{float, string, string}>
+     */
+    public static function duplicationBadgeProvider(): iterable
+    {
+        yield 'low tier' => [5.0, 'azure', 'tabler:copy'];
+        yield 'elevated tier' => [20.0, 'yellow', 'tabler:circle-half'];
+        yield 'high tier' => [40.0, 'orange', 'tabler:alert-triangle'];
+        yield 'critical tier' => [50.0, 'red', 'tabler:alert-triangle'];
+    }
+}

--- a/tests/Statistics/Unit/Application/Projection/AllocationProjectionDeduplicatorTest.php
+++ b/tests/Statistics/Unit/Application/Projection/AllocationProjectionDeduplicatorTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application\Projection;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\CaseId\CaseIdHasher;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Projection\AllocationProjectionDeduplicator;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class AllocationProjectionDeduplicatorTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testExecuteForHospitalRemovesDuplicatesOnlyInScopedHospital(): void
+    {
+        self::bootKernel();
+
+        $seedA = $this->seedReferenceGraph();
+        $seedB = $this->seedReferenceGraph();
+
+        /** @var CaseIdHasher $hasher */
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        $caseIdHash = $hasher->hashFrom('998877665');
+
+        $this->seedDuplicatePair($seedA, $caseIdHash);
+        $otherHospitalDuplicate = $this->seedDuplicatePair($seedB, $hasher->hashFrom('112233445'));
+
+        /** @var AllocationProjectionDeduplicator $deduplicator */
+        $deduplicator = self::getContainer()->get(AllocationProjectionDeduplicator::class);
+        $hospitalId = (int) $seedA['hospital']->getId();
+
+        $result = $deduplicator->executeForHospital($hospitalId, (int) $otherHospitalDuplicate['newerImportId']);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        self::assertSame(1, $result->totalDeletedAllocations());
+        self::assertSame(1, (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM allocation WHERE hospital_id = :hospitalId',
+            ['hospitalId' => $hospitalId],
+        ));
+        self::assertSame(2, (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM allocation WHERE hospital_id = :hospitalId',
+            ['hospitalId' => (int) $seedB['hospital']->getId()],
+        ));
+    }
+
+    public function testExecuteForHospitalAttributesDeletionsToTriggeringImport(): void
+    {
+        self::bootKernel();
+
+        $seed = $this->seedReferenceGraph();
+        /** @var CaseIdHasher $hasher */
+        $hasher = self::getContainer()->get(CaseIdHasher::class);
+        $fixture = $this->seedDuplicatePair($seed, $hasher->hashFrom('554433221'));
+
+        /** @var AllocationProjectionDeduplicator $deduplicator */
+        $deduplicator = self::getContainer()->get(AllocationProjectionDeduplicator::class);
+
+        $result = $deduplicator->executeForHospital(
+            (int) $seed['hospital']->getId(),
+            $fixture['newerImportId'],
+        );
+
+        self::assertSame(1, $result->totalDeletedAllocations());
+        self::assertSame(0, $result->deletedFromCurrentImport);
+        self::assertSame(1, $result->deletedFromOtherImports);
+    }
+
+    /**
+     * @param array{
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     hospital: object,
+     *     indicationNormalized: object,
+     *     indicationRaw: object,
+     *     speciality: object,
+     *     department: object,
+     *     assignment: object
+     * } $seed
+     *
+     * @return array{newerImportId: int, olderImportId: int}
+     */
+    private function seedDuplicatePair(array $seed, string $caseIdHash): array
+    {
+        $olderImport = ImportFactory::createOne([
+            'name' => 'Dedup Unit Old '.bin2hex(random_bytes(3)),
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2024-01-01 10:00:00'),
+        ]);
+        $newerImport = ImportFactory::createOne([
+            'name' => 'Dedup Unit New '.bin2hex(random_bytes(3)),
+            'hospital' => $seed['hospital'],
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2025-06-01 10:00:00'),
+        ]);
+
+        $shared = $this->allocationDefaults($seed, $olderImport, 30, '2025-03-01 08:00:00', '2025-03-01 08:30:00');
+        $shared['caseIdHash'] = $caseIdHash;
+        AllocationFactory::createOne($shared);
+
+        $newerDefaults = $this->allocationDefaults($seed, $newerImport, 30, '2025-03-01 08:00:00', '2025-03-01 08:30:00');
+        $newerDefaults['caseIdHash'] = $caseIdHash;
+        AllocationFactory::createOne($newerDefaults);
+
+        return [
+            'newerImportId' => (int) $newerImport->getId(),
+            'olderImportId' => (int) $olderImport->getId(),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     hospital: object,
+     *     indicationNormalized: object,
+     *     indicationRaw: object,
+     *     speciality: object,
+     *     department: object,
+     *     assignment: object
+     * }
+     */
+    private function seedReferenceGraph(): array
+    {
+        $user = UserFactory::createOne(['username' => 'dedup-unit-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DedupUnitState-'.bin2hex(random_bytes(3))]);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'DedupUnitDispatch-'.bin2hex(random_bytes(3)), 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'DedupUnitHospital-'.bin2hex(random_bytes(3)),
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        $speciality = SpecialityFactory::createOne(['name' => 'DedupUnitSpeciality-'.bin2hex(random_bytes(3))]);
+        $department = DepartmentFactory::createOne(['name' => 'DedupUnitDepartment-'.bin2hex(random_bytes(3))]);
+        $assignment = AssignmentFactory::createOne(['name' => 'DedupUnitAssignment-'.bin2hex(random_bytes(3))]);
+        OccasionFactory::createOne(['name' => 'DedupUnitOccasion-'.bin2hex(random_bytes(3))]);
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'DedupUnitRawIndication', 'code' => 800001]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'DedupUnitNormalizedIndication']);
+
+        return [
+            'user' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'hospital' => $hospital,
+            'speciality' => $speciality,
+            'department' => $department,
+            'assignment' => $assignment,
+            'indicationNormalized' => $indicationNormalized,
+            'indicationRaw' => $indicationRaw,
+        ];
+    }
+
+    /**
+     * @param array{
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     hospital: object,
+     *     indicationNormalized: object,
+     *     indicationRaw: object,
+     *     speciality: object,
+     *     department: object,
+     *     assignment: object
+     * } $seed
+     *
+     * @return array<string, mixed>
+     */
+    private function allocationDefaults(
+        array $seed,
+        object $import,
+        int $age,
+        string $createdAt,
+        string $arrivalAt,
+    ): array {
+        return [
+            'import' => $import,
+            'hospital' => $seed['hospital'],
+            'state' => $seed['state'],
+            'dispatchArea' => $seed['dispatchArea'],
+            'speciality' => $seed['speciality'],
+            'department' => $seed['department'],
+            'assignment' => $seed['assignment'],
+            'indicationRaw' => $seed['indicationRaw'],
+            'indicationNormalized' => $seed['indicationNormalized'],
+            'createdAt' => new \DateTimeImmutable($createdAt),
+            'arrivalAt' => new \DateTimeImmutable($arrivalAt),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => $age,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'occasion' => null,
+            'infection' => null,
+            'departmentWasClosed' => false,
+        ];
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -497,6 +497,22 @@
         <source>import.field.rowsRejected</source>
         <target>Rejected rows</target>
       </trans-unit>
+      <trans-unit id="DdupTotal01" resname="import.field.rowsDeduplicated">
+        <source>import.field.rowsDeduplicated</source>
+        <target>Deduplicated rows (total)</target>
+      </trans-unit>
+      <trans-unit id="DdupDisc01" resname="import.field.rowsDeduplicatedDiscarded">
+        <source>import.field.rowsDeduplicatedDiscarded</source>
+        <target>Deduplicated rows (Discarded)</target>
+      </trans-unit>
+      <trans-unit id="DdupRepl01" resname="import.field.rowsDeduplicatedReplaced">
+        <source>import.field.rowsDeduplicatedReplaced</source>
+        <target>Deduplicated rows (Replaced)</target>
+      </trans-unit>
+      <trans-unit id="DdupRate01" resname="import.field.duplicationRate">
+        <source>import.field.duplicationRate</source>
+        <target>Duplication rate</target>
+      </trans-unit>
       <trans-unit id="oiSvDD9" resname="import.field.runCount">
         <source>import.field.runCount</source>
         <target>Run count</target>


### PR DESCRIPTION
### Summary

- Added duplicate detection directly to the import pipeline
- Prevented duplicate allocations from being processed multiple times during import
- Improved handling of repeated or overlapping import data
- Extended projection and statistics handling to respect import-time deduplication
- Added safeguards to keep imports idempotent when the same data is imported repeatedly
- Added or updated tests covering duplicate detection and processing behavior

### Motivation

- Detect duplicates as early as possible during import processing
- Prevent duplicate allocations from propagating into projections and statistics
- Improve overall data quality and consistency
- Reduce the need for later cleanup and correction steps
- Make repeated imports safer and more predictable

### Notes for Reviewers

- Review duplicate detection criteria and matching logic carefully
- Verify legitimate allocations are not incorrectly filtered as duplicates
- Check behavior when importing overlapping datasets multiple times
- Ensure projections and statistics remain consistent after duplicate filtering
- Confirm tests cover duplicate, non-duplicate, and repeated import scenarios