### PR TITLE
feat(explorer): group edit drawer dropdowns by clinical category

### DIFF
--- a/src/Statistics/AnalysisExplorer/Application/ExplorerChoiceGrouper.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerChoiceGrouper.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class ExplorerChoiceGrouper
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @template T
+     *
+     * @param list<T>             $items
+     * @param list<string>        $groupOrder          translation keys in display order
+     * @param callable(T): string $groupTranslationKey
+     * @param callable(T): string $label
+     * @param callable(T): string $value
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function groupChoices(
+        array $items,
+        array $groupOrder,
+        callable $groupTranslationKey,
+        callable $label,
+        callable $value,
+        string $locale = 'en',
+    ): array {
+        /** @var array<string, list<array{label: string, value: string}>> $buckets */
+        $buckets = [];
+
+        foreach ($items as $item) {
+            $groupKey = $groupTranslationKey($item);
+            $buckets[$groupKey][] = [
+                'label' => $label($item),
+                'value' => $value($item),
+            ];
+        }
+
+        $collator = new \Collator($locale);
+        $grouped = [];
+
+        foreach ($groupOrder as $groupKey) {
+            if (!isset($buckets[$groupKey])) {
+                continue;
+            }
+
+            $grouped[$this->translator->trans($groupKey)] = $this->sortedChoices(
+                $buckets[$groupKey],
+                $collator,
+            );
+            unset($buckets[$groupKey]);
+        }
+
+        foreach ($buckets as $groupKey => $choices) {
+            $grouped[$this->translator->trans($groupKey)] = $this->sortedChoices(
+                $choices,
+                $collator,
+            );
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * @param list<array{label: string, value: string}> $choices
+     *
+     * @return array<string, string>
+     */
+    private function sortedChoices(array $choices, \Collator $collator): array
+    {
+        usort(
+            $choices,
+            static fn (array $left, array $right): int => $collator->compare($left['label'], $right['label']),
+        );
+
+        $sorted = [];
+        foreach ($choices as $choice) {
+            $sorted[$choice['label']] = $choice['value'];
+        }
+
+        return $sorted;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerDimensionCatalog.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerDimensionCatalog.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\ExplorerDimensionCategory;
+
+final class ExplorerDimensionCatalog
+{
+    /**
+     * @return list<ExplorerDimensionCategory>
+     */
+    public function categoryOrderFor(AnalysisDataSourceKey $dataSourceKey): array
+    {
+        return match ($dataSourceKey) {
+            AnalysisDataSourceKey::Allocations => [
+                ExplorerDimensionCategory::TimeAndCalendar,
+                ExplorerDimensionCategory::MissionAndAllocation,
+                ExplorerDimensionCategory::PatientAndDemographics,
+                ExplorerDimensionCategory::ClinicalCare,
+                ExplorerDimensionCategory::TransportAndDuration,
+                ExplorerDimensionCategory::HospitalAndGeography,
+            ],
+            AnalysisDataSourceKey::Hospitals => [
+                ExplorerDimensionCategory::HospitalProfile,
+                ExplorerDimensionCategory::GeographyAndParticipation,
+            ],
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function categoryGroupOrderFor(AnalysisDataSourceKey $dataSourceKey): array
+    {
+        return array_map(
+            static fn (ExplorerDimensionCategory $category): string => $category->labelTranslationKey(),
+            $this->categoryOrderFor($dataSourceKey),
+        );
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerEditChoicePresenter.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerEditChoicePresenter.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDimensionKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisMetricKey;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class ExplorerEditChoicePresenter
+{
+    public function __construct(
+        private ExplorerChoiceGrouper $choiceGrouper,
+        private ExplorerDimensionCatalog $dimensionCatalog,
+        private ExplorerMetricCatalog $metricCatalog,
+        private ExplorerMetricProfileRegistry $profileRegistry,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @param list<AnalysisDimensionKey> $dimensions
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function groupedDimensionChoices(
+        array $dimensions,
+        AnalysisDataSourceKey $dataSourceKey,
+        string $locale = 'en',
+    ): array {
+        return $this->choiceGrouper->groupChoices(
+            $dimensions,
+            $this->dimensionCatalog->categoryGroupOrderFor($dataSourceKey),
+            fn (AnalysisDimensionKey $dimension): string => $dimension
+                ->explorerCategory($dataSourceKey)
+                ->labelTranslationKey(),
+            fn (AnalysisDimensionKey $dimension): string => $this->translator->trans(
+                'stats.analysis_explorer.dimension.'.$dimension->value,
+            ),
+            static fn (AnalysisDimensionKey $dimension): string => $dimension->value,
+            $locale,
+        );
+    }
+
+    /**
+     * @param list<AnalysisMetricKey> $metrics
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function groupedMetricChoices(
+        array $metrics,
+        AnalysisDataSourceKey $dataSourceKey,
+        string $locale = 'en',
+    ): array {
+        return $this->choiceGrouper->groupChoices(
+            $metrics,
+            $this->metricCatalog->metricGroupOrderFor($dataSourceKey),
+            static fn (AnalysisMetricKey $metric): string => $metric->explorerGroupTranslationKey(),
+            fn (AnalysisMetricKey $metric): string => $this->metricChoiceLabel($metric),
+            static fn (AnalysisMetricKey $metric): string => $metric->value,
+            $locale,
+        );
+    }
+
+    private function metricChoiceLabel(AnalysisMetricKey $metric): string
+    {
+        $profile = $this->profileRegistry->profileFor($metric);
+        if ($profile instanceof \App\Statistics\AnalysisExplorer\Domain\DTO\ExplorerMetricProfileDefinition) {
+            return $this->translator->trans($profile->labelTranslationKey);
+        }
+
+        return $this->translator->trans('stats.analysis_explorer.metric.'.$metric->value);
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerMetricCatalog.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerMetricCatalog.php
@@ -96,4 +96,25 @@ final class ExplorerMetricCatalog
 
         return $keys;
     }
+
+    /**
+     * @return list<string>
+     */
+    public function metricGroupOrderFor(AnalysisDataSourceKey $dataSourceKey): array
+    {
+        return match ($dataSourceKey) {
+            AnalysisDataSourceKey::Allocations => [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.clinical_rates',
+                'stats.analysis_explorer.metric_group.shares',
+                'stats.analysis_explorer.metric_group.transport_times',
+            ],
+            AnalysisDataSourceKey::Hospitals => [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.beds',
+                'stats.analysis_explorer.metric_group.allocations',
+                'stats.analysis_explorer.metric_group.transport_times',
+            ],
+        };
+    }
 }

--- a/src/Statistics/AnalysisExplorer/Domain/Enum/AnalysisDimensionKey.php
+++ b/src/Statistics/AnalysisExplorer/Domain/Enum/AnalysisDimensionKey.php
@@ -60,6 +60,57 @@ enum AnalysisDimensionKey: string
         return $this->value;
     }
 
+    public function explorerCategory(AnalysisDataSourceKey $dataSourceKey): ExplorerDimensionCategory
+    {
+        return match ($dataSourceKey) {
+            AnalysisDataSourceKey::Allocations => match ($this) {
+                self::Time,
+                self::Weekday,
+                self::Hour,
+                self::DayTimeBucket,
+                self::ShiftBucket => ExplorerDimensionCategory::TimeAndCalendar,
+                self::Occasion,
+                self::Assignment,
+                self::Indication,
+                self::SecondaryIndication,
+                self::Speciality,
+                self::Department,
+                self::TransportType,
+                self::Urgency => ExplorerDimensionCategory::MissionAndAllocation,
+                self::Gender,
+                self::AgeGroup,
+                self::Infection,
+                self::Pregnancy,
+                self::WorkAccident => ExplorerDimensionCategory::PatientAndDemographics,
+                self::Resus,
+                self::Cathlab,
+                self::Cpr,
+                self::Ventilation,
+                self::Shock,
+                self::WithPhysician,
+                self::ClinicalResources,
+                self::ClinicalFeatures => ExplorerDimensionCategory::ClinicalCare,
+                self::TransportTimeBucket => ExplorerDimensionCategory::TransportAndDuration,
+                self::Hospital,
+                self::HospitalCohort,
+                self::State,
+                self::DispatchArea => ExplorerDimensionCategory::HospitalAndGeography,
+                default => throw new \LogicException(sprintf('Dimension "%s" is not part of the allocations explorer catalog.', $this->value)),
+            },
+            AnalysisDataSourceKey::Hospitals => match ($this) {
+                self::HospitalEntity,
+                self::HospitalLocation,
+                self::HospitalMasterCohort,
+                self::HospitalSize,
+                self::HospitalTier => ExplorerDimensionCategory::HospitalProfile,
+                self::HospitalDispatchArea,
+                self::HospitalPopulationGroup,
+                self::HospitalState => ExplorerDimensionCategory::GeographyAndParticipation,
+                default => throw new \LogicException(sprintf('Dimension "%s" is not part of the hospitals explorer catalog.', $this->value)),
+            },
+        };
+    }
+
     /**
      * @return list<self>
      */

--- a/src/Statistics/AnalysisExplorer/Domain/Enum/AnalysisMetricKey.php
+++ b/src/Statistics/AnalysisExplorer/Domain/Enum/AnalysisMetricKey.php
@@ -212,6 +212,41 @@ enum AnalysisMetricKey: string
         };
     }
 
+    public function explorerGroupTranslationKey(): string
+    {
+        return match ($this) {
+            self::AllocationCount, self::HospitalCount => 'stats.analysis_explorer.metric_group.counts',
+            self::PrevalenceRate => 'stats.analysis_explorer.metric_group.shares',
+            self::ResusRate,
+            self::CprRate,
+            self::ShockRate,
+            self::VentilationRate,
+            self::CathlabRate,
+            self::PregnancyRate,
+            self::WorkAccidentRate,
+            self::WithPhysicianRate,
+            self::InfectionRate => 'stats.analysis_explorer.metric_group.clinical_rates',
+            self::SumBeds,
+            self::AvgBeds,
+            self::MinBeds,
+            self::MaxBeds,
+            self::BedsDistribution => 'stats.analysis_explorer.metric_group.beds',
+            self::TotalAllocations,
+            self::AvgAllocationsPerHospital,
+            self::MinAllocations,
+            self::MaxAllocations,
+            self::AllocationsPerHospitalDistribution => 'stats.analysis_explorer.metric_group.allocations',
+            self::TransportTimeDistribution,
+            self::TransportTimePerHospitalDistribution,
+            self::MeanTransportTime,
+            self::MedianTransportTime,
+            self::P25TransportTime,
+            self::P75TransportTime,
+            self::P90TransportTime => 'stats.analysis_explorer.metric_group.transport_times',
+            default => 'stats.analysis_explorer.metric_group.counts',
+        };
+    }
+
     /**
      * @param list<self> $metricKeys
      *

--- a/src/Statistics/AnalysisExplorer/Domain/Enum/ExplorerDimensionCategory.php
+++ b/src/Statistics/AnalysisExplorer/Domain/Enum/ExplorerDimensionCategory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Domain\Enum;
+
+enum ExplorerDimensionCategory: string
+{
+    case TimeAndCalendar = 'time_and_calendar';
+    case MissionAndAllocation = 'mission_and_allocation';
+    case PatientAndDemographics = 'patient_and_demographics';
+    case ClinicalCare = 'clinical_care';
+    case TransportAndDuration = 'transport_and_duration';
+    case HospitalAndGeography = 'hospital_and_geography';
+    case HospitalProfile = 'hospital_profile';
+    case GeographyAndParticipation = 'geography_and_participation';
+
+    public function labelTranslationKey(): string
+    {
+        return 'stats.analysis_explorer.dimension_group.'.$this->value;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/UI/Form/ExplorerAdditionalTableMetricsType.php
+++ b/src/Statistics/AnalysisExplorer/UI/Form/ExplorerAdditionalTableMetricsType.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\UI\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<list<string>>
+ */
+final class ExplorerAdditionalTableMetricsType extends AbstractType
+{
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'explorer_metric_groups' => [],
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+        ]);
+
+        $resolver->setAllowedTypes('explorer_metric_groups', 'array');
+    }
+
+    #[\Override]
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['explorer_metric_groups'] = $options['explorer_metric_groups'];
+    }
+
+    #[\Override]
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/UI/Form/ExplorerEditFormType.php
+++ b/src/Statistics/AnalysisExplorer/UI/Form/ExplorerEditFormType.php
@@ -8,8 +8,8 @@ use App\Statistics\AnalysisExplorer\Application\AnalysisAxisResolver;
 use App\Statistics\AnalysisExplorer\Application\DataSourceCapabilitiesRegistry;
 use App\Statistics\AnalysisExplorer\Application\ExplorerColumnGrainResolver;
 use App\Statistics\AnalysisExplorer\Application\ExplorerConfigPreviewFactory;
+use App\Statistics\AnalysisExplorer\Application\ExplorerEditChoicePresenter;
 use App\Statistics\AnalysisExplorer\Application\ExplorerMetricCapabilityPolicy;
-use App\Statistics\AnalysisExplorer\Application\ExplorerMetricProfileRegistry;
 use App\Statistics\AnalysisExplorer\Application\ExplorerStatisticsFilterInputFactory;
 use App\Statistics\AnalysisExplorer\Domain\DTO\AnalysisAxisRef;
 use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
@@ -49,7 +49,7 @@ final class ExplorerEditFormType extends AbstractType
         private readonly ExplorerConfigPreviewFactory $previewFactory,
         private readonly ExplorerColumnGrainResolver $columnGrainResolver,
         private readonly ExplorerMetricCapabilityPolicy $metricCapabilityPolicy,
-        private readonly ExplorerMetricProfileRegistry $profileRegistry,
+        private readonly ExplorerEditChoicePresenter $editChoicePresenter,
         private readonly ExplorerStatisticsFilterInputFactory $filterInputFactory,
         private readonly StatisticsFilterFactory $statisticsFilterFactory,
         private readonly AnalysisAxisResolver $axisResolver,
@@ -104,7 +104,7 @@ final class ExplorerEditFormType extends AbstractType
             }
         });
 
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($locale): void {
             $submitted = $event->getData();
             if (!\is_array($submitted)) {
                 return;
@@ -119,10 +119,10 @@ final class ExplorerEditFormType extends AbstractType
 
             /** @var \Symfony\Component\Form\FormInterface<ExplorerEditFormData> $form */
             $form = $event->getForm();
-            $this->configureDynamicChoices($form, $preview);
+            $this->configureDynamicChoices($form, $preview, $locale);
         });
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($locale): void {
             $formData = $event->getData();
             if (!$formData instanceof ExplorerEditFormData) {
                 return;
@@ -130,7 +130,7 @@ final class ExplorerEditFormType extends AbstractType
 
             /** @var \Symfony\Component\Form\FormInterface<ExplorerEditFormData> $form */
             $form = $event->getForm();
-            $event->setData($this->configureDynamicChoices($form, $formData));
+            $event->setData($this->configureDynamicChoices($form, $formData, $locale));
         });
     }
 
@@ -182,8 +182,11 @@ final class ExplorerEditFormType extends AbstractType
     /**
      * @param \Symfony\Component\Form\FormInterface<ExplorerEditFormData> $form
      */
-    private function configureDynamicChoices(\Symfony\Component\Form\FormInterface $form, ExplorerEditFormData $formData): ExplorerEditFormData
-    {
+    private function configureDynamicChoices(
+        \Symfony\Component\Form\FormInterface $form,
+        ExplorerEditFormData $formData,
+        string $locale,
+    ): ExplorerEditFormData {
         $user = $this->security->getUser();
         $filter = $this->statisticsFilterFactory->createFromInput(
             $this->filterInputFactory->fromSideFormData($formData->scopePeriod),
@@ -220,7 +223,11 @@ final class ExplorerEditFormType extends AbstractType
         $form->add('rowDimension', ChoiceType::class, [
             'label' => 'stats.analysis_explorer.edit.row_dimension',
             'help' => 'stats.analysis_explorer.edit.row_dimension_help',
-            'choices' => $this->dimensionChoices($capabilities->dimensions),
+            'choices' => $this->editChoicePresenter->groupedDimensionChoices(
+                $capabilities->dimensions,
+                $dataSourceKey,
+                $locale,
+            ),
         ]);
 
         $form->add('rowGrain', ChoiceType::class, [
@@ -236,7 +243,7 @@ final class ExplorerEditFormType extends AbstractType
         $form->add('columnDimension', ChoiceType::class, [
             'label' => 'stats.analysis_explorer.edit.column_dimension',
             'help' => 'stats.analysis_explorer.edit.column_dimension_help',
-            'choices' => $this->columnDimensionChoices($rowAxis, $capabilities),
+            'choices' => $this->columnDimensionChoices($rowAxis, $capabilities, $dataSourceKey, $locale),
         ]);
 
         $columnGrainChoices = [];
@@ -253,10 +260,16 @@ final class ExplorerEditFormType extends AbstractType
             'disabled' => !$showColumnGrain,
         ]);
 
+        $groupedMetricChoices = $this->editChoicePresenter->groupedMetricChoices(
+            $compatibleMetrics,
+            $dataSourceKey,
+            $locale,
+        );
+
         $form->add('metric', ChoiceType::class, [
             'label' => 'stats.analysis_explorer.edit.chart_metric',
             'help' => 'stats.analysis_explorer.edit.chart_metric_help',
-            'choices' => $this->groupedMetricChoices($compatibleMetrics),
+            'choices' => $groupedMetricChoices,
         ]);
 
         $form->add('showPercentOfTotal', CheckboxType::class, [
@@ -266,13 +279,17 @@ final class ExplorerEditFormType extends AbstractType
             'disabled' => $isDistributionProfile || !$this->metricCapabilityPolicy->canShowPercentOfTotal($previewConfig),
         ]);
 
-        $form->add('additionalTableMetrics', ChoiceType::class, [
+        $groupedAdditionalMetricChoices = $this->editChoicePresenter->groupedMetricChoices(
+            $additionalMetricChoices,
+            $dataSourceKey,
+            $locale,
+        );
+
+        $form->add('additionalTableMetrics', ExplorerAdditionalTableMetricsType::class, [
             'label' => 'stats.analysis_explorer.edit.additional_table_metrics',
             'help' => 'stats.analysis_explorer.edit.additional_table_metrics_help',
-            'choices' => $this->groupedMetricChoices($additionalMetricChoices),
-            'multiple' => true,
-            'expanded' => true,
-            'required' => false,
+            'choices' => $this->flattenGroupedChoices($groupedAdditionalMetricChoices),
+            'explorer_metric_groups' => $groupedAdditionalMetricChoices,
             'disabled' => $isDistributionProfile || AnalysisDataSourceKey::Hospitals !== $dataSourceKey || [] === $additionalMetricChoices,
         ]);
 
@@ -425,82 +442,41 @@ final class ExplorerEditFormType extends AbstractType
     }
 
     /**
-     * @param list<AnalysisDimensionKey> $dimensions
-     *
-     * @return array<string, string>
-     */
-    private function dimensionChoices(array $dimensions): array
-    {
-        $choices = [];
-        foreach ($dimensions as $dimension) {
-            $choices[$this->translator->trans('stats.analysis_explorer.dimension.'.$dimension->value)] = $dimension->value;
-        }
-
-        return $choices;
-    }
-
-    /**
-     * @return array<string, string>
+     * @return array<string, array<string, string>|string>
      */
     private function columnDimensionChoices(
         AnalysisAxisRef $rowAxis,
         \App\Statistics\AnalysisExplorer\Domain\DataSourceCapabilities $capabilities,
+        AnalysisDataSourceKey $dataSourceKey,
+        string $locale,
     ): array {
-        $choices = [
-            $this->translator->trans('stats.analysis_explorer.edit.columns_none') => self::NONE_COLUMN,
-        ];
-
-        foreach ($capabilities->columnDimensionsFor($rowAxis) as $dimension) {
-            $choices[$this->translator->trans('stats.analysis_explorer.dimension.'.$dimension->value)] = $dimension->value;
-        }
-
-        return $choices;
+        return array_merge(
+            [
+                $this->translator->trans('stats.analysis_explorer.edit.columns_none') => self::NONE_COLUMN,
+            ],
+            $this->editChoicePresenter->groupedDimensionChoices(
+                $capabilities->columnDimensionsFor($rowAxis),
+                $dataSourceKey,
+                $locale,
+            ),
+        );
     }
 
     /**
-     * @param list<AnalysisMetricKey> $metrics
+     * @param array<string, array<string, string>> $groupedChoices
      *
-     * @return array<string, array<string, string>>
+     * @return array<string, string>
      */
-    private function groupedMetricChoices(array $metrics): array
+    private function flattenGroupedChoices(array $groupedChoices): array
     {
-        $grouped = [];
-        foreach ($metrics as $metric) {
-            $groupLabel = $this->translator->trans($this->metricGroupTranslationKey($metric));
-            $grouped[$groupLabel][$this->metricChoiceLabel($metric)] = $metric->value;
+        $flat = [];
+        foreach ($groupedChoices as $choices) {
+            foreach ($choices as $label => $value) {
+                $flat[$label] = $value;
+            }
         }
 
-        return $grouped;
-    }
-
-    private function metricGroupTranslationKey(AnalysisMetricKey $metric): string
-    {
-        $profile = $this->profileRegistry->profileFor($metric);
-        if ($profile instanceof \App\Statistics\AnalysisExplorer\Domain\DTO\ExplorerMetricProfileDefinition) {
-            return $profile->groupTranslationKey;
-        }
-
-        return match ($metric) {
-            AnalysisMetricKey::SumBeds,
-            AnalysisMetricKey::AvgBeds,
-            AnalysisMetricKey::MinBeds,
-            AnalysisMetricKey::MaxBeds => 'stats.analysis_explorer.metric_group.beds',
-            AnalysisMetricKey::TotalAllocations,
-            AnalysisMetricKey::AvgAllocationsPerHospital,
-            AnalysisMetricKey::MinAllocations,
-            AnalysisMetricKey::MaxAllocations => 'stats.analysis_explorer.metric_group.allocations',
-            default => 'stats.analysis_explorer.metric_group.counts',
-        };
-    }
-
-    private function metricChoiceLabel(AnalysisMetricKey $metric): string
-    {
-        $profile = $this->profileRegistry->profileFor($metric);
-        if ($profile instanceof \App\Statistics\AnalysisExplorer\Domain\DTO\ExplorerMetricProfileDefinition) {
-            return $this->translator->trans($profile->labelTranslationKey);
-        }
-
-        return $this->translator->trans('stats.analysis_explorer.metric.'.$metric->value);
+        return $flat;
     }
 
     /**

--- a/src/Statistics/UI/Twig/templates/analysis_explorer/_edit_drawer.html.twig
+++ b/src/Statistics/UI/Twig/templates/analysis_explorer/_edit_drawer.html.twig
@@ -194,7 +194,23 @@
                                 {% endif %}
                                 {% if not form.additionalTableMetrics.vars.disabled %}
                                     <div class="mt-3" data-testid="stats-analysis-explorer-additional-table-metrics-field">
-                                        {{ form_row(form.additionalTableMetrics, compactRow|merge({attr: refreshAttrs})) }}
+                                        {{ form_label(form.additionalTableMetrics) }}
+                                        {% if form.additionalTableMetrics.vars.help is not empty %}
+                                            <p class="form-text mt-0 mb-2">{{ form.additionalTableMetrics.vars.help|trans }}</p>
+                                        {% endif %}
+                                        {% for groupLabel, groupChoices in form.additionalTableMetrics.vars.explorer_metric_groups %}
+                                            <fieldset class="border-0 p-0 mb-2">
+                                                <legend class="fs-6 fw-semibold mb-1">{{ groupLabel }}</legend>
+                                                {% for label, value in groupChoices %}
+                                                    {% for child in form.additionalTableMetrics %}
+                                                        {% if child.vars.value == value %}
+                                                            {{ form_row(child, compactRow|merge({attr: refreshAttrs})) }}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                {% endfor %}
+                                            </fieldset>
+                                        {% endfor %}
+                                        {{ form_errors(form.additionalTableMetrics) }}
                                     </div>
                                 {% endif %}
                             </fieldset>

--- a/tests/Statistics/Functional/Controller/AnalysisExplorerLibraryControllerTest.php
+++ b/tests/Statistics/Functional/Controller/AnalysisExplorerLibraryControllerTest.php
@@ -46,7 +46,7 @@ final class AnalysisExplorerLibraryControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-analysis-explorer-view-card-'.$view->getId().'"]');
         $this->assertSelectorTextContains(
             '[data-testid="stats-analysis-explorer-view-card-'.$view->getId().'"]',
-            'Total allocations',
+            'Time period',
         );
         $this->assertSelectorExists('[data-testid="stats-analysis-explorer-open-'.$view->getId().'"]');
         $this->assertSelectorExists('[data-testid="stats-analysis-explorer-category-badge-allocations"]');

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerLibraryPageViewModelFactoryTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerLibraryPageViewModelFactoryTest.php
@@ -62,7 +62,7 @@ final class AnalysisExplorerLibraryPageViewModelFactoryTest extends KernelTestCa
         self::assertNotNull($overTime?->getId());
         $card = $cardsById[$overTime->getId()];
 
-        self::assertSame('Total allocations', $card['dimension']);
+        self::assertSame('Time period', $card['dimension']);
         self::assertSame('Month', $card['grain']);
         self::assertSame('Line chart', $card['chartType']);
         self::assertTrue($card['isSystem']);

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Statistics\Integration\AnalysisExplorer;
 
 use App\Statistics\AnalysisExplorer\Application\DefaultAnalysisViewFactory;
+use App\Statistics\AnalysisExplorer\Application\DefaultHospitalsAnalysisViewFactory;
 use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewLoader;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewService;
@@ -120,6 +121,61 @@ final class AnalysisExplorerShellTest extends WebTestCase
             0,
             $render->crawler()->filter('[data-testid="stats-analysis-explorer-structure-metric"]')->count(),
         );
+    }
+
+    public function testOpenEditGroupsRowDimensionChoices(): void
+    {
+        $testComponent = $this->createShellComponent();
+        $testComponent->render();
+        $testComponent->call('openEdit');
+
+        $render = $testComponent->render();
+        $rowDimensionSelect = $render->crawler()->filter('select[name*="rowDimension"]');
+        self::assertGreaterThan(0, $rowDimensionSelect->count());
+        self::assertGreaterThan(
+            0,
+            $rowDimensionSelect->filter('optgroup[label="Time and calendar"] option')->count(),
+        );
+        self::assertGreaterThan(
+            0,
+            $rowDimensionSelect->filter('optgroup[label="Clinical care"] option')->count(),
+        );
+    }
+
+    public function testOpenEditGroupsMetricChoices(): void
+    {
+        $testComponent = $this->createShellComponent();
+        $testComponent->render();
+        $testComponent->call('openEdit');
+
+        $render = $testComponent->render();
+        $metricSelect = $render->crawler()->filter('select[name*="metric"]');
+        self::assertGreaterThan(0, $metricSelect->count());
+        self::assertGreaterThan(
+            0,
+            $metricSelect->filter('optgroup[label="Clinical rates"] option')->count(),
+        );
+        self::assertGreaterThan(
+            0,
+            $metricSelect->filter('optgroup[label="Counts"] option')->count(),
+        );
+    }
+
+    public function testOpenEditGroupsHospitalAdditionalTableMetrics(): void
+    {
+        $testComponent = $this->createHospitalsShellComponent();
+        $testComponent->render();
+        $testComponent->call('openEdit');
+
+        $render = $testComponent->render();
+        $field = $render->crawler()->filter('[data-testid="stats-analysis-explorer-additional-table-metrics-field"]');
+        self::assertGreaterThan(0, $field->count());
+        self::assertGreaterThan(0, $field->filter('fieldset legend')->count());
+
+        $legendTexts = $field->filter('fieldset legend')->each(
+            static fn (\Symfony\Component\DomCrawler\Crawler $legend): string => trim($legend->text()),
+        );
+        self::assertContains('Beds', $legendTexts);
     }
 
     public function testMountDowngradesManipulatedHospitalAxisOnPublicScope(): void
@@ -804,6 +860,26 @@ final class AnalysisExplorerShellTest extends WebTestCase
         $user = UserFactory::createOne(['username' => 'explorer-live-'.bin2hex(random_bytes(4))]);
         $mapper = self::getContainer()->get(ExplorerConfigMapper::class);
         $viewFactory = self::getContainer()->get(DefaultAnalysisViewFactory::class);
+        $filter = new StatisticsFilter(
+            scope: StatisticsFilterScope::Public,
+            hospitalId: null,
+            cohortType: null,
+            period: StatisticsFilterPeriod::All,
+        );
+        $defaultConfig = $viewFactory->createDefault($filter);
+
+        return $this->createLiveComponent('AnalysisExplorerShell', [
+            'appliedConfigState' => $mapper->toStateArray($defaultConfig),
+            'locale' => 'en',
+            'libraryUrl' => '/statistics/analysis/library',
+        ])->actingAs($user);
+    }
+
+    private function createHospitalsShellComponent(): \Symfony\UX\LiveComponent\Test\TestLiveComponent
+    {
+        $user = UserFactory::createOne(['username' => 'explorer-hospitals-'.bin2hex(random_bytes(4))]);
+        $mapper = self::getContainer()->get(ExplorerConfigMapper::class);
+        $viewFactory = self::getContainer()->get(DefaultHospitalsAnalysisViewFactory::class);
         $filter = new StatisticsFilter(
             scope: StatisticsFilterScope::Public,
             hospitalId: null,

--- a/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionKeyCategoryTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionKeyCategoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDimensionKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisMetricKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\ExplorerDimensionCategory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AnalysisDimensionKeyCategoryTest extends TestCase
+{
+    #[DataProvider('allocationsCategoryProvider')]
+    public function testAllocationsExplorerCategory(AnalysisDimensionKey $dimension, ExplorerDimensionCategory $expected): void
+    {
+        self::assertSame(
+            $expected,
+            $dimension->explorerCategory(AnalysisDataSourceKey::Allocations),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{AnalysisDimensionKey, ExplorerDimensionCategory}>
+     */
+    public static function allocationsCategoryProvider(): iterable
+    {
+        yield 'time' => [AnalysisDimensionKey::Time, ExplorerDimensionCategory::TimeAndCalendar];
+        yield 'hour' => [AnalysisDimensionKey::Hour, ExplorerDimensionCategory::TimeAndCalendar];
+        yield 'indication' => [AnalysisDimensionKey::Indication, ExplorerDimensionCategory::MissionAndAllocation];
+        yield 'gender' => [AnalysisDimensionKey::Gender, ExplorerDimensionCategory::PatientAndDemographics];
+        yield 'resus' => [AnalysisDimensionKey::Resus, ExplorerDimensionCategory::ClinicalCare];
+        yield 'shock' => [AnalysisDimensionKey::Shock, ExplorerDimensionCategory::ClinicalCare];
+        yield 'transport_time_bucket' => [AnalysisDimensionKey::TransportTimeBucket, ExplorerDimensionCategory::TransportAndDuration];
+        yield 'hospital' => [AnalysisDimensionKey::Hospital, ExplorerDimensionCategory::HospitalAndGeography];
+    }
+
+    public function testHospitalsExplorerCategory(): void
+    {
+        self::assertSame(
+            ExplorerDimensionCategory::HospitalProfile,
+            AnalysisDimensionKey::HospitalEntity->explorerCategory(AnalysisDataSourceKey::Hospitals),
+        );
+        self::assertSame(
+            ExplorerDimensionCategory::GeographyAndParticipation,
+            AnalysisDimensionKey::HospitalState->explorerCategory(AnalysisDataSourceKey::Hospitals),
+        );
+    }
+
+    public function testAllAllocationsCatalogDimensionsHaveExplorerCategory(): void
+    {
+        foreach (AnalysisDimensionKey::allocationsCatalog() as $dimension) {
+            $category = $dimension->explorerCategory(AnalysisDataSourceKey::Allocations);
+
+            self::assertContains(
+                $category,
+                new \App\Statistics\AnalysisExplorer\Application\ExplorerDimensionCatalog()->categoryOrderFor(
+                    AnalysisDataSourceKey::Allocations,
+                ),
+                sprintf('Unexpected category for allocations dimension "%s".', $dimension->value),
+            );
+        }
+    }
+
+    public function testAllHospitalsCatalogDimensionsHaveExplorerCategory(): void
+    {
+        foreach (AnalysisDimensionKey::hospitalsCatalog() as $dimension) {
+            $category = $dimension->explorerCategory(AnalysisDataSourceKey::Hospitals);
+
+            self::assertContains(
+                $category,
+                new \App\Statistics\AnalysisExplorer\Application\ExplorerDimensionCatalog()->categoryOrderFor(
+                    AnalysisDataSourceKey::Hospitals,
+                ),
+                sprintf('Unexpected category for hospitals dimension "%s".', $dimension->value),
+            );
+        }
+    }
+
+    public function testMetricGroupTranslationKeys(): void
+    {
+        self::assertSame(
+            'stats.analysis_explorer.metric_group.clinical_rates',
+            AnalysisMetricKey::ResusRate->explorerGroupTranslationKey(),
+        );
+        self::assertSame(
+            'stats.analysis_explorer.metric_group.clinical_rates',
+            AnalysisMetricKey::ShockRate->explorerGroupTranslationKey(),
+        );
+        self::assertSame(
+            'stats.analysis_explorer.metric_group.shares',
+            AnalysisMetricKey::PrevalenceRate->explorerGroupTranslationKey(),
+        );
+        self::assertSame(
+            'stats.analysis_explorer.metric_group.allocations',
+            AnalysisMetricKey::TotalAllocations->explorerGroupTranslationKey(),
+        );
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerCatalogGroupOrderTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerCatalogGroupOrderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerDimensionCatalog;
+use App\Statistics\AnalysisExplorer\Application\ExplorerMetricCatalog;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class ExplorerCatalogGroupOrderTest extends TestCase
+{
+    public function testAllocationsMetricGroupOrder(): void
+    {
+        $catalog = new ExplorerMetricCatalog(new MetricRegistry());
+
+        self::assertSame(
+            [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.clinical_rates',
+                'stats.analysis_explorer.metric_group.shares',
+                'stats.analysis_explorer.metric_group.transport_times',
+            ],
+            $catalog->metricGroupOrderFor(AnalysisDataSourceKey::Allocations),
+        );
+    }
+
+    public function testHospitalsMetricGroupOrder(): void
+    {
+        $catalog = new ExplorerMetricCatalog(new MetricRegistry());
+
+        self::assertSame(
+            [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.beds',
+                'stats.analysis_explorer.metric_group.allocations',
+                'stats.analysis_explorer.metric_group.transport_times',
+            ],
+            $catalog->metricGroupOrderFor(AnalysisDataSourceKey::Hospitals),
+        );
+    }
+
+    public function testDimensionCategoryGroupOrderMatchesCategoryLabels(): void
+    {
+        $catalog = new ExplorerDimensionCatalog();
+
+        self::assertSame(
+            array_map(
+                static fn (\App\Statistics\AnalysisExplorer\Domain\Enum\ExplorerDimensionCategory $category): string => $category->labelTranslationKey(),
+                $catalog->categoryOrderFor(AnalysisDataSourceKey::Allocations),
+            ),
+            $catalog->categoryGroupOrderFor(AnalysisDataSourceKey::Allocations),
+        );
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerChoiceGrouperTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerChoiceGrouperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerChoiceGrouper;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisMetricKey;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ExplorerChoiceGrouperTest extends TestCase
+{
+    public function testGroupsChoicesInConfiguredOrderAndSortsAlphabeticallyWithinGroup(): void
+    {
+        $grouper = new ExplorerChoiceGrouper($this->translator());
+
+        $grouped = $grouper->groupChoices(
+            [
+                AnalysisMetricKey::ShockRate,
+                AnalysisMetricKey::CprRate,
+                AnalysisMetricKey::AllocationCount,
+                AnalysisMetricKey::PrevalenceRate,
+            ],
+            [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.clinical_rates',
+                'stats.analysis_explorer.metric_group.shares',
+            ],
+            static fn (AnalysisMetricKey $metric): string => $metric->explorerGroupTranslationKey(),
+            static fn (AnalysisMetricKey $metric): string => match ($metric) {
+                AnalysisMetricKey::AllocationCount => 'Allocations',
+                AnalysisMetricKey::CprRate => 'CPR rate',
+                AnalysisMetricKey::ShockRate => 'Shock rate',
+                AnalysisMetricKey::PrevalenceRate => 'Share within category (%)',
+            },
+            static fn (AnalysisMetricKey $metric): string => $metric->value,
+            'en',
+        );
+
+        self::assertSame(
+            ['Allocations' => 'allocation_count'],
+            $grouped['Counts'],
+        );
+        self::assertSame(
+            ['CPR rate' => 'cpr_rate', 'Shock rate' => 'shock_rate'],
+            $grouped['Clinical rates'],
+        );
+        self::assertSame(
+            ['Share within category (%)' => 'prevalence_rate'],
+            $grouped['Shares and distribution'],
+        );
+    }
+
+    public function testSkipsEmptyGroups(): void
+    {
+        $grouper = new ExplorerChoiceGrouper($this->translator());
+
+        $grouped = $grouper->groupChoices(
+            [AnalysisMetricKey::HospitalCount],
+            [
+                'stats.analysis_explorer.metric_group.counts',
+                'stats.analysis_explorer.metric_group.beds',
+            ],
+            static fn (AnalysisMetricKey $metric): string => $metric->explorerGroupTranslationKey(),
+            static fn (AnalysisMetricKey $metric): string => $metric->value,
+            static fn (AnalysisMetricKey $metric): string => $metric->value,
+            'en',
+        );
+
+        self::assertCount(1, $grouped);
+        self::assertArrayHasKey('Counts', $grouped);
+    }
+
+    private function translator(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'stats.analysis_explorer.metric_group.counts' => 'Counts',
+                'stats.analysis_explorer.metric_group.clinical_rates' => 'Clinical rates',
+                'stats.analysis_explorer.metric_group.shares' => 'Shares and distribution',
+                'stats.analysis_explorer.metric_group.beds' => 'Beds',
+                default => $id,
+            },
+        );
+
+        return $translator;
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditChoicePresenterTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditChoicePresenterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerChoiceGrouper;
+use App\Statistics\AnalysisExplorer\Application\ExplorerDimensionCatalog;
+use App\Statistics\AnalysisExplorer\Application\ExplorerEditChoicePresenter;
+use App\Statistics\AnalysisExplorer\Application\ExplorerMetricCatalog;
+use App\Statistics\AnalysisExplorer\Application\ExplorerMetricProfileRegistry;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDimensionKey;
+use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisMetricKey;
+use App\Statistics\GenericAnalysis\Registry\MetricRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ExplorerEditChoicePresenterTest extends TestCase
+{
+    public function testGroupedDimensionChoicesUseCategoryOrderAndAlphabeticalLabels(): void
+    {
+        $presenter = $this->presenter();
+
+        $grouped = $presenter->groupedDimensionChoices(
+            [
+                AnalysisDimensionKey::Hospital,
+                AnalysisDimensionKey::Hour,
+                AnalysisDimensionKey::Resus,
+                AnalysisDimensionKey::Indication,
+            ],
+            AnalysisDataSourceKey::Allocations,
+            'en',
+        );
+
+        self::assertSame(
+            ['Time and calendar', 'Mission and allocation', 'Clinical care', 'Hospital and geography'],
+            array_keys($grouped),
+        );
+        self::assertSame('hour', $grouped['Time and calendar']['Hour']);
+        self::assertSame('indication', $grouped['Mission and allocation']['Indication']);
+        self::assertSame('resus', $grouped['Clinical care']['Resuscitation room required']);
+        self::assertSame('hospital', $grouped['Hospital and geography']['Hospital']);
+    }
+
+    public function testGroupedMetricChoicesSeparateClinicalRatesFromCounts(): void
+    {
+        $presenter = $this->presenter();
+
+        $grouped = $presenter->groupedMetricChoices(
+            [
+                AnalysisMetricKey::ResusRate,
+                AnalysisMetricKey::AllocationCount,
+                AnalysisMetricKey::PrevalenceRate,
+            ],
+            AnalysisDataSourceKey::Allocations,
+            'en',
+        );
+
+        self::assertSame(['Counts', 'Clinical rates', 'Shares and distribution'], array_keys($grouped));
+        self::assertArrayHasKey('Resuscitation room rate', $grouped['Clinical rates']);
+    }
+
+    public function testGroupedMetricChoicesForHospitalsFollowConfiguredGroupOrder(): void
+    {
+        $presenter = $this->presenter();
+
+        $grouped = $presenter->groupedMetricChoices(
+            [
+                AnalysisMetricKey::TransportTimePerHospitalDistribution,
+                AnalysisMetricKey::HospitalCount,
+                AnalysisMetricKey::SumBeds,
+                AnalysisMetricKey::TotalAllocations,
+            ],
+            AnalysisDataSourceKey::Hospitals,
+            'en',
+        );
+
+        self::assertSame(
+            ['Counts', 'Beds', 'Allocations', 'Transport times'],
+            array_keys($grouped),
+        );
+    }
+
+    private function presenter(): ExplorerEditChoicePresenter
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'stats.analysis_explorer.dimension_group.time_and_calendar' => 'Time and calendar',
+                'stats.analysis_explorer.dimension_group.mission_and_allocation' => 'Mission and allocation',
+                'stats.analysis_explorer.dimension_group.clinical_care' => 'Clinical care',
+                'stats.analysis_explorer.dimension_group.hospital_and_geography' => 'Hospital and geography',
+                'stats.analysis_explorer.metric_group.counts' => 'Counts',
+                'stats.analysis_explorer.metric_group.clinical_rates' => 'Clinical rates',
+                'stats.analysis_explorer.metric_group.shares' => 'Shares and distribution',
+                'stats.analysis_explorer.metric_group.beds' => 'Beds',
+                'stats.analysis_explorer.metric_group.allocations' => 'Allocations',
+                'stats.analysis_explorer.metric_group.transport_times' => 'Transport times',
+                'stats.analysis_explorer.dimension.hour' => 'Hour',
+                'stats.analysis_explorer.dimension.indication' => 'Indication',
+                'stats.analysis_explorer.dimension.resus' => 'Resuscitation room required',
+                'stats.analysis_explorer.dimension.hospital' => 'Hospital',
+                'stats.analysis_explorer.metric.allocation_count' => 'Allocations',
+                'stats.analysis_explorer.metric.resus_rate' => 'Resuscitation room rate',
+                'stats.analysis_explorer.metric.prevalence_rate' => 'Share within category (%)',
+                'stats.analysis_explorer.metric.hospital_count' => 'Hospitals',
+                'stats.analysis_explorer.metric.sum_beds' => 'Total beds',
+                'stats.analysis_explorer.metric.total_allocations' => 'Total allocations',
+                'stats.analysis_explorer.metric_profile.transport_time_per_hospital_distribution' => 'Transport time per hospital distribution (box plot)',
+                default => $id,
+            },
+        );
+
+        return new ExplorerEditChoicePresenter(
+            new ExplorerChoiceGrouper($translator),
+            new ExplorerDimensionCatalog(),
+            new ExplorerMetricCatalog(new MetricRegistry()),
+            new ExplorerMetricProfileRegistry(),
+            $translator,
+        );
+    }
+}

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -7049,7 +7049,7 @@
       </trans-unit>
       <trans-unit id="statsAexM02" resname="stats.analysis_explorer.metric.resus_rate">
         <source>stats.analysis_explorer.metric.resus_rate</source>
-        <target>Resus rate</target>
+        <target>Resuscitation room rate</target>
       </trans-unit>
       <trans-unit id="statsAexM03" resname="stats.analysis_explorer.metric.cpr_rate">
         <source>stats.analysis_explorer.metric.cpr_rate</source>
@@ -7077,7 +7077,7 @@
       </trans-unit>
       <trans-unit id="statsAexM09" resname="stats.analysis_explorer.metric.with_physician_rate">
         <source>stats.analysis_explorer.metric.with_physician_rate</source>
-        <target>Physician accompaniment rate</target>
+        <target>Physician escort rate</target>
       </trans-unit>
       <trans-unit id="statsAexM09b" resname="stats.analysis_explorer.metric.infection_rate">
         <source>stats.analysis_explorer.metric.infection_rate</source>
@@ -7085,7 +7085,7 @@
       </trans-unit>
       <trans-unit id="statsAexM09c" resname="stats.analysis_explorer.metric.prevalence_rate">
         <source>stats.analysis_explorer.metric.prevalence_rate</source>
-        <target>Share of allocations (%)</target>
+        <target>Share within category (%)</target>
       </trans-unit>
       <trans-unit id="statsAexM10" resname="stats.analysis_explorer.edit.show_percent_of_total">
         <source>stats.analysis_explorer.edit.show_percent_of_total</source>
@@ -7149,7 +7149,7 @@
       </trans-unit>
       <trans-unit id="statsAex19" resname="stats.analysis_explorer.dimension.time">
         <source>stats.analysis_explorer.dimension.time</source>
-        <target>Total allocations</target>
+        <target>Time period</target>
       </trans-unit>
       <trans-unit id="statsAex20" resname="stats.analysis_explorer.dimension.gender">
         <source>stats.analysis_explorer.dimension.gender</source>
@@ -7545,7 +7545,7 @@
       </trans-unit>
       <trans-unit id="statsAex99" resname="stats.analysis_explorer.dimension.hospital_cohort">
         <source>stats.analysis_explorer.dimension.hospital_cohort</source>
-        <target>Hospital cohort</target>
+        <target>Hospital cohort (allocation)</target>
       </trans-unit>
       <trans-unit id="statsAex100" resname="stats.analysis_explorer.dimension.speciality">
         <source>stats.analysis_explorer.dimension.speciality</source>
@@ -7593,7 +7593,7 @@
       </trans-unit>
       <trans-unit id="statsAex108b" resname="stats.analysis_explorer.dimension.transport_time_bucket">
         <source>stats.analysis_explorer.dimension.transport_time_bucket</source>
-        <target>Transport time bucket</target>
+        <target>Transport time (intervals)</target>
       </trans-unit>
       <trans-unit id="statsAex109" resname="stats.analysis_explorer.dimension.day_time_bucket">
         <source>stats.analysis_explorer.dimension.day_time_bucket</source>
@@ -7605,7 +7605,7 @@
       </trans-unit>
       <trans-unit id="statsAex111" resname="stats.analysis_explorer.dimension.resus">
         <source>stats.analysis_explorer.dimension.resus</source>
-        <target>Resuscitation required</target>
+        <target>Resuscitation room required</target>
       </trans-unit>
       <trans-unit id="statsAex112" resname="stats.analysis_explorer.dimension.cathlab">
         <source>stats.analysis_explorer.dimension.cathlab</source>
@@ -7613,7 +7613,7 @@
       </trans-unit>
       <trans-unit id="statsAex113" resname="stats.analysis_explorer.dimension.cpr">
         <source>stats.analysis_explorer.dimension.cpr</source>
-        <target>CPR</target>
+        <target>CPR performed</target>
       </trans-unit>
       <trans-unit id="statsAex114" resname="stats.analysis_explorer.dimension.ventilation">
         <source>stats.analysis_explorer.dimension.ventilation</source>
@@ -7633,7 +7633,7 @@
       </trans-unit>
       <trans-unit id="statsAex118" resname="stats.analysis_explorer.dimension.with_physician">
         <source>stats.analysis_explorer.dimension.with_physician</source>
-        <target>Physician accompaniment</target>
+        <target>Physician escort</target>
       </trans-unit>
       <trans-unit id="statsAex119" resname="stats.analysis_explorer.dimension.hospital">
         <source>stats.analysis_explorer.dimension.hospital</source>
@@ -7947,6 +7947,46 @@
         <source>stats.analysis_explorer.metric_group.transport_times</source>
         <target>Transport times</target>
       </trans-unit>
+      <trans-unit id="statsAexMg05" resname="stats.analysis_explorer.metric_group.clinical_rates">
+        <source>stats.analysis_explorer.metric_group.clinical_rates</source>
+        <target>Clinical rates</target>
+      </trans-unit>
+      <trans-unit id="statsAexMg06" resname="stats.analysis_explorer.metric_group.shares">
+        <source>stats.analysis_explorer.metric_group.shares</source>
+        <target>Shares and distribution</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg01" resname="stats.analysis_explorer.dimension_group.time_and_calendar">
+        <source>stats.analysis_explorer.dimension_group.time_and_calendar</source>
+        <target>Time and calendar</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg02" resname="stats.analysis_explorer.dimension_group.mission_and_allocation">
+        <source>stats.analysis_explorer.dimension_group.mission_and_allocation</source>
+        <target>Mission and allocation</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg03" resname="stats.analysis_explorer.dimension_group.patient_and_demographics">
+        <source>stats.analysis_explorer.dimension_group.patient_and_demographics</source>
+        <target>Patient and demographics</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg04" resname="stats.analysis_explorer.dimension_group.clinical_care">
+        <source>stats.analysis_explorer.dimension_group.clinical_care</source>
+        <target>Clinical care</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg05" resname="stats.analysis_explorer.dimension_group.transport_and_duration">
+        <source>stats.analysis_explorer.dimension_group.transport_and_duration</source>
+        <target>Transport and duration</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg06" resname="stats.analysis_explorer.dimension_group.hospital_and_geography">
+        <source>stats.analysis_explorer.dimension_group.hospital_and_geography</source>
+        <target>Hospital and geography</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg07" resname="stats.analysis_explorer.dimension_group.hospital_profile">
+        <source>stats.analysis_explorer.dimension_group.hospital_profile</source>
+        <target>Hospital profile</target>
+      </trans-unit>
+      <trans-unit id="statsAexDg08" resname="stats.analysis_explorer.dimension_group.geography_and_participation">
+        <source>stats.analysis_explorer.dimension_group.geography_and_participation</source>
+        <target>Geography and participation</target>
+      </trans-unit>
       <trans-unit id="statsAexBx01" resname="stats.analysis_explorer.box_plot.column.distribution_count">
         <source>stats.analysis_explorer.box_plot.column.distribution_count</source>
         <target>n</target>
@@ -7973,7 +8013,7 @@
       </trans-unit>
       <trans-unit id="statsAexHd01" resname="stats.analysis_explorer.dimension.hospital_master_cohort">
         <source>stats.analysis_explorer.dimension.hospital_master_cohort</source>
-        <target>Master cohort</target>
+        <target>Hospital cohort (master data)</target>
       </trans-unit>
       <trans-unit id="statsAexHd02" resname="stats.analysis_explorer.dimension.hospital_tier">
         <source>stats.analysis_explorer.dimension.hospital_tier</source>


### PR DESCRIPTION
## Summary

This PR improves the **Analysis Explorer edit drawer** by grouping long, hard-to-scan dropdown lists into logical categories. Row/column dimensions and metrics are now rendered with **optgroups**, sorted **alphabetically within each group**, and use clearer **English labels** for clinically ambiguous options (especially resuscitation room vs. shock).

Saved analysis configurations remain unchanged — only UI labels and dropdown structure are affected.

## What changed

### Grouped dropdown structure
- **Row & column dimensions** are grouped into categories such as *Time and calendar*, *Mission and allocation*, *Clinical care*, and *Hospital and geography* (allocations) or *Hospital profile* / *Geography and participation* (hospitals).
- **Metrics** are grouped into *Counts*, *Clinical rates*, *Shares and distribution*, *Beds*, *Allocations*, and *Transport times* (depending on data source).
- **Additional hospital table metrics** are shown as fieldsets with group legends instead of a flat checkbox list.

### Domain & application layer
- New `ExplorerDimensionCategory` enum and category mapping on `AnalysisDimensionKey`.
- Central metric group mapping via `AnalysisMetricKey::explorerGroupTranslationKey()`.
- `ExplorerChoiceGrouper` for locale-aware alphabetical sorting within groups.
- `ExplorerEditChoicePresenter` to build grouped choice lists for the form.

### Label improvements (EN only)
- `time` → **Time period** (was misleadingly “Total allocations”)
- `resus` / `resus_rate` → **Resuscitation room required** / **Resuscitation room rate**
- `cpr` → **CPR performed**
- `with_physician` → **Physician escort**
- `prevalence_rate` → **Share within category (%)**
- Plus new `dimension_group.*` and `metric_group.clinical_rates` / `shares` translation keys

Individual boolean dimensions (`resus`, `cpr`, `shock`, etc.) remain available alongside aggregate dimensions (`clinical_resources`, `clinical_features`).

## Backwards compatibility

| Area | Impact |
|---|---|
| `config_json` / saved views | **No change** — technical keys unchanged |
| API / URLs | **No change** |
| EN UI labels | Cosmetic update only |

## Test plan

- [x] Unit tests for grouper, category mapping, catalog group order, and choice presenter
- [x] Integration tests verifying optgroups in row/metric dropdowns and fieldset grouping for hospital additional metrics
- [x] `make ci` passes (PHPStan, Psalm, linters)