### PR TITLE
fix(migration): drop projection backfill from deploy migration

### DIFF
--- a/migrations/Version20260624202617.php
+++ b/migrations/Version20260624202617.php
@@ -18,15 +18,6 @@ final class Version20260624202617 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE allocation_stats_projection ADD COLUMN IF NOT EXISTS secondary_transport_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE allocation_stats_projection ADD COLUMN IF NOT EXISTS department_was_closed BOOLEAN DEFAULT NULL');
-
-        $this->addSql(<<<'SQL'
-UPDATE allocation_stats_projection p
-SET
-    secondary_transport_id = a.secondary_transport_id,
-    department_was_closed = a.department_was_closed
-FROM allocation a
-WHERE a.id = p.id
-SQL);
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary

Removes the full-table `UPDATE` backfill from `Version20260624202617` so `doctrine:migrations:migrate` finishes within Deployer's SSH timeout during production deploys.

The migration now only adds the two nullable columns (`secondary_transport_id`, `department_was_closed`) to `allocation_stats_projection`. Existing rows will keep `NULL` until a manual rebuild is run.

## Why

The backfill joined ~2M projection rows against `allocation` synchronously during deploy, causing migrations to exceed Deployer's default timeout and abort the deployment.

## Test plan

- [x] `php bin/console doctrine:migrations:migrate --no-interaction` completes quickly on a database with a large `allocation_stats_projection` table
- [ ] Deploy succeeds end-to-end via Deployer
- [ ] (Optional, post-deploy) Run `app:statistics:rebuild-projection` and `app:statistics:refresh-mviews` to backfill existing rows