### PR TITLE
fix(upgrade-dev): Clear test cache during upgrade workflows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,7 @@
             "@load-fixtures"
         ],
         "setup-test-env": [
+            "@php bin/console cache:clear --no-warmup --env test",
             "@php bin/console doctrine:database:drop --if-exists --force --env test",
             "@php bin/console doctrine:database:create --env test",
             "@php bin/console doctrine:migrations:migrate --no-interaction --env test"

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -26,7 +26,7 @@ make setup-dev
 |--------|----------|
 | `setup-dev` | New machine: dev dependencies, fresh DB, fixtures, test DB |
 | `setup-prod` | Prod-like local run: `--no-dev`, empty DB, no fixtures |
-| `upgrade-dev` | Pull/update: keep existing dev DB, recreate test DB, migrate, refresh assets |
+| `upgrade-dev` | Pull/update: keep existing dev DB, recreate test DB (incl. test cache clear), migrate, refresh assets |
 | `upgrade-prod` | Same as upgrade-dev with prod env and `--no-dev` |
 | `purge` | Remove assets, uploads, `var/imports`, logs, cache; empty DB; no fixtures |
 | `reset` | Like `purge`, then load fixtures |
@@ -63,7 +63,7 @@ make start
 ```bash
 symfony composer setup-database
 symfony composer load-fixtures      # demo data (--group=dev)
-symfony composer setup-test-env     # fresh test DB (drop/create/migrate)
+symfony composer setup-test-env     # clear test cache, fresh test DB (drop/create/migrate)
 symfony composer upgrade-test-env   # same as setup-test-env; used by make upgrade-dev
 ```
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -49,6 +49,7 @@ php bin/console app:analyze-import-rejects --format=md
 - Different Messenger routing between `dev`, `test`, and `prod`
 - Database wiped unexpectedly: `make warmup` no longer runs `setup-env`. Avoid `make purge`, `make reset`, `symfony composer setup-database`, and `make setup-dev` if you need to keep an existing mirror DB; use `make upgrade-dev` instead.
 - `upgrade-dev` fails on test DB with `Duplicate table` (e.g. `messenger_messages`): the test database was likely created with `schema:create` and is out of sync with migrations. Run `make upgrade-dev` again after updating to the current workflow, or manually `symfony composer setup-test-env` to recreate the test DB. Your dev/mirror database is not affected.
+- Functional tests fail after a dependency upgrade with `Class "Symfony\Component\VarExporter\Internal\Hydrator" not found` (often when rendering UX Icons): the test cache in `var/cache/test` is stale. Run `bin/console cache:clear --env=test` once, or `symfony composer setup-test-env` (also clears the test cache). `make upgrade-dev` runs `setup-test-env` automatically.
 
 ## Further reading
 


### PR DESCRIPTION
### Summary

- Added test cache clearing to upgrade-related workflows
- Prevented stale Symfony test cache from causing failures after dependency or framework changes
- Updated relevant Makefile, CI, or maintenance commands where needed
- Improved reliability of local and CI upgrade validation

### Motivation

- Avoid confusing test failures caused by outdated cached container/configuration state
- Make dependency and framework upgrade workflows more predictable
- Reduce manual cleanup steps for developers
- Improve CI stability after upgrade-related changes

### Notes for Reviewers

- Verify the test cache is cleared at the right point in the workflow
- Check that the change does not add unnecessary overhead to normal development commands
- Confirm local and CI test execution still behave as expected
- This PR focuses on tooling/workflow reliability only