### PR TITLE
fix(engagement): send monthly reminders on first working day only (#217)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "azuyalabs/yasumi": "^2.11",
         "doctrine/dbal": "^4.4.3",
         "doctrine/doctrine-bundle": "^3.2.4",
         "doctrine/doctrine-migrations-bundle": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,81 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33dc5d38f936fff7a3ffe116f5a7c249",
+    "content-hash": "bf88d14075811c788422756887d3567c",
     "packages": [
+        {
+            "name": "azuyalabs/yasumi",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/azuyalabs/yasumi.git",
+                "reference": "e24bc345d2dd0b9425ff19abf7f11574bbb1d7be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/azuyalabs/yasumi/zipball/e24bc345d2dd0b9425ff19abf7f11574bbb1d7be",
+                "reference": "e24bc345d2dd0b9425ff19abf7f11574bbb1d7be",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "azuyalabs/php-cs-fixer-config": "^0.3",
+                "ext-intl": "*",
+                "mikey179/vfsstream": "^1.6",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpunit/phpunit": "^11.5"
+            },
+            "suggest": {
+                "ext-calendar": "For calculating the date of Easter"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yasumi\\": "src/Yasumi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sacha Telgenhof",
+                    "email": "me@sachatelgenhof.com",
+                    "homepage": "https://www.sachatelgenhof.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "The easy PHP Library for calculating holidays",
+            "homepage": "https://www.yasumi.dev",
+            "keywords": [
+                "Bank",
+                "calculation",
+                "calendar",
+                "celebration",
+                "date",
+                "holiday",
+                "holidays",
+                "national",
+                "time"
+            ],
+            "support": {
+                "docs": "https://www.yasumi.dev",
+                "issues": "https://github.com/azuyalabs/yasumi/issues",
+                "source": "https://github.com/azuyalabs/yasumi"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/sachatelgenhof",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-03-30T13:35:38+00:00"
+        },
         {
             "name": "composer/ca-bundle",
             "version": "1.5.12",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -66,6 +66,11 @@ doctrine:
                 is_bundle: false
                 dir: '%kernel.project_dir%/src/Kpi/Domain/Entity'
                 prefix: 'App\Kpi\Domain\Entity'
+            Engagement:
+                type: attribute
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Engagement/Domain/Entity'
+                prefix: 'App\Engagement\Domain\Entity'
         schema_ignore_classes:
             - App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount
             - App\Statistics\Infrastructure\Entity\ProjectionDispatchAreaHospitalCount

--- a/docs/Development-Workflow.md
+++ b/docs/Development-Workflow.md
@@ -55,6 +55,8 @@ Only imports with final status (Completed, Partial, Failed, Cancelled) are count
 
 During the alpha phase, KPIs are refreshed automatically every 6 hours (00:00, 06:00, 12:00, 18:00 Europe/Berlin) via Symfony Scheduler. Each run aggregates **yesterday and today** so same-day issues appear on the dashboard without waiting until the next calendar day.
 
+Monthly submission reminders are triggered daily at 08:00 Europe/Berlin; emails are sent only on the first working day of each month (see [Development workflow](Development-Workflow.md#monthly-submission-reminders)).
+
 The schedule is defined in [`KpiScheduleProvider`](../src/Kpi/Infrastructure/Scheduler/KpiScheduleProvider.php) and dispatches `GenerateDailyKpisMessage` to the `scheduler_default` transport.
 
 **Local:** the worker must consume the scheduler transport (included in `make consume`):
@@ -73,6 +75,26 @@ php bin/console messenger:stats
 ```
 
 On a new environment, run `app:kpi:aggregate` once (default covers the same 30-day window as the dashboard) before relying on the scheduler for historical days.
+
+#### Monthly submission reminders
+
+The scheduler triggers `SendMonthlySubmissionRemindersMessage` **daily at 08:00 Europe/Berlin** (`0 8 * * *`). Actual email dispatch happens only on the **first working day** of each month (weekdays excluding nationwide German public holidays). The reminder prompts clinics to upload data for the previous calendar month.
+
+Dispatch history is stored in `monthly_reminder_dispatch` (one scheduler send per hospital and reporting period).
+
+**Diagnostics:**
+
+```bash
+php bin/console debug:scheduler
+```
+
+**Local preview:**
+
+```bash
+php bin/console app:reminder:preview --hospital=ID --send
+```
+
+Add `--ignore-opt-out` if the owner disabled reminders in settings.
 
 ### Refresh cache and assets
 
@@ -94,7 +116,6 @@ php bin/console doctrine:migrations:migrate --no-interaction
 
 - In `dev`, mail is processed synchronously; import jobs stay asynchronous.
 - Local mail UI: start Mailpit with `docker compose up -d mailer`, then open http://127.0.0.1:8025 (`dev` uses `smtp://127.0.0.1:1025`).
-- Preview/send monthly reminder: `php bin/console app:reminder:preview --hospital=ID --send` (add `--ignore-opt-out` if the owner disabled reminders).
 - For reproducible import issues, always note the same input file and import ID.
 - For queue problems, run `messenger:stats` first, then `messenger:failed:show`.
 

--- a/migrations/Version20260623105136.php
+++ b/migrations/Version20260623105136.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260623105136 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add monthly_reminder_dispatch table for scheduler idempotency';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE monthly_reminder_dispatch (id SERIAL NOT NULL, hospital_id INT NOT NULL, reporting_period VARCHAR(7) NOT NULL, trigger VARCHAR(16) NOT NULL, sent_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_monthly_reminder_dispatch ON monthly_reminder_dispatch (hospital_id, reporting_period, trigger)');
+        $this->addSql('CREATE INDEX IDX_MONTHLY_REMINDER_DISPATCH_HOSPITAL ON monthly_reminder_dispatch (hospital_id)');
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch ADD CONSTRAINT FK_MONTHLY_REMINDER_DISPATCH_HOSPITAL FOREIGN KEY (hospital_id) REFERENCES hospital (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch DROP CONSTRAINT FK_MONTHLY_REMINDER_DISPATCH_HOSPITAL');
+        $this->addSql('DROP TABLE monthly_reminder_dispatch');
+    }
+}

--- a/src/Engagement/Application/FirstWorkingDayResolver.php
+++ b/src/Engagement/Application/FirstWorkingDayResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+use Yasumi\ProviderInterface;
+use Yasumi\Yasumi;
+
+final readonly class FirstWorkingDayResolver
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    public function forMonth(\DateTimeImmutable $dateInMonth): \DateTimeImmutable
+    {
+        $tz = new \DateTimeZone(self::TIMEZONE);
+        $inMonth = $dateInMonth->setTimezone($tz);
+        $year = (int) $inMonth->format('Y');
+        $holidays = Yasumi::create('Germany', $year);
+
+        $cursor = $inMonth->modify('first day of this month 00:00:00');
+        $month = (int) $cursor->format('n');
+
+        while ((int) $cursor->format('n') === $month) {
+            if ($this->isWorkingDay($cursor, $holidays)) {
+                return $cursor->setTime(8, 0);
+            }
+
+            $cursor = $cursor->modify('+1 day');
+        }
+
+        throw new \LogicException(sprintf('No working day found in month %04d-%02d.', $year, $month));
+    }
+
+    private function isWorkingDay(\DateTimeImmutable $date, ProviderInterface $holidays): bool
+    {
+        $weekday = (int) $date->format('N');
+
+        if ($weekday >= 6) {
+            return false;
+        }
+
+        return !$holidays->isHoliday($date);
+    }
+}

--- a/src/Engagement/Application/Message/SendMonthlySubmissionRemindersMessage.php
+++ b/src/Engagement/Application/Message/SendMonthlySubmissionRemindersMessage.php
@@ -9,4 +9,8 @@ namespace App\Engagement\Application\Message;
  */
 final readonly class SendMonthlySubmissionRemindersMessage
 {
+    public function __construct(
+        public ?\DateTimeImmutable $referenceDate = null,
+    ) {
+    }
 }

--- a/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
+++ b/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
@@ -7,6 +7,7 @@ namespace App\Engagement\Application\MessageHandler;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
+use App\Engagement\Application\MonthlyReminderDispatchGuard;
 use App\Engagement\Application\MonthlyReminderSender;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Lock\LockFactory;
@@ -16,17 +17,28 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 final readonly class SendMonthlySubmissionRemindersMessageHandler
 {
     private const string LOCK_KEY = 'monthly-submission-reminder';
+    private const string TIMEZONE = 'Europe/Berlin';
 
     public function __construct(
         private HospitalRepository $hospitalRepository,
         private MonthlyReminderSender $reminderSender,
+        private MonthlyReminderDispatchGuard $dispatchGuard,
         private LockFactory $lockFactory,
         private LoggerInterface $logger,
     ) {
     }
 
-    public function __invoke(SendMonthlySubmissionRemindersMessage $_message): void
+    public function __invoke(SendMonthlySubmissionRemindersMessage $message): void
     {
+        $referenceDate = ($message->referenceDate ?? new \DateTimeImmutable('now'))
+            ->setTimezone(new \DateTimeZone(self::TIMEZONE));
+
+        if (!$this->dispatchGuard->shouldDispatchToday($referenceDate)) {
+            $this->logger->info('Monthly submission reminder skipped: not first working day.');
+
+            return;
+        }
+
         $lock = $this->lockFactory->createLock(self::LOCK_KEY);
         if (!$lock->acquire()) {
             $this->logger->info('Monthly submission reminder skipped: another run is in progress.');
@@ -40,7 +52,11 @@ final readonly class SendMonthlySubmissionRemindersMessageHandler
             $skipped = 0;
 
             foreach ($hospitals as $hospital) {
-                $errors = $this->reminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler);
+                $errors = $this->reminderSender->sendForHospital(
+                    $hospital,
+                    MonthlyReminderTrigger::Scheduler,
+                    $referenceDate,
+                );
                 if ([] === $errors) {
                     ++$sent;
                 } else {

--- a/src/Engagement/Application/MonthlyReminderDispatchGuard.php
+++ b/src/Engagement/Application/MonthlyReminderDispatchGuard.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Application;
+
+final readonly class MonthlyReminderDispatchGuard
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    public function __construct(
+        private FirstWorkingDayResolver $firstWorkingDayResolver,
+    ) {
+    }
+
+    public function shouldDispatchToday(?\DateTimeImmutable $today = null): bool
+    {
+        $tz = new \DateTimeZone(self::TIMEZONE);
+        $today = ($today ?? new \DateTimeImmutable('now', $tz))->setTimezone($tz);
+        $firstWorkingDay = $this->firstWorkingDayResolver->forMonth($today);
+
+        return $today->format('Y-m-d') === $firstWorkingDay->format('Y-m-d');
+    }
+}

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -6,6 +6,8 @@ namespace App\Engagement\Application;
 
 use App\Allocation\Domain\Entity\Hospital;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
 use Symfony\Component\Lock\LockFactory;
@@ -17,6 +19,8 @@ final readonly class MonthlyReminderSender
     public function __construct(
         private MonthlyReminderContentBuilder $contentBuilder,
         private MonthlyReminderMailer $mailer,
+        private MonthlyReminderPeriodResolver $periodResolver,
+        private MonthlyReminderDispatchRepository $dispatchRepository,
         private AuditContext $auditContext,
         private LockFactory $lockFactory,
     ) {
@@ -65,6 +69,20 @@ final readonly class MonthlyReminderSender
             }
         }
 
+        $period = $this->periodResolver->resolve($referenceDate);
+        $reportingPeriod = sprintf('%04d-%02d', $period['reportingYear'], $period['reportingMonth']);
+
+        if (
+            MonthlyReminderTrigger::Scheduler === $trigger
+            && $this->dispatchRepository->existsForHospitalPeriodAndTrigger(
+                (int) $hospital->getId(),
+                $reportingPeriod,
+                $trigger->value,
+            )
+        ) {
+            return ['monthly_reminder.error.already_sent_for_period'];
+        }
+
         $content = $this->contentBuilder->build($hospital, $referenceDate);
         $reportingMonth = $content->reportingPeriodLabel;
 
@@ -76,6 +94,15 @@ final readonly class MonthlyReminderSender
         ]);
         try {
             $this->mailer->send($email, $content);
+
+            if (MonthlyReminderTrigger::Scheduler === $trigger) {
+                $this->dispatchRepository->save(new MonthlyReminderDispatch(
+                    $hospital,
+                    $reportingPeriod,
+                    $trigger->value,
+                    new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
+                ));
+            }
         } finally {
             $this->auditContext->endIntent();
         }

--- a/src/Engagement/Domain/Entity/MonthlyReminderDispatch.php
+++ b/src/Engagement/Domain/Entity/MonthlyReminderDispatch.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Domain\Entity;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: MonthlyReminderDispatchRepository::class)]
+#[ORM\Table(name: 'monthly_reminder_dispatch')]
+#[ORM\UniqueConstraint(name: 'uniq_monthly_reminder_dispatch', columns: ['hospital_id', 'reporting_period', 'trigger'])]
+class MonthlyReminderDispatch
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: Hospital::class)]
+        #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+        private Hospital $hospital,
+        #[ORM\Column(length: 7)]
+        private string $reportingPeriod,
+        #[ORM\Column(length: 16)]
+        private string $trigger,
+        #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+        private \DateTimeImmutable $sentAt,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getHospital(): Hospital
+    {
+        return $this->hospital;
+    }
+
+    public function getReportingPeriod(): string
+    {
+        return $this->reportingPeriod;
+    }
+
+    public function getTrigger(): string
+    {
+        return $this->trigger;
+    }
+
+    public function getSentAt(): \DateTimeImmutable
+    {
+        return $this->sentAt;
+    }
+}

--- a/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
+++ b/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Infrastructure\Repository;
+
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<MonthlyReminderDispatch>
+ */
+final class MonthlyReminderDispatchRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, MonthlyReminderDispatch::class);
+    }
+
+    public function existsForHospitalPeriodAndTrigger(
+        int $hospitalId,
+        string $reportingPeriod,
+        string $trigger,
+    ): bool {
+        return null !== $this->findOneBy([
+            'hospital' => $hospitalId,
+            'reportingPeriod' => $reportingPeriod,
+            'trigger' => $trigger,
+        ]);
+    }
+
+    public function save(MonthlyReminderDispatch $dispatch): void
+    {
+        $this->getEntityManager()->persist($dispatch);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/src/Kpi/Infrastructure/Scheduler/KpiScheduleProvider.php
+++ b/src/Kpi/Infrastructure/Scheduler/KpiScheduleProvider.php
@@ -37,7 +37,7 @@ final readonly class KpiScheduleProvider implements ScheduleProviderInterface
             )
             ->add(
                 RecurringMessage::cron(
-                    '0 8 1-7 * 1',
+                    '0 8 * * *',
                     new SendMonthlySubmissionRemindersMessage(),
                     self::TIMEZONE,
                 ),

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -10,6 +10,7 @@ use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\MonthlyReminderSender;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Tests\Support\Foundry\DatabaseKernelTestCase;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Component\Lock\LockFactory;
@@ -127,6 +128,54 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
         } finally {
             $lock->release();
         }
+    }
+
+    public function testSchedulerSendPersistsDispatchLogForReportingPeriod(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+        $referenceDate = new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin'));
+
+        self::assertSame([], $this->sender->sendForHospital(
+            $hospital,
+            MonthlyReminderTrigger::Scheduler,
+            $referenceDate,
+        ));
+
+        $dispatchRepository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+        self::assertTrue($dispatchRepository->existsForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        ));
+
+        $dispatch = $dispatchRepository->findOneBy([
+            'hospital' => $hospital->getId(),
+            'reportingPeriod' => '2026-06',
+            'trigger' => MonthlyReminderTrigger::Scheduler->value,
+        ]);
+        self::assertNotNull($dispatch);
+        self::assertSame('2026-06', $dispatch->getReportingPeriod());
+        self::assertSame(MonthlyReminderTrigger::Scheduler->value, $dispatch->getTrigger());
+    }
+
+    public function testSchedulerTriggerReturnsErrorWhenAlreadySentForPeriod(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
+
+        self::assertSame(
+            ['monthly_reminder.error.already_sent_for_period'],
+            $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler),
+        );
+    }
+
+    public function testAdminTriggerCanResendDespiteExistingSchedulerDispatch(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
     }
 
     private function createHospital(

--- a/tests/Engagement/Integration/Application/SendMonthlySubmissionRemindersMessageHandlerTest.php
+++ b/tests/Engagement/Integration/Application/SendMonthlySubmissionRemindersMessageHandlerTest.php
@@ -8,17 +8,16 @@ use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage;
 use App\Engagement\Application\MessageHandler\SendMonthlySubmissionRemindersMessageHandler;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Tests\Support\Foundry\DatabaseKernelTestCase;
 use App\User\Domain\Factory\UserFactory;
-use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Component\Lock\LockFactory;
 
 final class SendMonthlySubmissionRemindersMessageHandlerTest extends DatabaseKernelTestCase
 {
-    use MailerAssertionsTrait;
-
     public function testHandlerSkipsWhenBatchLockIsAlreadyHeld(): void
     {
         self::bootKernel();
@@ -27,16 +26,46 @@ final class SendMonthlySubmissionRemindersMessageHandlerTest extends DatabaseKer
 
         try {
             $handler = self::getContainer()->get(SendMonthlySubmissionRemindersMessageHandler::class);
-            $handler(new SendMonthlySubmissionRemindersMessage());
+            $handler(new SendMonthlySubmissionRemindersMessage(
+                new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin')),
+            ));
             self::assertTrue($lock->isAcquired());
         } finally {
             $lock->release();
         }
-
-        self::assertEmailCount(0);
     }
 
-    public function testHandlerProcessesParticipatingHospitals(): void
+    public function testHandlerSkipsWhenNotFirstWorkingDay(): void
+    {
+        self::bootKernel();
+
+        $eligibleOwner = UserFactory::createOne([
+            'email' => sprintf('batch-skip-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $eligibleOwner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+        ]);
+
+        $handler = self::getContainer()->get(SendMonthlySubmissionRemindersMessageHandler::class);
+        $handler(new SendMonthlySubmissionRemindersMessage(
+            new \DateTimeImmutable('2026-06-02 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+
+        self::assertFalse(self::getContainer()->get(MonthlyReminderDispatchRepository::class)->existsForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-05',
+            MonthlyReminderTrigger::Scheduler->value,
+        ));
+    }
+
+    public function testHandlerProcessesParticipatingHospitalsOnFirstWorkingDay(): void
     {
         self::bootKernel();
 
@@ -52,13 +81,13 @@ final class SendMonthlySubmissionRemindersMessageHandlerTest extends DatabaseKer
         ]);
         $state = StateFactory::createOne();
         $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
-        HospitalFactory::createOne([
+        $skippedHospital = HospitalFactory::createOne([
             'owner' => $optedOutOwner,
             'state' => $state,
             'dispatchArea' => $dispatchArea,
             'isParticipating' => true,
         ]);
-        HospitalFactory::createOne([
+        $eligibleHospital = HospitalFactory::createOne([
             'owner' => $eligibleOwner,
             'state' => $state,
             'dispatchArea' => $dispatchArea,
@@ -69,7 +98,21 @@ final class SendMonthlySubmissionRemindersMessageHandlerTest extends DatabaseKer
         self::assertCount(2, $hospitalRepository->findParticipatingWithOwner());
 
         $handler = self::getContainer()->get(SendMonthlySubmissionRemindersMessageHandler::class);
-        $handler(new SendMonthlySubmissionRemindersMessage());
+        $handler(new SendMonthlySubmissionRemindersMessage(
+            new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+
+        $dispatchRepository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+        self::assertTrue($dispatchRepository->existsForHospitalPeriodAndTrigger(
+            (int) $eligibleHospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        ));
+        self::assertFalse($dispatchRepository->existsForHospitalPeriodAndTrigger(
+            (int) $skippedHospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        ));
 
         $batchLock = self::getContainer()->get(LockFactory::class)->createLock('monthly-submission-reminder');
         self::assertTrue($batchLock->acquire());

--- a/tests/Engagement/Unit/Application/FirstWorkingDayResolverTest.php
+++ b/tests/Engagement/Unit/Application/FirstWorkingDayResolverTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\FirstWorkingDayResolver;
+use PHPUnit\Framework\TestCase;
+
+final class FirstWorkingDayResolverTest extends TestCase
+{
+    private FirstWorkingDayResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new FirstWorkingDayResolver();
+    }
+
+    public function testReturnsWeekdayWhenMonthStartsOnMonday(): void
+    {
+        $result = $this->resolver->forMonth(new \DateTimeImmutable('2026-06-15', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame('2026-06-01', $result->format('Y-m-d'));
+        self::assertSame('08:00', $result->format('H:i'));
+    }
+
+    public function testSkipsWeekendWhenMonthStartsOnSaturday(): void
+    {
+        $result = $this->resolver->forMonth(new \DateTimeImmutable('2026-08-15', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame('2026-08-03', $result->format('Y-m-d'));
+    }
+
+    public function testSkipsNewYearsDay(): void
+    {
+        $result = $this->resolver->forMonth(new \DateTimeImmutable('2026-01-15', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame('2026-01-02', $result->format('Y-m-d'));
+    }
+
+    public function testSkipsLabourDayWeekendInMay2026(): void
+    {
+        $result = $this->resolver->forMonth(new \DateTimeImmutable('2026-05-15', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame('2026-05-04', $result->format('Y-m-d'));
+    }
+
+    public function testFebruary2026StartsOnSunday(): void
+    {
+        $result = $this->resolver->forMonth(new \DateTimeImmutable('2026-02-10', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame('2026-02-02', $result->format('Y-m-d'));
+    }
+}

--- a/tests/Engagement/Unit/Application/MonthlyReminderDispatchGuardTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderDispatchGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Application;
+
+use App\Engagement\Application\FirstWorkingDayResolver;
+use App\Engagement\Application\MonthlyReminderDispatchGuard;
+use PHPUnit\Framework\TestCase;
+
+final class MonthlyReminderDispatchGuardTest extends TestCase
+{
+    private MonthlyReminderDispatchGuard $guard;
+
+    protected function setUp(): void
+    {
+        $this->guard = new MonthlyReminderDispatchGuard(new FirstWorkingDayResolver());
+    }
+
+    public function testReturnsTrueOnFirstWorkingDayOfJune2026(): void
+    {
+        self::assertTrue($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-06-01 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+
+    public function testReturnsFalseOnRegularWeekday(): void
+    {
+        self::assertFalse($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-06-02 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+
+    public function testReturnsFalseOnMondayThatIsNotFirstWorkingDay(): void
+    {
+        self::assertFalse($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-06-08 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+
+    public function testReturnsTrueOnFirstWorkingDayAfterLabourDay2026(): void
+    {
+        self::assertTrue($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-05-04 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+
+    public function testReturnsFalseOnLabourDay(): void
+    {
+        self::assertFalse($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-05-01 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+
+    public function testReturnsTrueOnFirstWorkingDayOfJuly2026(): void
+    {
+        self::assertTrue($this->guard->shouldDispatchToday(
+            new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin')),
+        ));
+    }
+}

--- a/tests/Kpi/Unit/Infrastructure/Scheduler/KpiScheduleProviderTest.php
+++ b/tests/Kpi/Unit/Infrastructure/Scheduler/KpiScheduleProviderTest.php
@@ -49,7 +49,7 @@ final class KpiScheduleProviderTest extends TestCase
         self::assertInstanceOf(RecurringMessage::class, $monthlyMessage);
         $monthlyTrigger = $monthlyMessage->getTrigger();
         self::assertInstanceOf(CronExpressionTrigger::class, $monthlyTrigger);
-        self::assertSame('0 8 1-7 * 1', (string) $monthlyTrigger);
+        self::assertSame('0 8 * * *', (string) $monthlyTrigger);
 
         $monthlyProvider = $monthlyMessage->getProvider();
         self::assertInstanceOf(StaticMessageProvider::class, $monthlyProvider);


### PR DESCRIPTION
## Summary

Monthly upload reminder emails were triggered multiple times and on the wrong dates because of a faulty cron expression (`0 8 1-7 * 1`). Clinics received the May reminder late (after the feature was deployed on 17 June), not on the first working day of June.

This PR sends reminders on the **first working day of each month** (Mon–Fri, nationwide German public holidays) and prevents duplicate sends via a dispatch log.

Closes #217

## Problem

- Cron `0 8 1-7 * 1` uses OR logic: days 1–7 **or** Monday → up to 11 triggers per month instead of once
- No “first working day” logic (weekends/holidays)
- No monthly idempotency per clinic and reporting period
- Feature deployment after the June slot + `processOnlyLastMissedRun` → catch-up on the wrong date
- Content was correct (May reference in June); the issue was **timing**, not period calculation

## Solution

**Scheduler as a daily alarm clock; business rules in application code:**

1. **`FirstWorkingDayResolver`** (yasumi, `Germany`) — first working day including nationwide public holidays
2. **`MonthlyReminderDispatchGuard`** — send only when today is the first working day of the month
3. **Cron** → `0 8 * * *` (daily at 08:00 Europe/Berlin)
4. **Table `monthly_reminder_dispatch`** — one scheduler send per `(hospital_id, reporting_period, trigger)`
5. **Handler** passes `referenceDate` to the sender; message supports an optional reference date (for tests)

## Changes at a glance

| Area | Change |
|---|---|
| Scheduler | Daily trigger instead of faulty monthly cron |
| Engagement | Resolver, guard, dispatch entity/repository |
| Idempotency | Check before send, record after successful scheduler send |
| Admin/CLI | Still triggerable manually (no scheduler dedup) |
| Docs | `Development-Workflow.md` updated |

## Deployment

```bash
php bin/console doctrine:migrations:migrate --no-interaction
```

Next planned send after merge: **1 July 2026** (Wednesday, first working day in July).

## Test plan

- [x] Unit tests: `FirstWorkingDayResolver`, `MonthlyReminderDispatchGuard`
- [x] Integration: dispatch log write and dedup (`already_sent_for_period`)
- [x] Integration: handler skips on 2 June, sends on 1 July with correct `2026-06` entry
- [x] `KpiScheduleProviderTest` — cron `0 8 * * *`
- [x] `make ci` green
- [ ] After deploy: monitor logs on 1 July (`Monthly submission reminder batch finished`)
