### PR TITLE
fix(allocation): Prevent Address embeddable Exception on rendering hospital data

### DIFF
--- a/src/Allocation/Domain/Entity/Address.php
+++ b/src/Allocation/Domain/Entity/Address.php
@@ -12,19 +12,19 @@ use Doctrine\ORM\Mapping as ORM;
 class Address
 {
     #[ORM\Column(type: Types::STRING)]
-    private string $street;
+    private string $street = '';
 
     #[ORM\Column(type: Types::STRING)]
-    private string $postalCode;
+    private string $postalCode = '';
 
     #[ORM\Column(type: Types::STRING)]
-    private string $city;
+    private string $city = '';
 
     #[ORM\Column(type: Types::STRING)]
-    private string $state;
+    private string $state = '';
 
     #[ORM\Column(type: Types::STRING)]
-    private string $country;
+    private string $country = '';
 
     public function getStreet(): string
     {

--- a/tests/Allocation/Unit/Entity/HospitalTest.php
+++ b/tests/Allocation/Unit/Entity/HospitalTest.php
@@ -21,6 +21,7 @@ final class HospitalTest extends TestCase
         $this->assertNull($hospital->getUpdatedAt());
         $this->assertNull($hospital->getName());
         $this->assertNull($hospital->getBeds());
+        $this->assertSame('', $hospital->getAddress()->getStreet());
     }
 
     public function testToStringShowsNameOrFallback(): void


### PR DESCRIPTION
## Summary

Loading `/explore/allocation/{id}` could fail during template rendering with:

> Typed property `App\Allocation\Domain\Entity\Address::$street` must not be accessed before initialization

The root cause was the `Address` embeddable: its fields were declared as non-nullable `string` properties without default values. `Hospital` creates an empty `new Address()` in its constructor. If the address was not fully populated before being read in Twig, accessing the getters triggered this PHP error.

## Solution

Initialize all `Address` properties with empty-string defaults (`''`). This follows the common Doctrine embeddable pattern for typed properties and prevents crashes on newly created hospitals, without changing existing database values.

## Test plan

- [x] Open `/explore/allocation/{id}` for an allocation with a hospital address → page renders without error
- [x] Hospital address is displayed correctly
- [x] `HospitalTest::testConstructorInitializesDefaults` passes