### PR TITLE
fix(overview): merge scoped and all-time overview slice query

### DIFF
--- a/src/Statistics/Application/Overview/OverviewChartsFactory.php
+++ b/src/Statistics/Application/Overview/OverviewChartsFactory.php
@@ -27,16 +27,11 @@ final readonly class OverviewChartsFactory
         BenchmarkReport $benchmarkReport,
     ): OverviewChartsViewModel {
         $slice = ($this->sliceQuery)($criteria);
-        $allTimeSlice = ($this->sliceQuery)(new OverviewQueryCriteria(
-            null,
-            null,
-            $criteria->hospitalIds,
-        ));
         $total = $metrics->scopedTotal;
 
         $dayTimeHeatmap = $this->indicationDashboardAssembler->buildDayTimeHeatmap($slice->dayTimeHeatmapCells);
         $shiftHeatmap = $this->indicationDashboardAssembler->buildShiftHeatmap($slice->shiftHeatmapCells);
-        $timeSeries = $this->indicationDashboardAssembler->buildTimeSeries($allTimeSlice->monthlyRows);
+        $timeSeries = $this->indicationDashboardAssembler->buildTimeSeries($slice->monthlyRows);
 
         return new OverviewChartsViewModel(
             [

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewSliceQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewSliceQuery.php
@@ -21,11 +21,51 @@ final readonly class OverviewSliceQuery
             return OverviewSliceData::empty();
         }
 
-        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
-
+        $needsAllTimeMonthlyRows = $criteria->from instanceof \DateTimeImmutable || $criteria->toExclusive instanceof \DateTimeImmutable;
         $transportBucketCase = StatisticsTransportTimeBucketSql::CASE_EXPRESSION;
 
-        $sql = <<<SQL
+        if ($needsAllTimeMonthlyRows) {
+            [$scopedWhere, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+            [$allTimeWhere] = OverviewProjectionSqlFilter::buildWhereClause(new OverviewQueryCriteria(
+                null,
+                null,
+                $criteria->hospitalIds,
+            ));
+
+            $sql = <<<SQL
+WITH scoped_slice AS (
+    SELECT
+        transport_time_minutes,
+        created_weekday,
+        day_time_bucket_code,
+        shift_bucket_code
+    FROM allocation_stats_projection
+    WHERE {$scopedWhere}
+),
+all_time_slice AS (
+    SELECT
+        created_year,
+        created_month
+    FROM allocation_stats_projection
+    WHERE {$allTimeWhere}
+)
+SELECT 'time_series_all_time' AS slice_kind, created_year::text AS dim1, created_month::text AS dim2, COUNT(*)::int AS count
+FROM all_time_slice GROUP BY created_year, created_month
+UNION ALL
+SELECT 'transport_time', bucket, NULL, COUNT(*)::int
+FROM (SELECT {$transportBucketCase} AS bucket FROM scoped_slice) grouped
+GROUP BY bucket
+UNION ALL
+SELECT 'day_time_heatmap', created_weekday::text, day_time_bucket_code::text, COUNT(*)::int
+FROM scoped_slice GROUP BY created_weekday, day_time_bucket_code
+UNION ALL
+SELECT 'shift_heatmap', created_weekday::text, shift_bucket_code::text, COUNT(*)::int
+FROM scoped_slice GROUP BY created_weekday, shift_bucket_code
+SQL;
+        } else {
+            [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
+
+            $sql = <<<SQL
 WITH slice AS (
     SELECT
         created_year,
@@ -50,6 +90,7 @@ UNION ALL
 SELECT 'shift_heatmap', created_weekday::text, shift_bucket_code::text, COUNT(*)::int
 FROM slice GROUP BY created_weekday, shift_bucket_code
 SQL;
+        }
 
         /** @var list<array{slice_kind:string,dim1:?string,dim2:?string,count:int|string}> $rows */
         $rows = $this->connection->fetchAllAssociative($sql, $params);
@@ -74,7 +115,7 @@ SQL;
             $dim2 = $row['dim2'] ?? '';
 
             match ($kind) {
-                'time_series' => $monthlyRows[] = [
+                'time_series', 'time_series_all_time' => $monthlyRows[] = [
                     'year' => (int) $dim1,
                     'month' => (int) $dim2,
                     'count' => $count,

--- a/tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php
+++ b/tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php
@@ -15,6 +15,7 @@ use Zenstruck\Foundry\Test\Factories;
 /**
  * Baseline before optimization (Jun 2026): 44 queries / ~299 ms on /statistics/ with broad hospital scope.
  * Target after Phase 1+2: ~18–22 queries on the synchronous overview path.
+ * All-time time series is loaded in the same OverviewSliceQuery as scoped heatmaps (no extra round-trip).
  */
 #[ResetDatabase]
 final class OverviewDashboardQueryCountTest extends WebTestCase

--- a/tests/Statistics/Integration/Query/Overview/OverviewSliceQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/OverviewSliceQueryTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\Overview;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use App\Statistics\Infrastructure\Query\Overview\OverviewSliceQuery;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class OverviewSliceQueryTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testReturnsAllTimeMonthlyRowsWithScopedHeatmaps(): void
+    {
+        self::bootKernel();
+
+        [$hospital, $import, $state, $dispatchArea] = $this->seedHospitalWithImport();
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::GROUND,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:30:00'),
+        ]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'createdAt' => new \DateTimeImmutable('2024-01-10 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2024-01-10 08:20:00'),
+        ]);
+
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($import->getId());
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospital->getId(),
+            null,
+            StatisticsFilterPeriod::Month,
+            2025,
+            6,
+        );
+        $bounds = StatisticsPeriodResolver::resolve($filter);
+        $criteria = OverviewQueryCriteria::fromPeriodBounds($bounds, [$hospital->getId()]);
+
+        $slice = self::getContainer()->get(OverviewSliceQuery::class)($criteria);
+
+        self::assertSame(
+            [
+                ['year' => 2024, 'month' => 1, 'count' => 1],
+                ['year' => 2025, 'month' => 6, 'count' => 1],
+            ],
+            $slice->monthlyRows,
+        );
+        self::assertSame(1, $this->sumHeatmapCounts($slice->dayTimeHeatmapCells));
+        self::assertSame(1, $this->sumHeatmapCounts($slice->shiftHeatmapCells));
+        self::assertSame(1, array_sum($slice->transportTimeBucketCounts));
+    }
+
+    public function testAllTimePeriodUsesSingleSlice(): void
+    {
+        self::bootKernel();
+
+        [$hospital, $import, $state, $dispatchArea] = $this->seedHospitalWithImport();
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::GROUND,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:30:00'),
+        ]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'createdAt' => new \DateTimeImmutable('2024-01-10 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2024-01-10 08:20:00'),
+        ]);
+
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($import->getId());
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospital->getId(),
+            null,
+            StatisticsFilterPeriod::AllTime,
+        );
+        $bounds = StatisticsPeriodResolver::resolve($filter);
+        $criteria = OverviewQueryCriteria::fromPeriodBounds($bounds, [$hospital->getId()]);
+
+        $slice = self::getContainer()->get(OverviewSliceQuery::class)($criteria);
+
+        self::assertSame(
+            [
+                ['year' => 2024, 'month' => 1, 'count' => 1],
+                ['year' => 2025, 'month' => 6, 'count' => 1],
+            ],
+            $slice->monthlyRows,
+        );
+        self::assertSame(2, $this->sumHeatmapCounts($slice->dayTimeHeatmapCells));
+        self::assertSame(2, array_sum($slice->transportTimeBucketCounts));
+    }
+
+    /**
+     * @return array{0: object, 1: object, 2: object, 3: object}
+     */
+    private function seedHospitalWithImport(): array
+    {
+        $user = UserFactory::createOne(['username' => 'overview-slice-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'OverviewSliceState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'OverviewSliceDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'OverviewSliceHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'OverviewSliceSpec']);
+        DepartmentFactory::createOne(['name' => 'OverviewSliceDept']);
+        AssignmentFactory::createOne(['name' => 'OverviewSliceAssign']);
+        IndicationRawFactory::createOne(['name' => 'OverviewSliceRaw', 'code' => 912_351]);
+        IndicationNormalizedFactory::createOne(['name' => 'OverviewSliceNorm']);
+
+        $import = ImportFactory::createOne(['name' => 'OverviewSliceImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        return [$hospital, $import, $state, $dispatchArea];
+    }
+
+    /**
+     * @param list<array{count:int}> $cells
+     */
+    private function sumHeatmapCounts(array $cells): int
+    {
+        return array_sum(array_column($cells, 'count'));
+    }
+}


### PR DESCRIPTION
## Summary

- Merges scoped overview slice data (heatmaps, transport-time buckets) and all-time monthly rows into a single `OverviewSliceQuery` round-trip.
- Removes the duplicate slice query from `OverviewChartsFactory` introduced in PR #226 while keeping overview charts aligned with Analysis Explorer (`allocations-over-time` uses all-time data).
- Restores the synchronous overview dashboard query budget (`OverviewDashboardQueryCountTest` stays at ≤ 30 queries).

## Test plan

- [x] `php bin/phpunit tests/Statistics/Integration/Query/Overview/OverviewSliceQueryTest.php`
- [x] `php bin/phpunit tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php`
- [x] `php bin/phpunit tests/Statistics/Functional/Controller/DashboardControllerTest.php`