### PR TITLE
refactor(tests): Use DAMA transaction rollbacks for faster tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,20 +105,13 @@ jobs:
                   php bin/console importmap:install
                   php bin/console asset-map:compile
 
-            - name: Prepare database
+            - name: Execute database-backed tests via ParaTest
               run: |
-                  php bin/console doctrine:database:drop --if-exists --force --env test
-                  php bin/console doctrine:database:create --env test
-                  php bin/console doctrine:migrations:migrate --no-interaction --env=test
-              env:
-                  DATABASE_URL: postgres://app:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/app
-
-            - name: Execute database-backed tests via PHPUnit
-              run: |
-                  bin/phpunit --testsuite all --exclude-testsuite unit --log-junit junit.xml --order-by duration --stop-on-failure
+                  vendor/bin/paratest --testsuite all --exclude-testsuite unit --processes=4 --log-junit junit.xml --order-by duration --stop-on-failure
                   php bin/report-slowest-tests 10 || true
               env:
                   DATABASE_URL: postgres://app:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/app
+                  XDEBUG_MODE: coverage
 
             - name: Upload coverage reports to Codecov
               if: success()

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
     },
     "require-dev": {
         "brianium/paratest": "^7.8",
+        "dama/doctrine-test-bundle": "^8.2",
         "deployer/deployer": "^8.0.5",
         "doctrine/doctrine-fixtures-bundle": "^4.3.1",
         "friendsofphp/php-cs-fixer": "^3.95.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd03dcc3074a0fe7b1d131f3b6b1d84b",
+    "content-hash": "840be432bfa475782097d312b727018c",
     "packages": [
         {
             "name": "composer/semver",
@@ -11386,6 +11386,75 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
         },
         {
             "name": "danog/advanced-json-rpc",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -25,4 +25,5 @@ return [
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
     Sentry\SentryBundle\SentryBundle::class => ['all' => true],
     Vich\UploaderBundle\VichUploaderBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/packages/dama_doctrine_test_bundle.yaml
+++ b/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/config/packages/zenstruck_foundry.yaml
+++ b/config/packages/zenstruck_foundry.yaml
@@ -1,4 +1,4 @@
-when@dev: &dev
+when@dev:
     # See full configuration: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#full-default-bundle-configuration
     zenstruck_foundry:
         orm:
@@ -11,4 +11,14 @@ when@dev: &dev
         faker:
             locale: de_DE
 
-when@test: *dev
+when@test:
+    zenstruck_foundry:
+        orm:
+            reset:
+                # Align test schema with migrations (incl. materialized views); DAMA rolls back per test.
+                mode: migrate
+        persistence:
+            flush_once: true
+
+        faker:
+            locale: de_DE

--- a/config/reference.php
+++ b/config/reference.php
@@ -1746,6 +1746,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         db_driver?: scalar|Param|null, // Default: null
  *     }>,
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1834,6 +1840,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         live_component?: LiveComponentConfig,
  *         sentry?: SentryConfig,
  *         vich_uploader?: VichUploaderConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/services/foundry_test.yaml
+++ b/config/services/foundry_test.yaml
@@ -3,7 +3,8 @@ when@test:
     services:
         App\Tests\Support\Foundry\MaterializedViewAwareOrmResetter:
             decorates: Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter
+            # Inner to DamaDatabaseResetter (priority 10) so static connections are disabled before migrate reset.
+            decoration_priority: 20
             arguments:
                 $decorated: '@.inner'
-                $materializedViewDropper: '@App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewDropper'
                 $materializedViewsInstaller: '@App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller'

--- a/docs/Statistics-projection-materialized-views.md
+++ b/docs/Statistics-projection-materialized-views.md
@@ -74,32 +74,43 @@ If views are missing after a fresh database, run Doctrine migrations first; the 
 
 ## Why tests need special handling
 
+### DAMA Doctrine Test Bundle (transaction rollback)
+
+Tests use [DAMA Doctrine Test Bundle](https://github.com/dmaicher/doctrine-test-bundle) together with Foundry. Each test method runs inside a database transaction that is rolled back automatically when the test finishes. That replaces the previous per-test schema drop/recreate cycle and is the main reason the DB test suite runs much faster.
+
+Implications for materialized views:
+
+- **Schema reset** (drop + recreate + MV install) runs **once per PHPUnit process** when the first `#[ResetDatabase]` test class starts — not before every test method.
+- **MV data** refreshed inside a test (via `RefreshesStatisticsMaterializedViewsTrait`) is rolled back with the test transaction; the view definitions persist.
+- **MV refresh after projection rebuild remains mandatory** when assertions use MV-backed queries or `StatisticsFilterFactory` scope rules.
+
+Configuration: `config/packages/dama_doctrine_test_bundle.yaml`, PHPUnit extension in `phpunit.dist.xml`.
+
 ### Foundry `ResetDatabase` and PostgreSQL
 
-Tests use [Zenstruck Foundry](https://github.com/zenstruck/foundry) with ORM reset mode **`schema`** (`config/packages/zenstruck_foundry.yaml`). Between tests, Foundry runs:
+Tests use [Zenstruck Foundry](https://github.com/zenstruck/foundry) with ORM reset mode **`migrate`** in `test` (`config/packages/zenstruck_foundry.yaml`). Without DAMA, Foundry would run before almost every test method:
 
 ```text
-doctrine:schema:drop --force --full-database
-doctrine:schema:update --force
+doctrine:database:drop --force
+doctrine:database:create
+doctrine:migrations:migrate
 ```
 
-PostgreSQL blocks dropping tables that are still referenced by materialized views. The overview views depend on `allocation_stats_projection`, so a plain schema drop fails with dependency errors.
+With DAMA enabled, Foundry's `DamaDatabaseResetter` performs that migration reset only **once per PHPUnit/ParaTest worker** at the start of the run; subsequent tests rely on transaction rollback.
+
+Overview materialized views are created by migration `Version20260519125102`. The test-only `MaterializedViewAwareOrmResetter` calls `OverviewMaterializedViewsInstaller::ensureInstalled()` after the migrate reset as a safety net when migrations did not run the view DDL.
 
 ### Test-only reset decorator
 
 Registered only when `APP_ENV=test` (`config/services/foundry_test.yaml`):
 
-**`MaterializedViewAwareOrmResetter`** decorates `Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter` and wraps each reset:
+**`MaterializedViewAwareOrmResetter`** decorates `Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter` (inner to Foundry's `DamaDatabaseResetter`, `decoration_priority: 20`) and wraps each migrate reset:
 
-1. **Before reset** — `StatisticsMaterializedViewDropper` runs:
-   ```sql
-   DROP MATERIALIZED VIEW IF EXISTS <view> CASCADE;
-   ```
-   for each overview view, then `OverviewMaterializedViewsInstaller::resetInstallationState()` clears the in-memory “already installed” flag.
+1. **Before reset** — `OverviewMaterializedViewsInstaller::resetInstallationState()` clears the in-memory “already installed” flag.
 
-2. **Foundry reset** — inner resetter drops and recreates the schema as usual.
+2. **Foundry reset** — inner resetter drops the database, recreates it, and runs migrations (DAMA disables static connections before this step).
 
-3. **After reset** — `OverviewMaterializedViewsInstaller::ensureInstalled()` recreates the overview views (same SQL as migrations) if they are absent.
+3. **After reset** — `OverviewMaterializedViewsInstaller::ensureInstalled()` recreates the overview views if they are absent (normally already created by migrations).
 
 This wiring does **not** run in `prod` or `dev`; it does not change runtime behavior outside tests.
 

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -96,6 +96,7 @@
     </coverage>
 
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
         <bootstrap class="Zenstruck\Browser\Test\BrowserExtension" />
         <bootstrap class="Zenstruck\Foundry\PHPUnit\FoundryExtension" />
     </extensions>

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,16 @@
 {
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        },
+        "files": [
+            "config/packages/dama_doctrine_test_bundle.yaml"
+        ]
+    },
     "doctrine/deprecations": {
         "version": "1.1",
         "recipe": {

--- a/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
+++ b/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace App\Tests\Support\Foundry;
 
-use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewDropper;
 use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
 
 /**
- * Drops statistics materialized views before Foundry's schema reset and recreates them afterwards.
+ * Ensures overview materialized views exist after Foundry's migrate reset.
+ *
+ * With reset mode `migrate`, the database is dropped and recreated via migrations (which
+ * create the views). MV DROP before reset is not needed and would fail when the worker
+ * database does not exist yet (e.g. ParaTest with TEST_TOKEN).
+ *
+ * Decorated inner to Foundry's DamaDatabaseResetter so DAMA disables static connections
+ * before the migrate reset runs.
  *
  * @see tests/Support/MaterializedView/README.md
  */
@@ -18,33 +24,21 @@ final readonly class MaterializedViewAwareOrmResetter implements OrmResetter
 {
     public function __construct(
         private OrmResetter $decorated,
-        private StatisticsMaterializedViewDropper $materializedViewDropper,
         private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
     ) {
     }
 
     public function resetBeforeFirstTest(KernelInterface $kernel): void
     {
-        $this->prepareSchemaReset();
+        $this->materializedViewsInstaller->resetInstallationState();
         $this->decorated->resetBeforeFirstTest($kernel);
-        $this->finishSchemaReset();
+        $this->materializedViewsInstaller->ensureInstalled();
     }
 
     public function resetBeforeEachTest(KernelInterface $kernel): void
     {
-        $this->prepareSchemaReset();
-        $this->decorated->resetBeforeEachTest($kernel);
-        $this->finishSchemaReset();
-    }
-
-    private function prepareSchemaReset(): void
-    {
-        $this->materializedViewDropper->dropAllForSchemaReset();
         $this->materializedViewsInstaller->resetInstallationState();
-    }
-
-    private function finishSchemaReset(): void
-    {
+        $this->decorated->resetBeforeEachTest($kernel);
         $this->materializedViewsInstaller->ensureInstalled();
     }
 }

--- a/tests/Support/MaterializedView/README.md
+++ b/tests/Support/MaterializedView/README.md
@@ -4,5 +4,5 @@ See the full guide: [docs/Statistics-projection-materialized-views.md](../../../
 
 Quick reminders:
 
-- **DROP before Foundry reset** — test-only `MaterializedViewAwareOrmResetter` drops `mv_projection_*` so `doctrine:schema:drop --full-database` can succeed.
+- **DROP before Foundry reset** — not required with `migrate` reset (database drop removes MVs). `MaterializedViewAwareOrmResetter` only ensures views exist after migrate reset.
 - **REFRESH after fixtures** — use `RefreshesStatisticsMaterializedViewsTrait::refreshStatisticsMaterializedViews()` when assertions use MV-backed queries or `StatisticsFilterFactory` state/dispatch scopes.

--- a/tests/Support/System/SystemWebTestCase.php
+++ b/tests/Support/System/SystemWebTestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\System;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+
+/**
+ * Ensures each ParaTest worker migrates its isolated test database before system HTTP tests run.
+ */
+#[ResetDatabase]
+abstract class SystemWebTestCase extends WebTestCase
+{
+}

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\System;
 
+use App\Tests\Support\System\SystemWebTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class AppRoutesTest extends WebTestCase
+class AppRoutesTest extends SystemWebTestCase
 {
     #[DataProvider('getPublicUrls')]
     public function testPublicUrlsAreReachable(string $url): void

--- a/tests/System/ErrorPreviewPagesTest.php
+++ b/tests/System/ErrorPreviewPagesTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\System;
 
+use App\Tests\Support\System\SystemWebTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ErrorPreviewPagesTest extends WebTestCase
+final class ErrorPreviewPagesTest extends SystemWebTestCase
 {
     #[DataProvider('providePreviewCodes')]
     public function testErrorPreviewRendersCustomPage(int $code, string $expectedTitleFragment, string $expectedHeader): void


### PR DESCRIPTION
### Summary

- Added DAMA transaction rollback support for the test suite
- Improved database test isolation by wrapping tests in transactions
- Reduced database reset overhead between test cases
- Updated test configuration and bootstrap setup where needed
- Adjusted affected tests to work correctly with transactional rollback behavior

### Motivation

- Improve test suite performance by avoiding expensive full database resets
- Keep database state isolated between tests more efficiently
- Reduce CI and local test execution time
- Make the growing functional/integration test suite more scalable

### Notes for Reviewers

- Verify DAMA test bundle/configuration is active only in the test environment
- Check that database-dependent tests remain isolated and deterministic
- Review tests that require committed transactions or async processing carefully
- Ensure fixtures and Foundry usage still behave correctly with transaction rollbacks
- Compare local/CI test execution time and confirm no new flaky behavior was introduced