### PR TITLE
refactor(symfony): Clean up services.yaml

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,16 +26,10 @@ parameters:
     env(SENTRY_ENABLE_LOGS): 'true'
 
 services:
-    # default configuration for services in *this* file
     _defaults:
-        autowire: true      # Automatically injects dependencies in your services.
-        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-        bind:
-            string $projectDir: '%kernel.project_dir%'
-            Doctrine\DBAL\Connection $defaultConnection: '@doctrine.dbal.default_connection'
+        autowire: true
+        autoconfigure: true
 
-    # makes classes in src/ available to be used as services
-    # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/'
         exclude:
@@ -43,47 +37,6 @@ services:
             - '**/Infrastructure/Factory'
             - '**/Infrastructure/Faker'
             - 'User/Domain/Factory'
-
-    Doctrine\DBAL\Connection: '@doctrine.dbal.default_connection'
-    App\Statistics\Application\Contract\HospitalAccessInterface: '@App\Statistics\Infrastructure\Adapter\DoctrineHospitalAccess'
-    App\Statistics\DataQuality\Application\Contract\DataQualityHospitalPopulationReaderInterface: '@App\Statistics\DataQuality\Infrastructure\Query\DataQualityHospitalPopulationQuery'
-    App\Statistics\GenericAnalysis\Application\Contract\CustomAnalysisAccessInterface: '@App\Statistics\GenericAnalysis\Infrastructure\Adapter\ParticipantCustomAnalysisAccess'
-    App\Statistics\Application\Contract\ImportTimelineInterface: '@App\Statistics\Infrastructure\Adapter\DoctrineImportTimeline'
-
-    App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller:
-        public: true
-        arguments:
-            $kernelEnvironment: '%kernel.environment%'
-    _instanceof:
-        App\Statistics\Application\Report\ReportDefinitionInterface:
-            tags: ['app.statistics.report_definition']
-        App\Statistics\AnalysisExplorer\Application\Contract\DataSourceCapabilitiesProviderInterface:
-            tags: ['app.analysis_explorer.capabilities_provider']
-        App\Statistics\AnalysisExplorer\Application\Contract\ExplorerAnalysisQueryMapperInterface:
-            tags: ['app.analysis_explorer.query_mapper']
-
-    App\Statistics\AnalysisExplorer\Application\DataSourceCapabilitiesRegistry:
-        arguments:
-            $providers: !tagged_iterator 'app.analysis_explorer.capabilities_provider'
-
-    App\Statistics\AnalysisExplorer\Application\ExplorerQueryMapperRegistry:
-        arguments:
-            $mappers: !tagged_iterator 'app.analysis_explorer.query_mapper'
-
-    App\Statistics\Application\Report\ReportDefinitionRegistry:
-        arguments:
-            $definitions: !tagged_iterator 'app.statistics.report_definition'
-
-    App\Statistics\UI\Http\Controller\StatisticsFilterValueResolver:
-        tags:
-            - { name: controller.argument_value_resolver, priority: 180 }
-
-    App\Statistics\CaseFlow\Application\CaseFlowGeoKeyResolver:
-        arguments:
-            $configPath: '%kernel.project_dir%/config/case_flow/dispatch_area_geo_map.yaml'
-
-    # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones
 
     app.lock.pdo:
         class: PDO
@@ -100,34 +53,6 @@ services:
         arguments: ['@app.lock.store']
 
     Symfony\Component\Lock\LockFactory: '@app.lock.factory'
-
-    App\Import\Infrastructure\Adapter\DoctrineAllocationPersister:
-        arguments:
-            $batchSize: 250
-    App\Import\Application\Service\AllocationImporter:
-        arguments:
-            $logger: '@monolog.logger.import'
-
-    App\Shared\Infrastructure\Mail\TransactionalMailer:
-        alias: App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer
-
-    App\User\Infrastructure\Security\FeedbackRecipientEmailResolver:
-        alias: App\User\Infrastructure\Security\FeedbackRecipientResolver
-
-    App\User\Infrastructure\Security\NotificationRecipientEmailResolver:
-        alias: App\User\Infrastructure\Security\NotificationRecipientResolver
-
-    App\Shared\Application\Notification\AdminNotificationSenderInterface:
-        alias: App\Shared\Infrastructure\Mail\AdminNotificationSender
-
-    App\Import\Infrastructure\Adapter\SplCsvRejectWriter:
-        arguments:
-            $rejectsBaseDir: '%app.rejects_base_dir%'
-        tags:
-            - { name: 'import.reject_writer' }
-    App\Import\Infrastructure\Adapter\DoctrineRejectWriter:
-        tags:
-            - { name: 'import.reject_writer' }
 
     sentry.callback.before_send:
         class: App\Shared\Infrastructure\Monitoring\Sentry\SentryBeforeSendCallback
@@ -154,17 +79,6 @@ services:
         class: Sentry\SentryBundle\Monolog\LogsHandler
         arguments:
             - !php/const Monolog\Logger::WARNING
-
-    App\Statistics\GenericAnalysis\Application\Contract\AnalysisExportServiceInterface:
-        alias: App\Statistics\GenericAnalysis\Application\AnalysisExportService
-
-    App\Content\Infrastructure\Media\LocalMediaFileLocator:
-        arguments:
-            $uploadDir: '%app.media_upload_dir%'
-
-    App\Content\Application\Page\PageImageContentAnalyzer:
-        arguments:
-            $contentWidthEstimate: '%app.page_content_width_estimate%'
 
 when@test:
     services:

--- a/src/Content/Application/Page/PageImageContentAnalyzer.php
+++ b/src/Content/Application/Page/PageImageContentAnalyzer.php
@@ -13,6 +13,7 @@ use App\Content\Infrastructure\Media\LocalMediaFileLocator;
 use App\Content\Infrastructure\Media\MediaDimensionsExtractor;
 use App\Content\Infrastructure\Repository\MediaRepository;
 use App\Content\Infrastructure\Repository\PageRepository;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final readonly class PageImageContentAnalyzer
 {
@@ -24,6 +25,7 @@ final readonly class PageImageContentAnalyzer
         private MediaRepository $mediaRepository,
         private LocalMediaFileLocator $fileLocator,
         private MediaDimensionsExtractor $dimensionsExtractor,
+        #[Autowire('%app.page_content_width_estimate%')]
         private int $contentWidthEstimate,
     ) {
     }

--- a/src/Content/Infrastructure/Media/LocalMediaFileLocator.php
+++ b/src/Content/Infrastructure/Media/LocalMediaFileLocator.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Content\Infrastructure\Media;
 
 use App\Content\Domain\Entity\Media;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final readonly class LocalMediaFileLocator
 {
     /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
     public function __construct(
+        #[Autowire('%app.media_upload_dir%')]
         private string $uploadDir,
     ) {
     }

--- a/src/DataFixtures/Pattern/Infrastructure/PatternYamlPaths.php
+++ b/src/DataFixtures/Pattern/Infrastructure/PatternYamlPaths.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\DataFixtures\Pattern\Infrastructure;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
 final readonly class PatternYamlPaths
 {
     public function __construct(
+        #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
     ) {
     }

--- a/src/DataFixtures/Reference/ReferenceYamlPaths.php
+++ b/src/DataFixtures/Reference/ReferenceYamlPaths.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\DataFixtures\Reference;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
 final readonly class ReferenceYamlPaths
 {
     public function __construct(
+        #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
     ) {
     }

--- a/src/Import/Application/Contracts/RejectWriterInterface.php
+++ b/src/Import/Application/Contracts/RejectWriterInterface.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Import\Application\Contracts;
 
 use App\Import\Domain\Entity\Import;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('import.reject_writer')]
 interface RejectWriterInterface
 {
     public function start(Import $import): void;

--- a/src/Import/Infrastructure/Adapter/DoctrineRejectWriter.php
+++ b/src/Import/Infrastructure/Adapter/DoctrineRejectWriter.php
@@ -10,7 +10,7 @@ use App\Import\Domain\Entity\ImportReject;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
-#[AsTaggedItem('import.reject_writer')]
+#[AsTaggedItem(index: 'db')]
 final class DoctrineRejectWriter implements RejectWriterInterface
 {
     private ?int $importId = null;

--- a/src/Import/Infrastructure/Adapter/SplCsvRejectWriter.php
+++ b/src/Import/Infrastructure/Adapter/SplCsvRejectWriter.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
-#[AsTaggedItem('import.reject_writer')]
+#[AsTaggedItem(index: 'csv')]
 final class SplCsvRejectWriter implements RejectWriterInterface
 {
     private ?\SplFileObject $file = null;

--- a/src/Import/UI/Console/Command/AnalyzeImportRejectsCommand.php
+++ b/src/Import/UI/Console/Command/AnalyzeImportRejectsCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -27,6 +28,7 @@ final class AnalyzeImportRejectsCommand extends Command
         private readonly ImportRejectAnalysisService $analysisService,
         private readonly RejectAnalysisExporterRegistry $exporterRegistry,
         private readonly Filesystem $filesystem,
+        #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
     ) {
         parent::__construct();

--- a/src/Shared/Infrastructure/Consent/CookieConsentRequestSubscriber.php
+++ b/src/Shared/Infrastructure/Consent/CookieConsentRequestSubscriber.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace App\Shared\Infrastructure\Consent;
 
 use App\User\Domain\Entity\User;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /** @psalm-suppress UnusedClass */
-final readonly class CookieConsentRequestSubscriber implements EventSubscriberInterface
+final readonly class CookieConsentRequestSubscriber
 {
     public function __construct(
         private CookieConsentService $cookieConsentService,
@@ -20,14 +20,7 @@ final readonly class CookieConsentRequestSubscriber implements EventSubscriberIn
     ) {
     }
 
-    #[\Override]
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            KernelEvents::REQUEST => ['onKernelRequest', 28],
-        ];
-    }
-
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 28)]
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {

--- a/src/Shared/Infrastructure/Consent/CookieConsentResponseSubscriber.php
+++ b/src/Shared/Infrastructure/Consent/CookieConsentResponseSubscriber.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Consent;
 
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /** @psalm-suppress UnusedClass */
-final readonly class CookieConsentResponseSubscriber implements EventSubscriberInterface
+final readonly class CookieConsentResponseSubscriber
 {
     public function __construct(
         private CookieConsentService $cookieConsentService,
     ) {
     }
 
-    #[\Override]
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            KernelEvents::RESPONSE => ['onKernelResponse', -128],
-        ];
-    }
-
+    #[AsEventListener(event: KernelEvents::RESPONSE, priority: -128)]
     public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMainRequest()) {

--- a/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
+++ b/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
@@ -10,11 +10,13 @@ use App\Shared\Application\Notification\AdminNotificationType;
 use App\User\Infrastructure\Security\NotificationRecipientEmailResolver;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /** @psalm-suppress UnusedClass */
+#[AsAlias(AdminNotificationSenderInterface::class)]
 final readonly class AdminNotificationSender implements AdminNotificationSenderInterface
 {
     /** @psalm-suppress PossiblyUnusedMethod */

--- a/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
@@ -9,12 +9,14 @@ use App\Feedback\Domain\Enum\FeedbackCategory;
 use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 
-/** @psalm-suppress UnusedClass Wired via services.yaml alias to TransactionalMailer. */
+/** @psalm-suppress UnusedClass */
+#[AsAlias(TransactionalMailer::class)]
 final readonly class SymfonyTransactionalMailer implements TransactionalMailer
 {
     private const string SUBJECT_VERIFICATION = 'Please confirm your email address';

--- a/src/Statistics/AnalysisExplorer/Application/Contract/DataSourceCapabilitiesProviderInterface.php
+++ b/src/Statistics/AnalysisExplorer/Application/Contract/DataSourceCapabilitiesProviderInterface.php
@@ -8,7 +8,9 @@ use App\Statistics\AnalysisExplorer\Domain\DataSourceCapabilities;
 use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\User\Domain\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('app.analysis_explorer.capabilities_provider')]
 interface DataSourceCapabilitiesProviderInterface
 {
     public function supports(AnalysisDataSourceKey $dataSourceKey): bool;

--- a/src/Statistics/AnalysisExplorer/Application/Contract/ExplorerAnalysisQueryMapperInterface.php
+++ b/src/Statistics/AnalysisExplorer/Application/Contract/ExplorerAnalysisQueryMapperInterface.php
@@ -6,7 +6,9 @@ namespace App\Statistics\AnalysisExplorer\Application\Contract;
 
 use App\Statistics\AnalysisExplorer\Domain\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery as GenericAnalysisQuery;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('app.analysis_explorer.query_mapper')]
 interface ExplorerAnalysisQueryMapperInterface
 {
     public function supports(AnalysisQuery $query): bool;

--- a/src/Statistics/AnalysisExplorer/Application/DataSourceCapabilitiesRegistry.php
+++ b/src/Statistics/AnalysisExplorer/Application/DataSourceCapabilitiesRegistry.php
@@ -9,6 +9,7 @@ use App\Statistics\AnalysisExplorer\Domain\DataSourceCapabilities;
 use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\User\Domain\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 final readonly class DataSourceCapabilitiesRegistry
 {
@@ -16,6 +17,7 @@ final readonly class DataSourceCapabilitiesRegistry
      * @param iterable<DataSourceCapabilitiesProviderInterface> $providers
      */
     public function __construct(
+        #[AutowireIterator('app.analysis_explorer.capabilities_provider')]
         private iterable $providers,
     ) {
     }

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerQueryMapperRegistry.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerQueryMapperRegistry.php
@@ -7,6 +7,7 @@ namespace App\Statistics\AnalysisExplorer\Application;
 use App\Statistics\AnalysisExplorer\Application\Contract\ExplorerAnalysisQueryMapperInterface;
 use App\Statistics\AnalysisExplorer\Domain\AnalysisQuery;
 use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery as GenericAnalysisQuery;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 final readonly class ExplorerQueryMapperRegistry
 {
@@ -14,6 +15,7 @@ final readonly class ExplorerQueryMapperRegistry
      * @param iterable<ExplorerAnalysisQueryMapperInterface> $mappers
      */
     public function __construct(
+        #[AutowireIterator('app.analysis_explorer.query_mapper')]
         private iterable $mappers,
     ) {
     }

--- a/src/Statistics/Application/Report/ReportDefinitionInterface.php
+++ b/src/Statistics/Application/Report/ReportDefinitionInterface.php
@@ -7,6 +7,7 @@ namespace App\Statistics\Application\Report;
 use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticWidget;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * Curated statistics report.
@@ -14,6 +15,7 @@ use App\Statistics\Application\DTO\StatisticWidget;
  * {@see build()} receives {@see StatisticsContext} so hospital scopes such as "My hospitals"
  * can respect the signed-in user (same idea as analysis).
  */
+#[AutoconfigureTag('app.statistics.report_definition')]
 interface ReportDefinitionInterface
 {
     public function key(): string;

--- a/src/Statistics/Application/Report/ReportDefinitionRegistry.php
+++ b/src/Statistics/Application/Report/ReportDefinitionRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Statistics\Application\Report;
 
 use App\Statistics\Application\Report\Exception\UnknownReportDefinitionException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 final class ReportDefinitionRegistry
 {
@@ -14,8 +15,10 @@ final class ReportDefinitionRegistry
     /**
      * @param iterable<ReportDefinitionInterface> $definitions
      */
-    public function __construct(iterable $definitions)
-    {
+    public function __construct(
+        #[AutowireIterator('app.statistics.report_definition')]
+        iterable $definitions,
+    ) {
         foreach ($definitions as $definition) {
             $this->byKey[$definition->key()] = $definition;
         }

--- a/src/Statistics/CaseFlow/Application/CaseFlowGeoKeyResolver.php
+++ b/src/Statistics/CaseFlow/Application/CaseFlowGeoKeyResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Statistics\CaseFlow\Application;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
 /**
  * Maps dispatch area names to GeoJSON feature keys for Hessen choropleth.
  */
@@ -12,8 +14,10 @@ final class CaseFlowGeoKeyResolver
     /** @var array<string, string> */
     private array $nameToGeoKey;
 
-    public function __construct(string $configPath)
-    {
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/config/case_flow/dispatch_area_geo_map.yaml')]
+        string $configPath,
+    ) {
         if (!is_file($configPath)) {
             $this->nameToGeoKey = [];
 

--- a/src/Statistics/DataQuality/Infrastructure/Query/DataQualityHospitalPopulationQuery.php
+++ b/src/Statistics/DataQuality/Infrastructure/Query/DataQualityHospitalPopulationQuery.php
@@ -12,7 +12,9 @@ use App\Statistics\Application\Cohort\HospitalCohort;
 use App\Statistics\DataQuality\Application\Contract\DataQualityHospitalPopulationReaderInterface;
 use App\Statistics\DataQuality\Dto\DataQualityHospitalSnapshot;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+#[AsAlias(DataQualityHospitalPopulationReaderInterface::class)]
 final readonly class DataQualityHospitalPopulationQuery implements DataQualityHospitalPopulationReaderInterface
 {
     public function __construct(

--- a/src/Statistics/GenericAnalysis/Application/AnalysisExportService.php
+++ b/src/Statistics/GenericAnalysis/Application/AnalysisExportService.php
@@ -8,8 +8,10 @@ use App\Statistics\GenericAnalysis\Application\Contract\AnalysisExportServiceInt
 use App\Statistics\GenericAnalysis\Application\Export\ExportFilenameFactory;
 use App\Statistics\GenericAnalysis\Application\Export\TabularExportDocument;
 use App\Statistics\GenericAnalysis\Application\Export\TabularExporterRegistry;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[AsAlias(AnalysisExportServiceInterface::class)]
 final readonly class AnalysisExportService implements AnalysisExportServiceInterface
 {
     public function __construct(

--- a/src/Statistics/GenericAnalysis/Infrastructure/Adapter/ParticipantCustomAnalysisAccess.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Adapter/ParticipantCustomAnalysisAccess.php
@@ -7,7 +7,9 @@ namespace App\Statistics\GenericAnalysis\Infrastructure\Adapter;
 use App\Statistics\GenericAnalysis\Application\Contract\CustomAnalysisAccessInterface;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+#[AsAlias(CustomAnalysisAccessInterface::class)]
 final readonly class ParticipantCustomAnalysisAccess implements CustomAnalysisAccessInterface
 {
     #[\Override]

--- a/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
+++ b/src/Statistics/Infrastructure/Adapter/DoctrineHospitalAccess.php
@@ -10,7 +10,9 @@ use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+#[AsAlias(HospitalAccessInterface::class)]
 final readonly class DoctrineHospitalAccess implements HospitalAccessInterface
 {
     public function __construct(

--- a/src/Statistics/Infrastructure/Adapter/DoctrineImportTimeline.php
+++ b/src/Statistics/Infrastructure/Adapter/DoctrineImportTimeline.php
@@ -6,7 +6,9 @@ namespace App\Statistics\Infrastructure\Adapter;
 
 use App\Import\Infrastructure\Repository\ImportRepository;
 use App\Statistics\Application\Contract\ImportTimelineInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+#[AsAlias(ImportTimelineInterface::class)]
 final readonly class DoctrineImportTimeline implements ImportTimelineInterface
 {
     public function __construct(

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewMaterializedViewsInstaller.php
@@ -7,10 +7,13 @@ namespace App\Statistics\Infrastructure\Query\Overview;
 use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
 use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Ensures overview materialized views exist (required when the test DB is reset via schema tooling).
  */
+#[Autoconfigure(public: true)]
 final class OverviewMaterializedViewsInstaller
 {
     private static bool $ensured = false;
@@ -18,6 +21,7 @@ final class OverviewMaterializedViewsInstaller
     public function __construct(
         private readonly Connection $connection,
         private readonly MaterializedViewRefresher $materializedViewRefresher,
+        #[Autowire('%kernel.environment%')]
         private readonly string $kernelEnvironment,
     ) {
     }

--- a/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
@@ -6,8 +6,10 @@ namespace App\User\Infrastructure\Security;
 
 use App\User\Domain\Security\UserRole;
 use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
 /** @psalm-suppress UnusedClass */
+#[AsAlias(FeedbackRecipientEmailResolver::class)]
 final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmailResolver
 {
     /** @psalm-suppress PossiblyUnusedMethod */

--- a/src/User/Infrastructure/Security/NotificationRecipientResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientResolver.php
@@ -7,8 +7,10 @@ namespace App\User\Infrastructure\Security;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
 /** @psalm-suppress UnusedClass */
+#[AsAlias(NotificationRecipientEmailResolver::class)]
 final readonly class NotificationRecipientResolver implements NotificationRecipientEmailResolver
 {
     /** @psalm-suppress PossiblyUnusedMethod */


### PR DESCRIPTION
## Summary

This pull request modernizes the Symfony service configuration by gradually moving explicit entries from `config/services.yaml` into PHP attributes and autowiring. The goal is a clearer, more maintainable DI setup aligned with Symfony 8.1 best practices — following the pattern already established in the import module.

`services.yaml` was reduced from roughly 175 to about 90 lines. It now contains only central parameters, the `App\` resource scan, and infrastructure wiring that does not map cleanly to attributes: the PDO advisory lock chain, Sentry callback factories, and Monolog Sentry handlers, including the `when@test` override for `FlockStore`.

## Key changes

**Import:** Reject writer tagging moves from YAML to `#[AutoconfigureTag]` on `RejectWriterInterface` and `#[AsTaggedItem]` with explicit indices (`db`, `csv`) on the implementations. This aligns tagging with other import interfaces such as `AllocationEntityResolverInterface`.

**Statistics:** `_instanceof` tags and `tagged_iterator` definitions for report and analysis explorer registries are removed. The respective interfaces now carry `#[AutoconfigureTag]`, and registry constructors use `#[AutowireIterator]`.

**Interface aliases:** Nine aliases previously defined in YAML (including `HospitalAccessInterface`, `TransactionalMailer`, and mail/notification resolvers) are now declared on the implementations via `#[AsAlias]`.

**Scalar configuration:** Parameters such as `kernel.environment`, media upload path, page content width, and `kernel.project_dir` are injected explicitly via `#[Autowire]`. The global `$projectDir` bind in `_defaults` is removed.

**Consent:** Both cookie consent subscribers use `#[AsEventListener]` instead of `EventSubscriberInterface`; the existing priorities (28 on `REQUEST`, -128 on `RESPONSE`) are preserved.

**Removed as redundant:** duplicate reject writer tags, `DoctrineAllocationPersister` batch size, `AllocationImporter` logger wiring, `StatisticsFilterValueResolver` priority (all controllers use explicit `#[ValueResolver(...)]`), the unused `$defaultConnection` bind, and the explicit `Doctrine\DBAL\Connection` alias.

## Intentionally unchanged

Lock infrastructure, Sentry callbacks, Monolog handlers, and the dev/test-specific service imports (`foundry.yaml`, `foundry_test.yaml`, `doctrine_fixtures.yaml`) remain in YAML.

## Verification

Container lint (`bin/console lint:container`) and the full PHPUnit suite (1846 tests) pass successfully.