### PR TITLE
feat(user): add show/hide password toggle for password fields

### DIFF
--- a/assets/controllers/password_visibility_controller.js
+++ b/assets/controllers/password_visibility_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['input', 'toggle', 'showIcon', 'hideIcon'];
+
+    static values = {
+        showLabel: String,
+        hideLabel: String,
+    };
+
+    toggle() {
+        const visible = this.inputTarget.type === 'text';
+        this.inputTarget.type = visible ? 'password' : 'text';
+        this.updateUi(!visible);
+    }
+
+    updateUi(pressed) {
+        this.toggleTarget.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+
+        const label = pressed ? this.hideLabelValue : this.showLabelValue;
+        this.toggleTarget.setAttribute('aria-label', label);
+        this.toggleTarget.setAttribute('title', label);
+
+        if (this.hasShowIconTarget) {
+            this.showIconTarget.classList.toggle('d-none', pressed);
+        }
+
+        if (this.hasHideIconTarget) {
+            this.hideIconTarget.classList.toggle('d-none', !pressed);
+        }
+    }
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -386,3 +386,14 @@
     color: inherit;
     text-decoration-color: var(--tblr-secondary, #667382);
 }
+
+.input-group [data-testid^="password-toggle-"] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-inline: 0.5rem;
+}
+
+.input-group [data-testid^="password-toggle-"] .icon {
+    margin: 0;
+}

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -25,7 +25,8 @@ twig:
         '%kernel.project_dir%/src/Shared/UI/Twig/templates': Shared
         '%kernel.project_dir%/src/Statistics/UI/Twig/templates': Statistics
 
-    form_themes: [ 'bootstrap_5_layout.html.twig' ]
+    form_themes:
+        - '@Shared/form/password_visibility_theme.html.twig'
 
 when@test:
     twig:

--- a/src/Shared/UI/Twig/templates/form/password_visibility_theme.html.twig
+++ b/src/Shared/UI/Twig/templates/form/password_visibility_theme.html.twig
@@ -1,0 +1,29 @@
+{% use 'bootstrap_5_layout.html.twig' %}
+
+{%- block password_widget -%}
+    <div data-controller="password-visibility"
+         data-password-visibility-show-label-value="{{ 'label.password.show'|trans }}"
+         data-password-visibility-hide-label-value="{{ 'label.password.hide'|trans }}">
+        <div class="input-group">
+            {%- set type = type|default('password') -%}
+            {%- set attr = attr|merge({'data-password-visibility-target': 'input'}) -%}
+            {{- block('form_widget_simple') -}}
+            <button type="button"
+                    class="btn"
+                    data-password-visibility-target="toggle"
+                    data-action="password-visibility#toggle"
+                    aria-pressed="false"
+                    aria-label="{{ 'label.password.show'|trans }}"
+                    title="{{ 'label.password.show'|trans }}"
+                    aria-controls="{{ id }}"
+                    data-testid="password-toggle-{{ id }}">
+                <span data-password-visibility-target="showIcon">
+                    <twig:ux:icon name="tabler:eye" class="icon" />
+                </span>
+                <span class="d-none" data-password-visibility-target="hideIcon">
+                    <twig:ux:icon name="tabler:eye-off" class="icon" />
+                </span>
+            </button>
+        </div>
+    </div>
+{%- endblock password_widget -%}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -12,6 +12,7 @@ use App\User\Domain\Factory\UserFactory;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Mime\Email;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
@@ -210,5 +211,28 @@ final class RegistrationControllerTest extends WebTestCase
 
         \Zenstruck\Foundry\Persistence\refresh($user);
         self::assertTrue($user->isVerified());
+    }
+
+    public function testRegistrationPasswordFieldHasAccessibleVisibilityToggle(): void
+    {
+        $this->browser()
+            ->visit('/register')
+            ->assertSuccessful()
+            ->assertSeeElement('input[name="registration_form[plainPassword]"][type="password"]')
+            ->assertSeeElement('[data-testid="password-toggle-registration_form_plainPassword"]')
+            ->use(static function (Crawler $crawler): void {
+                $input = $crawler->filter('input[name="registration_form[plainPassword]"]');
+                $toggle = $crawler->filter('[data-testid="password-toggle-registration_form_plainPassword"]');
+
+                self::assertSame('registration_form[plainPassword]', $input->attr('name'));
+                self::assertNull($input->attr('autocomplete'));
+                self::assertSame('password', $input->attr('type'));
+                self::assertSame('button', $toggle->attr('type'));
+                self::assertSame('false', $toggle->attr('aria-pressed'));
+                self::assertSame('registration_form_plainPassword', $toggle->attr('aria-controls'));
+                self::assertNotEmpty($toggle->attr('aria-label'));
+                self::assertSame('Show password', $toggle->attr('aria-label'));
+            })
+        ;
     }
 }

--- a/tests/User/Functional/Controller/SecurityControllerTest.php
+++ b/tests/User/Functional/Controller/SecurityControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\User\Functional\Controller;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
@@ -135,6 +136,29 @@ final class SecurityControllerTest extends WebTestCase
             ->visit('/settings')
             ->assertSuccessful()
             ->assertSee('Login')
+        ;
+    }
+
+    public function testLoginPasswordFieldHasAccessibleVisibilityToggle(): void
+    {
+        $this->browser()
+            ->visit('/login')
+            ->assertSuccessful()
+            ->assertSeeElement('input[name="login[password]"][type="password"]')
+            ->assertSeeElement('[data-testid="password-toggle-login_password"]')
+            ->use(static function (Crawler $crawler): void {
+                $input = $crawler->filter('input[name="login[password]"]');
+                $toggle = $crawler->filter('[data-testid="password-toggle-login_password"]');
+
+                self::assertSame('login[password]', $input->attr('name'));
+                self::assertNull($input->attr('autocomplete'));
+                self::assertSame('password', $input->attr('type'));
+                self::assertSame('button', $toggle->attr('type'));
+                self::assertSame('false', $toggle->attr('aria-pressed'));
+                self::assertSame('login_password', $toggle->attr('aria-controls'));
+                self::assertNotEmpty($toggle->attr('aria-label'));
+                self::assertSame('Show password', $toggle->attr('aria-label'));
+            })
         ;
     }
 }

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -1297,6 +1297,14 @@
         <source>allocation.urgency.3</source>
         <target>Ambulante Versorgung</target>
       </trans-unit>
+      <trans-unit id="pwdShow01De" resname="label.password.show">
+        <source>label.password.show</source>
+        <target>Passwort anzeigen</target>
+      </trans-unit>
+      <trans-unit id="pwdHide01De" resname="label.password.hide">
+        <source>label.password.hide</source>
+        <target>Passwort verbergen</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -1153,6 +1153,14 @@
         <source>label.password</source>
         <target>Password</target>
       </trans-unit>
+      <trans-unit id="pwdShow01" resname="label.password.show">
+        <source>label.password.show</source>
+        <target>Show password</target>
+      </trans-unit>
+      <trans-unit id="pwdHide01" resname="label.password.hide">
+        <source>label.password.hide</source>
+        <target>Hide password</target>
+      </trans-unit>
       <trans-unit id="dzmkSoD" resname="label.pregnant">
         <source>label.pregnant</source>
         <target>Pregnant</target>


### PR DESCRIPTION
## Summary

- Adds a reusable show/hide password toggle for all `PasswordType` fields via a custom Symfony form theme and Stimulus controller.
- Login and registration forms get an icon-only button attached to the password input; tooltip and screen reader labels update on toggle.
- Field names, IDs, and autocomplete behavior remain unchanged to keep password manager compatibility.
- Closes #83 

## Implementation

- Custom form theme: `@Shared/form/password_visibility_theme.html.twig`
- Stimulus controller: `password_visibility_controller.js`
- Translations: `label.password.show` / `label.password.hide` (EN + DE)

## Test plan

- [x] Functional tests for login and registration toggle markup and accessibility attributes
- [x] `make ci` passes locally
- [x] Manual check: toggle shows/hides password on `/login` and `/register`
- [x] Manual check: password manager autofill still works