### PR TITLE
fix(statistics): break out of turbo frame for top report card links

### DIFF
--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_main.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_main.html.twig
@@ -77,6 +77,7 @@
     <turbo-frame id="stats-overview-top-reports"
                  src="{{ overviewTopReportsUrl }}"
                  loading="lazy"
+                 target="_top"
                  data-testid="stats-overview-top-reports-frame">
         <div class="row g-3" data-testid="stats-overview-top-reports">
             <div class="col-12 text-center text-muted py-4">

--- a/tests/Statistics/Functional/Controller/DashboardControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerTest.php
@@ -61,6 +61,10 @@ class DashboardControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-executive-kpi-median_transport"]');
         $this->assertSelectorExists('[data-testid="stats-executive-indications"]');
         $this->assertSelectorExists('[data-testid="stats-overview-top-reports-frame"]');
+        self::assertSame(
+            '_top',
+            $crawler->filter('[data-testid="stats-overview-top-reports-frame"]')->attr('target'),
+        );
         $this->assertSelectorNotExists('[data-testid="stats-overview-top-specialities"]');
         $this->assertSelectorExists('[data-testid="stats-overview-time-series"]');
         $this->assertSelectorExists('[data-testid="stats-overview-heatmap"]');


### PR DESCRIPTION
Set target="_top" on the lazy-loaded overview top-reports frame so report links navigate the full page instead of showing Turbo "Content missing".