### PR TITLE
refactor(console): migrate app commands to Symfony 8.1 invokable style

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -102,10 +102,5 @@
                 <file name="src/Import/Application/ImportDispatchExitCode.php" />
             </errorLevel>
         </UnusedConstructor>
-        <RedundantCast>
-            <errorLevel type="suppress">
-                <directory name="src/*/UI/Console/Command/" />
-            </errorLevel>
-        </RedundantCast>
     </issueHandlers>
 </psalm>

--- a/src/Allocation/UI/Console/Command/AuditAllocationIndicationFilterCommand.php
+++ b/src/Allocation/UI/Console/Command/AuditAllocationIndicationFilterCommand.php
@@ -10,42 +10,34 @@ use App\Allocation\Infrastructure\Query\ListAllocationsQuery;
 use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:audit-allocation-indication-filter',
     description: 'Compare EXPLAIN-based result estimates with actual allocation rows per normalized indication code.',
 )]
-final class AuditAllocationIndicationFilterCommand extends Command
+final readonly class AuditAllocationIndicationFilterCommand
 {
     public function __construct(
-        private readonly ListAllocationsQuery $listAllocationsQuery,
-        private readonly EntityManagerInterface $entityManager,
+        private ListAllocationsQuery $listAllocationsQuery,
+        private EntityManagerInterface $entityManager,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('code', null, InputOption::VALUE_REQUIRED, 'Audit only this indication code')
-            ->addOption('min-estimate', null, InputOption::VALUE_REQUIRED, 'Only report mismatches with estimate >= this value', '1')
-            ->addOption('json', null, InputOption::VALUE_NONE, 'Output problematic codes as JSON');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $minEstimate = max(0, (int) $input->getOption('min-estimate'));
-        $singleCode = $input->getOption('code');
-        $codes = null !== $singleCode && '' !== $singleCode
-            ? [(int) $singleCode]
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Audit only this indication code')]
+        ?string $code = null,
+        #[Option(description: 'Only report mismatches with estimate >= this value', name: 'min-estimate')]
+        int $minEstimate = 1,
+        #[Option(description: 'Output problematic codes as JSON')]
+        bool $json = false,
+    ): int {
+        $minEstimate = max(0, $minEstimate);
+        $codes = null !== $code && '' !== $code
+            ? [(int) $code]
             : $this->loadDistinctIndicationCodes();
 
         $io->title(sprintf('Auditing %d indication code(s)', \count($codes)));
@@ -53,19 +45,19 @@ final class AuditAllocationIndicationFilterCommand extends Command
         $problematic = [];
         $scanned = 0;
 
-        foreach ($codes as $code) {
+        foreach ($codes as $indicationCode) {
             ++$scanned;
-            $dto = new AllocationQueryParametersDTO(indication: $code);
+            $dto = new AllocationQueryParametersDTO(indication: $indicationCode);
             $paginator = $this->listAllocationsQuery->getPaginator($dto);
             $pageRows = iterator_to_array($paginator->getResults());
             $estimated = $paginator->getEstimatedNumResults();
-            $actualNormalized = $this->countByNormalizedCode($code);
-            $actualRaw = $this->countByRawCode($code);
+            $actualNormalized = $this->countByNormalizedCode($indicationCode);
+            $actualRaw = $this->countByRawCode($indicationCode);
 
             $estimateForCompare = $estimated ?? 0;
             if ($estimateForCompare >= $minEstimate && 0 === \count($pageRows) && 0 === $actualNormalized) {
                 $problematic[] = [
-                    'code' => $code,
+                    'code' => $indicationCode,
                     'estimated' => $estimated,
                     'actualNormalized' => $actualNormalized,
                     'actualRaw' => $actualRaw,
@@ -73,7 +65,7 @@ final class AuditAllocationIndicationFilterCommand extends Command
             }
         }
 
-        if ($input->getOption('json')) {
+        if ($json) {
             $io->writeln(json_encode($problematic, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
 
             return Command::SUCCESS;

--- a/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
+++ b/src/Allocation/UI/Console/Command/BackfillAllocationIndicationNormalizedCommand.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Console\Command;
 
 use App\Allocation\Application\Indication\BackfillAllocationIndicationNormalizedService;
+use App\Allocation\UI\Console\Input\BackfillAllocationIndicationNormalizedInput;
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -19,36 +19,26 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:allocation:backfill-indications',
     description: 'Sync indication_raw.normalized from target and copy normalized IDs onto allocations (optional projection rebuild).',
 )]
-final class BackfillAllocationIndicationNormalizedCommand extends Command
+final readonly class BackfillAllocationIndicationNormalizedCommand
 {
     private const int GC_EVERY_N_IMPORTS = 25;
 
     public function __construct(
-        private readonly BackfillAllocationIndicationNormalizedService $backfillService,
-        private readonly AllocationStatsProjectionRebuildInterface $projectionRebuilder,
-        private readonly Connection $connection,
+        private BackfillAllocationIndicationNormalizedService $backfillService,
+        private AllocationStatsProjectionRebuildInterface $projectionRebuilder,
+        private Connection $connection,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report how many rows would change')
-            ->addOption('skip-raw-sync', null, InputOption::VALUE_NONE, 'Do not copy indication_raw.target_id to normalized_id')
-            ->addOption('skip-allocations', null, InputOption::VALUE_NONE, 'Do not update allocation indication columns')
-            ->addOption('rebuild-projection', null, InputOption::VALUE_NONE, 'Rebuild allocation_stats_projection per import after backfill');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $dryRun = (bool) $input->getOption('dry-run');
-        $syncRaw = !(bool) $input->getOption('skip-raw-sync');
-        $backfillAllocations = !(bool) $input->getOption('skip-allocations');
-        $rebuildProjection = (bool) $input->getOption('rebuild-projection');
+    public function __invoke(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        #[MapInput] BackfillAllocationIndicationNormalizedInput $input,
+    ): int {
+        $dryRun = $input->dryRun;
+        $syncRaw = !$input->skipRawSync;
+        $backfillAllocations = !$input->skipAllocations;
+        $rebuildProjection = $input->rebuildProjection;
 
         $io->title('Backfill allocation indication_normalized');
 

--- a/src/Allocation/UI/Console/Input/BackfillAllocationIndicationNormalizedInput.php
+++ b/src/Allocation/UI/Console/Input/BackfillAllocationIndicationNormalizedInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+
+final class BackfillAllocationIndicationNormalizedInput
+{
+    #[Option(description: 'Only report how many rows would change', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    #[Option(description: 'Do not copy indication_raw.target_id to normalized_id', name: 'skip-raw-sync')]
+    public bool $skipRawSync = false;
+
+    #[Option(description: 'Do not update allocation indication columns', name: 'skip-allocations')]
+    public bool $skipAllocations = false;
+
+    #[Option(description: 'Rebuild allocation_stats_projection per import after backfill', name: 'rebuild-projection')]
+    public bool $rebuildProjection = false;
+}

--- a/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
+++ b/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
@@ -7,45 +7,31 @@ namespace App\Content\UI\Console\Command;
 use App\Content\Application\Media\MediaDimensionsBackfillService;
 use App\Content\Application\Page\PageImageContentAnalyzer;
 use App\Content\Application\Page\PageImageContentMigrationService;
+use App\Content\UI\Console\Input\AnalyzePageImagesInput;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:content:analyze-page-images',
     description: 'Analyze page image references, backfill media dimensions, and optionally migrate layout sizes.',
 )]
-final class AnalyzePageImagesCommand extends Command
+final readonly class AnalyzePageImagesCommand
 {
     public function __construct(
-        private readonly PageImageContentAnalyzer $analyzer,
-        private readonly MediaDimensionsBackfillService $dimensionsBackfillService,
-        private readonly PageImageContentMigrationService $migrationService,
+        private PageImageContentAnalyzer $analyzer,
+        private MediaDimensionsBackfillService $dimensionsBackfillService,
+        private PageImageContentMigrationService $migrationService,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report findings without writing changes (default)')
-            ->addOption('apply', null, InputOption::VALUE_NONE, 'Apply selected write operations')
-            ->addOption('backfill-dimensions', null, InputOption::VALUE_NONE, 'Backfill missing media width/height from local files')
-            ->addOption('migrate-size', null, InputOption::VALUE_NONE, 'Migrate image blocks from size lg to auto when recommended')
-            ->addOption('fix-richtext-snippets', null, InputOption::VALUE_NONE, 'Replace --size-lg with --size-auto in HTML snippets')
-            ->addOption('page-id', null, InputOption::VALUE_REQUIRED, 'Analyze or migrate a single page');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $dryRun = !$input->getOption('apply');
-        $pageId = $this->parsePageId($input->getOption('page-id'));
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] AnalyzePageImagesInput $input,
+    ): int {
+        $dryRun = !$input->apply;
+        $pageId = $this->parsePageId($input->pageId);
 
         $io->title('Analyze page images');
 
@@ -77,7 +63,7 @@ final class AnalyzePageImagesCommand extends Command
             );
         }
 
-        if ($input->getOption('backfill-dimensions')) {
+        if ($input->backfillDimensions) {
             $result = $this->dimensionsBackfillService->backfill($dryRun);
             $io->section('Media dimension backfill');
             $io->table(
@@ -90,21 +76,21 @@ final class AnalyzePageImagesCommand extends Command
             );
         }
 
-        if ($input->getOption('migrate-size')) {
+        if ($input->migrateSize) {
             $result = $this->migrationService->migrateSizes($dryRun, $pageId);
             $io->section('Image block size migration');
             $io->writeln(sprintf('Updated image blocks: %d', $result->updatedBlocks));
             $io->writeln(sprintf('Affected pages: %d', $result->updatedPages));
         }
 
-        if ($input->getOption('fix-richtext-snippets')) {
+        if ($input->fixRichtextSnippets) {
             $result = $this->migrationService->fixRichtextSnippets($dryRun, $pageId);
             $io->section('Richtext snippet migration');
             $io->writeln(sprintf('Updated HTML blocks: %d', $result->updatedBlocks));
             $io->writeln(sprintf('Affected pages: %d', $result->updatedPages));
         }
 
-        if ($dryRun && ($input->getOption('backfill-dimensions') || $input->getOption('migrate-size') || $input->getOption('fix-richtext-snippets'))) {
+        if ($dryRun && ($input->backfillDimensions || $input->migrateSize || $input->fixRichtextSnippets)) {
             $io->success('Dry run finished. Re-run with --apply to persist changes.');
         } else {
             $io->success('Analysis finished.');
@@ -113,9 +99,9 @@ final class AnalyzePageImagesCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function parsePageId(mixed $value): ?int
+    private function parsePageId(?string $value): ?int
     {
-        if (!is_string($value) || !ctype_digit($value)) {
+        if (null === $value || !ctype_digit($value)) {
             return null;
         }
 

--- a/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
+++ b/src/Content/UI/Console/Command/AnalyzePageImagesCommand.php
@@ -30,7 +30,7 @@ final readonly class AnalyzePageImagesCommand
         SymfonyStyle $io,
         #[MapInput] AnalyzePageImagesInput $input,
     ): int {
-        $dryRun = !$input->apply;
+        $dryRun = !$input->apply || $input->dryRun;
         $pageId = $this->parsePageId($input->pageId);
 
         $io->title('Analyze page images');

--- a/src/Content/UI/Console/Input/AnalyzePageImagesInput.php
+++ b/src/Content/UI/Console/Input/AnalyzePageImagesInput.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+
+final class AnalyzePageImagesInput
+{
+    #[Option(description: 'Only report findings without writing changes (default)', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    #[Option(description: 'Apply selected write operations')]
+    public bool $apply = false;
+
+    #[Option(description: 'Backfill missing media width/height from local files', name: 'backfill-dimensions')]
+    public bool $backfillDimensions = false;
+
+    #[Option(description: 'Migrate image blocks from size lg to auto when recommended', name: 'migrate-size')]
+    public bool $migrateSize = false;
+
+    #[Option(description: 'Replace --size-lg with --size-auto in HTML snippets', name: 'fix-richtext-snippets')]
+    public bool $fixRichtextSnippets = false;
+
+    #[Option(description: 'Analyze or migrate a single page', name: 'page-id')]
+    public ?string $pageId = null;
+}

--- a/src/DataFixtures/Pattern/Command/ExportDistributionPatternsCommand.php
+++ b/src/DataFixtures/Pattern/Command/ExportDistributionPatternsCommand.php
@@ -6,44 +6,34 @@ namespace App\DataFixtures\Pattern\Command;
 
 use App\DataFixtures\Pattern\Application\PatternExporter;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:fixtures:export-patterns',
     description: 'Export distribution patterns from allocation_stats_projection into fixtures/patterns/',
 )]
-final class ExportDistributionPatternsCommand extends Command
+final readonly class ExportDistributionPatternsCommand
 {
     public function __construct(
-        private readonly PatternExporter $exporter,
+        private PatternExporter $exporter,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this->addOption('min-sample-size', null, InputOption::VALUE_REQUIRED, 'Minimum rows required per segment', '100');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $ui = new SymfonyStyle($input, $output);
-        $minSampleSize = (int) $input->getOption('min-sample-size');
-
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Minimum rows required per segment', name: 'min-sample-size')]
+        int $minSampleSize = 100,
+    ): int {
         $exported = $this->exporter->exportAll($minSampleSize);
         if ([] === $exported) {
-            $ui->warning(sprintf('No patterns exported (minimum sample size: %d).', $minSampleSize));
+            $io->warning(sprintf('No patterns exported (minimum sample size: %d).', $minSampleSize));
 
             return Command::FAILURE;
         }
 
-        $ui->success(sprintf('Exported patterns: %s', implode(', ', $exported)));
+        $io->success(sprintf('Exported patterns: %s', implode(', ', $exported)));
 
         return Command::SUCCESS;
     }

--- a/src/DataFixtures/Pattern/Command/ValidateDistributionPatternsCommand.php
+++ b/src/DataFixtures/Pattern/Command/ValidateDistributionPatternsCommand.php
@@ -6,45 +6,36 @@ namespace App\DataFixtures\Pattern\Command;
 
 use App\DataFixtures\Pattern\Application\PatternValidator;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:fixtures:validate-patterns',
     description: 'Validate committed distribution pattern YAML files',
 )]
-final class ValidateDistributionPatternsCommand extends Command
+final readonly class ValidateDistributionPatternsCommand
 {
     public function __construct(
-        private readonly PatternValidator $validator,
+        private PatternValidator $validator,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this->addOption('min-sample-size', null, InputOption::VALUE_REQUIRED, 'Minimum sample_size per pattern', '100');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $ui = new SymfonyStyle($input, $output);
-        $minSampleSize = (int) $input->getOption('min-sample-size');
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Minimum sample_size per pattern', name: 'min-sample-size')]
+        int $minSampleSize = 100,
+    ): int {
         $errors = $this->validator->validateAll($minSampleSize);
 
         if ([] === $errors) {
-            $ui->success('All distribution patterns are valid.');
+            $io->success('All distribution patterns are valid.');
 
             return Command::SUCCESS;
         }
 
-        $ui->error('Pattern validation failed:');
-        $ui->listing($errors);
+        $io->error('Pattern validation failed:');
+        $io->listing($errors);
 
         return Command::FAILURE;
     }

--- a/src/DataFixtures/Reference/Command/LoadReferenceIndicationGroupsCommand.php
+++ b/src/DataFixtures/Reference/Command/LoadReferenceIndicationGroupsCommand.php
@@ -9,54 +9,44 @@ use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:reference:load-indication-groups',
     description: 'Load indication groups from fixtures/reference/indication_groups.yaml without purging the database.',
 )]
-final class LoadReferenceIndicationGroupsCommand extends Command
+final readonly class LoadReferenceIndicationGroupsCommand
 {
     private const string DEFAULT_USER = 'admin';
 
     public function __construct(
-        private readonly IndicationGroupReferenceLoader $loader,
-        private readonly UserRepository $userRepository,
-        private readonly EntityManagerInterface $entityManager,
+        private IndicationGroupReferenceLoader $loader,
+        private UserRepository $userRepository,
+        private EntityManagerInterface $entityManager,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report planned changes without writing to the database')
-            ->addOption('update', null, InputOption::VALUE_NONE, 'Update existing groups (category and indication membership) to match the YAML')
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Load only N groups (deterministic subset, same as dev fixtures)')
-            ->addOption('user', null, InputOption::VALUE_REQUIRED, 'Username or email for createdBy on new groups', self::DEFAULT_USER);
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $dryRun = $input->getOption('dry-run');
-        $updateExisting = $input->getOption('update');
-        $userOption = $input->getOption('user');
-
-        $user = $this->resolveUser($userOption);
-        if (!$user instanceof User) {
-            $io->error(sprintf('No user found for "%s". Create a user first or pass --user=.', $userOption));
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Report planned changes without writing to the database', name: 'dry-run')]
+        bool $dryRun = false,
+        #[Option(description: 'Update existing groups (category and indication membership) to match the YAML')]
+        bool $update = false,
+        #[Option(description: 'Load only N groups (deterministic subset, same as dev fixtures)')]
+        ?int $limit = null,
+        #[Option(description: 'Username or email for createdBy on new groups')]
+        string $user = self::DEFAULT_USER,
+    ): int {
+        $resolvedUser = $this->resolveUser($user);
+        if (!$resolvedUser instanceof User) {
+            $io->error(sprintf('No user found for "%s". Create a user first or pass --user=.', $user));
 
             return Command::FAILURE;
         }
 
-        $definitions = $this->resolveDefinitions($input);
+        $definitions = $this->resolveDefinitions($limit);
         if ([] === $definitions) {
             $io->warning('No indication group definitions to load.');
 
@@ -67,14 +57,14 @@ final class LoadReferenceIndicationGroupsCommand extends Command
         $io->writeln(sprintf(
             'Definitions: %d | Mode: %s%s',
             \count($definitions),
-            $updateExisting ? 'create + update' : 'create missing only',
+            $update ? 'create + update' : 'create missing only',
             $dryRun ? ' (dry run)' : '',
         ));
 
         $result = $this->loader->syncGroups(
-            $user,
+            $resolvedUser,
             $definitions,
-            updateExisting: $updateExisting,
+            updateExisting: $update,
             dryRun: $dryRun,
         );
 
@@ -112,19 +102,17 @@ final class LoadReferenceIndicationGroupsCommand extends Command
     /**
      * @return list<array{name: string, category: ?string, codes: list<string>}>
      */
-    private function resolveDefinitions(InputInterface $input): array
+    private function resolveDefinitions(?int $limit): array
     {
-        $limit = $input->getOption('limit');
-        if (null === $limit || '' === $limit) {
+        if (null === $limit) {
             return $this->loader->allDefinitions();
         }
 
-        $count = (int) $limit;
-        if ($count <= 0) {
+        if ($limit <= 0) {
             return [];
         }
 
-        return $this->loader->pickDeterministicSubset($count);
+        return $this->loader->pickDeterministicSubset($limit);
     }
 
     private function resolveUser(string $identifier): ?User

--- a/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
+++ b/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
@@ -9,11 +9,10 @@ use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\MonthlyReminderContentBuilder;
 use App\Engagement\Application\MonthlyReminderSender;
+use App\Engagement\UI\Console\Input\MonthlyReminderPreviewInput;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -23,54 +22,37 @@ use Twig\Environment;
     name: 'app:reminder:preview',
     description: 'Preview the monthly submission reminder email for a hospital.',
 )]
-final class MonthlyReminderPreviewCommand extends Command
+final readonly class MonthlyReminderPreviewCommand
 {
     public function __construct(
-        private readonly HospitalRepository $hospitalRepository,
-        private readonly MonthlyReminderContentBuilder $contentBuilder,
-        private readonly Environment $twig,
-        private readonly MonthlyReminderSender $reminderSender,
-        private readonly TranslatorInterface $translator,
-        #[Autowire('%env(MAILER_DSN)%')] private readonly string $mailerDsn,
-        #[Autowire('%kernel.environment%')] private readonly string $appEnvironment,
+        private HospitalRepository $hospitalRepository,
+        private MonthlyReminderContentBuilder $contentBuilder,
+        private Environment $twig,
+        private MonthlyReminderSender $reminderSender,
+        private TranslatorInterface $translator,
+        #[Autowire('%env(MAILER_DSN)%')] private string $mailerDsn,
+        #[Autowire('%kernel.environment%')] private string $appEnvironment,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('hospital', null, InputOption::VALUE_REQUIRED, 'Hospital ID')
-            ->addOption('send', null, InputOption::VALUE_NONE, 'Send the email to the hospital owner')
-            ->addOption('ignore-opt-out', null, InputOption::VALUE_NONE, 'Send even if the owner opted out (like admin action)')
-            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'Write HTML to file path')
-            ->addOption('date', null, InputOption::VALUE_REQUIRED, 'Reference date (Y-m-d) for period calculation');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $hospitalId = (int) $input->getOption('hospital');
-        if ($hospitalId <= 0) {
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] MonthlyReminderPreviewInput $input,
+    ): int {
+        if (null === $input->hospital || $input->hospital <= 0) {
             $io->error('Option --hospital is required.');
 
             return Command::INVALID;
         }
 
-        $hospital = $this->hospitalRepository->findById($hospitalId);
+        $hospital = $this->hospitalRepository->findById($input->hospital);
         if (!$hospital instanceof Hospital) {
-            $io->error(sprintf('Hospital %d not found.', $hospitalId));
+            $io->error(sprintf('Hospital %d not found.', $input->hospital));
 
             return Command::FAILURE;
         }
 
-        $referenceDate = null;
-        $dateRaw = $input->getOption('date');
-        if (\is_string($dateRaw) && '' !== $dateRaw) {
-            $referenceDate = new \DateTimeImmutable($dateRaw, new \DateTimeZone('Europe/Berlin'));
-        }
+        $referenceDate = $input->date;
 
         $content = $this->contentBuilder->build($hospital, $referenceDate);
         $html = $this->twig->render('@Engagement/email/monthly_submission_reminder.html.twig', [
@@ -78,9 +60,9 @@ final class MonthlyReminderPreviewCommand extends Command
             'app_title' => 'Preview',
         ]);
 
-        $outputPath = $input->getOption('output');
-        $shouldSend = true === $input->getOption('send');
-        if (\is_string($outputPath) && '' !== $outputPath) {
+        $outputPath = $input->output;
+        $shouldSend = $input->send;
+        if (null !== $outputPath && '' !== $outputPath) {
             file_put_contents($outputPath, $html);
             $io->success(sprintf('Wrote preview to %s', $outputPath));
         } elseif (!$shouldSend) {
@@ -96,7 +78,7 @@ final class MonthlyReminderPreviewCommand extends Command
                 return Command::FAILURE;
             }
 
-            $trigger = $input->getOption('ignore-opt-out')
+            $trigger = $input->ignoreOptOut
                 ? MonthlyReminderTrigger::Admin
                 : MonthlyReminderTrigger::Cli;
 

--- a/src/Engagement/UI/Console/Input/MonthlyReminderPreviewInput.php
+++ b/src/Engagement/UI/Console/Input/MonthlyReminderPreviewInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class MonthlyReminderPreviewInput
+{
+    #[Option(description: 'Hospital ID')]
+    #[Assert\Positive]
+    public ?int $hospital = null;
+
+    #[Option(description: 'Send the email to the hospital owner')]
+    public bool $send = false;
+
+    #[Option(description: 'Send even if the owner opted out (like admin action)', name: 'ignore-opt-out')]
+    public bool $ignoreOptOut = false;
+
+    #[Option(description: 'Write HTML to file path')]
+    public ?string $output = null;
+
+    #[Option(description: 'Reference date (Y-m-d) for period calculation')]
+    public ?\DateTimeImmutable $date = null;
+}

--- a/src/Import/Domain/Enum/RejectAnalysisExportFormat.php
+++ b/src/Import/Domain/Enum/RejectAnalysisExportFormat.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Enum;
+
+enum RejectAnalysisExportFormat: string
+{
+    case Csv = 'csv';
+    case Markdown = 'md';
+    case Json = 'json';
+}

--- a/src/Import/UI/Console/Command/AnalyzeImportRejectsCommand.php
+++ b/src/Import/UI/Console/Command/AnalyzeImportRejectsCommand.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Import\UI\Console\Command;
 
 use App\Import\Application\Analysis\ImportRejectAnalysisService;
+use App\Import\Domain\Enum\RejectAnalysisExportFormat;
 use App\Import\Infrastructure\Analysis\Export\RejectAnalysisExporterRegistry;
+use App\Import\UI\Console\Input\AnalyzeImportRejectsInput;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
@@ -20,57 +20,30 @@ use Symfony\Component\Filesystem\Path;
     name: 'app:analyze-import-rejects',
     description: 'Analyze import rejects grouped by field, value, and reason for transformer planning.',
 )]
-final class AnalyzeImportRejectsCommand extends Command
+final readonly class AnalyzeImportRejectsCommand
 {
     private const string DEFAULT_OUTPUT_CSV = 'var/export/import-reject-analysis.csv';
 
     public function __construct(
-        private readonly ImportRejectAnalysisService $analysisService,
-        private readonly RejectAnalysisExporterRegistry $exporterRegistry,
-        private readonly Filesystem $filesystem,
+        private ImportRejectAnalysisService $analysisService,
+        private RejectAnalysisExporterRegistry $exporterRegistry,
+        private Filesystem $filesystem,
         #[Autowire('%kernel.project_dir%')]
-        private readonly string $projectDir,
+        private string $projectDir,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Export format: csv, md, json', 'csv')
-            ->addOption('output', null, InputOption::VALUE_REQUIRED, 'Output file path', self::DEFAULT_OUTPUT_CSV)
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit to top N groups after sorting')
-            ->addOption('include-examples', null, InputOption::VALUE_NONE, 'Include example raw row JSON in output')
-            ->addOption('min-count', null, InputOption::VALUE_REQUIRED, 'Minimum count per group', '1');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $format = strtolower((string) $input->getOption('format'));
-        if (!\in_array($format, ['csv', 'md', 'json'], true)) {
-            $io->error('Option --format must be one of: csv, md, json');
-
-            return Command::INVALID;
-        }
-
-        $outputPath = $this->resolveOutputPath(
-            (string) $input->getOption('output'),
-            $format,
-        );
-
-        $limitOption = $input->getOption('limit');
-        $limit = null !== $limitOption && '' !== $limitOption ? max(1, (int) $limitOption) : null;
-        $minCount = max(1, (int) $input->getOption('min-count'));
-        $includeExamples = (bool) $input->getOption('include-examples');
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] AnalyzeImportRejectsInput $input,
+    ): int {
+        $format = $input->format->value;
+        $outputPath = $this->resolveOutputPath($input->output, $format);
 
         $result = $this->analysisService->analyze(
-            minCount: $minCount,
-            limit: $limit,
-            includeExamples: $includeExamples,
+            minCount: $input->minCount,
+            limit: $input->limit,
+            includeExamples: $input->includeExamples,
         );
 
         $this->filesystem->mkdir(Path::getDirectory($outputPath));
@@ -96,8 +69,8 @@ final class AnalyzeImportRejectsCommand extends Command
         $defaultCsv = Path::join($this->projectDir, self::DEFAULT_OUTPUT_CSV);
         if ($output === $defaultCsv) {
             return match ($format) {
-                'md' => Path::join($this->projectDir, 'var/export/import-reject-analysis.md'),
-                'json' => Path::join($this->projectDir, 'var/export/import-reject-analysis.json'),
+                RejectAnalysisExportFormat::Markdown->value => Path::join($this->projectDir, 'var/export/import-reject-analysis.md'),
+                RejectAnalysisExportFormat::Json->value => Path::join($this->projectDir, 'var/export/import-reject-analysis.json'),
                 default => $output,
             };
         }

--- a/src/Import/UI/Console/Command/GenerateCsvFixturesCommand.php
+++ b/src/Import/UI/Console/Command/GenerateCsvFixturesCommand.php
@@ -6,8 +6,6 @@ namespace App\Import\UI\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -16,20 +14,16 @@ use Symfony\Component\HttpKernel\KernelInterface;
     name: 'app:generate-csv-fixtures',
     description: 'Generate CSV encoding fixtures (dev/test only).',
 )]
-final class GenerateCsvFixturesCommand extends Command
+final readonly class GenerateCsvFixturesCommand
 {
     public function __construct(
-        private readonly KernelInterface $kernel,
-        private readonly Filesystem $fs = new Filesystem(),
+        private KernelInterface $kernel,
+        private Filesystem $fs = new Filesystem(),
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
-
         if (!\in_array($this->kernel->getEnvironment(), ['dev', 'test'], true)) {
             $io->error(sprintf('Forbidden in "%s" environment.', $this->kernel->getEnvironment()));
 

--- a/src/Import/UI/Console/Command/ImportAllocationsCommand.php
+++ b/src/Import/UI/Console/Command/ImportAllocationsCommand.php
@@ -9,36 +9,26 @@ use App\Import\Application\Exception\ImportCreatorMissingException;
 use App\Import\Application\Exception\ImportNotFoundException;
 use App\Import\Application\ImportDispatchExitCode;
 use App\Import\Application\Service\ImportAllocationsDispatcher;
+use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'app:import:allocations',
     description: 'Dispatch an allocation import job via Messenger using the import creator as audit user. Exit codes: 0=success, 1=import/creator not found or dispatch failed, 2=invalid arguments.',
 )]
-final class ImportAllocationsCommand extends Command
+final readonly class ImportAllocationsCommand
 {
     public function __construct(
-        private readonly ImportAllocationsDispatcher $dispatcher,
+        private ImportAllocationsDispatcher $dispatcher,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addArgument('importId', InputArgument::REQUIRED, 'ID of the Import entity (required)');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $importId = (int) $input->getArgument('importId');
-
+    public function __invoke(
+        OutputInterface $output,
+        #[Argument(description: 'ID of the Import entity (required)', name: 'importId')]
+        int $importId,
+    ): int {
         try {
             $this->dispatcher->dispatch($importId);
         } catch (ImportNotFoundException|ImportCreatorMissingException|DispatchException $e) {

--- a/src/Import/UI/Console/Command/RequeueAllImportsCommand.php
+++ b/src/Import/UI/Console/Command/RequeueAllImportsCommand.php
@@ -9,45 +9,28 @@ use App\Import\Application\DTO\ImportRequeueBatchSummary;
 use App\Import\Application\ImportDispatchExitCode;
 use App\Import\Application\Service\ImportRequeueBatchOrchestrator;
 use App\Import\Application\Service\ImportRequeueRunControl;
+use App\Import\UI\Console\Input\ImportRequeueInput;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:import:requeue-all',
     description: 'Re-queue all allocation imports via Messenger sequentially. Exit codes: 0=all dispatched, 1=some dispatch failures, 2=critical (signal, max retries, invalid options). Requires ext-pcntl for graceful SIGINT/SIGTERM handling.',
 )]
-final class RequeueAllImportsCommand extends Command implements SignalableCommandInterface
+final class RequeueAllImportsCommand implements SignalableCommandInterface
 {
     private ?ImportRequeueRunControl $runControl = null;
 
     public function __construct(
         private readonly ImportRequeueBatchOrchestrator $orchestrator,
     ) {
-        parent::__construct();
-    }
-
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show which imports would be dispatched without persisting or dispatching')
-            ->addOption('from-id', null, InputOption::VALUE_REQUIRED, 'Start from this import ID', '1')
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of imports to process')
-            ->addOption('only-id', null, InputOption::VALUE_REQUIRED, 'Process only this import ID')
-            ->addOption('resume', null, InputOption::VALUE_NONE, 'Resume the latest incomplete batch run')
-            ->addOption('run-id', null, InputOption::VALUE_REQUIRED, 'Resume a specific batch run by ID')
-            ->addOption('max-retries-per-import', null, InputOption::VALUE_REQUIRED, 'Max dispatch attempts per import before critical exit', '3');
     }
 
     /**
      * @return list<int>
      */
-    #[\Override]
     public function getSubscribedSignals(): array
     {
         if (!\function_exists('pcntl_signal')) {
@@ -57,7 +40,6 @@ final class RequeueAllImportsCommand extends Command implements SignalableComman
         return [\SIGINT, \SIGTERM];
     }
 
-    #[\Override]
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
         $this->runControl?->requestStop($signal);
@@ -65,28 +47,18 @@ final class RequeueAllImportsCommand extends Command implements SignalableComman
         return false;
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $fromId = max(1, (int) $input->getOption('from-id'));
-        $limitOption = $input->getOption('limit');
-        $limit = null !== $limitOption && '' !== $limitOption ? max(1, (int) $limitOption) : null;
-        $onlyIdOption = $input->getOption('only-id');
-        $onlyId = null !== $onlyIdOption && '' !== $onlyIdOption ? (int) $onlyIdOption : null;
-        $runIdOption = $input->getOption('run-id');
-        $runId = null !== $runIdOption && '' !== $runIdOption ? (int) $runIdOption : null;
-        $maxRetries = max(1, (int) $input->getOption('max-retries-per-import'));
-
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] ImportRequeueInput $input,
+    ): int {
         $options = new ImportRequeueBatchOptions(
-            dryRun: (bool) $input->getOption('dry-run'),
-            fromId: $fromId,
-            limit: $limit,
-            onlyId: $onlyId,
-            resume: (bool) $input->getOption('resume'),
-            runId: $runId,
-            maxRetriesPerImport: $maxRetries,
+            dryRun: $input->dryRun,
+            fromId: $input->fromId,
+            limit: $input->limit,
+            onlyId: $input->onlyId,
+            resume: $input->resume,
+            runId: $input->runId,
+            maxRetriesPerImport: $input->maxRetriesPerImport,
         );
 
         $this->runControl = new ImportRequeueRunControl();

--- a/src/Import/UI/Console/Command/RequeueAllImportsCommand.php
+++ b/src/Import/UI/Console/Command/RequeueAllImportsCommand.php
@@ -31,6 +31,7 @@ final class RequeueAllImportsCommand implements SignalableCommandInterface
     /**
      * @return list<int>
      */
+    #[\Override]
     public function getSubscribedSignals(): array
     {
         if (!\function_exists('pcntl_signal')) {
@@ -40,6 +41,7 @@ final class RequeueAllImportsCommand implements SignalableCommandInterface
         return [\SIGINT, \SIGTERM];
     }
 
+    #[\Override]
     public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
         $this->runControl?->requestStop($signal);

--- a/src/Import/UI/Console/Input/AnalyzeImportRejectsInput.php
+++ b/src/Import/UI/Console/Input/AnalyzeImportRejectsInput.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Console\Input;
+
+use App\Import\Domain\Enum\RejectAnalysisExportFormat;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class AnalyzeImportRejectsInput
+{
+    #[Option(description: 'Export format: csv, md, json')]
+    public RejectAnalysisExportFormat $format = RejectAnalysisExportFormat::Csv;
+
+    #[Option(description: 'Output file path')]
+    public string $output = 'var/export/import-reject-analysis.csv';
+
+    #[Option(description: 'Limit to top N groups after sorting')]
+    #[Assert\Positive]
+    public ?int $limit = null;
+
+    #[Option(description: 'Include example raw row JSON in output', name: 'include-examples')]
+    public bool $includeExamples = false;
+
+    #[Option(description: 'Minimum count per group', name: 'min-count')]
+    #[Assert\Positive]
+    public int $minCount = 1;
+}

--- a/src/Import/UI/Console/Input/ImportRequeueInput.php
+++ b/src/Import/UI/Console/Input/ImportRequeueInput.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class ImportRequeueInput
+{
+    #[Option(description: 'Show which imports would be dispatched without persisting or dispatching', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    #[Option(description: 'Start from this import ID', name: 'from-id')]
+    #[Assert\Positive]
+    public int $fromId = 1;
+
+    #[Option(description: 'Limit the number of imports to process')]
+    #[Assert\Positive]
+    public ?int $limit = null;
+
+    #[Option(description: 'Process only this import ID', name: 'only-id')]
+    #[Assert\Positive]
+    public ?int $onlyId = null;
+
+    #[Option(description: 'Resume the latest incomplete batch run')]
+    public bool $resume = false;
+
+    #[Option(description: 'Resume a specific batch run by ID', name: 'run-id')]
+    #[Assert\Positive]
+    public ?int $runId = null;
+
+    #[Option(description: 'Max dispatch attempts per import before critical exit', name: 'max-retries-per-import')]
+    #[Assert\Positive]
+    public int $maxRetriesPerImport = 3;
+}

--- a/src/Install/UI/Console/Command/InstallCommand.php
+++ b/src/Install/UI/Console/Command/InstallCommand.php
@@ -9,8 +9,6 @@ use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -18,7 +16,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
     name: 'app:install',
     description: 'Run one-time server bootstrap (initial admin user and future install steps).',
 )]
-final class InstallCommand extends Command
+final readonly class InstallCommand
 {
     private const string BOOTSTRAP_ADMIN_USERNAME = 'admin';
 
@@ -27,18 +25,14 @@ final class InstallCommand extends Command
     private const string BOOTSTRAP_ADMIN_PLAIN_PASSWORD = 'Ivena123';
 
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly UserRepository $userRepository,
-        private readonly UserPasswordHasherInterface $passwordHasher,
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+        private UserPasswordHasherInterface $passwordHasher,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
-
         // Add further one-time bootstrap steps here as private methods, in order.
         $this->ensureBootstrapAdmin($io);
 

--- a/src/Kpi/UI/Console/Command/KpiAggregateCommand.php
+++ b/src/Kpi/UI/Console/Command/KpiAggregateCommand.php
@@ -5,53 +5,29 @@ declare(strict_types=1);
 namespace App\Kpi\UI\Console\Command;
 
 use App\Kpi\Application\Service\KpiAggregationService;
+use App\Kpi\UI\Console\Input\KpiAggregateInput;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:kpi:aggregate',
     description: 'Aggregate daily KPI metrics from import data into kpi_daily (idempotent per day).',
 )]
-final class KpiAggregateCommand extends Command
+final readonly class KpiAggregateCommand
 {
     private const string TIMEZONE = 'Europe/Berlin';
 
-    /** Matches the 30-day window shown on the admin KPI dashboard. */
-    private const int DEFAULT_DAYS_WITHOUT_DATE = 30;
-
     public function __construct(
-        private readonly KpiAggregationService $aggregationService,
+        private KpiAggregationService $aggregationService,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption(
-                'date',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Aggregate a single calendar day (YYYY-MM-DD, Europe/Berlin).',
-            )
-            ->addOption(
-                'days',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'When --date is omitted: number of days to aggregate ending yesterday (default: 30, matches dashboard). Use 1 for cron.',
-                (string) self::DEFAULT_DAYS_WITHOUT_DATE,
-            );
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] KpiAggregateInput $input,
+    ): int {
         $tz = new \DateTimeZone(self::TIMEZONE);
 
         try {
@@ -65,9 +41,9 @@ final class KpiAggregateCommand extends Command
         $totalRows = 0;
         $daysWithData = 0;
 
-        foreach ($dates as $date) {
+        foreach ($dates as $aggregationDate) {
             try {
-                $count = $this->aggregationService->aggregateForDate($date);
+                $count = $this->aggregationService->aggregateForDate($aggregationDate);
             } catch (\Throwable $exception) {
                 $io->error($exception->getMessage());
 
@@ -101,15 +77,13 @@ final class KpiAggregateCommand extends Command
     /**
      * @return list<\DateTimeImmutable>
      */
-    private function resolveDates(InputInterface $input, \DateTimeZone $tz): array
+    private function resolveDates(KpiAggregateInput $input, \DateTimeZone $tz): array
     {
-        $dateOption = $input->getOption('date');
-
-        if (\is_string($dateOption) && '' !== $dateOption) {
-            return [$this->parseDate($dateOption, $tz)];
+        if (\is_string($input->date) && '' !== $input->date) {
+            return [$this->parseDate($input->date, $tz)];
         }
 
-        $days = (int) $input->getOption('days');
+        $days = $input->days;
         if ($days < 1 || $days > 366) {
             throw new \InvalidArgumentException('The --days option must be between 1 and 366.');
         }

--- a/src/Kpi/UI/Console/Input/KpiAggregateInput.php
+++ b/src/Kpi/UI/Console/Input/KpiAggregateInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Kpi\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class KpiAggregateInput
+{
+    #[Option(description: 'Aggregate a single calendar day (YYYY-MM-DD, Europe/Berlin).')]
+    public ?string $date = null;
+
+    #[Option(description: 'When --date is omitted: number of days to aggregate ending yesterday (default: 30, matches dashboard). Use 1 for cron.')]
+    #[Assert\Range(min: 1, max: 366)]
+    public int $days = 30;
+}

--- a/src/Statistics/AnalysisExplorer/UI/Console/ExplorerSystemViewSyncCommand.php
+++ b/src/Statistics/AnalysisExplorer/UI/Console/ExplorerSystemViewSyncCommand.php
@@ -7,26 +7,21 @@ namespace App\Statistics\AnalysisExplorer\UI\Console;
 use App\Statistics\AnalysisExplorer\Application\ExplorerSystemViewSeeder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'statistics:explorer-views:sync',
     description: 'Insert or update system demo views for Analysis Explorer V2.',
 )]
-final class ExplorerSystemViewSyncCommand extends Command
+final readonly class ExplorerSystemViewSyncCommand
 {
     public function __construct(
-        private readonly ExplorerSystemViewSeeder $seeder,
+        private ExplorerSystemViewSeeder $seeder,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
         $io->title('Sync Analysis Explorer system views');
 
         $result = $this->seeder->sync();

--- a/src/Statistics/CaseFlow/UI/Command/BuildCaseFlowGeoJsonCommand.php
+++ b/src/Statistics/CaseFlow/UI/Command/BuildCaseFlowGeoJsonCommand.php
@@ -7,8 +7,6 @@ namespace App\Statistics\CaseFlow\UI\Command;
 use App\Statistics\CaseFlow\Infrastructure\GeoJson\HessenDispatchAreaGeoJsonBuilder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Yaml\Yaml;
@@ -17,21 +15,17 @@ use Symfony\Component\Yaml\Yaml;
     name: 'app:case-flow:build-geojson',
     description: 'Build merged Hessen dispatch-area GeoJSON for Case flow map overlays',
 )]
-final class BuildCaseFlowGeoJsonCommand extends Command
+final readonly class BuildCaseFlowGeoJsonCommand
 {
     public function __construct(
-        private readonly HessenDispatchAreaGeoJsonBuilder $builder,
+        private HessenDispatchAreaGeoJsonBuilder $builder,
         #[Autowire('%kernel.project_dir%')]
-        private readonly string $projectDir,
+        private string $projectDir,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
-
         $sourcesPath = $this->projectDir.'/config/case_flow/dispatch_area_geo_sources.yaml';
         $rawPath = $this->projectDir.'/assets/geo/.source/hessen-kreise-raw.geojson';
         $outputPath = $this->projectDir.'/assets/geo/hessen-landkreise.geojson';

--- a/src/Statistics/HospitalPopulation/UI/Command/GeocodeHospitalCoordinatesCommand.php
+++ b/src/Statistics/HospitalPopulation/UI/Command/GeocodeHospitalCoordinatesCommand.php
@@ -5,31 +5,27 @@ declare(strict_types=1);
 namespace App\Statistics\HospitalPopulation\UI\Command;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Statistics\HospitalPopulation\Infrastructure\Geocoding\HospitalPopulationCoordinates;
 use App\Statistics\HospitalPopulation\Infrastructure\Geocoding\HospitalPopulationGeocodingLookupFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:hospital-population:geocode',
     description: 'Fill missing hospital coordinates from static geocoding lookup',
 )]
-final class GeocodeHospitalCoordinatesCommand extends Command
+final readonly class GeocodeHospitalCoordinatesCommand
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly HospitalPopulationGeocodingLookupFactory $geocodingLookupFactory,
+        private EntityManagerInterface $entityManager,
+        private HospitalPopulationGeocodingLookupFactory $geocodingLookupFactory,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io): int
     {
-        $io = new SymfonyStyle($input, $output);
         $lookup = $this->geocodingLookupFactory->create();
 
         /** @var list<Hospital> $hospitals */
@@ -50,7 +46,7 @@ final class GeocodeHospitalCoordinatesCommand extends Command
                 $hospital->getDispatchArea()?->getName(),
             );
 
-            if (!$coordinates instanceof \App\Statistics\HospitalPopulation\Infrastructure\Geocoding\HospitalPopulationCoordinates) {
+            if (!$coordinates instanceof HospitalPopulationCoordinates) {
                 ++$skipped;
                 continue;
             }

--- a/src/Statistics/UI/Console/Command/DeduplicateProjectionCommand.php
+++ b/src/Statistics/UI/Console/Command/DeduplicateProjectionCommand.php
@@ -10,12 +10,12 @@ use App\Statistics\Application\Projection\Dto\DeduplicationReport;
 use App\Statistics\Application\Projection\Dto\DeduplicationStrategySummary;
 use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
 use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use App\Statistics\UI\Console\Input\DeduplicateProjectionInput;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -23,32 +23,23 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:projection:deduplicate',
     description: 'Detect and remove duplicate allocation_stats_projection rows caused by duplicate allocations.',
 )]
-final class DeduplicateProjectionCommand extends Command
+final readonly class DeduplicateProjectionCommand
 {
     private const int PROGRESS_BAR_THRESHOLD = 100;
 
     public function __construct(
-        private readonly AllocationProjectionDeduplicator $deduplicator,
-        private readonly MaterializedViewRefresher $materializedViewRefresher,
-        private readonly Connection $connection,
+        private AllocationProjectionDeduplicator $deduplicator,
+        private MaterializedViewRefresher $materializedViewRefresher,
+        private Connection $connection,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report duplicates without deleting (default)')
-            ->addOption('execute', null, InputOption::VALUE_NONE, 'Delete duplicates, remove orphan projections, and refresh materialized views');
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-        $execute = (bool) $input->getOption('execute');
-        $dryRun = !$execute || (bool) $input->getOption('dry-run');
+    public function __invoke(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        #[MapInput] DeduplicateProjectionInput $input,
+    ): int {
+        $dryRun = !$input->execute || $input->dryRun;
 
         $io->title('Deduplicate allocation_stats_projection');
 

--- a/src/Statistics/UI/Console/Command/RebuildAllocationStatsProjectionCommand.php
+++ b/src/Statistics/UI/Console/Command/RebuildAllocationStatsProjectionCommand.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -18,22 +17,19 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'app:statistics:rebuild-projection',
     description: 'Rebuild allocation_stats_projection from existing allocations.',
 )]
-final class RebuildAllocationStatsProjectionCommand extends Command
+final readonly class RebuildAllocationStatsProjectionCommand
 {
     private const int GC_EVERY_N_IMPORTS = 25;
 
     public function __construct(
-        private readonly Connection $connection,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly AllocationStatsProjectionRebuildInterface $rebuilder,
+        private Connection $connection,
+        private EntityManagerInterface $entityManager,
+        private AllocationStatsProjectionRebuildInterface $rebuilder,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    public function __invoke(SymfonyStyle $io, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
         $io->title('Rebuilding allocation_stats_projection');
 
         $startedAt = microtime(true);

--- a/src/Statistics/UI/Console/Command/RefreshMaterializedViewsCommand.php
+++ b/src/Statistics/UI/Console/Command/RefreshMaterializedViewsCommand.php
@@ -7,41 +7,27 @@ namespace App\Statistics\UI\Console\Command;
 use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
 use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:statistics:refresh-mviews',
     description: 'Refresh statistics materialized views (all groups by default).',
 )]
-final class RefreshMaterializedViewsCommand extends Command
+final readonly class RefreshMaterializedViewsCommand
 {
     public function __construct(
-        private readonly MaterializedViewRefresher $materializedViewRefresher,
+        private MaterializedViewRefresher $materializedViewRefresher,
     ) {
-        parent::__construct();
     }
 
-    #[\Override]
-    protected function configure(): void
-    {
-        $this->addOption(
-            'overview',
-            null,
-            InputOption::VALUE_NONE,
-            'Refresh only overview materialized views (state/dispatch hospital counts and hospital dimensions)',
-        );
-    }
-
-    #[\Override]
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $io = new SymfonyStyle($input, $output);
-
-        $groups = $input->getOption('overview')
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Refresh only overview materialized views (state/dispatch hospital counts and hospital dimensions)')]
+        bool $overview = false,
+    ): int {
+        $groups = $overview
             ? [StatisticsMaterializedViewGroups::OVERVIEW]
             : [];
 

--- a/src/Statistics/UI/Console/Input/DeduplicateProjectionInput.php
+++ b/src/Statistics/UI/Console/Input/DeduplicateProjectionInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+
+final class DeduplicateProjectionInput
+{
+    #[Option(description: 'Only report duplicates without deleting (default)', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    #[Option(description: 'Delete duplicates, remove orphan projections, and refresh materialized views')]
+    public bool $execute = false;
+}

--- a/src/Statistics/UI/Http/Controller/ReportsController.php
+++ b/src/Statistics/UI/Http/Controller/ReportsController.php
@@ -98,7 +98,7 @@ final class ReportsController extends AbstractController
             'overviewPeriodViewModel' => $overviewPeriodViewModel,
             'statsUseOverviewPeriodControls' => true,
             'reportsPage' => $reportsPage,
-            'statsExplorerSections' => $this->statisticsExplorerViewModelFactory->create($request, 'reports', null, $definition->key()),
+            'statsExplorerSections' => $this->statisticsExplorerViewModelFactory->create($request, 'reports', $definition->key()),
             'statsFilterDrawerValues' => $drawerState['values'],
             'statsActiveFilterCount' => $drawerState['activeCount'],
             'statsFilterDrawerResetUrl' => $this->generateUrl('app_stats_reports'),

--- a/src/Statistics/UI/Http/Controller/StatisticsExplorerViewModelFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsExplorerViewModelFactory.php
@@ -29,7 +29,6 @@ final readonly class StatisticsExplorerViewModelFactory
     public function create(
         Request $request,
         string $currentPage,
-        ?string $currentAnalysisKey = null,
         ?string $currentReportKey = null,
     ): array {
         if ('dashboard' === $currentPage) {


### PR DESCRIPTION
## Summary

This PR modernizes all 19 application console commands for Symfony 8.1. Instead of `extends Command` with `configure()` and manual `$input->getOption()` calls, commands are now invokable classes that declare CLI input via attributes and receive `SymfonyStyle` through method injection.

The CLI surface is unchanged: command names, option names, defaults, and exit codes behave as before. Existing functional command tests continue to pass without modification.

## What changed

**Invokable commands**
All app commands now use `__invoke()` instead of `execute()`. Parameterless maintenance commands only inject `SymfonyStyle`; commands with progress bars additionally receive `OutputInterface`.

**Attribute-based input**
Commands with few options use `#[Option]` and `#[Argument]` directly on `__invoke()` parameters. Commands with richer input use dedicated `#[MapInput]` DTOs under `src/{Context}/UI/Console/Input/`, with validator constraints where validation already existed.

**Notable details**
- New backed enum `RejectAnalysisExportFormat` for import reject export formats
- `RequeueAllImportsCommand` keeps `SignalableCommandInterface` as an invokable command
- `ImportRequeueInput` maps to the existing application DTO `ImportRequeueBatchOptions`
- Obsolete `RedundantCast` suppressions for console commands were removed from `psalm.xml`
- Unused `$currentAnalysisKey` parameter removed from `StatisticsExplorerViewModelFactory`

## Notes

`#[MapEntity]` is not used yet: the attribute is not available in the installed Symfony 8.1.0 console bridge, so hospital lookup in `MonthlyReminderPreviewCommand` still goes through `HospitalRepository`. Date parsing for KPI aggregation lives in `KpiAggregateInput` and the command’s existing validation logic, because `BuiltinTypeValueResolver` resolves `#[Option]` values before `DateTimeValueResolver` on direct `__invoke()` parameters.