### PR TITLE
feat: Add monthly submission reminder workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ jobs:
         env:
             # Required for Symfony console/PHPStan (no .env.local in CI). Not a production secret.
             APP_SECRET: ci-lint-placeholder-not-for-production
+            # PHPStan boots Doctrine via tests/object-manager.php; CI has no PostgreSQL service.
+            DATABASE_URL: 'sqlite:///${{ github.workspace }}/var/lint.db'
+            MESSENGER_TRANSPORT_DSN: sync://
         strategy:
             fail-fast: true
             matrix:
@@ -29,7 +32,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   coverage: "none"
-                  extensions: intl
+                  extensions: intl, pdo_sqlite
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,8 +10,8 @@ services:
   mailer:
     image: axllent/mailpit
     ports:
-      - "1025"
-      - "8025"
+      - "1025:1025"
+      - "8025:8025"
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1

--- a/config/packages/dev/mailer.yaml
+++ b/config/packages/dev/mailer.yaml
@@ -1,0 +1,4 @@
+# Local dev: deliver mail to Mailpit (compose.override.yaml) unless MAILER_DSN is overridden in .env.local.
+framework:
+    mailer:
+        dsn: 'smtp://127.0.0.1:1025'

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -52,3 +52,4 @@ when@test:
                 App\Import\Application\Message\ImportAllocationsMessage: sync
                 App\Statistics\Application\Message\RebuildAllocationStatsProjection: sync
                 App\Kpi\Application\Message\GenerateDailyKpisMessage: sync
+                App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage: sync

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -18,6 +18,7 @@ twig:
         '%kernel.project_dir%/src/Admin/UI/Twig/templates': Admin
         '%kernel.project_dir%/src/Allocation/UI/Twig/templates': Allocation
         '%kernel.project_dir%/src/Content/UI/Twig/templates': Content
+        '%kernel.project_dir%/src/Engagement/UI/Twig/templates': Engagement
         '%kernel.project_dir%/src/Feedback/UI/Twig/templates': Feedback
         '%kernel.project_dir%/src/Import/UI/Twig/templates': Import
         '%kernel.project_dir%/src/User/UI/Twig/templates': User

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -162,3 +162,10 @@ services:
     App\Content\Application\Page\PageImageContentAnalyzer:
         arguments:
             $contentWidthEstimate: '%app.page_content_width_estimate%'
+
+when@test:
+    services:
+        app.lock.store:
+            class: Symfony\Component\Lock\Store\FlockStore
+            arguments:
+                - '%kernel.cache_dir%/lock'

--- a/docs/Development-Workflow.md
+++ b/docs/Development-Workflow.md
@@ -93,6 +93,8 @@ php bin/console doctrine:migrations:migrate --no-interaction
 ## Tips
 
 - In `dev`, mail is processed synchronously; import jobs stay asynchronous.
+- Local mail UI: start Mailpit with `docker compose up -d mailer`, then open http://127.0.0.1:8025 (`dev` uses `smtp://127.0.0.1:1025`).
+- Preview/send monthly reminder: `php bin/console app:reminder:preview --hospital=ID --send` (add `--ignore-opt-out` if the owner disabled reminders).
 - For reproducible import issues, always note the same input file and import ID.
 - For queue problems, run `messenger:stats` first, then `messenger:failed:show`.
 

--- a/migrations/Version20260617075013.php
+++ b/migrations/Version20260617075013.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260617075013 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add monthly submission reminder notification preference to user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD receives_monthly_submission_reminder BOOLEAN DEFAULT true NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP receives_monthly_submission_reminder');
+    }
+}

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -26,6 +26,7 @@
         <testsuite name="unit">
             <directory>tests/Allocation/Unit</directory>
             <directory>tests/Content/Unit</directory>
+            <directory>tests/Engagement/Unit</directory>
             <directory>tests/Feedback/Unit</directory>
             <directory>tests/Import/Unit</directory>
             <directory>tests/Kpi/Unit</directory>
@@ -37,6 +38,7 @@
         <testsuite name="integration">
             <directory>tests/Allocation/Integration</directory>
             <directory>tests/Content/Integration</directory>
+            <directory>tests/Engagement/Integration</directory>
             <directory>tests/Import/Integration</directory>
             <directory>tests/Kpi/Integration</directory>
             <directory>tests/Shared/Integration</directory>
@@ -48,6 +50,7 @@
             <directory>tests/Admin/Functional</directory>
             <directory>tests/Allocation/Functional</directory>
             <directory>tests/Content/Functional</directory>
+            <directory>tests/Engagement/Functional</directory>
             <directory>tests/Feedback/Functional</directory>
             <directory>tests/Import/Functional</directory>
             <directory>tests/Install/Functional</directory>

--- a/psalm.xml
+++ b/psalm.xml
@@ -54,6 +54,7 @@
                 <directory name="src/Import/Infrastructure/Resolver/" />
                 <directory name="src/Statistics/" />
                 <directory name="src/Kpi/" />
+                <directory name="src/Engagement/" />
             </errorLevel>
         </PossiblyUnusedMethod>
         <PossiblyUnusedProperty>
@@ -82,6 +83,7 @@
                 <directory name="src/Import/Infrastructure/Repository/" />
                 <directory name="src/Import/Infrastructure/Analysis/" />
                 <directory name="src/Statistics/" />
+                <directory name="src/Engagement/" />
             </errorLevel>
         </UnusedClass>
         <UnusedMethodCall>

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 
 $entityPath = __DIR__.'/src/**/Domain/Entity/*';
 
@@ -29,6 +30,9 @@ return RectorConfig::configure()
         Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector::class => [$entityPath],
         Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class => [$entityPath],
         Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector::class => [$entityPath],
+        ControllerMethodInjectionToConstructorRector::class => [
+            __DIR__.'/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php',
+        ],
     ])
     ->withCache(__DIR__.'/var/cache/rector')
     ->withParallel();

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -8,11 +8,14 @@ use App\Allocation\Domain\Entity\Hospital;
 use App\Allocation\Domain\Enum\HospitalLocation;
 use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Application\MonthlyReminderSender;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
@@ -21,7 +24,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends AbstractCrudController<Hospital>
@@ -31,6 +36,9 @@ final class HospitalCrudController extends AbstractCrudController
 {
     public function __construct(
         private readonly AuditContext $auditContext,
+        private readonly MonthlyReminderSender $monthlyReminderSender,
+        private readonly TranslatorInterface $translator,
+        private readonly AdminUrlGenerator $adminUrlGenerator,
     ) {
     }
 
@@ -75,9 +83,42 @@ final class HospitalCrudController extends AbstractCrudController
     #[\Override]
     public function configureActions(Actions $actions): Actions
     {
+        $sendReminder = Action::new('sendMonthlyReminder', 'admin.hospital.action.send_reminder', 'fas fa-envelope')
+            ->linkToCrudAction('sendMonthlyReminder')
+            ->displayIf(static fn (Hospital $hospital): bool => $hospital->isParticipating() && $hospital->getOwner() instanceof \App\User\Domain\Entity\User)
+            ->setHtmlAttributes([
+                'data-ea-confirm' => 'admin.hospital.action.send_reminder.confirm',
+            ]);
+
         return $actions
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
-            ->add(Crud::PAGE_EDIT, Action::INDEX);
+            ->add(Crud::PAGE_EDIT, Action::INDEX)
+            ->add(Crud::PAGE_DETAIL, $sendReminder);
+    }
+
+    public function sendMonthlyReminder(): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        $context = $this->getContext();
+        if (!$context instanceof AdminContext) {
+            throw new \LogicException('EasyAdmin context is missing.');
+        }
+
+        /** @var Hospital $hospital */
+        $hospital = $context->getEntity()->getInstance();
+        $errors = $this->monthlyReminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Admin);
+        if ([] === $errors) {
+            $this->addFlash('success', 'flash.admin.hospital.reminder.sent');
+        } else {
+            $this->addFlash('error', $this->translator->trans($errors[0]));
+        }
+
+        return $this->redirect(
+            $this->adminUrlGenerator
+                ->setController(self::class)
+                ->setAction(Action::DETAIL)
+                ->setEntityId($hospital->getId())
+                ->generateUrl(),
+        );
     }
 
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -36,7 +36,6 @@ final class HospitalCrudController extends AbstractCrudController
 {
     public function __construct(
         private readonly AuditContext $auditContext,
-        private readonly MonthlyReminderSender $monthlyReminderSender,
         private readonly TranslatorInterface $translator,
         private readonly AdminUrlGenerator $adminUrlGenerator,
     ) {
@@ -96,7 +95,7 @@ final class HospitalCrudController extends AbstractCrudController
             ->add(Crud::PAGE_DETAIL, $sendReminder);
     }
 
-    public function sendMonthlyReminder(): \Symfony\Component\HttpFoundation\RedirectResponse
+    public function sendMonthlyReminder(MonthlyReminderSender $monthlyReminderSender): \Symfony\Component\HttpFoundation\RedirectResponse
     {
         $context = $this->getContext();
         if (!$context instanceof AdminContext) {
@@ -105,7 +104,7 @@ final class HospitalCrudController extends AbstractCrudController
 
         /** @var Hospital $hospital */
         $hospital = $context->getEntity()->getInstance();
-        $errors = $this->monthlyReminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Admin);
+        $errors = $monthlyReminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Admin);
         if ([] === $errors) {
             $this->addFlash('success', 'flash.admin.hospital.reminder.sent');
         } else {

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -253,4 +253,21 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
 
         return $out;
     }
+
+    /**
+     * @return list<Hospital>
+     */
+    public function findParticipatingWithOwner(): array
+    {
+        /** @var list<Hospital> $hospitals */
+        $hospitals = $this->createQueryBuilder('h')
+            ->addSelect('o')
+            ->innerJoin('h.owner', 'o')
+            ->andWhere('h.isParticipating = true')
+            ->orderBy('h.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $hospitals;
+    }
 }

--- a/src/Engagement/Application/Dto/MonthlyReminderChartBar.php
+++ b/src/Engagement/Application/Dto/MonthlyReminderChartBar.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Dto;
+
+final readonly class MonthlyReminderChartBar
+{
+    public function __construct(
+        public string $label,
+        public int $allocationCount,
+        public int $barHeightPx,
+        public bool $isReportingMonth,
+    ) {
+    }
+}

--- a/src/Engagement/Application/Dto/MonthlyReminderContent.php
+++ b/src/Engagement/Application/Dto/MonthlyReminderContent.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Dto;
+
+final readonly class MonthlyReminderContent
+{
+    /**
+     * @param list<MonthlyReminderChartBar> $chartBars
+     * @param list<MonthlyReminderSegment>  $urgencySegments
+     * @param list<MonthlyReminderSegment>  $genderSegments
+     * @param list<MonthlyReminderInsight>  $insights
+     * @param array<string, string>         $submissionMonths Y-m => success|failed|missing
+     */
+    public function __construct(
+        public string $hospitalName,
+        public string $reportingPeriodLabel,
+        public string $uploadMonthLabel,
+        public string $preheader,
+        public bool $isPersonalized,
+        public int $allocationCount,
+        public ?float $allocationMomPercent,
+        public string $lastImportLabel,
+        public bool $lastImportStale,
+        public float $withPhysicianPercent,
+        public ?float $withPhysicianBaselineDeltaPp,
+        public ?string $baselinePeriodLabel,
+        public float $medianTransportMinutes,
+        public ?float $medianTransportBaselineDeltaMinutes,
+        public string $trendSummary,
+        public array $chartBars,
+        public array $urgencySegments,
+        public ?string $urgencyBenchmarkNote,
+        public array $genderSegments,
+        public array $insights,
+        public int $submissionMonthsCompleted,
+        public int $submissionMonthsTotal,
+        public int $submissionProgressPercent,
+        public array $submissionMonths,
+        public ?string $longestSubmissionGapLabel,
+        public string $importCreateUrl,
+        public string $statisticsDashboardUrl,
+        public string $benchmarkingUrl,
+        public string $notificationsSettingsUrl,
+        public ?int $platformAllocationCount = null,
+        public ?float $platformAllocationMomPercent = null,
+        public ?int $platformActiveHospitals = null,
+        public ?int $platformImportsLastMonth = null,
+    ) {
+    }
+}

--- a/src/Engagement/Application/Dto/MonthlyReminderInsight.php
+++ b/src/Engagement/Application/Dto/MonthlyReminderInsight.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Dto;
+
+enum MonthlyReminderInsightTrend: string
+{
+    case Up = 'up';
+    case Down = 'down';
+    case Neutral = 'neutral';
+}
+
+final readonly class MonthlyReminderInsight
+{
+    public function __construct(
+        public string $title,
+        public string $body,
+        public MonthlyReminderInsightTrend $trend,
+        public ?string $linkUrl = null,
+    ) {
+    }
+}

--- a/src/Engagement/Application/Dto/MonthlyReminderSegment.php
+++ b/src/Engagement/Application/Dto/MonthlyReminderSegment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Dto;
+
+final readonly class MonthlyReminderSegment
+{
+    public function __construct(
+        public string $label,
+        public float $percent,
+        public string $color,
+    ) {
+    }
+}

--- a/src/Engagement/Application/Dto/MonthlyReminderTrigger.php
+++ b/src/Engagement/Application/Dto/MonthlyReminderTrigger.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Dto;
+
+enum MonthlyReminderTrigger: string
+{
+    case Scheduler = 'scheduler';
+    case Admin = 'admin';
+    case Cli = 'cli';
+}

--- a/src/Engagement/Application/Message/SendMonthlySubmissionRemindersMessage.php
+++ b/src/Engagement/Application/Message/SendMonthlySubmissionRemindersMessage.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\Message;
+
+/**
+ * Triggers monthly data submission reminder emails for all participating hospitals with an owner.
+ */
+final readonly class SendMonthlySubmissionRemindersMessage
+{
+}

--- a/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
+++ b/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application\MessageHandler;
+
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
+use App\Engagement\Application\MonthlyReminderSender;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class SendMonthlySubmissionRemindersMessageHandler
+{
+    private const string LOCK_KEY = 'monthly-submission-reminder';
+
+    public function __construct(
+        private HospitalRepository $hospitalRepository,
+        private MonthlyReminderSender $reminderSender,
+        private LockFactory $lockFactory,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SendMonthlySubmissionRemindersMessage $_message): void
+    {
+        $lock = $this->lockFactory->createLock(self::LOCK_KEY);
+        if (!$lock->acquire()) {
+            $this->logger->info('Monthly submission reminder skipped: another run is in progress.');
+
+            return;
+        }
+
+        try {
+            $hospitals = $this->hospitalRepository->findParticipatingWithOwner();
+            $sent = 0;
+            $skipped = 0;
+
+            foreach ($hospitals as $hospital) {
+                $errors = $this->reminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler);
+                if ([] === $errors) {
+                    ++$sent;
+                } else {
+                    ++$skipped;
+                    $this->logger->info('Monthly submission reminder skipped for hospital.', [
+                        'hospital_id' => $hospital->getId(),
+                        'errors' => $errors,
+                    ]);
+                }
+            }
+
+            $this->logger->info('Monthly submission reminder batch finished.', [
+                'sent' => $sent,
+                'skipped' => $skipped,
+            ]);
+        } finally {
+            $lock->release();
+        }
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderChartBuilder.php
+++ b/src/Engagement/Application/MonthlyReminderChartBuilder.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Engagement\Application\Dto\MonthlyReminderChartBar;
+use App\Statistics\Application\ChartBucketMapper;
+
+final readonly class MonthlyReminderChartBuilder
+{
+    private const int MAX_BAR_HEIGHT_PX = 80;
+
+    public function __construct(
+        private ChartBucketMapper $chartBucketMapper,
+    ) {
+    }
+
+    /**
+     * @param list<string>                              $monthKeys
+     * @param list<string>                              $labels
+     * @param list<array{year:int,month:int,count:int}> $allocationRows
+     *
+     * @return list<MonthlyReminderChartBar>
+     */
+    public function build(
+        array $monthKeys,
+        array $labels,
+        array $allocationRows,
+        string $reportingMonthKey,
+    ): array {
+        $allocationCounts = $this->chartBucketMapper->mapMonthlyCounts(
+            $monthKeys,
+            $this->chartBucketMapper->monthRowsToBucketCounts($allocationRows),
+        );
+
+        $maxValue = max(1, ...$allocationCounts);
+
+        $bars = [];
+        foreach ($monthKeys as $index => $monthKey) {
+            $allocation = $allocationCounts[$index] ?? 0;
+            $bars[] = new MonthlyReminderChartBar(
+                $labels[$index] ?? $monthKey,
+                $allocation,
+                (int) round((float) $allocation / (float) $maxValue * (float) self::MAX_BAR_HEIGHT_PX),
+                $monthKey === $reportingMonthKey,
+            );
+        }
+
+        return $bars;
+    }
+
+    /**
+     * @param list<int> $values last N monthly counts
+     */
+    public function summarizeTrend(array $values): string
+    {
+        if (\count($values) < 2) {
+            return '';
+        }
+
+        $recent = \array_slice($values, -6);
+        if (\count($recent) < 2) {
+            return '';
+        }
+
+        $first = (float) $recent[0];
+        $last = (float) $recent[\count($recent) - 1];
+        if ($first <= 0.0) {
+            if ($last > 0.0) {
+                return 'monthly_reminder.trend.growing_from_zero';
+            }
+
+            return 'monthly_reminder.trend.stable';
+        }
+
+        $totalChange = (($last - $first) / $first) * 100.0;
+        $months = \count($recent) - 1;
+        $avgMonthly = $totalChange / (float) max(1, $months);
+
+        if ($avgMonthly >= 2.0) {
+            return 'monthly_reminder.trend.growing';
+        }
+        if ($avgMonthly <= -2.0) {
+            return 'monthly_reminder.trend.declining';
+        }
+
+        return 'monthly_reminder.trend.stable';
+    }
+
+    public function percentChange(int $current, int $previous): ?float
+    {
+        if ($previous <= 0) {
+            return $current > 0 ? 100.0 : null;
+        }
+
+        return round(((float) ($current - $previous) / (float) $previous) * 100.0, 1);
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderComparisonFilterFactory.php
+++ b/src/Engagement/Application/MonthlyReminderComparisonFilterFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+
+final readonly class MonthlyReminderComparisonFilterFactory
+{
+    public function createPrimaryFilter(
+        int $hospitalId,
+        StatisticsFilterPeriod $period,
+        ?int $referenceYear,
+        ?int $referenceMonth,
+    ): StatisticsFilter {
+        return new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospitalId,
+            null,
+            $period,
+            $referenceYear,
+            $referenceMonth,
+        );
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderContentBuilder.php
+++ b/src/Engagement/Application/MonthlyReminderContentBuilder.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Engagement\Application\Dto\MonthlyReminderContent;
+use App\Engagement\Application\Dto\MonthlyReminderInsight;
+use App\Engagement\Application\Dto\MonthlyReminderInsightTrend;
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Kpi\Infrastructure\Repository\KpiDailyRepository;
+use App\Statistics\Application\ChartBucketMapper;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricKey;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewDashboardMetricsQuery;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class MonthlyReminderContentBuilder
+{
+    private const int MIN_ALLOCATIONS_PERSONALIZED = 20;
+
+    private const int STALE_IMPORT_DAYS = 90;
+
+    public function __construct(
+        private MonthlyReminderPeriodResolver $periodResolver,
+        private MonthlyReminderComparisonFilterFactory $comparisonFilterFactory,
+        private MonthlyReminderSelfBenchmarkFactory $selfBenchmarkFactory,
+        private ProjectionTimeSeriesQuery $timeSeriesQuery,
+        private ImportRepository $importRepository,
+        private GetOverviewDashboardMetricsQuery $overviewMetricsQuery,
+        private MonthlyReminderChartBuilder $chartBuilder,
+        private MonthlyReminderInsightSelector $insightSelector,
+        private KpiDailyRepository $kpiDailyRepository,
+        private ChartBucketMapper $chartBucketMapper,
+        private TranslatorInterface $translator,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function build(Hospital $hospital, ?\DateTimeImmutable $referenceDate = null): MonthlyReminderContent
+    {
+        $period = $this->periodResolver->resolve($referenceDate);
+        $hospitalId = (int) $hospital->getId();
+        $hospitalIds = [$hospitalId];
+
+        $reportingKey = sprintf('%04d-%02d', $period['reportingYear'], $period['reportingMonth']);
+        $previousMonthStart = $period['reportingMonthStart']->modify('-1 month');
+        $previousReportingKey = $previousMonthStart->format('Y-m');
+        $yearAgoKey = $period['reportingMonthStart']->modify('-1 year')->format('Y-m');
+
+        $chartAllocationRows = $this->timeSeriesQuery->countByMonthInPeriod(
+            $period['chartStart'],
+            null,
+            $hospitalIds,
+        );
+
+        $allocationBuckets = $this->chartBucketMapper->monthRowsToBucketCounts($chartAllocationRows);
+        $reportingAllocations = $allocationBuckets[$reportingKey] ?? 0;
+        $previousAllocations = $allocationBuckets[$previousReportingKey] ?? 0;
+        $yearAgoAllocations = $allocationBuckets[$yearAgoKey] ?? 0;
+
+        $latestImport = $this->importRepository->findLatestSuccessfulByHospital($hospitalId);
+        $daysSinceImport = $this->daysSinceImport($latestImport, $period['referenceDate']);
+        $isStaleImport = null === $daysSinceImport || $daysSinceImport > self::STALE_IMPORT_DAYS;
+        $isPersonalized = $reportingAllocations >= self::MIN_ALLOCATIONS_PERSONALIZED
+            || (null !== $daysSinceImport && $daysSinceImport <= 60);
+
+        $primaryFilter = $this->comparisonFilterFactory->createPrimaryFilter(
+            $hospitalId,
+            StatisticsFilterPeriod::Month,
+            $period['reportingYear'],
+            $period['reportingMonth'],
+        );
+        $selfReport = $this->selfBenchmarkFactory->build(
+            $hospitalId,
+            $period['reportingYear'],
+            $period['reportingMonth'],
+        );
+
+        $overviewMetrics = ($this->overviewMetricsQuery)(
+            OverviewQueryCriteria::fromPeriodBounds(
+                StatisticsPeriodResolver::resolve($primaryFilter),
+                $hospitalIds,
+            ),
+        );
+
+        $withPhysicianPercent = $overviewMetrics->scopedTotal > 0
+            ? round(100 * $overviewMetrics->withPhysician / $overviewMetrics->scopedTotal, 1)
+            : 0.0;
+
+        $physicianMetric = $this->findMetric($selfReport->kpiMetrics, BenchmarkMetricKey::WithPhysician);
+        $transportMetric = $this->findMetric($selfReport->kpiMetrics, BenchmarkMetricKey::MedianTransport);
+        $resusMetric = $this->findMetric($selfReport->kpiMetrics, BenchmarkMetricKey::Resus);
+
+        $chartBars = $this->chartBuilder->build(
+            $period['chartMonthKeys'],
+            $period['chartLabels'],
+            $chartAllocationRows,
+            $reportingKey,
+        );
+        $allocationSeries = array_map(static fn (Dto\MonthlyReminderChartBar $bar): int => $bar->allocationCount, $chartBars);
+        $trendKey = $this->chartBuilder->summarizeTrend($allocationSeries);
+
+        $submissionMonths = $this->importRepository->monthlySubmissionStatusForHospital(
+            $hospitalId,
+            $period['chartMonthKeys'],
+            $period['chartStart'],
+        );
+        $completedMonths = count(array_filter($submissionMonths, static fn (string $s): bool => 'success' === $s));
+        $totalMonths = \count($period['chartMonthKeys']);
+
+        $rejectionDelta = $this->rejectionRateDelta(
+            $hospitalId,
+            $period['reportingMonthStart'],
+            $period['reportingMonthEnd'],
+            $previousMonthStart,
+        );
+
+        $importCreateUrl = $this->urlGenerator->generate('app_import_new', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $statisticsUrl = $this->urlGenerator->generate('app_stats_dashboard', [
+            'scope' => StatisticsFilterScope::Hospital->value,
+            'hospital' => $hospitalId,
+            'period' => StatisticsFilterPeriod::Month->value,
+            'year' => $period['reportingYear'],
+            'month' => $period['reportingMonth'],
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+        $selfBenchmarkUrl = $this->urlGenerator->generate('app_stats_benchmarking', [
+            'scope' => StatisticsFilterScope::Hospital->value,
+            'hospital' => $hospitalId,
+            'period' => StatisticsFilterPeriod::Month->value,
+            'year' => $period['reportingYear'],
+            'month' => $period['reportingMonth'],
+            StatisticsQueryKeys::COMPARISON_SCOPE => StatisticsFilterScope::Hospital->value,
+            StatisticsQueryKeys::COMPARISON_HOSPITAL => $hospitalId,
+            StatisticsQueryKeys::COMPARISON_PERIOD => StatisticsFilterPeriod::All->value,
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+        $benchmarkingUrl = $this->urlGenerator->generate('app_stats_benchmarking', [
+            'scope' => StatisticsFilterScope::Hospital->value,
+            'hospital' => $hospitalId,
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+        $notificationsSettingsUrl = $this->urlGenerator->generate(
+            'app_settings_notifications',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $baselinePeriodLabel = $this->translator->trans('monthly_reminder.baseline.period_label');
+        $reportingPeriodLabel = $this->formatMonthYear($period['reportingYear'], $period['reportingMonth']);
+
+        $allocationMom = $this->chartBuilder->percentChange($reportingAllocations, $previousAllocations);
+        $allocationYoy = $this->chartBuilder->percentChange($reportingAllocations, $yearAgoAllocations);
+
+        $insights = $isPersonalized
+            ? $this->insightSelector->select(
+                $allocationMom,
+                $allocationYoy,
+                array_values(array_filter([$physicianMetric, $resusMetric])),
+                $selfReport->indicationMix,
+                $rejectionDelta,
+                $selfBenchmarkUrl,
+                $baselinePeriodLabel,
+                $reportingPeriodLabel,
+            )
+            : $this->fallbackInsights($benchmarkingUrl);
+
+        $platformData = $isPersonalized ? [] : $this->platformFallbackData(
+            $period,
+            $reportingKey,
+            $previousReportingKey,
+        );
+
+        $uploadMonthLabel = $this->formatMonthYear($period['uploadYear'], $period['uploadMonth']);
+
+        $preheader = $this->translator->trans('monthly_reminder.preheader', [
+            'period' => $reportingPeriodLabel,
+            'count' => $reportingAllocations,
+            'delta' => null !== $allocationMom ? $this->formatSignedPercent($allocationMom) : '—',
+            'upload_month' => $uploadMonthLabel,
+        ]);
+
+        return new MonthlyReminderContent(
+            hospitalName: (string) $hospital->getName(),
+            reportingPeriodLabel: $reportingPeriodLabel,
+            uploadMonthLabel: $uploadMonthLabel,
+            preheader: $preheader,
+            isPersonalized: $isPersonalized,
+            allocationCount: $reportingAllocations,
+            allocationMomPercent: $allocationMom,
+            lastImportLabel: $this->formatLastImportLabel($latestImport),
+            lastImportStale: $isStaleImport,
+            withPhysicianPercent: $withPhysicianPercent,
+            withPhysicianBaselineDeltaPp: $physicianMetric?->absoluteDelta,
+            baselinePeriodLabel: $baselinePeriodLabel,
+            medianTransportMinutes: $transportMetric instanceof \App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric ? $transportMetric->primaryValue : 0.0,
+            medianTransportBaselineDeltaMinutes: $transportMetric?->absoluteDelta,
+            trendSummary: '' !== $trendKey ? $this->translator->trans($trendKey, [
+                'percent' => number_format(abs($this->averageMonthlyChange($allocationSeries)), 1, '.', ''),
+            ]) : '',
+            chartBars: $chartBars,
+            urgencySegments: $this->insightSelector->urgencySegments(
+                $overviewMetrics->urgencyCounts,
+                $overviewMetrics->scopedTotal,
+            ),
+            urgencyBenchmarkNote: $this->urgencyBenchmarkNote($selfReport, $baselinePeriodLabel),
+            genderSegments: $this->insightSelector->genderSegments(
+                $overviewMetrics->genderCounts,
+                $overviewMetrics->scopedTotal,
+            ),
+            insights: $insights,
+            submissionMonthsCompleted: $completedMonths,
+            submissionMonthsTotal: $totalMonths,
+            submissionProgressPercent: $totalMonths > 0 ? (int) round(100 * $completedMonths / $totalMonths) : 0,
+            submissionMonths: $submissionMonths,
+            longestSubmissionGapLabel: $this->longestGapLabel($submissionMonths, $period['chartMonthKeys']),
+            importCreateUrl: $importCreateUrl,
+            statisticsDashboardUrl: $statisticsUrl,
+            benchmarkingUrl: $benchmarkingUrl,
+            notificationsSettingsUrl: $notificationsSettingsUrl,
+            platformAllocationCount: $platformData['allocationCount'] ?? null,
+            platformAllocationMomPercent: $platformData['allocationMomPercent'] ?? null,
+            platformActiveHospitals: $platformData['activeHospitals'] ?? null,
+            platformImportsLastMonth: $platformData['importsLastMonth'] ?? null,
+        );
+    }
+
+    /**
+     * @param list<\App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric> $metrics
+     */
+    private function findMetric(array $metrics, BenchmarkMetricKey $key): ?\App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric
+    {
+        foreach ($metrics as $metric) {
+            if ($metric->key === $key) {
+                return $metric;
+            }
+        }
+
+        return null;
+    }
+
+    private function daysSinceImport(?Import $import, \DateTimeImmutable $referenceDate): ?int
+    {
+        $createdAt = $import?->getCreatedAt();
+        if (!$createdAt instanceof \DateTimeImmutable) {
+            return null;
+        }
+
+        return (int) $createdAt->diff($referenceDate)->days;
+    }
+
+    private function formatLastImportLabel(?Import $import): string
+    {
+        $createdAt = $import?->getCreatedAt();
+        if (!$createdAt instanceof \DateTimeImmutable) {
+            return $this->translator->trans('monthly_reminder.kpi.last_import.none');
+        }
+
+        return $this->translator->trans('monthly_reminder.kpi.last_import.date', [
+            'date' => $this->formatMonthYear((int) $createdAt->format('Y'), (int) $createdAt->format('n')),
+        ]);
+    }
+
+    private function formatMonthYear(int $year, int $month): string
+    {
+        $date = new \DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month));
+
+        return $this->translator->trans('monthly_reminder.month_year', [
+            'month' => $date->format('F'),
+            'year' => $year,
+        ]);
+    }
+
+    private function formatSignedPercent(float $value): string
+    {
+        return ($value >= 0 ? '+' : '').number_format($value, 1, '.', '').'%';
+    }
+
+    private function rejectionRateDelta(
+        int $hospitalId,
+        \DateTimeImmutable $reportingStart,
+        \DateTimeImmutable $reportingEnd,
+        \DateTimeImmutable $previousStart,
+    ): ?float {
+        $current = $this->kpiDailyRepository->rejectionRateForHospitalInRange($hospitalId, $reportingStart, $reportingEnd);
+        $previous = $this->kpiDailyRepository->rejectionRateForHospitalInRange(
+            $hospitalId,
+            $previousStart,
+            $reportingStart,
+        );
+        if (null === $current || null === $previous) {
+            return null;
+        }
+
+        return round($current - $previous, 1);
+    }
+
+    private function urgencyBenchmarkNote(
+        \App\Statistics\Benchmarking\Application\DTO\BenchmarkReport $report,
+        string $baselinePeriodLabel,
+    ): ?string {
+        foreach ($report->urgency->buckets as $bucket) {
+            if ('1' !== $bucket->key && 'urgency_1' !== $bucket->key) {
+                continue;
+            }
+            if (abs($bucket->primaryShare - $bucket->comparisonShare) < 1.0) {
+                return null;
+            }
+
+            return $this->translator->trans('monthly_reminder.urgency.benchmark', [
+                'urgency' => $this->translator->trans(AllocationUrgency::EMERGENCY->label()),
+                'percent' => number_format($bucket->primaryShare, 1, '.', ''),
+                'delta' => $this->formatSignedPercent($bucket->primaryShare - $bucket->comparisonShare),
+                'baseline' => $baselinePeriodLabel,
+            ]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, string> $submissionMonths
+     * @param list<string>          $monthKeys
+     */
+    private function longestGapLabel(array $submissionMonths, array $monthKeys): ?string
+    {
+        $longest = 0;
+        $gapStart = null;
+        $gapEnd = null;
+        $current = 0;
+        $currentStart = null;
+
+        foreach ($monthKeys as $key) {
+            if ('success' === ($submissionMonths[$key] ?? 'missing')) {
+                if ($current > $longest) {
+                    $longest = $current;
+                    $gapStart = $currentStart;
+                    $gapEnd = $key;
+                }
+                $current = 0;
+                $currentStart = null;
+
+                continue;
+            }
+            if (0 === $current) {
+                $currentStart = $key;
+            }
+            ++$current;
+        }
+
+        if ($current > $longest) {
+            $longest = $current;
+            $gapStart = $currentStart;
+            $lastMonthKey = [] !== $monthKeys ? $monthKeys[array_key_last($monthKeys)] : null;
+            $gapEnd = $lastMonthKey;
+        }
+
+        if ($longest < 2 || null === $gapStart || null === $gapEnd) {
+            return null;
+        }
+
+        return $this->translator->trans('monthly_reminder.submission.gap', [
+            'months' => $longest,
+            'from' => $this->formatMonthKey($gapStart),
+            'to' => $this->formatMonthKey($gapEnd),
+        ]);
+    }
+
+    private function formatMonthKey(string $key): string
+    {
+        [$year, $month] = explode('-', $key);
+
+        return $this->formatMonthYear((int) $year, (int) $month);
+    }
+
+    /**
+     * @return list<MonthlyReminderInsight>
+     */
+    private function fallbackInsights(string $benchmarkingUrl): array
+    {
+        return [
+            new MonthlyReminderInsight(
+                $this->translator->trans('monthly_reminder.fallback.insight.upload.title'),
+                $this->translator->trans('monthly_reminder.fallback.insight.upload.body'),
+                MonthlyReminderInsightTrend::Neutral,
+            ),
+            new MonthlyReminderInsight(
+                $this->translator->trans('monthly_reminder.fallback.insight.platform.title'),
+                $this->translator->trans('monthly_reminder.fallback.insight.platform.body'),
+                MonthlyReminderInsightTrend::Neutral,
+                $benchmarkingUrl,
+            ),
+        ];
+    }
+
+    /**
+     * @param array{
+     *     referenceDate: \DateTimeImmutable,
+     *     reportingYear: int,
+     *     reportingMonth: int,
+     *     reportingMonthStart: \DateTimeImmutable,
+     *     reportingMonthEnd: \DateTimeImmutable,
+     *     uploadYear: int,
+     *     uploadMonth: int,
+     *     chartStart: \DateTimeImmutable,
+     *     chartMonthKeys: list<string>,
+     *     chartLabels: list<string>,
+     * } $period
+     *
+     * @return array{allocationCount: int, allocationMomPercent: ?float, activeHospitals: int, importsLastMonth: int}
+     */
+    private function platformFallbackData(array $period, string $reportingKey, string $previousKey): array
+    {
+        $platformRows = $this->timeSeriesQuery->countByMonthInPeriod($period['chartStart'], null, null);
+        $buckets = $this->chartBucketMapper->monthRowsToBucketCounts($platformRows);
+        $current = $buckets[$reportingKey] ?? 0;
+        $previous = $buckets[$previousKey] ?? 0;
+
+        $globalImports = $this->importRepository->countImportsByMonthInRange(
+            $period['chartStart'],
+            null,
+        );
+        $importBuckets = $this->chartBucketMapper->monthRowsToBucketCounts($globalImports);
+
+        return [
+            'allocationCount' => $current,
+            'allocationMomPercent' => $this->chartBuilder->percentChange($current, $previous),
+            'activeHospitals' => $this->kpiDailyRepository->countActiveHospitalsLast30Days(),
+            'importsLastMonth' => $importBuckets[$reportingKey] ?? 0,
+        ];
+    }
+
+    /**
+     * @param list<int> $values
+     */
+    private function averageMonthlyChange(array $values): float
+    {
+        $recent = \array_slice($values, -6);
+        if (\count($recent) < 2) {
+            return 0.0;
+        }
+
+        $first = (float) $recent[0];
+        $last = (float) $recent[\count($recent) - 1];
+        if ($first <= 0.0) {
+            return 0.0;
+        }
+
+        return (($last - $first) / $first * 100.0) / (float) max(1, \count($recent) - 1);
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderInsightSelector.php
+++ b/src/Engagement/Application/MonthlyReminderInsightSelector.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Engagement\Application\Dto\MonthlyReminderInsight;
+use App\Engagement\Application\Dto\MonthlyReminderInsightTrend;
+use App\Engagement\Application\Dto\MonthlyReminderSegment;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkDistribution;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkDistributionBucket;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricFormat;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricKey;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class MonthlyReminderInsightSelector
+{
+    private const float BASELINE_RATIO_HIGH = 1.1;
+
+    private const float BASELINE_RATIO_LOW = 0.9;
+
+    private const float VOLUME_CHANGE_THRESHOLD = 5.0;
+
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @param list<BenchmarkMetric> $metrics
+     *
+     * @return list<MonthlyReminderInsight>
+     */
+    public function select(
+        ?float $allocationMomPercent,
+        ?float $allocationYoyPercent,
+        array $metrics,
+        BenchmarkDistribution $indicationMix,
+        ?float $rejectionRateDeltaPp,
+        string $benchmarkingUrl,
+        string $baselinePeriodLabel,
+        string $reportingPeriodLabel,
+    ): array {
+        $candidates = [];
+
+        if (null !== $allocationYoyPercent && abs($allocationYoyPercent) >= self::VOLUME_CHANGE_THRESHOLD) {
+            $candidates[] = new MonthlyReminderInsight(
+                $this->translator->trans('monthly_reminder.insight.volume_yoy.title'),
+                $this->translator->trans('monthly_reminder.insight.volume_yoy.body', [
+                    'percent' => $this->formatSignedPercent($allocationYoyPercent),
+                ]),
+                $allocationYoyPercent >= 0 ? MonthlyReminderInsightTrend::Up : MonthlyReminderInsightTrend::Down,
+            );
+        } elseif (null !== $allocationMomPercent && abs($allocationMomPercent) >= self::VOLUME_CHANGE_THRESHOLD) {
+            $candidates[] = new MonthlyReminderInsight(
+                $this->translator->trans('monthly_reminder.insight.volume_mom.title'),
+                $this->translator->trans('monthly_reminder.insight.volume_mom.body', [
+                    'percent' => $this->formatSignedPercent($allocationMomPercent),
+                ]),
+                $allocationMomPercent >= 0 ? MonthlyReminderInsightTrend::Up : MonthlyReminderInsightTrend::Down,
+            );
+        }
+
+        foreach ($metrics as $metric) {
+            $insight = $this->baselineMetricInsight(
+                $metric,
+                $benchmarkingUrl,
+                $baselinePeriodLabel,
+                $reportingPeriodLabel,
+            );
+            if ($insight instanceof MonthlyReminderInsight) {
+                $candidates[] = $insight;
+            }
+        }
+
+        $indicationInsight = $this->indicationInsight(
+            $indicationMix,
+            $benchmarkingUrl,
+            $baselinePeriodLabel,
+            $reportingPeriodLabel,
+        );
+        if ($indicationInsight instanceof MonthlyReminderInsight) {
+            $candidates[] = $indicationInsight;
+        }
+
+        if (null !== $rejectionRateDeltaPp && $rejectionRateDeltaPp <= -1.0) {
+            $candidates[] = new MonthlyReminderInsight(
+                $this->translator->trans('monthly_reminder.insight.quality.title'),
+                $this->translator->trans('monthly_reminder.insight.quality.body', [
+                    'delta' => number_format(abs($rejectionRateDeltaPp), 1, '.', ''),
+                ]),
+                MonthlyReminderInsightTrend::Up,
+            );
+        }
+
+        return \array_slice($candidates, 0, 3);
+    }
+
+    /**
+     * @param array<string, int> $genderCounts
+     *
+     * @return list<MonthlyReminderSegment>
+     */
+    public function genderSegments(array $genderCounts, int $total): array
+    {
+        $colors = [
+            AllocationGender::MALE->value => '#206bc4',
+            AllocationGender::FEMALE->value => '#d63384',
+            AllocationGender::OTHER->value => '#7950f2',
+        ];
+
+        $segments = [];
+        foreach (AllocationGender::cases() as $case) {
+            $count = $genderCounts[$case->value] ?? 0;
+            $segments[] = new MonthlyReminderSegment(
+                $this->translator->trans($case->label()),
+                $total > 0 ? round(100 * $count / $total, 1) : 0.0,
+                $colors[$case->value] ?? '#667382',
+            );
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param array<int, int> $urgencyCounts
+     *
+     * @return list<MonthlyReminderSegment>
+     */
+    public function urgencySegments(array $urgencyCounts, int $total): array
+    {
+        $colors = [
+            AllocationUrgency::EMERGENCY->value => '#d63939',
+            AllocationUrgency::INPATIENT->value => '#f59f00',
+            AllocationUrgency::OUTPATIENT->value => '#2fb344',
+        ];
+
+        $segments = [];
+        foreach (AllocationUrgency::cases() as $case) {
+            $count = $urgencyCounts[$case->value] ?? 0;
+            $segments[] = new MonthlyReminderSegment(
+                $this->translator->trans($case->label()),
+                $total > 0 ? round(100 * $count / $total, 1) : 0.0,
+                $colors[$case->value] ?? '#667382',
+            );
+        }
+
+        return $segments;
+    }
+
+    private function baselineMetricInsight(
+        BenchmarkMetric $metric,
+        string $benchmarkingUrl,
+        string $baselinePeriodLabel,
+        string $reportingPeriodLabel,
+    ): ?MonthlyReminderInsight {
+        if (BenchmarkMetricFormat::Percent !== $metric->format) {
+            return null;
+        }
+
+        if ($metric->ratio < self::BASELINE_RATIO_HIGH && $metric->ratio > self::BASELINE_RATIO_LOW) {
+            return null;
+        }
+
+        $key = match ($metric->key) {
+            BenchmarkMetricKey::Resus => 'monthly_reminder.insight.resus',
+            BenchmarkMetricKey::Cpr => 'monthly_reminder.insight.cpr',
+            BenchmarkMetricKey::WithPhysician => 'monthly_reminder.insight.physician',
+            default => 'monthly_reminder.insight.benchmark',
+        };
+
+        return new MonthlyReminderInsight(
+            $this->translator->trans($key.'.title'),
+            $this->translator->trans($key.'.body', [
+                'period' => $reportingPeriodLabel,
+                'primary_percent' => number_format($metric->primaryValue, 1, '.', ''),
+                'baseline_percent' => number_format($metric->comparisonValue, 1, '.', ''),
+                'delta_pp' => $this->formatSignedPercent($metric->absoluteDelta),
+                'baseline' => $baselinePeriodLabel,
+            ]),
+            $metric->absoluteDelta >= 0 ? MonthlyReminderInsightTrend::Up : MonthlyReminderInsightTrend::Down,
+            $benchmarkingUrl,
+        );
+    }
+
+    private function indicationInsight(
+        BenchmarkDistribution $mix,
+        string $benchmarkingUrl,
+        string $baselinePeriodLabel,
+        string $reportingPeriodLabel,
+    ): ?MonthlyReminderInsight {
+        $top = null;
+        $maxDeviation = 0.0;
+        foreach ($mix->buckets as $bucket) {
+            $deviation = abs($bucket->primaryShare - $bucket->comparisonShare);
+            if ($deviation > $maxDeviation) {
+                $maxDeviation = $deviation;
+                $top = $bucket;
+            }
+        }
+
+        if (!$top instanceof BenchmarkDistributionBucket || $maxDeviation < 1.0) {
+            return null;
+        }
+
+        return new MonthlyReminderInsight(
+            $this->translator->trans('monthly_reminder.insight.indication.title'),
+            $this->translator->trans('monthly_reminder.insight.indication.body', [
+                'period' => $reportingPeriodLabel,
+                'indication' => $top->label,
+                'primary_percent' => number_format($top->primaryShare, 1, '.', ''),
+                'baseline_percent' => number_format($top->comparisonShare, 1, '.', ''),
+                'delta_pp' => $this->formatSignedPercent($top->primaryShare - $top->comparisonShare),
+                'baseline' => $baselinePeriodLabel,
+            ]),
+            $top->primaryShare >= $top->comparisonShare
+                ? MonthlyReminderInsightTrend::Up
+                : MonthlyReminderInsightTrend::Down,
+            $benchmarkingUrl,
+        );
+    }
+
+    private function formatSignedPercent(float $value): string
+    {
+        $prefix = $value >= 0 ? '+' : '';
+
+        return $prefix.number_format($value, 1, '.', '').'%';
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderMailer.php
+++ b/src/Engagement/Application/MonthlyReminderMailer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Engagement\Application\Dto\MonthlyReminderContent;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class MonthlyReminderMailer
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private MailConfig $mailConfig,
+        private TranslatorInterface $translator,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function send(string $recipientEmail, MonthlyReminderContent $content): void
+    {
+        $email = new TemplatedEmail()
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
+            ->to($recipientEmail)
+            ->subject($this->translator->trans('monthly_reminder.subject', [
+                'hospital' => $content->hospitalName,
+                'period' => $content->reportingPeriodLabel,
+            ]))
+            ->htmlTemplate('@Engagement/email/monthly_submission_reminder.html.twig')
+            ->context([
+                'content' => $content,
+                'app_title' => $this->mailConfig->appName,
+            ]);
+
+        $replyTo = $this->mailConfig->replyTo();
+        if (null !== $replyTo) {
+            $email->replyTo($replyTo);
+        }
+
+        $this->mailer->send($email);
+
+        $this->logger->info('Monthly submission reminder sent.', [
+            'recipient' => $recipientEmail,
+            'hospital' => $content->hospitalName,
+        ]);
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderPeriodResolver.php
+++ b/src/Engagement/Application/MonthlyReminderPeriodResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+final readonly class MonthlyReminderPeriodResolver
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    /**
+     * @return array{
+     *     referenceDate: \DateTimeImmutable,
+     *     reportingYear: int,
+     *     reportingMonth: int,
+     *     reportingMonthStart: \DateTimeImmutable,
+     *     reportingMonthEnd: \DateTimeImmutable,
+     *     uploadYear: int,
+     *     uploadMonth: int,
+     *     chartStart: \DateTimeImmutable,
+     *     chartMonthKeys: list<string>,
+     *     chartLabels: list<string>,
+     * }
+     */
+    public function resolve(?\DateTimeImmutable $referenceDate = null): array
+    {
+        $tz = new \DateTimeZone(self::TIMEZONE);
+        $reference = ($referenceDate ?? new \DateTimeImmutable('now', $tz))->setTimezone($tz);
+
+        $currentMonthStart = $reference->modify('first day of this month 00:00:00');
+        $reportingMonthStart = $currentMonthStart->modify('-1 month');
+        $reportingYear = (int) $reportingMonthStart->format('Y');
+        $reportingMonth = (int) $reportingMonthStart->format('n');
+        $reportingMonthEnd = $reportingMonthStart->modify('+1 month');
+
+        $chartStart = $currentMonthStart->modify('-11 months');
+        $chartMonthKeys = [];
+        $chartLabels = [];
+        $cursor = $chartStart;
+        while ($cursor <= $currentMonthStart) {
+            $chartMonthKeys[] = $cursor->format('Y-m');
+            $chartLabels[] = $cursor->format('M');
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        return [
+            'referenceDate' => $reference,
+            'reportingYear' => $reportingYear,
+            'reportingMonth' => $reportingMonth,
+            'reportingMonthStart' => $reportingMonthStart,
+            'reportingMonthEnd' => $reportingMonthEnd,
+            'uploadYear' => (int) $currentMonthStart->format('Y'),
+            'uploadMonth' => (int) $currentMonthStart->format('n'),
+            'chartStart' => $chartStart,
+            'chartMonthKeys' => $chartMonthKeys,
+            'chartLabels' => $chartLabels,
+        ];
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderSelfBenchmarkFactory.php
+++ b/src/Engagement/Application/MonthlyReminderSelfBenchmarkFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Benchmarking\Application\BenchmarkCriteriaFactory;
+use App\Statistics\Benchmarking\Application\BenchmarkReportService;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkReport;
+
+final readonly class MonthlyReminderSelfBenchmarkFactory
+{
+    public function __construct(
+        private MonthlyReminderComparisonFilterFactory $filterFactory,
+        private BenchmarkCriteriaFactory $benchmarkCriteriaFactory,
+        private BenchmarkReportService $benchmarkReportService,
+    ) {
+    }
+
+    public function build(int $hospitalId, int $reportingYear, int $reportingMonth): BenchmarkReport
+    {
+        $monthFilter = $this->filterFactory->createPrimaryFilter(
+            $hospitalId,
+            StatisticsFilterPeriod::Month,
+            $reportingYear,
+            $reportingMonth,
+        );
+        $baselineFilter = $this->filterFactory->createPrimaryFilter(
+            $hospitalId,
+            StatisticsFilterPeriod::All,
+            null,
+            null,
+        );
+
+        $context = new StatisticsContext(null, $monthFilter);
+
+        return $this->benchmarkReportService->build(
+            $this->benchmarkCriteriaFactory->create($context, $baselineFilter),
+        );
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
+use Symfony\Component\Lock\LockFactory;
+
+final readonly class MonthlyReminderSender
+{
+    private const int MANUAL_LOCK_TTL_SECONDS = 300;
+
+    public function __construct(
+        private MonthlyReminderContentBuilder $contentBuilder,
+        private MonthlyReminderMailer $mailer,
+        private AuditContext $auditContext,
+        private LockFactory $lockFactory,
+    ) {
+    }
+
+    /**
+     * @return list<string> validation errors; empty list means sent
+     */
+    public function sendForHospital(
+        Hospital $hospital,
+        MonthlyReminderTrigger $trigger,
+        ?\DateTimeImmutable $referenceDate = null,
+    ): array {
+        if (!$hospital->isParticipating()) {
+            return ['monthly_reminder.error.not_participating'];
+        }
+
+        $owner = $hospital->getOwner();
+        if (!$owner instanceof User) {
+            return ['monthly_reminder.error.no_owner'];
+        }
+
+        $email = trim((string) $owner->getEmail());
+        if ('' === $email) {
+            return ['monthly_reminder.error.no_email'];
+        }
+
+        if (!$owner->isVerified()) {
+            return ['monthly_reminder.error.email_not_verified'];
+        }
+
+        if (
+            MonthlyReminderTrigger::Admin !== $trigger
+            && !$owner->receivesMonthlySubmissionReminder()
+        ) {
+            return ['monthly_reminder.error.opted_out'];
+        }
+
+        if (MonthlyReminderTrigger::Admin === $trigger) {
+            $lock = $this->lockFactory->createLock(
+                sprintf('reminder-manual-%d', (int) $hospital->getId()),
+                self::MANUAL_LOCK_TTL_SECONDS,
+            );
+            if (!$lock->acquire()) {
+                return ['monthly_reminder.error.already_sent_recently'];
+            }
+        }
+
+        $content = $this->contentBuilder->build($hospital, $referenceDate);
+        $reportingMonth = $content->reportingPeriodLabel;
+
+        $this->auditContext->beginIntent('hospital.reminder_sent', [
+            'hospital_id' => $hospital->getId(),
+            'owner_id' => $owner->getId(),
+            'reporting_period' => $reportingMonth,
+            'trigger' => $trigger->value,
+        ]);
+        try {
+            $this->mailer->send($email, $content);
+        } finally {
+            $this->auditContext->endIntent();
+        }
+
+        return [];
+    }
+}

--- a/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
+++ b/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\UI\Console\Command;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Application\MonthlyReminderContentBuilder;
+use App\Engagement\Application\MonthlyReminderSender;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+#[AsCommand(
+    name: 'app:reminder:preview',
+    description: 'Preview the monthly submission reminder email for a hospital.',
+)]
+final class MonthlyReminderPreviewCommand extends Command
+{
+    public function __construct(
+        private readonly HospitalRepository $hospitalRepository,
+        private readonly MonthlyReminderContentBuilder $contentBuilder,
+        private readonly Environment $twig,
+        private readonly MonthlyReminderSender $reminderSender,
+        private readonly TranslatorInterface $translator,
+        #[Autowire('%env(MAILER_DSN)%')] private readonly string $mailerDsn,
+        #[Autowire('%kernel.environment%')] private readonly string $appEnvironment,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption('hospital', null, InputOption::VALUE_REQUIRED, 'Hospital ID')
+            ->addOption('send', null, InputOption::VALUE_NONE, 'Send the email to the hospital owner')
+            ->addOption('ignore-opt-out', null, InputOption::VALUE_NONE, 'Send even if the owner opted out (like admin action)')
+            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'Write HTML to file path')
+            ->addOption('date', null, InputOption::VALUE_REQUIRED, 'Reference date (Y-m-d) for period calculation');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $hospitalId = (int) $input->getOption('hospital');
+        if ($hospitalId <= 0) {
+            $io->error('Option --hospital is required.');
+
+            return Command::INVALID;
+        }
+
+        $hospital = $this->hospitalRepository->findById($hospitalId);
+        if (!$hospital instanceof Hospital) {
+            $io->error(sprintf('Hospital %d not found.', $hospitalId));
+
+            return Command::FAILURE;
+        }
+
+        $referenceDate = null;
+        $dateRaw = $input->getOption('date');
+        if (\is_string($dateRaw) && '' !== $dateRaw) {
+            $referenceDate = new \DateTimeImmutable($dateRaw, new \DateTimeZone('Europe/Berlin'));
+        }
+
+        $content = $this->contentBuilder->build($hospital, $referenceDate);
+        $html = $this->twig->render('@Engagement/email/monthly_submission_reminder.html.twig', [
+            'content' => $content,
+            'app_title' => 'Preview',
+        ]);
+
+        $outputPath = $input->getOption('output');
+        $shouldSend = true === $input->getOption('send');
+        if (\is_string($outputPath) && '' !== $outputPath) {
+            file_put_contents($outputPath, $html);
+            $io->success(sprintf('Wrote preview to %s', $outputPath));
+        } elseif (!$shouldSend) {
+            $io->writeln($html);
+        }
+
+        if ($shouldSend) {
+            if ('dev' !== $this->appEnvironment && str_starts_with($this->mailerDsn, 'null://')) {
+                $io->warning('MAILER_DSN is set to a null transport — no mail will be delivered. Set MAILER_DSN=smtp://127.0.0.1:1025 for Mailpit.');
+            } elseif ('dev' === $this->appEnvironment && !$this->isSmtpReachable('127.0.0.1', 1025)) {
+                $io->error('Mailpit is not reachable on 127.0.0.1:1025. Start it with: docker compose up -d mailer');
+
+                return Command::FAILURE;
+            }
+
+            $trigger = $input->getOption('ignore-opt-out')
+                ? MonthlyReminderTrigger::Admin
+                : MonthlyReminderTrigger::Cli;
+
+            $errors = $this->reminderSender->sendForHospital($hospital, $trigger, $referenceDate);
+            if ([] !== $errors) {
+                foreach ($errors as $errorKey) {
+                    $io->error($this->translator->trans($errorKey));
+                }
+                if ('monthly_reminder.error.opted_out' === ($errors[0] ?? null)) {
+                    $io->note('Use --ignore-opt-out to send anyway for manual testing.');
+                }
+
+                return Command::FAILURE;
+            }
+            $owner = $hospital->getOwner();
+            $email = $owner?->getEmail();
+            $io->success(sprintf('Sent reminder to %s (check Mailpit at http://127.0.0.1:8025)', $email ?? 'unknown'));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function isSmtpReachable(string $host, int $port): bool
+    {
+        $socket = @fsockopen($host, $port, $errno, $errstr, 1.0);
+
+        if (false === $socket) {
+            return false;
+        }
+
+        fclose($socket);
+
+        return true;
+    }
+}

--- a/src/Engagement/UI/Twig/templates/email/_monthly_reminder_chart.html.twig
+++ b/src/Engagement/UI/Twig/templates/email/_monthly_reminder_chart.html.twig
@@ -1,0 +1,18 @@
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;table-layout:fixed;">
+    <tr valign="bottom">
+        {% for bar in content.chartBars %}
+            {% if not loop.first %}
+                <td style="width:4px;"></td>
+            {% endif %}
+            <td align="center" valign="bottom" style="padding:0;">
+                <div style="font-size:10px;color:#3A4859;padding-bottom:4px;{{ bar.isReportingMonth ? 'font-weight:600;' : '' }}">{{ bar.allocationCount }}</div>
+                <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                    <tr>
+                        <td style="height:{{ bar.barHeightPx }}px;background-color:{{ bar.isReportingMonth ? '#206bc4' : '#6b9bd2' }};font-size:0;line-height:0;border-radius:2px 2px 0 0;" title="{{ bar.allocationCount }}">&nbsp;</td>
+                    </tr>
+                </table>
+                <div style="font-size:11px;color:#667382;padding-top:6px;{{ bar.isReportingMonth ? 'font-weight:600;' : '' }}">{{ bar.label }}</div>
+            </td>
+        {% endfor %}
+    </tr>
+</table>

--- a/src/Engagement/UI/Twig/templates/email/_monthly_reminder_hero_kpis.html.twig
+++ b/src/Engagement/UI/Twig/templates/email/_monthly_reminder_hero_kpis.html.twig
@@ -1,0 +1,39 @@
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;margin-top:16px;">
+    <tr>
+        <td align="center" style="width:50%;padding:8px;vertical-align:top;">
+            <div style="font-size:24px;font-weight:600;color:#232b42;">{{ content.allocationCount|number_format(0, '.', '.') }}</div>
+            {% if content.allocationMomPercent is not null %}
+                <div style="font-size:12px;color:{{ content.allocationMomPercent >= 0 ? '#2fb344' : '#d63939' }};">
+                    {{ content.allocationMomPercent >= 0 ? '▲' : '▼' }} {{ content.allocationMomPercent|abs }}%
+                </div>
+            {% endif %}
+            <div style="color:#667382;font-size:12px;margin-top:4px;">{{ 'monthly_reminder.kpi.allocations'|trans }}</div>
+        </td>
+        <td align="center" style="width:50%;padding:8px;vertical-align:top;">
+            <div style="font-size:16px;font-weight:600;color:{{ content.lastImportStale ? '#d63939' : '#232b42' }};">{{ content.lastImportLabel }}</div>
+            <div style="color:#667382;font-size:12px;margin-top:4px;">{{ 'monthly_reminder.kpi.last_import.label'|trans }}</div>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="width:50%;padding:8px;vertical-align:top;">
+            <div style="font-size:24px;font-weight:600;color:#232b42;">{{ content.withPhysicianPercent }}%</div>
+            {% if content.withPhysicianBaselineDeltaPp is not null and content.baselinePeriodLabel %}
+                <div style="font-size:12px;color:#667382;">{{ 'monthly_reminder.kpi.physician_baseline_delta'|trans({
+                    delta: (content.withPhysicianBaselineDeltaPp >= 0 ? '+' : '') ~ content.withPhysicianBaselineDeltaPp|number_format(1) ~ '%',
+                    baseline: content.baselinePeriodLabel,
+                }) }}</div>
+            {% endif %}
+            <div style="color:#667382;font-size:12px;margin-top:4px;">{{ 'monthly_reminder.kpi.physician'|trans }}</div>
+        </td>
+        <td align="center" style="width:50%;padding:8px;vertical-align:top;">
+            <div style="font-size:24px;font-weight:600;color:#232b42;">{{ content.medianTransportMinutes|number_format(0, '.', '.') }} min</div>
+            {% if content.medianTransportBaselineDeltaMinutes is not null and content.baselinePeriodLabel %}
+                <div style="font-size:12px;color:#667382;">{{ 'monthly_reminder.kpi.transport_baseline_delta'|trans({
+                    delta: (content.medianTransportBaselineDeltaMinutes >= 0 ? '+' : '') ~ content.medianTransportBaselineDeltaMinutes|number_format(1),
+                    baseline: content.baselinePeriodLabel,
+                }) }}</div>
+            {% endif %}
+            <div style="color:#667382;font-size:12px;margin-top:4px;">{{ 'monthly_reminder.kpi.transport'|trans }}</div>
+        </td>
+    </tr>
+</table>

--- a/src/Engagement/UI/Twig/templates/email/_monthly_reminder_insights.html.twig
+++ b/src/Engagement/UI/Twig/templates/email/_monthly_reminder_insights.html.twig
@@ -1,0 +1,28 @@
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+    {% for insight in content.insights %}
+        <tr>
+            <td style="padding:{% if loop.first %}0{% else %}16px{% endif %} 0 16px;{% if not loop.first %}border-top:1px solid #dce0e5;{% endif %}">
+                <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                    <tr>
+                        <td style="width:24px;vertical-align:top;padding-right:12px;">
+                            {% if insight.trend.value == 'up' %}
+                                <span style="color:#2fb344;font-size:16px;">▲</span>
+                            {% elseif insight.trend.value == 'down' %}
+                                <span style="color:#d63939;font-size:16px;">▼</span>
+                            {% else %}
+                                <span style="color:#667382;font-size:16px;">●</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div style="font-weight:600;color:#232b42;margin-bottom:4px;">{{ insight.title }}</div>
+                            <p style="margin:0 0 8px;color:#3A4859;">{{ insight.body }}</p>
+                            {% if insight.linkUrl %}
+                                <a href="{{ insight.linkUrl }}" style="color:#206bc4;text-decoration:none;font-size:13px;">{{ 'monthly_reminder.insight.link'|trans }}</a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    {% endfor %}
+</table>

--- a/src/Engagement/UI/Twig/templates/email/_monthly_reminder_segments.html.twig
+++ b/src/Engagement/UI/Twig/templates/email/_monthly_reminder_segments.html.twig
@@ -1,0 +1,19 @@
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;height:8px;border-collapse:collapse;">
+    <tr>
+        {% for segment in segments %}
+            {% if segment.percent > 0 %}
+                <td style="width:{{ segment.percent }}%;background-color:{{ segment.color }};font-size:0;line-height:0;{% if loop.first %}border-radius:4px 0 0 4px;{% endif %}{% if loop.last %}border-radius:0 4px 4px 0;{% endif %}">&nbsp;</td>
+            {% endif %}
+        {% endfor %}
+    </tr>
+</table>
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;margin-top:8px;border-collapse:collapse;">
+    {% for segment in segments %}
+        <tr>
+            <td style="font-size:12px;color:#667382;padding:2px 0;">
+                <span style="display:inline-block;width:8px;height:8px;background:{{ segment.color }};border-radius:2px;margin-right:6px;vertical-align:middle;"></span>
+                {{ segment.label }}: {{ segment.percent }}%
+            </td>
+        </tr>
+    {% endfor %}
+</table>

--- a/src/Engagement/UI/Twig/templates/email/monthly_submission_reminder.html.twig
+++ b/src/Engagement/UI/Twig/templates/email/monthly_submission_reminder.html.twig
@@ -1,0 +1,159 @@
+{%- set fg = '#3A4859' -%}
+{%- set fgHeading = '#232b42' -%}
+{%- set link = '#206bc4' -%}
+{%- set boxBg = '#ffffff' -%}
+{%- set pageBg = '#f6f7f9' -%}
+{%- set border = '#dce0e5' -%}
+{%- set muted = '#667382' -%}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>{{ 'monthly_reminder.subject'|trans({hospital: content.hospitalName, period: content.reportingPeriodLabel}) }}</title>
+</head>
+<body style="margin:0;padding:0;background-color:{{ pageBg }};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:14px;line-height:1.6;color:{{ fg }};">
+<span style="display:none;max-height:0;overflow:hidden;color:transparent;">{{ content.preheader }}</span>
+<center style="width:100%;background-color:{{ pageBg }};">
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto;max-width:640px;width:100%;border-collapse:collapse;">
+        <tr>
+            <td style="padding:24px 16px 48px;">
+                <div style="background:{{ boxBg }};border:1px solid {{ border }};border-radius:4px;box-shadow:0 1px 4px rgba(0,0,0,0.05);">
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                        <tr>
+                            <td align="center" style="padding:40px 48px 0;">
+                                <h1 style="margin:0;text-align:center;font-size:28px;line-height:1.3;color:{{ fgHeading }};font-weight:600;">
+                                    {{ 'monthly_reminder.heading'|trans({hospital: content.hospitalName}) }}
+                                </h1>
+                                <p style="color:{{ muted }};margin:8px 0 0;text-align:center;">{{ content.reportingPeriodLabel }}</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:32px 48px 0;">
+                                {{ include('@Engagement/email/_monthly_reminder_hero_kpis.html.twig') }}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td align="center" style="padding:24px 48px 40px;">
+                                <a href="{{ content.importCreateUrl }}" style="display:inline-block;background-color:{{ link }};color:#ffffff;text-decoration:none;font-weight:500;font-size:15px;border-radius:4px;padding:12px 24px;">
+                                    {{ 'monthly_reminder.cta.upload'|trans({month: content.uploadMonthLabel}) }}
+                                </a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:32px 48px;border-top:1px solid {{ border }};margin-top:32px;">
+                                <h4 style="font-weight:600;color:{{ fgHeading }};font-size:16px;margin:0 0 16px;">{{ 'monthly_reminder.section.trend'|trans }}</h4>
+                                {{ include('@Engagement/email/_monthly_reminder_chart.html.twig') }}
+                                {% if content.trendSummary %}
+                                    <p style="color:{{ muted }};margin:16px 0 0;">{{ content.trendSummary }}</p>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if content.isPersonalized %}
+                            <tr>
+                                <td style="padding:32px 48px;border-top:1px solid {{ border }};">
+                                    <h4 style="font-weight:600;color:{{ fgHeading }};font-size:16px;margin:0 0 16px;">{{ 'monthly_reminder.section.profile'|trans }}</h4>
+                                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                                        <tr>
+                                            <td style="width:48%;vertical-align:top;padding-right:12px;">
+                                                <div style="font-weight:600;margin-bottom:8px;">{{ 'monthly_reminder.profile.urgency'|trans }}</div>
+                                                {{ include('@Engagement/email/_monthly_reminder_segments.html.twig', {segments: content.urgencySegments}) }}
+                                                {% if content.urgencyBenchmarkNote %}
+                                                    <p style="color:{{ muted }};font-size:13px;margin:8px 0 0;">{{ content.urgencyBenchmarkNote }}</p>
+                                                {% endif %}
+                                            </td>
+                                            <td style="width:48%;vertical-align:top;padding-left:12px;">
+                                                <div style="font-weight:600;margin-bottom:8px;">{{ 'monthly_reminder.profile.gender'|trans }}</div>
+                                                {{ include('@Engagement/email/_monthly_reminder_segments.html.twig', {segments: content.genderSegments}) }}
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        {% else %}
+                            <tr>
+                                <td style="padding:32px 48px;border-top:1px solid {{ border }};">
+                                    <h4 style="font-weight:600;color:{{ fgHeading }};font-size:16px;margin:0 0 16px;">{{ 'monthly_reminder.section.platform'|trans }}</h4>
+                                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                                        <tr>
+                                            <td align="center" style="width:25%;padding:8px;">
+                                                <div style="font-size:20px;font-weight:600;color:{{ fgHeading }};">{{ content.platformAllocationCount|default('—') }}</div>
+                                                <div style="color:{{ muted }};font-size:12px;">{{ 'monthly_reminder.platform.allocations'|trans }}</div>
+                                            </td>
+                                            <td align="center" style="width:25%;padding:8px;">
+                                                <div style="font-size:20px;font-weight:600;color:{{ fgHeading }};">{{ content.platformActiveHospitals|default('—') }}</div>
+                                                <div style="color:{{ muted }};font-size:12px;">{{ 'monthly_reminder.platform.hospitals'|trans }}</div>
+                                            </td>
+                                            <td align="center" style="width:25%;padding:8px;">
+                                                <div style="font-size:20px;font-weight:600;color:{{ fgHeading }};">{{ content.platformImportsLastMonth|default('—') }}</div>
+                                                <div style="color:{{ muted }};font-size:12px;">{{ 'monthly_reminder.platform.imports'|trans }}</div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        {% endif %}
+                        {% if content.insights|length > 0 %}
+                            <tr>
+                                <td style="padding:32px 48px;border-top:1px solid {{ border }};">
+                                    <h4 style="font-weight:600;color:{{ fgHeading }};font-size:16px;margin:0 0 16px;">{{ 'monthly_reminder.section.insights'|trans }}</h4>
+                                    {{ include('@Engagement/email/_monthly_reminder_insights.html.twig') }}
+                                </td>
+                            </tr>
+                        {% endif %}
+                        <tr>
+                            <td style="padding:32px 48px;border-top:1px solid {{ border }};">
+                                <h4 style="font-weight:600;color:{{ fgHeading }};font-size:16px;margin:0 0 8px;">{{ 'monthly_reminder.section.submission'|trans }}</h4>
+                                <p style="color:{{ muted }};margin:0 0 12px;">{{ 'monthly_reminder.submission.progress'|trans({
+                                    completed: content.submissionMonthsCompleted,
+                                    total: content.submissionMonthsTotal,
+                                }) }}</p>
+                                {% set submissionProgress = content.submissionProgressPercent %}
+                                <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;height:8px;border-collapse:collapse;">
+                                    <tr>
+                                        {% if submissionProgress > 0 %}
+                                            <td style="width:{{ submissionProgress }}%;background-color:{{ link }};border-radius:{{ submissionProgress >= 100 ? '4px' : '4px 0 0 4px' }};font-size:0;line-height:0;">&nbsp;</td>
+                                        {% endif %}
+                                        {% if submissionProgress < 100 %}
+                                            <td style="width:{{ submissionProgress > 0 ? 100 - submissionProgress : 100 }}%;background-color:#e9f0f9;border-radius:{{ submissionProgress <= 0 ? '4px' : '0 4px 4px 0' }};font-size:0;line-height:0;">&nbsp;</td>
+                                        {% endif %}
+                                    </tr>
+                                </table>
+                                <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;margin-top:16px;border-collapse:collapse;">
+                                    <tr>
+                                        {% for monthKey, status in content.submissionMonths %}
+                                            {% set bg = status == 'success' ? '#2fb344' : (status == 'failed' ? '#f59f00' : '#fafafa') %}
+                                            {% set color = status == 'success' ? '#ffffff' : '#667382' %}
+                                            <td style="padding:2px;">
+                                                <div style="background:{{ bg }};color:{{ color }};font-size:10px;text-align:center;border-radius:4px;padding:8px 0;">{{ monthKey|slice(5, 2) }}</div>
+                                            </td>
+                                        {% endfor %}
+                                    </tr>
+                                </table>
+                                {% if content.longestSubmissionGapLabel %}
+                                    <p style="color:{{ muted }};font-size:13px;margin:12px 0 0;">{{ content.longestSubmissionGapLabel }}</p>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:0 48px 40px;">
+                                <p style="margin:16px 0 0;text-align:center;">
+                                    <a href="{{ content.statisticsDashboardUrl }}" style="color:{{ link }};text-decoration:none;">{{ 'monthly_reminder.link.dashboard'|trans }}</a>
+                                    &nbsp;·&nbsp;
+                                    <a href="{{ content.benchmarkingUrl }}" style="color:{{ link }};text-decoration:none;">{{ 'monthly_reminder.link.benchmarking'|trans }}</a>
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <div style="text-align:center;margin-top:20px;font-size:12px;color:#8491a1;">
+                    {{ 'email.footer.transactional'|trans({app: app_title}) }}
+                    <br>
+                    <a href="{{ content.notificationsSettingsUrl }}" style="color:{{ link }};text-decoration:none;">{{ 'monthly_reminder.email.manage_notifications'|trans }}</a>
+                </div>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/src/Import/Infrastructure/Repository/ImportRepository.php
+++ b/src/Import/Infrastructure/Repository/ImportRepository.php
@@ -180,6 +180,118 @@ final class ImportRepository extends ServiceEntityRepository
         return $rows;
     }
 
+    public function findLatestSuccessfulByHospital(int $hospitalId): ?Import
+    {
+        /** @var Import|null $import */
+        $import = $this->createQueryBuilder('i')
+            ->where('IDENTITY(i.hospital) = :hospitalId')
+            ->andWhere('i.status IN (:statuses)')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('statuses', [ImportStatus::COMPLETED, ImportStatus::PARTIAL])
+            ->orderBy('i.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $import;
+    }
+
+    /**
+     * @return list<array{year: int, month: int, count: int}>
+     */
+    public function countSuccessfulImportsByMonthForHospital(int $hospitalId, \DateTimeInterface $from): array
+    {
+        $qb = $this->createQueryBuilder('i')
+            ->where('IDENTITY(i.hospital) = :hospitalId')
+            ->andWhere('i.status IN (:statuses)')
+            ->andWhere('i.createdAt >= :from')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('statuses', [ImportStatus::COMPLETED, ImportStatus::PARTIAL])
+            ->setParameter('from', $from)
+            ->orderBy('i.createdAt', 'ASC');
+
+        /** @var Import[] $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $this->bucketImportsByMonth($rows);
+    }
+
+    /**
+     * @param list<string> $monthKeys list of Y-m keys in chronological order
+     *
+     * @return array<string, string> Y-m => success|failed|missing
+     */
+    public function monthlySubmissionStatusForHospital(int $hospitalId, array $monthKeys, \DateTimeInterface $from): array
+    {
+        $qb = $this->createQueryBuilder('i')
+            ->where('IDENTITY(i.hospital) = :hospitalId')
+            ->andWhere('i.createdAt >= :from')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('from', $from)
+            ->orderBy('i.createdAt', 'ASC');
+
+        /** @var Import[] $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        $statusByMonth = array_fill_keys($monthKeys, 'missing');
+        foreach ($rows as $import) {
+            $createdAt = $import->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+            $key = $createdAt->format('Y-m');
+            if (!\array_key_exists($key, $statusByMonth)) {
+                continue;
+            }
+            $isSuccess = \in_array($import->getStatus(), [ImportStatus::COMPLETED, ImportStatus::PARTIAL], true);
+            if ($isSuccess) {
+                $statusByMonth[$key] = 'success';
+
+                continue;
+            }
+            if ('missing' === $statusByMonth[$key]) {
+                $statusByMonth[$key] = 'failed';
+            }
+        }
+
+        return $statusByMonth;
+    }
+
+    /**
+     * @param Import[] $rows
+     *
+     * @return list<array{year: int, month: int, count: int}>
+     */
+    private function bucketImportsByMonth(array $rows): array
+    {
+        $buckets = [];
+        foreach ($rows as $import) {
+            $createdAt = $import->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+            $key = $createdAt->format('Y-m');
+            if (!isset($buckets[$key])) {
+                $buckets[$key] = 0;
+            }
+            ++$buckets[$key];
+        }
+
+        $result = [];
+        foreach ($buckets as $key => $count) {
+            [$year, $month] = explode('-', $key);
+            $result[] = [
+                'year' => (int) $year,
+                'month' => (int) $month,
+                'count' => $count,
+            ];
+        }
+
+        usort($result, static fn (array $a, array $b): int => [$a['year'], $a['month']] <=> [$b['year'], $b['month']]);
+
+        return $result;
+    }
+
     /**
      * @return list<Import>
      */

--- a/src/Kpi/Infrastructure/Repository/KpiDailyRepository.php
+++ b/src/Kpi/Infrastructure/Repository/KpiDailyRepository.php
@@ -123,6 +123,35 @@ final class KpiDailyRepository extends ServiceEntityRepository
         return round($rejected / $total * 100, 2);
     }
 
+    public function rejectionRateForHospitalInRange(int $hospitalId, \DateTimeImmutable $from, \DateTimeImmutable $toExclusive): ?float
+    {
+        /** @var array{recordsRejected: int|string|null, recordsTotal: int|string|null}|null $row */
+        $row = $this->createQueryBuilder('k')
+            ->select(
+                'COALESCE(SUM(k.recordsRejected), 0) AS recordsRejected',
+                'COALESCE(SUM(k.recordsTotal), 0) AS recordsTotal',
+            )
+            ->where('IDENTITY(k.hospital) = :hospitalId')
+            ->andWhere('k.date >= :from')
+            ->andWhere('k.date < :toExclusive')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('from', $from->setTime(0, 0))
+            ->setParameter('toExclusive', $toExclusive->setTime(0, 0))
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (!\is_array($row)) {
+            return null;
+        }
+
+        $total = (int) ($row['recordsTotal'] ?? 0);
+        if ($total <= 0) {
+            return null;
+        }
+
+        return self::calculateRejectionRate((int) ($row['recordsRejected'] ?? 0), $total);
+    }
+
     private function dateDaysAgo(int $days): \DateTimeImmutable
     {
         $tz = new \DateTimeZone(self::TIMEZONE);

--- a/src/Kpi/Infrastructure/Scheduler/KpiScheduleProvider.php
+++ b/src/Kpi/Infrastructure/Scheduler/KpiScheduleProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Kpi\Infrastructure\Scheduler;
 
+use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
 use App\Kpi\Application\Message\GenerateDailyKpisMessage;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
 use Symfony\Component\Scheduler\RecurringMessage;
@@ -15,6 +16,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[AsSchedule]
 final readonly class KpiScheduleProvider implements ScheduleProviderInterface
 {
+    private const string TIMEZONE = 'Europe/Berlin';
+
     public function __construct(
         private CacheInterface $cache,
     ) {
@@ -30,6 +33,13 @@ final readonly class KpiScheduleProvider implements ScheduleProviderInterface
                 RecurringMessage::cron(
                     '0 */6 * * *',
                     new GenerateDailyKpisMessage(),
+                ),
+            )
+            ->add(
+                RecurringMessage::cron(
+                    '0 8 1-7 * 1',
+                    new SendMonthlySubmissionRemindersMessage(),
+                    self::TIMEZONE,
                 ),
             );
     }

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -58,6 +58,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     #[ORM\Column(options: ['default' => true])]
     private bool $isEnabled = true;
 
+    #[ORM\Column(options: ['default' => true])]
+    private bool $receivesMonthlySubmissionReminder = true;
+
     /**
      * @var Collection<int, Hospital>
      */
@@ -187,6 +190,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     public function setIsEnabled(bool $isEnabled): static
     {
         $this->isEnabled = $isEnabled;
+
+        return $this;
+    }
+
+    public function receivesMonthlySubmissionReminder(): bool
+    {
+        return $this->receivesMonthlySubmissionReminder;
+    }
+
+    public function setReceivesMonthlySubmissionReminder(bool $receivesMonthlySubmissionReminder): static
+    {
+        $this->receivesMonthlySubmissionReminder = $receivesMonthlySubmissionReminder;
 
         return $this;
     }

--- a/src/User/UI/Form/SettingsNotificationsType.php
+++ b/src/User/UI/Form/SettingsNotificationsType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @extends AbstractType<array<string, mixed>>
+ */
+final class SettingsNotificationsType extends AbstractType
+{
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('receivesMonthlySubmissionReminder', CheckboxType::class, [
+            'required' => false,
+            'label' => 'label.settings.notifications.monthly_reminder',
+            'help' => 'help.settings.notifications.monthly_reminder',
+        ]);
+    }
+}

--- a/src/User/UI/Http/Controller/SettingsController.php
+++ b/src/User/UI/Http/Controller/SettingsController.php
@@ -9,6 +9,7 @@ use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\EmailVerifier;
 use App\User\UI\Form\ForceChangePasswordType;
 use App\User\UI\Form\SettingsEmailType;
+use App\User\UI\Form\SettingsNotificationsType;
 use App\User\UI\Form\SettingsPasswordType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -151,6 +152,38 @@ final class SettingsController extends AbstractController
 
         return $this->render('@User/settings/password.html.twig', [
             'passwordForm' => $form,
+        ]);
+    }
+
+    #[Route('/settings/notifications', name: 'app_settings_notifications')]
+    public function notifications(Request $request): Response
+    {
+        $user = $this->requireUser();
+
+        $form = $this->createForm(SettingsNotificationsType::class, [
+            'receivesMonthlySubmissionReminder' => $user->receivesMonthlySubmissionReminder(),
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var array{receivesMonthlySubmissionReminder?: bool} $data */
+            $data = $form->getData();
+
+            $user->setReceivesMonthlySubmissionReminder($data['receivesMonthlySubmissionReminder'] ?? false);
+            $this->auditContext->beginIntent('user.settings.notifications_updated', []);
+            try {
+                $this->entityManager->flush();
+            } finally {
+                $this->auditContext->endIntent();
+            }
+
+            $this->addFlash('success', 'flash.settings.notifications.updated');
+
+            return $this->redirectToRoute('app_settings_notifications');
+        }
+
+        return $this->render('@User/settings/notifications.html.twig', [
+            'notificationsForm' => $form,
         ]);
     }
 

--- a/src/User/UI/Twig/templates/settings/_sidebar.html.twig
+++ b/src/User/UI/Twig/templates/settings/_sidebar.html.twig
@@ -1,0 +1,19 @@
+<div class="col-12 col-md-3 border-end">
+    <div class="card-body">
+        <h4 class="subheader">{{ 'label.settings.my_account'|trans }}</h4>
+        <div class="list-group list-group-transparent">
+            <a class="list-group-item list-group-item-action d-flex align-items-center{{ active == 'account' ? ' active' : '' }}" href="{{ path('app_settings_index') }}">
+                {{ 'label.settings.my_account'|trans }}
+            </a>
+            <a class="list-group-item list-group-item-action d-flex align-items-center{{ active == 'email' ? ' active' : '' }}" href="{{ path('app_settings_email') }}">
+                {{ 'label.settings.change_email'|trans }}
+            </a>
+            <a class="list-group-item list-group-item-action d-flex align-items-center{{ active == 'password' ? ' active' : '' }}" href="{{ path('app_settings_password') }}">
+                {{ 'label.settings.set_new_password'|trans }}
+            </a>
+            <a class="list-group-item list-group-item-action d-flex align-items-center{{ active == 'notifications' ? ' active' : '' }}" href="{{ path('app_settings_notifications') }}">
+                {{ 'label.settings.notifications'|trans }}
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/User/UI/Twig/templates/settings/email.html.twig
+++ b/src/User/UI/Twig/templates/settings/email.html.twig
@@ -25,22 +25,7 @@
         <div class="container-xl">
             <div class="card">
                 <div class="row g-0">
-                    <div class="col-12 col-md-3 border-end">
-                        <div class="card-body">
-                            <h4 class="subheader">{{ 'label.settings.my_account'|trans }}</h4>
-                            <div class="list-group list-group-transparent">
-                                <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ path('app_settings_index') }}">
-                                    {{ 'label.settings.my_account'|trans }}
-                                </a>
-                                <a class="list-group-item list-group-item-action d-flex align-items-center active" href="{{ path('app_settings_email') }}">
-                                    {{ 'label.settings.change_email'|trans }}
-                                </a>
-                                <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ path('app_settings_password') }}">
-                                    {{ 'label.settings.set_new_password'|trans }}
-                                </a>
-                            </div>
-                        </div>
-                    </div>
+                    {{ include('@User/settings/_sidebar.html.twig', {active: 'email'}) }}
                     <div class="col-12 col-md-9">
                         {{ form_start(emailForm) }}
                         <div class="card-header">

--- a/src/User/UI/Twig/templates/settings/index.html.twig
+++ b/src/User/UI/Twig/templates/settings/index.html.twig
@@ -27,22 +27,7 @@
                 <div class="col-12">
                     <div class="card">
                         <div class="row g-0">
-                            <div class="col-12 col-md-3 border-end">
-                                <div class="card-body">
-                                    <h4 class="subheader">{{ 'label.settings.my_account'|trans }}</h4>
-                                    <div class="list-group list-group-transparent">
-                                        <a class="list-group-item list-group-item-action d-flex align-items-center active" href="{{ path('app_settings_index') }}">
-                                            {{ 'label.settings.my_account'|trans }}
-                                        </a>
-                                        <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ path('app_settings_email') }}">
-                                            {{ 'label.settings.change_email'|trans }}
-                                        </a>
-                                        <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ path('app_settings_password') }}">
-                                            {{ 'label.settings.set_new_password'|trans }}
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
+                            {{ include('@User/settings/_sidebar.html.twig', {active: 'account'}) }}
                             <div class="col-12 col-md-9">
                                 <div class="card-header">
                                     <h3 class="card-title">{{ 'label.settings.my_account'|trans }}</h3>

--- a/src/User/UI/Twig/templates/settings/notifications.html.twig
+++ b/src/User/UI/Twig/templates/settings/notifications.html.twig
@@ -1,19 +1,19 @@
 {% extends '@Shared/_layout_vertical.html.twig' %}
 
-{% block title %}{{ 'title.settings.change_password'|trans }} - {{ parent() }}{% endblock %}
+{% block title %}{{ 'title.settings.notifications'|trans }} - {{ parent() }}{% endblock %}
 
 {% block page_header %}
     <div class="container-xl">
         <twig:Breadcrumbs
             :items="[
                 { label: 'title.settings', path: path('app_settings_index') },
-                { label: 'title.settings.change_password' },
+                { label: 'title.settings.notifications' },
             ]"
         />
         <div class="page-header d-print-none">
             <div class="row g-2 align-items-center">
                 <div class="col">
-                    <h2 class="page-title">{{ 'title.settings.change_password'|trans }}</h2>
+                    <h2 class="page-title">{{ 'title.settings.notifications'|trans }}</h2>
                 </div>
             </div>
         </div>
@@ -25,22 +25,21 @@
         <div class="container-xl">
             <div class="card">
                 <div class="row g-0">
-                    {{ include('@User/settings/_sidebar.html.twig', {active: 'password'}) }}
+                    {{ include('@User/settings/_sidebar.html.twig', {active: 'notifications'}) }}
                     <div class="col-12 col-md-9">
-                        {{ form_start(passwordForm) }}
+                        {{ form_start(notificationsForm) }}
                         <div class="card-header">
-                            <h3 class="card-title">{{ 'title.settings.change_password'|trans }}</h3>
+                            <h3 class="card-title">{{ 'title.settings.notifications'|trans }}</h3>
                         </div>
                         <div class="card-body">
-                            {{ form_row(passwordForm.currentPassword) }}
-                            {{ form_row(passwordForm.plainPassword.first) }}
-                            {{ form_row(passwordForm.plainPassword.second) }}
+                            <p class="text-secondary">{{ 'text.settings.notifications_intro'|trans }}</p>
+                            {{ form_row(notificationsForm.receivesMonthlySubmissionReminder) }}
                         </div>
                         <div class="card-footer d-flex justify-content-end gap-2">
                             <a class="btn btn-link" href="{{ path('app_settings_index') }}">{{ 'btn.cancel'|trans }}</a>
-                            <button class="btn btn-primary">{{ 'label.settings.save_password'|trans }}</button>
+                            <button class="btn btn-primary">{{ 'label.btn.save'|trans }}</button>
                         </div>
-                        {{ form_end(passwordForm) }}
+                        {{ form_end(notificationsForm) }}
                     </div>
                 </div>
             </div>

--- a/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
+++ b/tests/Allocation/Integration/Repository/HospitalRepositoryQueryTest.php
@@ -160,4 +160,34 @@ final class HospitalRepositoryQueryTest extends KernelTestCase
         self::assertContains($grantedHospital->getId(), $ids);
         self::assertCount(1, $ids);
     }
+
+    public function testFindParticipatingWithOwnerReturnsOnlyParticipatingHospitalsWithOwner(): void
+    {
+        $owner = UserFactory::createOne(['username' => 'reminder-owner-'.bin2hex(random_bytes(6))]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        $eligible = HospitalFactory::createOne([
+            'owner' => $owner,
+            'isParticipating' => true,
+        ]);
+        HospitalFactory::createOne([
+            'owner' => $owner,
+            'isParticipating' => false,
+        ]);
+        HospitalFactory::createOne([
+            'owner' => null,
+            'isParticipating' => true,
+        ]);
+
+        $result = $this->repo->findParticipatingWithOwner();
+        $ids = array_map(static fn (Hospital $hospital): ?int => $hospital->getId(), $result);
+
+        self::assertContains($eligible->getId(), $ids);
+        self::assertContainsOnlyInstancesOf(Hospital::class, $result);
+        foreach ($result as $hospital) {
+            self::assertTrue($hospital->isParticipating());
+            self::assertNotNull($hospital->getOwner());
+        }
+    }
 }

--- a/tests/Engagement/Functional/Command/MonthlyReminderPreviewCommandTest.php
+++ b/tests/Engagement/Functional/Command/MonthlyReminderPreviewCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Functional\Command;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Engagement\UI\Console\Command\MonthlyReminderPreviewCommand;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class MonthlyReminderPreviewCommandTest extends DatabaseKernelTestCase
+{
+    public function testRequiresHospitalOption(): void
+    {
+        self::bootKernel();
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::INVALID, $tester->execute([]));
+        self::assertStringContainsString('Option --hospital is required', $tester->getDisplay());
+    }
+
+    public function testFailsWhenHospitalIsNotFound(): void
+    {
+        self::bootKernel();
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::FAILURE, $tester->execute(['--hospital' => '999999']));
+        self::assertStringContainsString('not found', $tester->getDisplay());
+    }
+
+    public function testWritesHtmlPreviewToStdout(): void
+    {
+        self::bootKernel();
+        $hospital = $this->createHospital(optedOut: true);
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::SUCCESS, $tester->execute([
+            '--hospital' => (string) $hospital->getId(),
+            '--date' => '2026-06-17',
+        ]));
+        self::assertStringContainsString('<!DOCTYPE html>', $tester->getDisplay());
+    }
+
+    public function testSendFailsForOptedOutOwnerAndShowsHint(): void
+    {
+        self::bootKernel();
+        $hospital = $this->createHospital(optedOut: true);
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::FAILURE, $tester->execute([
+            '--hospital' => (string) $hospital->getId(),
+            '--send' => true,
+            '--date' => '2026-06-17',
+        ]));
+        self::assertStringContainsString('Use --ignore-opt-out', $tester->getDisplay());
+    }
+
+    public function testSendSucceedsWithIgnoreOptOut(): void
+    {
+        self::bootKernel();
+        $hospital = $this->createHospital(optedOut: true);
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::SUCCESS, $tester->execute([
+            '--hospital' => (string) $hospital->getId(),
+            '--send' => true,
+            '--ignore-opt-out' => true,
+            '--date' => '2026-06-17',
+        ]));
+        self::assertStringContainsString('Sent reminder to', $tester->getDisplay());
+    }
+
+    public function testWritesHtmlPreviewToFile(): void
+    {
+        self::bootKernel();
+        $hospital = $this->createHospital(optedOut: true);
+        $outputPath = sys_get_temp_dir().'/monthly-reminder-preview-'.bin2hex(random_bytes(4)).'.html';
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        try {
+            self::assertSame(Command::SUCCESS, $tester->execute([
+                '--hospital' => (string) $hospital->getId(),
+                '--output' => $outputPath,
+                '--date' => '2026-06-17',
+            ]));
+            self::assertStringContainsString('Wrote preview to', $tester->getDisplay());
+            self::assertStringContainsString('<!DOCTYPE html>', (string) file_get_contents($outputPath));
+        } finally {
+            @unlink($outputPath);
+        }
+    }
+
+    private function createHospital(bool $optedOut): object
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('preview-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => !$optedOut,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+
+        return HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+    }
+}

--- a/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Integration\Application;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Engagement\Application\MonthlyReminderContentBuilder;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+
+final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
+{
+    private MonthlyReminderContentBuilder $builder;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->builder = $container->get(MonthlyReminderContentBuilder::class);
+        $this->connection = $container->get(Connection::class);
+    }
+
+    public function testBuildUsesFallbackContentWhenHospitalHasLittleData(): void
+    {
+        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $hospital = $this->seedHospital();
+
+        $content = $this->builder->build($hospital->_real(), $referenceDate);
+
+        self::assertFalse($content->isPersonalized);
+        self::assertSame(0, $content->allocationCount);
+        self::assertCount(2, $content->insights);
+        self::assertNotNull($content->platformAllocationCount);
+        self::assertNotNull($content->longestSubmissionGapLabel);
+        self::assertNotSame('', $content->lastImportLabel);
+        self::assertTrue($content->lastImportStale);
+    }
+
+    public function testBuildPersonalizedContentWhenReportingMonthHasEnoughAllocations(): void
+    {
+        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $seed = $this->seedHospitalGraph();
+        $hospital = $seed['hospital'];
+        $import = ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $seed['user'],
+            'createdAt' => new \DateTimeImmutable('2026-05-10'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+
+        for ($i = 0; $i < 20; ++$i) {
+            AllocationFactory::createOne([
+                'import' => $import,
+                'hospital' => $hospital,
+                'state' => $seed['state'],
+                'dispatchArea' => $seed['dispatchArea'],
+                'indicationRaw' => $seed['raw'],
+                'indicationNormalized' => $seed['normalized'],
+                'createdAt' => new \DateTimeImmutable('2026-05-15'),
+            ]);
+        }
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport((int) $import->getId());
+
+        $this->insertHospitalKpi(
+            (int) $hospital->getId(),
+            '2026-04-01',
+            100,
+            15,
+        );
+        $this->insertHospitalKpi(
+            (int) $hospital->getId(),
+            '2026-05-01',
+            100,
+            5,
+        );
+
+        $content = $this->builder->build($hospital->_real(), $referenceDate);
+
+        self::assertTrue($content->isPersonalized);
+        self::assertGreaterThanOrEqual(20, $content->allocationCount);
+        self::assertNotSame('', $content->preheader);
+        self::assertGreaterThan(0, $content->submissionMonthsTotal);
+        self::assertNotEmpty($content->chartBars);
+        self::assertNull($content->platformAllocationCount);
+    }
+
+    private function seedHospital(): mixed
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('content-builder-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+
+        return HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'name' => 'Reminder Content Hospital',
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     hospital: object,
+     *     user: object,
+     *     state: object,
+     *     dispatchArea: object,
+     *     raw: object,
+     *     normalized: object,
+     * }
+     */
+    private function seedHospitalGraph(): array
+    {
+        $user = UserFactory::createOne([
+            'email' => sprintf('content-graph-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'name' => 'Personalized Reminder Hospital',
+        ]);
+
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        AssignmentFactory::createOne();
+        OccasionFactory::createOne();
+        InfectionFactory::createOne();
+        $raw = IndicationRawFactory::createOne();
+        $normalized = IndicationNormalizedFactory::createOne();
+
+        return [
+            'hospital' => $hospital,
+            'user' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'raw' => $raw,
+            'normalized' => $normalized,
+        ];
+    }
+
+    private function insertHospitalKpi(int $hospitalId, string $date, int $recordsTotal, int $recordsRejected): void
+    {
+        $this->connection->insert('kpi_daily', [
+            'date' => $date,
+            'hospital_id' => $hospitalId,
+            'imports_count' => 1,
+            'successful_imports_count' => 1,
+            'records_total' => $recordsTotal,
+            'records_processed' => $recordsTotal,
+            'records_rejected' => $recordsRejected,
+            'failed_imports_count' => 0,
+            'created_at' => new \DateTimeImmutable()->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/tests/Engagement/Integration/Application/MonthlyReminderSelfBenchmarkFactoryTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSelfBenchmarkFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Integration\Application;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Engagement\Application\MonthlyReminderComparisonFilterFactory;
+use App\Engagement\Application\MonthlyReminderSelfBenchmarkFactory;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkReport;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+
+final class MonthlyReminderSelfBenchmarkFactoryTest extends DatabaseKernelTestCase
+{
+    public function testComparisonFilterFactoryBuildsMonthAndRollingBaselineForSameHospital(): void
+    {
+        self::bootKernel();
+
+        $filterFactory = self::getContainer()->get(MonthlyReminderComparisonFilterFactory::class);
+
+        $monthFilter = $filterFactory->createPrimaryFilter(
+            40,
+            StatisticsFilterPeriod::Month,
+            2026,
+            5,
+        );
+        $baselineFilter = $filterFactory->createPrimaryFilter(
+            40,
+            StatisticsFilterPeriod::All,
+            null,
+            null,
+        );
+
+        self::assertSame(StatisticsFilterScope::Hospital, $monthFilter->scope);
+        self::assertSame(40, $monthFilter->hospitalId);
+        self::assertSame(StatisticsFilterPeriod::Month, $monthFilter->period);
+        self::assertSame(2026, $monthFilter->referenceYear);
+        self::assertSame(5, $monthFilter->referenceMonth);
+
+        self::assertSame(StatisticsFilterScope::Hospital, $baselineFilter->scope);
+        self::assertSame(40, $baselineFilter->hospitalId);
+        self::assertSame(StatisticsFilterPeriod::All, $baselineFilter->period);
+        self::assertNull($baselineFilter->referenceYear);
+        self::assertNull($baselineFilter->referenceMonth);
+    }
+
+    public function testBuildReturnsBenchmarkReportForHospital(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne([
+            'email' => sprintf('self-benchmark-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        $factory = self::getContainer()->get(MonthlyReminderSelfBenchmarkFactory::class);
+
+        $report = $factory->build($hospital->getId(), 2026, 5);
+
+        self::assertInstanceOf(BenchmarkReport::class, $report);
+    }
+}

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -12,6 +12,7 @@ use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\MonthlyReminderSender;
 use App\Tests\Support\Foundry\DatabaseKernelTestCase;
 use App\User\Domain\Factory\UserFactory;
+use Symfony\Component\Lock\LockFactory;
 use Zenstruck\Foundry\Persistence\Proxy;
 
 final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
@@ -51,16 +52,100 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
         self::assertSame([], $errors);
     }
 
+    public function testSkipsWhenHospitalIsNotParticipating(): void
+    {
+        $hospital = $this->createHospital(optedOut: false, participating: false);
+
+        self::assertSame(
+            ['monthly_reminder.error.not_participating'],
+            $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Scheduler),
+        );
+    }
+
+    public function testSkipsWhenHospitalHasNoOwner(): void
+    {
+        $creator = UserFactory::createOne([
+            'email' => sprintf('creator-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => null,
+            'createdBy' => $creator,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        self::assertSame(
+            ['monthly_reminder.error.no_owner'],
+            $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Scheduler),
+        );
+    }
+
+    public function testSkipsWhenOwnerEmailIsBlank(): void
+    {
+        $owner = UserFactory::createOne([
+            'email' => '   ',
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+        ]);
+        $hospital = $this->createHospital(optedOut: false, owner: $owner);
+
+        self::assertSame(
+            ['monthly_reminder.error.no_email'],
+            $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Scheduler),
+        );
+    }
+
+    public function testSkipsWhenOwnerIsNotVerified(): void
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('unverified-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => false,
+            'receivesMonthlySubmissionReminder' => true,
+        ]);
+        $hospital = $this->createHospital(optedOut: false, owner: $owner);
+
+        self::assertSame(
+            ['monthly_reminder.error.email_not_verified'],
+            $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Scheduler),
+        );
+    }
+
+    public function testAdminTriggerReturnsErrorWhenManualLockIsAlreadyHeld(): void
+    {
+        $hospital = $this->createHospital(optedOut: true);
+        $hospitalId = (int) $hospital->getId();
+        $lock = self::getContainer()->get(LockFactory::class)->createLock(sprintf('reminder-manual-%d', $hospitalId));
+        self::assertTrue($lock->acquire());
+
+        try {
+            self::assertSame(
+                ['monthly_reminder.error.already_sent_recently'],
+                $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Admin),
+            );
+        } finally {
+            $lock->release();
+        }
+    }
+
     /**
      * @return Proxy<Hospital>
      */
-    private function createHospital(bool $optedOut): Proxy
-    {
-        $owner = UserFactory::createOne([
-            'email' => sprintf('reminder-%s@example.test', bin2hex(random_bytes(4))),
-            'isVerified' => true,
-            'receivesMonthlySubmissionReminder' => !$optedOut,
-        ]);
+    private function createHospital(
+        bool $optedOut,
+        bool $participating = true,
+        mixed $owner = 'default',
+    ): Proxy {
+        if ('default' === $owner) {
+            $owner = UserFactory::createOne([
+                'email' => sprintf('reminder-%s@example.test', bin2hex(random_bytes(4))),
+                'isVerified' => true,
+                'receivesMonthlySubmissionReminder' => !$optedOut,
+            ]);
+        }
+
         $state = StateFactory::createOne();
         $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
 
@@ -68,6 +153,7 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
             'owner' => $owner,
             'state' => $state,
             'dispatchArea' => $dispatchArea,
+            'isParticipating' => $participating,
         ]);
     }
 }

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Integration\Application;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Application\MonthlyReminderSender;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Zenstruck\Foundry\Persistence\Proxy;
+
+final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
+{
+    private MonthlyReminderSender $sender;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->sender = self::getContainer()->get(MonthlyReminderSender::class);
+    }
+
+    public function testSchedulerTriggerSkipsWhenUserOptedOut(): void
+    {
+        $hospital = $this->createHospital(optedOut: true);
+
+        $errors = $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Scheduler);
+
+        self::assertSame(['monthly_reminder.error.opted_out'], $errors);
+    }
+
+    public function testCliTriggerSkipsWhenUserOptedOut(): void
+    {
+        $hospital = $this->createHospital(optedOut: true);
+
+        $errors = $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Cli);
+
+        self::assertSame(['monthly_reminder.error.opted_out'], $errors);
+    }
+
+    public function testAdminTriggerSendsDespiteOptOut(): void
+    {
+        $hospital = $this->createHospital(optedOut: true);
+
+        $errors = $this->sender->sendForHospital($hospital->_real(), MonthlyReminderTrigger::Admin);
+
+        self::assertSame([], $errors);
+    }
+
+    /**
+     * @return Proxy<Hospital>
+     */
+    private function createHospital(bool $optedOut): Proxy
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('reminder-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => !$optedOut,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+
+        return HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+    }
+}

--- a/tests/Engagement/Integration/Application/SendMonthlySubmissionRemindersMessageHandlerTest.php
+++ b/tests/Engagement/Integration/Application/SendMonthlySubmissionRemindersMessageHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Integration\Application;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
+use App\Engagement\Application\MessageHandler\SendMonthlySubmissionRemindersMessageHandler;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\Lock\LockFactory;
+
+final class SendMonthlySubmissionRemindersMessageHandlerTest extends DatabaseKernelTestCase
+{
+    use MailerAssertionsTrait;
+
+    public function testHandlerSkipsWhenBatchLockIsAlreadyHeld(): void
+    {
+        self::bootKernel();
+        $lock = self::getContainer()->get(LockFactory::class)->createLock('monthly-submission-reminder');
+        self::assertTrue($lock->acquire());
+
+        try {
+            $handler = self::getContainer()->get(SendMonthlySubmissionRemindersMessageHandler::class);
+            $handler(new SendMonthlySubmissionRemindersMessage());
+            self::assertTrue($lock->isAcquired());
+        } finally {
+            $lock->release();
+        }
+
+        self::assertEmailCount(0);
+    }
+
+    public function testHandlerProcessesParticipatingHospitals(): void
+    {
+        self::bootKernel();
+
+        $optedOutOwner = UserFactory::createOne([
+            'email' => sprintf('batch-skipped-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => false,
+        ]);
+        $eligibleOwner = UserFactory::createOne([
+            'email' => sprintf('batch-sent-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        HospitalFactory::createOne([
+            'owner' => $optedOutOwner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+        ]);
+        HospitalFactory::createOne([
+            'owner' => $eligibleOwner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+        ]);
+
+        $hospitalRepository = self::getContainer()->get(HospitalRepository::class);
+        self::assertCount(2, $hospitalRepository->findParticipatingWithOwner());
+
+        $handler = self::getContainer()->get(SendMonthlySubmissionRemindersMessageHandler::class);
+        $handler(new SendMonthlySubmissionRemindersMessage());
+
+        $batchLock = self::getContainer()->get(LockFactory::class)->createLock('monthly-submission-reminder');
+        self::assertTrue($batchLock->acquire());
+        $batchLock->release();
+    }
+}

--- a/tests/Engagement/Unit/Application/MonthlyReminderChartBuilderTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderChartBuilderTest.php
@@ -30,4 +30,51 @@ final class MonthlyReminderChartBuilderTest extends TestCase
         self::assertTrue($bars[1]->isReportingMonth);
         self::assertSame(100.0, $builder->percentChange(20, 10));
     }
+
+    public function testPercentChangeReturnsNullWhenBothMonthsAreZero(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        self::assertNull($builder->percentChange(0, 0));
+    }
+
+    public function testSummarizeTrendDetectsGrowingSeries(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        self::assertSame(
+            'monthly_reminder.trend.growing',
+            $builder->summarizeTrend([5, 8, 12, 16, 20, 30]),
+        );
+    }
+
+    public function testSummarizeTrendDetectsDecliningSeries(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        self::assertSame(
+            'monthly_reminder.trend.declining',
+            $builder->summarizeTrend([30, 25, 20, 15, 10, 5]),
+        );
+    }
+
+    public function testSummarizeTrendDetectsGrowthFromZero(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        self::assertSame(
+            'monthly_reminder.trend.growing_from_zero',
+            $builder->summarizeTrend([0, 0, 0, 5]),
+        );
+    }
+
+    public function testSummarizeTrendReturnsStableForFlatSeries(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        self::assertSame(
+            'monthly_reminder.trend.stable',
+            $builder->summarizeTrend([10, 10, 10, 10]),
+        );
+    }
 }

--- a/tests/Engagement/Unit/Application/MonthlyReminderChartBuilderTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderChartBuilderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\MonthlyReminderChartBuilder;
+use App\Statistics\Application\ChartBucketMapper;
+use PHPUnit\Framework\TestCase;
+
+final class MonthlyReminderChartBuilderTest extends TestCase
+{
+    public function testBuildCreatesBarsForEachMonth(): void
+    {
+        $builder = new MonthlyReminderChartBuilder(new ChartBucketMapper());
+
+        $bars = $builder->build(
+            ['2025-11', '2025-12'],
+            ['Nov', 'Dec'],
+            [
+                ['year' => 2025, 'month' => 11, 'count' => 10],
+                ['year' => 2025, 'month' => 12, 'count' => 20],
+            ],
+            '2025-12',
+        );
+
+        self::assertCount(2, $bars);
+        self::assertSame(10, $bars[0]->allocationCount);
+        self::assertSame(20, $bars[1]->allocationCount);
+        self::assertTrue($bars[1]->isReportingMonth);
+        self::assertSame(100.0, $builder->percentChange(20, 10));
+    }
+}

--- a/tests/Engagement/Unit/Application/MonthlyReminderInsightSelectorTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderInsightSelectorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\MonthlyReminderInsightSelector;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkDistribution;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricFormat;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricKey;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class MonthlyReminderInsightSelectorTest extends TestCase
+{
+    public function testPhysicianInsightUsesBaselineDeltaInPercentagePoints(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            null,
+            null,
+            [
+                new BenchmarkMetric(
+                    BenchmarkMetricKey::WithPhysician,
+                    15.9,
+                    13.4,
+                    2.5,
+                    18.7,
+                    1.19,
+                    BenchmarkMetricFormat::Percent,
+                ),
+            ],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.physician.title', $insights[0]->title);
+        self::assertStringContainsString('15.9', $insights[0]->body);
+        self::assertStringContainsString('13.4', $insights[0]->body);
+        self::assertStringContainsString('+2.5%', $insights[0]->body);
+        self::assertSame('https://example.test/stats', $insights[0]->linkUrl);
+    }
+
+    public function testMetricInsideBaselineBandProducesNoInsight(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            null,
+            null,
+            [
+                new BenchmarkMetric(
+                    BenchmarkMetricKey::WithPhysician,
+                    14.0,
+                    13.4,
+                    0.6,
+                    4.5,
+                    1.04,
+                    BenchmarkMetricFormat::Percent,
+                ),
+            ],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertSame([], $insights);
+    }
+
+    private function translator(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static function (string $id, array $parameters = []): string {
+                if ([] === $parameters) {
+                    return $id;
+                }
+
+                $parts = [];
+                foreach ($parameters as $key => $value) {
+                    $parts[] = sprintf('%s=%s', $key, $value);
+                }
+
+                return $id.' ['.implode(', ', $parts).']';
+            },
+        );
+
+        return $translator;
+    }
+}

--- a/tests/Engagement/Unit/Application/MonthlyReminderInsightSelectorTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderInsightSelectorTest.php
@@ -75,6 +75,142 @@ final class MonthlyReminderInsightSelectorTest extends TestCase
         self::assertSame([], $insights);
     }
 
+    public function testVolumeMomInsightIsSelectedWhenChangeIsSignificant(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            8.5,
+            null,
+            [],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.volume_mom.title', $insights[0]->title);
+    }
+
+    public function testVolumeYoyInsightTakesPriorityOverMom(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            12.0,
+            -6.0,
+            [],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.volume_yoy.title', $insights[0]->title);
+    }
+
+    public function testQualityInsightWhenRejectionRateImproves(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            null,
+            null,
+            [],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            -2.4,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.quality.title', $insights[0]->title);
+    }
+
+    public function testResusInsightUsesBaselineComparison(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            null,
+            null,
+            [
+                new BenchmarkMetric(
+                    BenchmarkMetricKey::Resus,
+                    4.0,
+                    2.0,
+                    2.0,
+                    100.0,
+                    2.0,
+                    BenchmarkMetricFormat::Percent,
+                ),
+            ],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.resus.title', $insights[0]->title);
+    }
+
+    public function testIndicationInsightUsesLargestDeviationBucket(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $insights = $selector->select(
+            null,
+            null,
+            [],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, [
+                new \App\Statistics\Benchmarking\Application\DTO\BenchmarkDistributionBucket(
+                    'a',
+                    'Chest pain',
+                    10,
+                    8,
+                    12.0,
+                    8.0,
+                    1.5,
+                ),
+            ]),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+        );
+
+        self::assertCount(1, $insights);
+        self::assertSame('monthly_reminder.insight.indication.title', $insights[0]->title);
+        self::assertStringContainsString('Chest pain', $insights[0]->body);
+    }
+
+    public function testGenderAndUrgencySegmentsReturnPercentages(): void
+    {
+        $selector = new MonthlyReminderInsightSelector($this->translator());
+
+        $genderSegments = $selector->genderSegments([
+            'M' => 30,
+            'F' => 70,
+        ], 100);
+        $urgencySegments = $selector->urgencySegments([
+            1 => 10,
+            2 => 20,
+            3 => 70,
+        ], 100);
+
+        self::assertCount(3, $genderSegments);
+        self::assertSame(30.0, $genderSegments[0]->percent);
+        self::assertCount(3, $urgencySegments);
+        self::assertSame(70.0, $urgencySegments[2]->percent);
+    }
+
     private function translator(): TranslatorInterface
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\Dto\MonthlyReminderContent;
+use App\Engagement\Application\MonthlyReminderMailer;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class MonthlyReminderMailerTest extends TestCase
+{
+    public function testSendUsesConfiguredSenderSubjectAndTemplate(): void
+    {
+        $content = $this->content();
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = []): string => match ($id) {
+                'monthly_reminder.subject' => sprintf('Reminder for %s (%s)', $parameters['hospital'], $parameters['period']),
+                default => $id,
+            },
+        );
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame('no-reply@example.test', $email->getFrom()[0]->getAddress());
+                self::assertSame('IVENA Stats', $email->getFrom()[0]->getName());
+                self::assertSame(['owner@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getTo(),
+                ));
+                self::assertSame('Reminder for Test Hospital (May 2026)', $email->getSubject());
+                self::assertSame('@Engagement/email/monthly_submission_reminder.html.twig', $email->getHtmlTemplate());
+                self::assertSame('IVENA Stats', $email->getContext()['app_title'] ?? null);
+
+                return true;
+            }));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info');
+
+        new MonthlyReminderMailer(
+            $mailer,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'IVENA Stats',
+                appName: 'IVENA Stats',
+                replyTo: '',
+            ),
+            $translator,
+            $logger,
+        )->send('owner@example.test', $content);
+    }
+
+    public function testReplyToIsAppliedWhenConfigured(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('subject');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(['support@example.test'], array_map(
+                    static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
+                    $email->getReplyTo(),
+                ));
+
+                return true;
+            }));
+
+        new MonthlyReminderMailer(
+            $mailer,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'IVENA Stats',
+                appName: 'IVENA Stats',
+                replyTo: 'support@example.test',
+            ),
+            $translator,
+            $this->createMock(LoggerInterface::class),
+        )->send('owner@example.test', $this->content());
+    }
+
+    private function content(): MonthlyReminderContent
+    {
+        return new MonthlyReminderContent(
+            hospitalName: 'Test Hospital',
+            reportingPeriodLabel: 'May 2026',
+            uploadMonthLabel: 'June 2026',
+            preheader: 'Preview',
+            isPersonalized: true,
+            allocationCount: 10,
+            allocationMomPercent: null,
+            lastImportLabel: 'None',
+            lastImportStale: true,
+            withPhysicianPercent: 0.0,
+            withPhysicianBaselineDeltaPp: null,
+            baselinePeriodLabel: 'baseline',
+            medianTransportMinutes: 0.0,
+            medianTransportBaselineDeltaMinutes: null,
+            trendSummary: '',
+            chartBars: [],
+            urgencySegments: [],
+            urgencyBenchmarkNote: null,
+            genderSegments: [],
+            insights: [],
+            submissionMonthsCompleted: 0,
+            submissionMonthsTotal: 12,
+            submissionProgressPercent: 0,
+            submissionMonths: [],
+            longestSubmissionGapLabel: null,
+            importCreateUrl: 'https://example.test/import',
+            statisticsDashboardUrl: 'https://example.test/stats',
+            benchmarkingUrl: 'https://example.test/benchmark',
+            notificationsSettingsUrl: 'https://example.test/settings',
+        );
+    }
+}

--- a/tests/Engagement/Unit/Application/MonthlyReminderPeriodResolverTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderPeriodResolverTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\MonthlyReminderPeriodResolver;
+use PHPUnit\Framework\TestCase;
+
+final class MonthlyReminderPeriodResolverTest extends TestCase
+{
+    public function testResolveUsesPreviousMonthAsReportingPeriod(): void
+    {
+        $resolver = new MonthlyReminderPeriodResolver();
+        $result = $resolver->resolve(new \DateTimeImmutable('2026-01-15 10:00:00', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame(2025, $result['reportingYear']);
+        self::assertSame(12, $result['reportingMonth']);
+        self::assertSame(2026, $result['uploadYear']);
+        self::assertSame(1, $result['uploadMonth']);
+        self::assertCount(12, $result['chartMonthKeys']);
+        self::assertSame('2026-01', $result['chartMonthKeys'][11]);
+        self::assertSame('2025-02', $result['chartMonthKeys'][0]);
+    }
+}

--- a/tests/Import/Integration/Repository/ImportRepositoryMonthlyReminderQueryTest.php
+++ b/tests/Import/Integration/Repository/ImportRepositoryMonthlyReminderQueryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+
+final class ImportRepositoryMonthlyReminderQueryTest extends DatabaseKernelTestCase
+{
+    private ImportRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->repository = self::getContainer()->get(ImportRepository::class);
+    }
+
+    public function testFindLatestSuccessfulByHospitalReturnsMostRecentCompletedImport(): void
+    {
+        [$hospital, $user] = $this->seedHospital();
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-03-01'),
+            'status' => ImportStatus::FAILED,
+        ]);
+        $latest = ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-05-15'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-04-01'),
+            'status' => ImportStatus::PARTIAL,
+        ]);
+
+        $found = $this->repository->findLatestSuccessfulByHospital((int) $hospital->getId());
+
+        self::assertNotNull($found);
+        self::assertSame($latest->getId(), $found->getId());
+    }
+
+    public function testCountImportsByMonthInRangeBucketsImportsChronologically(): void
+    {
+        [$hospital, $user] = $this->seedHospital();
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-04-10'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-05-12'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-05-20'),
+            'status' => ImportStatus::FAILED,
+        ]);
+
+        $rows = $this->repository->countImportsByMonthInRange(
+            new \DateTimeImmutable('2026-04-01'),
+            new \DateTimeImmutable('2026-06-01'),
+        );
+
+        self::assertSame([
+            ['year' => 2026, 'month' => 4, 'count' => 1],
+            ['year' => 2026, 'month' => 5, 'count' => 2],
+        ], $rows);
+    }
+
+    public function testMonthlySubmissionStatusForHospitalTracksSuccessFailedAndMissing(): void
+    {
+        [$hospital, $user] = $this->seedHospital();
+        $monthKeys = ['2026-03', '2026-04', '2026-05'];
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-03-05'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => new \DateTimeImmutable('2026-05-05'),
+            'status' => ImportStatus::FAILED,
+        ]);
+
+        $status = $this->repository->monthlySubmissionStatusForHospital(
+            (int) $hospital->getId(),
+            $monthKeys,
+            new \DateTimeImmutable('2026-03-01'),
+        );
+
+        self::assertSame([
+            '2026-03' => 'success',
+            '2026-04' => 'missing',
+            '2026-05' => 'failed',
+        ], $status);
+    }
+
+    /**
+     * @return array{0: object, 1: object}
+     */
+    private function seedHospital(): array
+    {
+        $user = UserFactory::createOne([
+            'email' => sprintf('import-repo-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        return [$hospital, $user];
+    }
+}

--- a/tests/Kpi/Integration/Repository/KpiDailyRepositoryMonthlyReminderQueryTest.php
+++ b/tests/Kpi/Integration/Repository/KpiDailyRepositoryMonthlyReminderQueryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Kpi\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Kpi\Infrastructure\Repository\KpiDailyRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+
+final class KpiDailyRepositoryMonthlyReminderQueryTest extends DatabaseKernelTestCase
+{
+    private KpiDailyRepository $repository;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->repository = $container->get(KpiDailyRepository::class);
+        $this->connection = $container->get(Connection::class);
+    }
+
+    public function testRejectionRateForHospitalInRangeAggregatesDailyRows(): void
+    {
+        $hospitalId = $this->seedHospitalId();
+        $this->insertHospitalKpi($hospitalId, '2026-04-01', 100, 10);
+        $this->insertHospitalKpi($hospitalId, '2026-05-01', 200, 20);
+
+        $aprilRate = $this->repository->rejectionRateForHospitalInRange(
+            $hospitalId,
+            new \DateTimeImmutable('2026-04-01'),
+            new \DateTimeImmutable('2026-05-01'),
+        );
+        $mayRate = $this->repository->rejectionRateForHospitalInRange(
+            $hospitalId,
+            new \DateTimeImmutable('2026-05-01'),
+            new \DateTimeImmutable('2026-06-01'),
+        );
+
+        self::assertSame(10.0, $aprilRate);
+        self::assertSame(10.0, $mayRate);
+    }
+
+    public function testRejectionRateForHospitalInRangeReturnsNullWithoutData(): void
+    {
+        $hospitalId = $this->seedHospitalId();
+
+        self::assertNull($this->repository->rejectionRateForHospitalInRange(
+            $hospitalId,
+            new \DateTimeImmutable('2026-04-01'),
+            new \DateTimeImmutable('2026-05-01'),
+        ));
+    }
+
+    public function testCountActiveHospitalsLast30DaysCountsDistinctHospitalsWithSuccessfulImports(): void
+    {
+        $firstHospitalId = $this->seedHospitalId();
+        $secondHospitalId = $this->seedHospitalId();
+        $inactiveHospitalId = $this->seedHospitalId();
+
+        $today = new \DateTimeImmutable('today')->format('Y-m-d');
+        $this->insertHospitalKpi($firstHospitalId, $today, 50, 5, successfulImports: 1);
+        $this->insertHospitalKpi($secondHospitalId, $today, 40, 4, successfulImports: 1);
+        $this->insertHospitalKpi($inactiveHospitalId, $today, 10, 1, successfulImports: 0);
+
+        self::assertSame(2, $this->repository->countActiveHospitalsLast30Days());
+    }
+
+    private function seedHospitalId(): int
+    {
+        $user = UserFactory::createOne([
+            'email' => sprintf('kpi-repo-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        return (int) $hospital->getId();
+    }
+
+    private function insertHospitalKpi(
+        int $hospitalId,
+        string $date,
+        int $recordsTotal,
+        int $recordsRejected,
+        int $successfulImports = 1,
+    ): void {
+        $this->connection->insert('kpi_daily', [
+            'date' => $date,
+            'hospital_id' => $hospitalId,
+            'imports_count' => 1,
+            'successful_imports_count' => $successfulImports,
+            'records_total' => $recordsTotal,
+            'records_processed' => $recordsTotal,
+            'records_rejected' => $recordsRejected,
+            'failed_imports_count' => 0,
+            'created_at' => new \DateTimeImmutable()->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/tests/Kpi/Unit/Infrastructure/Scheduler/KpiScheduleProviderTest.php
+++ b/tests/Kpi/Unit/Infrastructure/Scheduler/KpiScheduleProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Kpi\Unit\Infrastructure\Scheduler;
 
+use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
 use App\Kpi\Application\Message\GenerateDailyKpisMessage;
 use App\Kpi\Infrastructure\Scheduler\KpiScheduleProvider;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,7 @@ final class KpiScheduleProviderTest extends TestCase
 
         $recurringMessages = $provider->getSchedule()->getRecurringMessages();
 
-        self::assertCount(1, $recurringMessages);
+        self::assertCount(2, $recurringMessages);
 
         $recurringMessage = $recurringMessages[0];
         self::assertInstanceOf(RecurringMessage::class, $recurringMessage);
@@ -43,5 +44,22 @@ final class KpiScheduleProviderTest extends TestCase
 
         self::assertCount(1, $messages);
         self::assertInstanceOf(GenerateDailyKpisMessage::class, $messages[0]);
+
+        $monthlyMessage = $recurringMessages[1];
+        self::assertInstanceOf(RecurringMessage::class, $monthlyMessage);
+        $monthlyTrigger = $monthlyMessage->getTrigger();
+        self::assertInstanceOf(CronExpressionTrigger::class, $monthlyTrigger);
+        self::assertSame('0 8 1-7 * 1', (string) $monthlyTrigger);
+
+        $monthlyProvider = $monthlyMessage->getProvider();
+        self::assertInstanceOf(StaticMessageProvider::class, $monthlyProvider);
+        $monthlyMessages = iterator_to_array($monthlyProvider->getMessages(new MessageContext(
+            name: 'default',
+            id: 'monthly-test',
+            trigger: $monthlyTrigger,
+            triggeredAt: new \DateTimeImmutable(),
+        )));
+        self::assertCount(1, $monthlyMessages);
+        self::assertInstanceOf(SendMonthlySubmissionRemindersMessage::class, $monthlyMessages[0]);
     }
 }

--- a/tests/User/Functional/Controller/SettingsControllerTest.php
+++ b/tests/User/Functional/Controller/SettingsControllerTest.php
@@ -152,4 +152,45 @@ final class SettingsControllerTest extends WebTestCase
             ->assertSee('Current password is invalid.')
         ;
     }
+
+    public function testAuthenticatedUserCanOpenNotificationsPage(): void
+    {
+        UserFactory::new([
+            'email' => 'notifications-page@example.test',
+            'isVerified' => true,
+            'username' => 'notifications-page-user',
+        ])->create();
+
+        $this->loginWithConsent($this->browser(), 'notifications-page-user')
+            ->visit('/settings/notifications')
+            ->assertSuccessful()
+            ->assertSee('Notifications')
+            ->assertSee('Monthly data submission reminder')
+        ;
+    }
+
+    public function testUserCanOptOutOfMonthlyReminder(): void
+    {
+        $user = UserFactory::new([
+            'email' => 'notifications-optout@example.test',
+            'isVerified' => true,
+            'username' => 'notifications-optout-user',
+            'receivesMonthlySubmissionReminder' => true,
+        ])->create();
+
+        self::assertTrue($user->receivesMonthlySubmissionReminder());
+
+        $browser = $this->loginWithConsent($this->browser(), 'notifications-optout-user');
+        $browser
+            ->visit('/settings/notifications')
+            ->assertSuccessful()
+            ->uncheckField('Monthly data submission reminder')
+            ->click('Save')
+            ->assertSuccessful()
+            ->assertSee('Notification preferences saved.')
+        ;
+
+        $user->_refresh();
+        self::assertFalse($user->receivesMonthlySubmissionReminder());
+    }
 }

--- a/translations/admin+intl-icu.en.xlf
+++ b/translations/admin+intl-icu.en.xlf
@@ -313,6 +313,18 @@
         <source>kpi.failure_reason.generic</source>
         <target>Import processing failed</target>
       </trans-unit>
+      <trans-unit id="admMr01" resname="admin.hospital.action.send_reminder">
+        <source>admin.hospital.action.send_reminder</source>
+        <target>Send monthly reminder</target>
+      </trans-unit>
+      <trans-unit id="admMr02" resname="admin.hospital.action.send_reminder.confirm">
+        <source>admin.hospital.action.send_reminder.confirm</source>
+        <target>Send the monthly data submission reminder to the hospital owner now?</target>
+      </trans-unit>
+      <trans-unit id="admMr03" resname="flash.admin.hospital.reminder.sent">
+        <source>flash.admin.hospital.reminder.sent</source>
+        <target>Monthly reminder queued for delivery to the hospital owner.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -389,6 +389,10 @@
         <source>flash.settings.password.updated</source>
         <target>Password updated.</target>
       </trans-unit>
+      <trans-unit id="notif01" resname="flash.settings.notifications.updated">
+        <source>flash.settings.notifications.updated</source>
+        <target>Notification preferences saved.</target>
+      </trans-unit>
       <trans-unit id="vHELHHc" resname="help.no_hospitals_assigned">
         <source>help.no_hospitals_assigned</source>
         <target>Sorry there are no hospitals assigned to your account.</target>
@@ -400,6 +404,10 @@
       <trans-unit id="9xtc9Dc" resname="help.settings.username_fixed">
         <source>help.settings.username_fixed</source>
         <target>Username is fixed and cannot be changed.</target>
+      </trans-unit>
+      <trans-unit id="notif02" resname="help.settings.notifications.monthly_reminder">
+        <source>help.settings.notifications.monthly_reminder</source>
+        <target>Receive a monthly email with hospital insights and a reminder to upload your latest data.</target>
       </trans-unit>
       <trans-unit id="SZjOELg" resname="hospital.location.Mixed">
         <source>hospital.location.Mixed</source>
@@ -1172,6 +1180,14 @@
       <trans-unit id="FYr3SWn" resname="label.settings.my_account">
         <source>label.settings.my_account</source>
         <target>My Account</target>
+      </trans-unit>
+      <trans-unit id="notif03" resname="label.settings.notifications">
+        <source>label.settings.notifications</source>
+        <target>Notifications</target>
+      </trans-unit>
+      <trans-unit id="notif04" resname="label.settings.notifications.monthly_reminder">
+        <source>label.settings.notifications.monthly_reminder</source>
+        <target>Monthly data submission reminder</target>
       </trans-unit>
       <trans-unit id="Tha5z5U" resname="label.settings.profile_details">
         <source>label.settings.profile_details</source>
@@ -2439,6 +2455,10 @@
         <source>text.settings.account_intro</source>
         <target>Manage your account profile, email, and password.</target>
       </trans-unit>
+      <trans-unit id="notif05" resname="text.settings.notifications_intro">
+        <source>text.settings.notifications_intro</source>
+        <target>Choose which emails you want to receive.</target>
+      </trans-unit>
       <trans-unit id="GhGeHI9" resname="title.allocation.list">
         <source>title.allocation.list</source>
         <target>Listing Allocations</target>
@@ -2702,6 +2722,10 @@
       <trans-unit id="CpWB5qC" resname="title.settings.change_password_breadcrumb">
         <source>title.settings.change_password_breadcrumb</source>
         <target>Settings / Change password</target>
+      </trans-unit>
+      <trans-unit id="notif06" resname="title.settings.notifications">
+        <source>title.settings.notifications</source>
+        <target>Notifications</target>
       </trans-unit>
       <trans-unit id="uhopb3E" resname="title.speciality.list">
         <source>title.speciality.list</source>
@@ -3345,7 +3369,7 @@
       </trans-unit>
       <trans-unit id="statsOvHs08" resname="stats.overview.hospital_summary.unscoped_hint">
         <source>stats.overview.hospital_summary.unscoped_hint</source>
-        <target>Showing all hospitals — no clinics are assigned to your account.</target>
+        <target>Showing all hospitals — no hospitals are assigned to your account.</target>
       </trans-unit>
       <trans-unit id="statsOvHs09" resname="stats.overview.hospital_summary.gender_card_title">
         <source>stats.overview.hospital_summary.gender_card_title</source>
@@ -5773,7 +5797,7 @@
       </trans-unit>
       <trans-unit id="statsEv21" resname="stats.data_quality.dimension.representativeness.hint_divergent">
         <source>stats.data_quality.dimension.representativeness.hint_divergent</source>
-        <target>Notable deviations from the clinic base</target>
+        <target>Notable deviations from the hospital base</target>
       </trans-unit>
       <trans-unit id="statsEv22" resname="stats.data_quality.dimension.subgroup.metric">
         <source>stats.data_quality.dimension.subgroup.metric</source>
@@ -5801,7 +5825,7 @@
       </trans-unit>
       <trans-unit id="statsEv28" resname="stats.data_quality.explanation.high">
         <source>stats.data_quality.explanation.high</source>
-        <target>Deployment statistics are well interpretable. Participating hospitals adequately cover the selected clinic base.</target>
+        <target>Deployment statistics are well interpretable. Participating hospitals adequately cover the selected hospital base.</target>
       </trans-unit>
       <trans-unit id="statsEv29" resname="stats.data_quality.explanation.medium">
         <source>stats.data_quality.explanation.medium</source>
@@ -5817,11 +5841,11 @@
       </trans-unit>
       <trans-unit id="statsEv32" resname="stats.data_quality.explanation.low_coverage_and_representativeness">
         <source>stats.data_quality.explanation.low_coverage_and_representativeness</source>
-        <target>Deployment statistics are barely reliable because coverage is low and participating hospitals differ strongly from the clinic base.</target>
+        <target>Deployment statistics are barely reliable because coverage is low and participating hospitals differ strongly from the hospital base.</target>
       </trans-unit>
       <trans-unit id="statsEv33" resname="stats.data_quality.explanation.low_representativeness">
         <source>stats.data_quality.explanation.low_representativeness</source>
-        <target>Deployment statistics are limited interpretable because participating hospitals differ from the clinic base (deviation {difference}).</target>
+        <target>Deployment statistics are limited interpretable because participating hospitals differ from the hospital base (deviation {difference}).</target>
       </trans-unit>
       <trans-unit id="statsEv34" resname="stats.data_quality.explanation.low_allocation_volume">
         <source>stats.data_quality.explanation.low_allocation_volume</source>
@@ -5853,11 +5877,11 @@
       </trans-unit>
       <trans-unit id="statsEv41" resname="stats.data_quality.representativeness.limited">
         <source>stats.data_quality.representativeness.limited</source>
-        <target>Limited reliability due to small clinic base</target>
+        <target>Limited reliability due to small hospital base</target>
       </trans-unit>
       <trans-unit id="statsEv56" resname="stats.data_quality.representativeness.help">
         <source>stats.data_quality.representativeness.help</source>
-        <target>Compares the distribution of participating hospitals with the full clinic base across size, care level, urbanity and district. A lower difference means the sample is more representative.</target>
+        <target>Compares the distribution of participating hospitals with the full hospital base across size, care level, urbanity and district. A lower difference means the sample is more representative.</target>
       </trans-unit>
       <trans-unit id="statsEv57" resname="stats.data_quality.subgroup.help">
         <source>stats.data_quality.subgroup.help</source>
@@ -6393,11 +6417,271 @@
       </trans-unit>
       <trans-unit id="hag18" resname="flash.hospital_access_grant.duplicate">
         <source>flash.hospital_access_grant.duplicate</source>
-        <target>This user already has an access grant for this clinic.</target>
+        <target>This user already has an access grant for this hospital.</target>
       </trans-unit>
       <trans-unit id="hag19" resname="label.delete">
         <source>label.delete</source>
         <target>Delete</target>
+      </trans-unit>
+      <trans-unit id="mr001" resname="monthly_reminder.subject">
+        <source>monthly_reminder.subject</source>
+        <target>Monthly overview: {hospital} ({period})</target>
+      </trans-unit>
+      <trans-unit id="mr002" resname="monthly_reminder.heading">
+        <source>monthly_reminder.heading</source>
+        <target>Monthly overview: {hospital}</target>
+      </trans-unit>
+      <trans-unit id="mr003" resname="monthly_reminder.preheader">
+        <source>monthly_reminder.preheader</source>
+        <target>{period}: {count} allocations ({delta} vs. previous month) — upload data for {upload_month}</target>
+      </trans-unit>
+      <trans-unit id="mr004" resname="monthly_reminder.month_year">
+        <source>monthly_reminder.month_year</source>
+        <target>{month} {year}</target>
+      </trans-unit>
+      <trans-unit id="mr005" resname="monthly_reminder.cta.upload">
+        <source>monthly_reminder.cta.upload</source>
+        <target>Upload data for {month}</target>
+      </trans-unit>
+      <trans-unit id="mr006" resname="monthly_reminder.section.trend">
+        <source>monthly_reminder.section.trend</source>
+        <target>Allocation trend — last 12 months</target>
+      </trans-unit>
+      <trans-unit id="mr007" resname="monthly_reminder.section.profile">
+        <source>monthly_reminder.section.profile</source>
+        <target>Clinical profile</target>
+      </trans-unit>
+      <trans-unit id="mr008" resname="monthly_reminder.section.platform">
+        <source>monthly_reminder.section.platform</source>
+        <target>Platform trends</target>
+      </trans-unit>
+      <trans-unit id="mr009" resname="monthly_reminder.section.insights">
+        <source>monthly_reminder.section.insights</source>
+        <target>Your insights</target>
+      </trans-unit>
+      <trans-unit id="mr010" resname="monthly_reminder.section.submission">
+        <source>monthly_reminder.section.submission</source>
+        <target>Data submission — last 12 months</target>
+      </trans-unit>
+      <trans-unit id="mr011" resname="monthly_reminder.kpi.allocations">
+        <source>monthly_reminder.kpi.allocations</source>
+        <target>Allocations (reporting month)</target>
+      </trans-unit>
+      <trans-unit id="mr012" resname="monthly_reminder.kpi.last_import.label">
+        <source>monthly_reminder.kpi.last_import.label</source>
+        <target>Last import</target>
+      </trans-unit>
+      <trans-unit id="mr013" resname="monthly_reminder.kpi.last_import.none">
+        <source>monthly_reminder.kpi.last_import.none</source>
+        <target>No import yet</target>
+      </trans-unit>
+      <trans-unit id="mr014" resname="monthly_reminder.kpi.last_import.date">
+        <source>monthly_reminder.kpi.last_import.date</source>
+        <target>Data through {date}</target>
+      </trans-unit>
+      <trans-unit id="mr015" resname="monthly_reminder.kpi.physician">
+        <source>monthly_reminder.kpi.physician</source>
+        <target>Physician escort rate</target>
+      </trans-unit>
+      <trans-unit id="mr016" resname="monthly_reminder.kpi.transport">
+        <source>monthly_reminder.kpi.transport</source>
+        <target>Median transport time</target>
+      </trans-unit>
+      <trans-unit id="mr063" resname="monthly_reminder.kpi.physician_baseline_delta">
+        <source>monthly_reminder.kpi.physician_baseline_delta</source>
+        <target>{delta} vs. {baseline}</target>
+      </trans-unit>
+      <trans-unit id="mr064" resname="monthly_reminder.kpi.transport_baseline_delta">
+        <source>monthly_reminder.kpi.transport_baseline_delta</source>
+        <target>{delta} min vs. {baseline}</target>
+      </trans-unit>
+      <trans-unit id="mr017" resname="monthly_reminder.chart.allocations">
+        <source>monthly_reminder.chart.allocations</source>
+        <target>Allocations</target>
+      </trans-unit>
+      <trans-unit id="mr018" resname="monthly_reminder.chart.imports">
+        <source>monthly_reminder.chart.imports</source>
+        <target>Imports</target>
+      </trans-unit>
+      <trans-unit id="mr019" resname="monthly_reminder.profile.urgency">
+        <source>monthly_reminder.profile.urgency</source>
+        <target>Urgency mix</target>
+      </trans-unit>
+      <trans-unit id="mr020" resname="monthly_reminder.profile.gender">
+        <source>monthly_reminder.profile.gender</source>
+        <target>Gender mix</target>
+      </trans-unit>
+      <trans-unit id="mr021" resname="monthly_reminder.platform.allocations">
+        <source>monthly_reminder.platform.allocations</source>
+        <target>Platform allocations</target>
+      </trans-unit>
+      <trans-unit id="mr022" resname="monthly_reminder.platform.hospitals">
+        <source>monthly_reminder.platform.hospitals</source>
+        <target>Active hospitals</target>
+      </trans-unit>
+      <trans-unit id="mr023" resname="monthly_reminder.platform.imports">
+        <source>monthly_reminder.platform.imports</source>
+        <target>Imports last month</target>
+      </trans-unit>
+      <trans-unit id="mr024" resname="monthly_reminder.submission.progress">
+        <source>monthly_reminder.submission.progress</source>
+        <target>{completed} of {total} months with a successful import</target>
+      </trans-unit>
+      <trans-unit id="mr025" resname="monthly_reminder.submission.gap">
+        <source>monthly_reminder.submission.gap</source>
+        <target>Longest gap: {months} months ({from} – {to})</target>
+      </trans-unit>
+      <trans-unit id="mr026" resname="monthly_reminder.link.dashboard">
+        <source>monthly_reminder.link.dashboard</source>
+        <target>Open statistics dashboard</target>
+      </trans-unit>
+      <trans-unit id="mr027" resname="monthly_reminder.link.benchmarking">
+        <source>monthly_reminder.link.benchmarking</source>
+        <target>Open benchmarking</target>
+      </trans-unit>
+      <trans-unit id="mr028" resname="monthly_reminder.insight.link">
+        <source>monthly_reminder.insight.link</source>
+        <target>View in benchmarking</target>
+      </trans-unit>
+      <trans-unit id="mr065" resname="monthly_reminder.baseline.period_label">
+        <source>monthly_reminder.baseline.period_label</source>
+        <target>your last 12 months</target>
+      </trans-unit>
+      <trans-unit id="mr029" resname="monthly_reminder.trend.growing">
+        <source>monthly_reminder.trend.growing</source>
+        <target>Over the last six months, volume grew by an average of {percent}% per month.</target>
+      </trans-unit>
+      <trans-unit id="mr030" resname="monthly_reminder.trend.declining">
+        <source>monthly_reminder.trend.declining</source>
+        <target>Over the last six months, volume declined by an average of {percent}% per month.</target>
+      </trans-unit>
+      <trans-unit id="mr031" resname="monthly_reminder.trend.stable">
+        <source>monthly_reminder.trend.stable</source>
+        <target>Volume has remained relatively stable over the last six months.</target>
+      </trans-unit>
+      <trans-unit id="mr032" resname="monthly_reminder.trend.growing_from_zero">
+        <source>monthly_reminder.trend.growing_from_zero</source>
+        <target>Recent months show increasing activity after a quiet period.</target>
+      </trans-unit>
+      <trans-unit id="mr033" resname="monthly_reminder.urgency.benchmark">
+        <source>monthly_reminder.urgency.benchmark</source>
+        <target>{urgency} share: {percent}% ({delta} vs. {baseline})</target>
+      </trans-unit>
+      <trans-unit id="mr034" resname="monthly_reminder.insight.volume_yoy.title">
+        <source>monthly_reminder.insight.volume_yoy.title</source>
+        <target>Year-over-year volume</target>
+      </trans-unit>
+      <trans-unit id="mr035" resname="monthly_reminder.insight.volume_yoy.body">
+        <source>monthly_reminder.insight.volume_yoy.body</source>
+        <target>{percent} allocations compared with the same month last year.</target>
+      </trans-unit>
+      <trans-unit id="mr036" resname="monthly_reminder.insight.volume_mom.title">
+        <source>monthly_reminder.insight.volume_mom.title</source>
+        <target>Month-over-month volume</target>
+      </trans-unit>
+      <trans-unit id="mr037" resname="monthly_reminder.insight.volume_mom.body">
+        <source>monthly_reminder.insight.volume_mom.body</source>
+        <target>{percent} allocations compared with the previous month.</target>
+      </trans-unit>
+      <trans-unit id="mr038" resname="monthly_reminder.insight.resus.title">
+        <source>monthly_reminder.insight.resus.title</source>
+        <target>Resuscitation rate</target>
+      </trans-unit>
+      <trans-unit id="mr039" resname="monthly_reminder.insight.resus.body">
+        <source>monthly_reminder.insight.resus.body</source>
+        <target>Resuscitation rate in {period}: {primary_percent}% vs. {baseline_percent}% over {baseline} ({delta_pp}).</target>
+      </trans-unit>
+      <trans-unit id="mr040" resname="monthly_reminder.insight.cpr.title">
+        <source>monthly_reminder.insight.cpr.title</source>
+        <target>CPR rate</target>
+      </trans-unit>
+      <trans-unit id="mr041" resname="monthly_reminder.insight.cpr.body">
+        <source>monthly_reminder.insight.cpr.body</source>
+        <target>CPR rate in {period}: {primary_percent}% vs. {baseline_percent}% over {baseline} ({delta_pp}).</target>
+      </trans-unit>
+      <trans-unit id="mr042" resname="monthly_reminder.insight.physician.title">
+        <source>monthly_reminder.insight.physician.title</source>
+        <target>Physician escort rate</target>
+      </trans-unit>
+      <trans-unit id="mr043" resname="monthly_reminder.insight.physician.body">
+        <source>monthly_reminder.insight.physician.body</source>
+        <target>Physician escort rate in {period}: {primary_percent}% vs. {baseline_percent}% over {baseline} ({delta_pp}).</target>
+      </trans-unit>
+      <trans-unit id="mr044" resname="monthly_reminder.insight.benchmark.title">
+        <source>monthly_reminder.insight.benchmark.title</source>
+        <target>Benchmark note</target>
+      </trans-unit>
+      <trans-unit id="mr045" resname="monthly_reminder.insight.benchmark.body">
+        <source>monthly_reminder.insight.benchmark.body</source>
+        <target>In {period}: {primary_percent}% vs. {baseline_percent}% over {baseline} ({delta_pp}).</target>
+      </trans-unit>
+      <trans-unit id="mr046" resname="monthly_reminder.insight.direction.above">
+        <source>monthly_reminder.insight.direction.above</source>
+        <target>above</target>
+      </trans-unit>
+      <trans-unit id="mr047" resname="monthly_reminder.insight.direction.below">
+        <source>monthly_reminder.insight.direction.below</source>
+        <target>below</target>
+      </trans-unit>
+      <trans-unit id="mr048" resname="monthly_reminder.insight.indication.title">
+        <source>monthly_reminder.insight.indication.title</source>
+        <target>Indication mix</target>
+      </trans-unit>
+      <trans-unit id="mr049" resname="monthly_reminder.insight.indication.body">
+        <source>monthly_reminder.insight.indication.body</source>
+        <target>{indication} in {period}: {primary_percent}% vs. {baseline_percent}% over {baseline} ({delta_pp}).</target>
+      </trans-unit>
+      <trans-unit id="mr050" resname="monthly_reminder.insight.quality.title">
+        <source>monthly_reminder.insight.quality.title</source>
+        <target>Import quality</target>
+      </trans-unit>
+      <trans-unit id="mr051" resname="monthly_reminder.insight.quality.body">
+        <source>monthly_reminder.insight.quality.body</source>
+        <target>Rejection rate improved by {delta} percentage points.</target>
+      </trans-unit>
+      <trans-unit id="mr052" resname="monthly_reminder.fallback.insight.upload.title">
+        <source>monthly_reminder.fallback.insight.upload.title</source>
+        <target>Keep your data current</target>
+      </trans-unit>
+      <trans-unit id="mr053" resname="monthly_reminder.fallback.insight.upload.body">
+        <source>monthly_reminder.fallback.insight.upload.body</source>
+        <target>Upload your latest data to unlock personalized insights and benchmarking for your hospital.</target>
+      </trans-unit>
+      <trans-unit id="mr054" resname="monthly_reminder.fallback.insight.platform.title">
+        <source>monthly_reminder.fallback.insight.platform.title</source>
+        <target>Platform activity</target>
+      </trans-unit>
+      <trans-unit id="mr055" resname="monthly_reminder.fallback.insight.platform.body">
+        <source>monthly_reminder.fallback.insight.platform.body</source>
+        <target>See how your hospital compares once your recent data is available on the platform.</target>
+      </trans-unit>
+      <trans-unit id="mr056" resname="monthly_reminder.error.not_participating">
+        <source>monthly_reminder.error.not_participating</source>
+        <target>This hospital is not marked as participating.</target>
+      </trans-unit>
+      <trans-unit id="mr057" resname="monthly_reminder.error.no_owner">
+        <source>monthly_reminder.error.no_owner</source>
+        <target>This hospital has no owner assigned.</target>
+      </trans-unit>
+      <trans-unit id="mr058" resname="monthly_reminder.error.no_email">
+        <source>monthly_reminder.error.no_email</source>
+        <target>The hospital owner has no email address.</target>
+      </trans-unit>
+      <trans-unit id="mr059" resname="monthly_reminder.error.email_not_verified">
+        <source>monthly_reminder.error.email_not_verified</source>
+        <target>The hospital owner's email address is not verified.</target>
+      </trans-unit>
+      <trans-unit id="mr060" resname="monthly_reminder.error.already_sent_recently">
+        <source>monthly_reminder.error.already_sent_recently</source>
+        <target>A reminder was sent recently. Please wait a few minutes before sending again.</target>
+      </trans-unit>
+      <trans-unit id="mr061" resname="monthly_reminder.error.opted_out">
+        <source>monthly_reminder.error.opted_out</source>
+        <target>User has opted out of monthly reminders.</target>
+      </trans-unit>
+      <trans-unit id="mr062" resname="monthly_reminder.email.manage_notifications">
+        <source>monthly_reminder.email.manage_notifications</source>
+        <target>Manage notification preferences</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
### Summary

- Added a monthly submission reminder workflow
- Introduced reminder handling for pending or missing monthly data submissions
- Integrated reminder logic with the existing mail/notification infrastructure
- Added configurable scheduling or command support for triggering reminders
- Added or updated email templates, translations, and related notification content
- Added tests covering reminder generation, recipient selection, and delivery behavior

### Motivation

- Help ensure monthly data submissions are completed on time
- Reduce manual follow-up effort for administrators
- Improve data completeness and reporting reliability
- Provide a reusable foundation for future scheduled operational notifications

### Notes for Reviewers

- Verify reminder triggering conditions and scheduling behavior
- Check recipient selection and hospital/submission scope handling
- Review email content, translations, and template rendering
- Ensure reminders are not sent repeatedly or to unintended recipients
- Confirm tests cover missing, completed, and edge-case submission states