### PR TITLE
feat(export): Add scoped CSV export for owned hospital allocations

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -144,24 +144,28 @@
 }
 
 .filter-drawer .accordion-body,
-.analysis-explorer-edit-drawer .accordion-body {
+.analysis-explorer-edit-drawer .accordion-body,
+.export-filter-accordion .accordion-body {
     padding: 0.375rem 0.5rem;
 }
 
 .filter-drawer .accordion-button,
-.analysis-explorer-edit-drawer .accordion-button {
+.analysis-explorer-edit-drawer .accordion-button,
+.export-filter-accordion .accordion-button {
     font-size: 0.9375rem;
     padding: 0.5rem 0.75rem;
     gap: 0.375rem;
 }
 
 .filter-drawer .accordion-button::after,
-.analysis-explorer-edit-drawer .accordion-button::after {
+.analysis-explorer-edit-drawer .accordion-button::after,
+.export-filter-accordion .accordion-button::after {
     display: none;
 }
 
 .filter-drawer .analysis-explorer-accordion-state-icon,
-.analysis-explorer-edit-drawer .analysis-explorer-accordion-state-icon {
+.analysis-explorer-edit-drawer .analysis-explorer-accordion-state-icon,
+.export-filter-accordion .analysis-explorer-accordion-state-icon {
     display: inline-flex;
     align-items: center;
     flex-shrink: 0;
@@ -169,33 +173,39 @@
 }
 
 .filter-drawer .analysis-explorer-accordion-state-icon .icon,
-.analysis-explorer-edit-drawer .analysis-explorer-accordion-state-icon .icon {
+.analysis-explorer-edit-drawer .analysis-explorer-accordion-state-icon .icon,
+.export-filter-accordion .analysis-explorer-accordion-state-icon .icon {
     width: 1rem;
     height: 1rem;
 }
 
 .filter-drawer .accordion-button .analysis-explorer-accordion-state-icon--expanded,
-.analysis-explorer-edit-drawer .accordion-button .analysis-explorer-accordion-state-icon--expanded {
+.analysis-explorer-edit-drawer .accordion-button .analysis-explorer-accordion-state-icon--expanded,
+.export-filter-accordion .accordion-button .analysis-explorer-accordion-state-icon--expanded {
     display: inline-flex;
 }
 
 .filter-drawer .accordion-button .analysis-explorer-accordion-state-icon--collapsed,
-.analysis-explorer-edit-drawer .accordion-button .analysis-explorer-accordion-state-icon--collapsed {
+.analysis-explorer-edit-drawer .accordion-button .analysis-explorer-accordion-state-icon--collapsed,
+.export-filter-accordion .accordion-button .analysis-explorer-accordion-state-icon--collapsed {
     display: none;
 }
 
 .filter-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--expanded,
-.analysis-explorer-edit-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--expanded {
+.analysis-explorer-edit-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--expanded,
+.export-filter-accordion .accordion-button.collapsed .analysis-explorer-accordion-state-icon--expanded {
     display: none;
 }
 
 .filter-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--collapsed,
-.analysis-explorer-edit-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--collapsed {
+.analysis-explorer-edit-drawer .accordion-button.collapsed .analysis-explorer-accordion-state-icon--collapsed,
+.export-filter-accordion .accordion-button.collapsed .analysis-explorer-accordion-state-icon--collapsed {
     display: inline-flex;
 }
 
 .filter-drawer .accordion-button:not(.collapsed),
-.analysis-explorer-edit-drawer .accordion-button:not(.collapsed) {
+.analysis-explorer-edit-drawer .accordion-button:not(.collapsed),
+.export-filter-accordion .accordion-button:not(.collapsed) {
     box-shadow: none;
 }
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,12 +25,14 @@
         <ClassMustBeFinal>
             <errorLevel type="suppress">
                 <directory name="src/*/Domain/Entity"/>
+                <directory name="src/Shared/Application/Export/"/>
             </errorLevel>
         </ClassMustBeFinal>
         <PossiblyUnusedMethod>
             <errorLevel type="suppress">
                 <file name="src/Shared/Infrastructure/Pagination/Paginator.php" />
                 <file name="src/Shared/Infrastructure/Pagination/CursorPaginator.php" />
+                <directory name="src/Shared/Application/Export/" />
                 <directory name="src/*/Application/Contracts/" />
                 <directory name="src/*/Application/DTO/" />
                 <directory name="src/*/Application/Page/" />
@@ -63,6 +65,8 @@
         <PossiblyUnusedProperty>
             <errorLevel type="suppress">
                 <directory name="src/*/Application/DTO/" />
+                <directory name="src/Allocation/Application/Export/DTO/" />
+                <directory name="src/Shared/Application/Export/" />
                 <directory name="src/*/Application/Page/DTO/" />
                 <directory name="src/*/UI/Http/DTO/" />
                 <directory name="src/Import/Infrastructure/Adapter/" />

--- a/src/Allocation/Application/Export/AllocationExportValueFormatter.php
+++ b/src/Allocation/Application/Export/AllocationExportValueFormatter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class AllocationExportValueFormatter
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function gender(mixed $value, ?string $locale = null): ?string
+    {
+        $enum = $this->resolveGender($value);
+        if (!$enum instanceof AllocationGender) {
+            return null;
+        }
+
+        return $this->translator->trans($enum->label(), [], null, $locale);
+    }
+
+    public function urgency(mixed $value): ?string
+    {
+        $enum = $this->resolveUrgency($value);
+
+        return $enum instanceof AllocationUrgency ? $enum->skLabel() : null;
+    }
+
+    public function transportType(mixed $value, ?string $locale = null): ?string
+    {
+        $enum = $this->resolveTransportType($value);
+        if (!$enum instanceof AllocationTransportType) {
+            return null;
+        }
+
+        return $this->translator->trans($enum->label(), [], null, $locale);
+    }
+
+    private function resolveGender(mixed $value): ?AllocationGender
+    {
+        if ($value instanceof AllocationGender) {
+            return $value;
+        }
+
+        if (\is_string($value) && '' !== $value) {
+            return AllocationGender::tryFrom($value);
+        }
+
+        return null;
+    }
+
+    private function resolveUrgency(mixed $value): ?AllocationUrgency
+    {
+        if ($value instanceof AllocationUrgency) {
+            return $value;
+        }
+
+        return AllocationUrgency::tryFromQueryValue($value);
+    }
+
+    private function resolveTransportType(mixed $value): ?AllocationTransportType
+    {
+        if ($value instanceof AllocationTransportType) {
+            return $value;
+        }
+
+        if (\is_string($value) && '' !== $value) {
+            return AllocationTransportType::tryFrom($value);
+        }
+
+        return null;
+    }
+}

--- a/src/Allocation/Application/Export/AllocationListFilterApplicator.php
+++ b/src/Allocation/Application/Export/AllocationListFilterApplicator.php
@@ -117,6 +117,24 @@ final class AllocationListFilterApplicator
                 ->setParameter('specialityId', $criteria->speciality);
         }
 
+        if (null !== $criteria->assignment) {
+            $qb->andWhere('IDENTITY(a.assignment) = :assignmentId')
+                ->setParameter('assignmentId', $criteria->assignment);
+        }
+
+        if (null !== $criteria->occasion) {
+            $qb->andWhere('IDENTITY(a.occasion) = :occasionId')
+                ->setParameter('occasionId', $criteria->occasion);
+        }
+
+        if (null !== $criteria->departmentWasClosed) {
+            $qb->andWhere('a.departmentWasClosed = :departmentWasClosed')
+                ->setParameter(
+                    'departmentWasClosed',
+                    filter_var($criteria->departmentWasClosed, FILTER_VALIDATE_BOOLEAN),
+                );
+        }
+
         if (null !== $criteria->transportType && '' !== $criteria->transportType) {
             $qb->andWhere('a.transportType = :transportType')
                 ->setParameter('transportType', AllocationTransportType::from($criteria->transportType));

--- a/src/Allocation/Application/Export/AllocationListFilterApplicator.php
+++ b/src/Allocation/Application/Export/AllocationListFilterApplicator.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Application\Export\DTO\AllocationListFilterCriteria;
+use App\Allocation\Application\Export\DTO\ExportDateTimeRange;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalSize;
+use App\Allocation\Domain\Enum\HospitalTier;
+use Doctrine\ORM\QueryBuilder;
+
+final class AllocationListFilterApplicator
+{
+    public function apply(QueryBuilder $qb, AllocationListFilterCriteria $criteria): void
+    {
+        if (null !== $criteria->importId) {
+            $qb->andWhere('a.import = :importId')
+                ->setParameter('importId', $criteria->importId);
+        }
+
+        if (null !== $criteria->tier && '' !== $criteria->tier) {
+            $qb->andWhere('h.tier = :tier')
+                ->setParameter('tier', HospitalTier::from($criteria->tier));
+        }
+
+        if (null !== $criteria->location && '' !== $criteria->location) {
+            $qb->andWhere('h.location = :location')
+                ->setParameter('location', HospitalLocation::from($criteria->location));
+        }
+
+        if (null !== $criteria->size && '' !== $criteria->size) {
+            $qb->andWhere('h.size = :size')
+                ->setParameter('size', HospitalSize::from($criteria->size));
+        }
+
+        if (null !== $criteria->urgency && '' !== $criteria->urgency) {
+            $urgency = AllocationUrgency::tryFromQueryValue($criteria->urgency);
+            if ($urgency instanceof AllocationUrgency) {
+                $qb->andWhere('a.urgency = :urgency')
+                    ->setParameter('urgency', $urgency->value);
+            }
+        }
+
+        if (null !== $criteria->state) {
+            $qb->andWhere('s.id = :stateId')
+                ->setParameter('stateId', $criteria->state);
+        }
+
+        if (null !== $criteria->dispatchArea) {
+            $qb->andWhere('da.id = :dispatchAreaId')
+                ->setParameter('dispatchAreaId', $criteria->dispatchArea);
+        }
+
+        if (null !== $criteria->requiresResus) {
+            $qb->andWhere('a.requiresResus = :requiresResus')
+                ->setParameter(
+                    'requiresResus',
+                    filter_var($criteria->requiresResus, FILTER_VALIDATE_BOOLEAN)
+                );
+        }
+
+        if (null !== $criteria->requiresCathlab) {
+            $qb->andWhere('a.requiresCathlab = :requiresCathlab')
+                ->setParameter(
+                    'requiresCathlab',
+                    filter_var($criteria->requiresCathlab, FILTER_VALIDATE_BOOLEAN)
+                );
+        }
+
+        foreach ([
+            'isVentilated' => 'a.isVentilated',
+            'isShock' => 'a.isShock',
+            'isCPR' => 'a.isCPR',
+            'isPregnant' => 'a.isPregnant',
+            'isWorkAccident' => 'a.isWorkAccident',
+        ] as $param => $booleanField) {
+            if (null !== $criteria->{$param}) {
+                $qb->andWhere($booleanField.' = :'.$param)
+                    ->setParameter(
+                        $param,
+                        filter_var($criteria->{$param}, FILTER_VALIDATE_BOOLEAN)
+                    );
+            }
+        }
+
+        if (null !== $criteria->isInfectious) {
+            $isInfectious = filter_var($criteria->isInfectious, FILTER_VALIDATE_BOOLEAN);
+            $qb->andWhere($isInfectious ? 'a.infection IS NOT NULL' : 'a.infection IS NULL');
+        }
+
+        if (null !== $criteria->infection) {
+            $qb->andWhere('i.id = :infectionId')
+                ->setParameter('infectionId', $criteria->infection);
+        }
+
+        if (null !== $criteria->indication) {
+            $qb->andWhere('inor.code = :indication')
+                ->setParameter('indication', $criteria->indication);
+        }
+
+        if (null !== $criteria->secondaryTransport) {
+            $qb->andWhere('st.id = :secondaryTransportId')
+                ->setParameter('secondaryTransportId', $criteria->secondaryTransport);
+        }
+
+        if (null !== $criteria->department) {
+            $qb->andWhere('IDENTITY(a.department) = :departmentId')
+                ->setParameter('departmentId', $criteria->department);
+        }
+
+        if (null !== $criteria->speciality) {
+            $qb->andWhere('IDENTITY(a.speciality) = :specialityId')
+                ->setParameter('specialityId', $criteria->speciality);
+        }
+
+        if (null !== $criteria->transportType && '' !== $criteria->transportType) {
+            $qb->andWhere('a.transportType = :transportType')
+                ->setParameter('transportType', AllocationTransportType::from($criteria->transportType));
+        }
+    }
+
+    public function applyArrivalAtRange(QueryBuilder $qb, ExportDateTimeRange $range): void
+    {
+        $qb->andWhere('a.arrivalAt >= :exportFrom')
+            ->andWhere('a.arrivalAt <= :exportTo')
+            ->setParameter('exportFrom', $range->from)
+            ->setParameter('exportTo', $range->to);
+    }
+}

--- a/src/Allocation/Application/Export/DTO/AllocationListFilterCriteria.php
+++ b/src/Allocation/Application/Export/DTO/AllocationListFilterCriteria.php
@@ -27,6 +27,9 @@ final readonly class AllocationListFilterCriteria
         public ?int $infection = null,
         public ?int $department = null,
         public ?int $speciality = null,
+        public ?int $assignment = null,
+        public ?int $occasion = null,
+        public ?int $departmentWasClosed = null,
         public ?string $transportType = null,
     ) {
     }

--- a/src/Allocation/Application/Export/DTO/AllocationListFilterCriteria.php
+++ b/src/Allocation/Application/Export/DTO/AllocationListFilterCriteria.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export\DTO;
+
+final readonly class AllocationListFilterCriteria
+{
+    public function __construct(
+        public ?int $importId = null,
+        public ?string $tier = null,
+        public ?string $location = null,
+        public ?string $size = null,
+        public ?string $urgency = null,
+        public ?int $dispatchArea = null,
+        public ?int $state = null,
+        public ?int $requiresResus = null,
+        public ?int $requiresCathlab = null,
+        public ?int $indication = null,
+        public ?int $secondaryTransport = null,
+        public ?int $isVentilated = null,
+        public ?int $isShock = null,
+        public ?int $isCPR = null,
+        public ?int $isPregnant = null,
+        public ?int $isWorkAccident = null,
+        public ?int $isInfectious = null,
+        public ?int $infection = null,
+        public ?int $department = null,
+        public ?int $speciality = null,
+        public ?string $transportType = null,
+    ) {
+    }
+}

--- a/src/Allocation/Application/Export/DTO/ExportDateTimeRange.php
+++ b/src/Allocation/Application/Export/DTO/ExportDateTimeRange.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export\DTO;
+
+final readonly class ExportDateTimeRange
+{
+    public function __construct(
+        public \DateTimeImmutable $from,
+        public \DateTimeImmutable $to,
+    ) {
+    }
+}

--- a/src/Allocation/Application/Export/DTO/OwnHospitalAllocationsExportFilter.php
+++ b/src/Allocation/Application/Export/DTO/OwnHospitalAllocationsExportFilter.php
@@ -29,7 +29,11 @@ final readonly class OwnHospitalAllocationsExportFilter
         public ?int $infection = null,
         public ?int $department = null,
         public ?int $speciality = null,
+        public ?int $assignment = null,
+        public ?int $occasion = null,
+        public ?int $departmentWasClosed = null,
         public ?string $transportType = null,
+        public bool $includeIndicationRaw = false,
     ) {
     }
 
@@ -50,6 +54,9 @@ final readonly class OwnHospitalAllocationsExportFilter
             infection: $this->infection,
             department: $this->department,
             speciality: $this->speciality,
+            assignment: $this->assignment,
+            occasion: $this->occasion,
+            departmentWasClosed: $this->departmentWasClosed,
             transportType: $this->transportType,
         );
     }
@@ -79,7 +86,11 @@ final readonly class OwnHospitalAllocationsExportFilter
             'infection' => $this->infection,
             'department' => $this->department,
             'speciality' => $this->speciality,
+            'assignment' => $this->assignment,
+            'occasion' => $this->occasion,
+            'departmentWasClosed' => $this->departmentWasClosed,
             'transportType' => $this->transportType,
+            'includeIndicationRaw' => $this->includeIndicationRaw,
         ];
     }
 }

--- a/src/Allocation/Application/Export/DTO/OwnHospitalAllocationsExportFilter.php
+++ b/src/Allocation/Application/Export/DTO/OwnHospitalAllocationsExportFilter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export\DTO;
+
+final readonly class OwnHospitalAllocationsExportFilter
+{
+    /**
+     * @param list<int>|null $hospitalIds
+     */
+    public function __construct(
+        public \DateTimeInterface $dateFrom,
+        public \DateTimeInterface $dateTo,
+        public ?\DateTimeInterface $timeFrom = null,
+        public ?\DateTimeInterface $timeTo = null,
+        public ?array $hospitalIds = null,
+        public ?string $urgency = null,
+        public ?int $requiresResus = null,
+        public ?int $requiresCathlab = null,
+        public ?int $indication = null,
+        public ?int $secondaryTransport = null,
+        public ?int $isVentilated = null,
+        public ?int $isShock = null,
+        public ?int $isCPR = null,
+        public ?int $isPregnant = null,
+        public ?int $isWorkAccident = null,
+        public ?int $isInfectious = null,
+        public ?int $infection = null,
+        public ?int $department = null,
+        public ?int $speciality = null,
+        public ?string $transportType = null,
+    ) {
+    }
+
+    public function toListFilterCriteria(): AllocationListFilterCriteria
+    {
+        return new AllocationListFilterCriteria(
+            urgency: $this->urgency,
+            requiresResus: $this->requiresResus,
+            requiresCathlab: $this->requiresCathlab,
+            indication: $this->indication,
+            secondaryTransport: $this->secondaryTransport,
+            isVentilated: $this->isVentilated,
+            isShock: $this->isShock,
+            isCPR: $this->isCPR,
+            isPregnant: $this->isPregnant,
+            isWorkAccident: $this->isWorkAccident,
+            isInfectious: $this->isInfectious,
+            infection: $this->infection,
+            department: $this->department,
+            speciality: $this->speciality,
+            transportType: $this->transportType,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toAuditArray(): array
+    {
+        return [
+            'dateFrom' => $this->dateFrom->format('Y-m-d'),
+            'dateTo' => $this->dateTo->format('Y-m-d'),
+            'timeFrom' => $this->timeFrom?->format('H:i:s'),
+            'timeTo' => $this->timeTo?->format('H:i:s'),
+            'hospitalIds' => $this->hospitalIds,
+            'urgency' => $this->urgency,
+            'requiresResus' => $this->requiresResus,
+            'requiresCathlab' => $this->requiresCathlab,
+            'indication' => $this->indication,
+            'secondaryTransport' => $this->secondaryTransport,
+            'isVentilated' => $this->isVentilated,
+            'isShock' => $this->isShock,
+            'isCPR' => $this->isCPR,
+            'isPregnant' => $this->isPregnant,
+            'isWorkAccident' => $this->isWorkAccident,
+            'isInfectious' => $this->isInfectious,
+            'infection' => $this->infection,
+            'department' => $this->department,
+            'speciality' => $this->speciality,
+            'transportType' => $this->transportType,
+        ];
+    }
+}

--- a/src/Allocation/Application/Export/ExportAccessService.php
+++ b/src/Allocation/Application/Export/ExportAccessService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Application\Service\HospitalPermissionAccess;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Security\UserRole;
+
+final readonly class ExportAccessService
+{
+    public function __construct(
+        private HospitalPermissionAccess $hospitalPermissionAccess,
+    ) {
+    }
+
+    public function canExport(User $user): bool
+    {
+        if (!\in_array(UserRole::PARTICIPANT, $user->getRoles(), true)
+            && !\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
+            return false;
+        }
+
+        return [] !== $this->resolveExportHospitalIds($user);
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function resolveExportHospitalIds(User $user): array
+    {
+        return $this->hospitalPermissionAccess->resolveHospitalIdsWithPermission($user, HospitalPermission::Export);
+    }
+
+    /**
+     * @param list<int>|null $requestedHospitalIds
+     *
+     * @return list<int>
+     */
+    public function resolveEffectiveHospitalIds(User $user, ?array $requestedHospitalIds): array
+    {
+        $allowed = $this->resolveExportHospitalIds($user);
+        if ([] === $allowed) {
+            return [];
+        }
+
+        if (null === $requestedHospitalIds || [] === $requestedHospitalIds) {
+            return $allowed;
+        }
+
+        $requested = array_values(array_unique(array_map(intval(...), $requestedHospitalIds)));
+        $effective = array_values(array_intersect($requested, $allowed));
+
+        return [] !== $effective ? $effective : $allowed;
+    }
+}

--- a/src/Allocation/Application/Export/ExportDateTimeRangeResolver.php
+++ b/src/Allocation/Application/Export/ExportDateTimeRangeResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Application\Export\DTO\ExportDateTimeRange;
+
+final class ExportDateTimeRangeResolver
+{
+    public function resolve(
+        \DateTimeInterface $dateFrom,
+        \DateTimeInterface $dateTo,
+        ?\DateTimeInterface $timeFrom = null,
+        ?\DateTimeInterface $timeTo = null,
+    ): ExportDateTimeRange {
+        $from = \DateTimeImmutable::createFromInterface($dateFrom);
+        $to = \DateTimeImmutable::createFromInterface($dateTo);
+
+        if ($timeFrom instanceof \DateTimeInterface) {
+            $from = $from->setTime(
+                (int) $timeFrom->format('H'),
+                (int) $timeFrom->format('i'),
+                (int) $timeFrom->format('s'),
+            );
+        } else {
+            $from = $from->setTime(0, 0, 0);
+        }
+
+        if ($timeTo instanceof \DateTimeInterface) {
+            $to = $to->setTime(
+                (int) $timeTo->format('H'),
+                (int) $timeTo->format('i'),
+                (int) $timeTo->format('s'),
+            );
+        } else {
+            $to = $to->setTime(23, 59, 59);
+        }
+
+        if ($from > $to) {
+            throw new \InvalidArgumentException('Export date range start must not be after end.');
+        }
+
+        return new ExportDateTimeRange($from, $to);
+    }
+}

--- a/src/Allocation/Application/Export/ExportHospitalFormOptionsProvider.php
+++ b/src/Allocation/Application/Export/ExportHospitalFormOptionsProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Statistics\Application\StatisticsHospitalScopeLabelResolver;
+use App\User\Domain\Entity\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class ExportHospitalFormOptionsProvider
+{
+    public function __construct(
+        private HospitalRepository $hospitalRepository,
+        private StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function formOptionsFor(User $user, ?string $locale = null): array
+    {
+        $options = $this->optionsFor($user, $locale);
+        unset($options['default_hospital_ids']);
+
+        return $options;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function defaultHospitalIdsFor(User $user): array
+    {
+        /** @var list<int> $ids */
+        $ids = $this->optionsFor($user)['default_hospital_ids'];
+
+        return $ids;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function optionsFor(User $user, ?string $locale = null): array
+    {
+        $hospitals = $this->hospitalRepository->findExportableHospitalSummaries($user);
+        $choices = [];
+        foreach ($hospitals as $row) {
+            $choices[(string) $row['name']] = $row['id'];
+        }
+
+        $hospitalIds = array_values($choices);
+
+        return [
+            'hospital_choices' => $choices,
+            'default_hospital_ids' => $hospitalIds,
+            'hospitals_section_label' => $this->hospitalScopeLabelResolver->groupLabel($user, $locale),
+            'hospitals_help' => \count($hospitals) > 1
+                ? $this->translator->trans('help.export.hospitals', [], null, $locale)
+                : '',
+        ];
+    }
+}

--- a/src/Allocation/Application/Export/OwnHospitalAllocationsExportFilterMapper.php
+++ b/src/Allocation/Application/Export/OwnHospitalAllocationsExportFilterMapper.php
@@ -35,7 +35,11 @@ final class OwnHospitalAllocationsExportFilterMapper
             infection: $data->infection,
             department: $data->department,
             speciality: $data->speciality,
+            assignment: $data->assignment,
+            occasion: $data->occasion,
+            departmentWasClosed: $data->departmentWasClosed ? 1 : null,
             transportType: $this->emptyToNull($data->transportType),
+            includeIndicationRaw: $data->includeIndicationRaw,
         );
     }
 

--- a/src/Allocation/Application/Export/OwnHospitalAllocationsExportFilterMapper.php
+++ b/src/Allocation/Application/Export/OwnHospitalAllocationsExportFilterMapper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+
+final class OwnHospitalAllocationsExportFilterMapper
+{
+    public function fromFormData(OwnHospitalAllocationsExportFormData $data): OwnHospitalAllocationsExportFilter
+    {
+        if (!$data->dateFrom instanceof \DateTimeInterface || !$data->dateTo instanceof \DateTimeInterface) {
+            throw new \InvalidArgumentException('Export requires dateFrom and dateTo.');
+        }
+
+        return new OwnHospitalAllocationsExportFilter(
+            dateFrom: $data->dateFrom,
+            dateTo: $data->dateTo,
+            timeFrom: $data->timeFrom,
+            timeTo: $data->timeTo,
+            hospitalIds: $this->normalizeHospitalIds($data->hospitals),
+            urgency: $this->emptyToNull($data->urgency),
+            requiresResus: $data->requiresResus ? 1 : null,
+            requiresCathlab: $data->requiresCathlab ? 1 : null,
+            indication: $data->indication,
+            secondaryTransport: $data->secondaryTransport,
+            isVentilated: $data->isVentilated ? 1 : null,
+            isShock: $data->isShock ? 1 : null,
+            isCPR: $data->isCPR ? 1 : null,
+            isPregnant: $data->isPregnant ? 1 : null,
+            isWorkAccident: $data->isWorkAccident ? 1 : null,
+            isInfectious: $data->isInfectious ? 1 : null,
+            infection: $data->infection,
+            department: $data->department,
+            speciality: $data->speciality,
+            transportType: $this->emptyToNull($data->transportType),
+        );
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return list<int>|null
+     */
+    private function normalizeHospitalIds(array $hospitalIds): ?array
+    {
+        if ([] === $hospitalIds) {
+            return null;
+        }
+
+        return array_values(array_unique(array_map(intval(...), $hospitalIds)));
+    }
+
+    private function emptyToNull(?string $value): ?string
+    {
+        return null === $value || '' === $value ? null : $value;
+    }
+}

--- a/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
+++ b/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Export;
+
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery;
+use App\Shared\Application\Export\CsvStreamExportResponseFactory;
+use App\Shared\Application\Export\ExporterInterface;
+use App\User\Domain\Entity\User;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
+{
+    public const string KEY = 'own_hospital_allocations';
+
+    /**
+     * @var list<string>
+     */
+    private const array CSV_HEADERS = [
+        'id',
+        'arrivalAt',
+        'createdAt',
+        'hospital',
+        'state',
+        'dispatchArea',
+        'gender',
+        'age',
+        'urgency',
+        'transportType',
+        'indicationNormalized',
+        'secondaryTransport',
+        'department',
+        'speciality',
+        'requiresResus',
+        'requiresCathlab',
+        'isCPR',
+        'isVentilated',
+        'isShock',
+        'isPregnant',
+        'isWorkAccident',
+        'isWithPhysician',
+        'infection',
+    ];
+
+    public function __construct(
+        private ExportAccessService $exportAccessService,
+        private OwnHospitalAllocationsExportQuery $exportQuery,
+        private CsvStreamExportResponseFactory $csvStreamExportResponseFactory,
+    ) {
+    }
+
+    #[\Override]
+    public function key(): string
+    {
+        return self::KEY;
+    }
+
+    #[\Override]
+    public function assertCanExport(User $user): void
+    {
+        if (!$this->exportAccessService->canExport($user)) {
+            throw new AccessDeniedException('Export is not allowed for this user.');
+        }
+    }
+
+    #[\Override]
+    public function resolveScopeHospitalIds(User $user): array
+    {
+        return $this->exportAccessService->resolveExportHospitalIds($user);
+    }
+
+    #[\Override]
+    public function count(User $user, object $criteria): int
+    {
+        $filter = $this->assertFilter($criteria);
+
+        return $this->exportQuery->count(
+            $this->resolveHospitalIdsForExport($user, $filter),
+            $filter,
+        );
+    }
+
+    #[\Override]
+    public function writeCsv(User $user, object $criteria, $stream): int
+    {
+        $filter = $this->assertFilter($criteria);
+        $this->csvStreamExportResponseFactory->writeRow($stream, self::CSV_HEADERS);
+
+        $written = 0;
+        foreach ($this->exportQuery->iterateRows($this->resolveHospitalIdsForExport($user, $filter), $filter) as $row) {
+            $this->csvStreamExportResponseFactory->writeRow($stream, $this->formatRow($row));
+            ++$written;
+        }
+
+        return $written;
+    }
+
+    #[\Override]
+    public function buildFilename(): string
+    {
+        return sprintf('allocations-export-%s.csv', new \DateTimeImmutable('now')->format('Y-m-d'));
+    }
+
+    #[\Override]
+    public function serializeCriteria(object $criteria): array
+    {
+        return $this->assertFilter($criteria)->toAuditArray();
+    }
+
+    private function assertFilter(object $criteria): OwnHospitalAllocationsExportFilter
+    {
+        if (!$criteria instanceof OwnHospitalAllocationsExportFilter) {
+            throw new \InvalidArgumentException(sprintf('Expected %s, got %s.', OwnHospitalAllocationsExportFilter::class, $criteria::class));
+        }
+
+        return $criteria;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function resolveHospitalIdsForExport(User $user, OwnHospitalAllocationsExportFilter $filter): array
+    {
+        return $this->exportAccessService->resolveEffectiveHospitalIds($user, $filter->hospitalIds);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return list<string|int|float|null>
+     */
+    private function formatRow(array $row): array
+    {
+        return [
+            $row['id'] ?? null,
+            $this->formatDateTime($row['arrivalAt'] ?? null),
+            $this->formatDateTime($row['createdAt'] ?? null),
+            $row['hospital'] ?? null,
+            $row['state'] ?? null,
+            $row['dispatchArea'] ?? null,
+            $this->formatEnum($row['gender'] ?? null),
+            $row['age'] ?? null,
+            $this->formatEnum($row['urgency'] ?? null),
+            $this->formatEnum($row['transportType'] ?? null),
+            $row['indicationNormalized'] ?? null,
+            $row['secondaryTransport'] ?? null,
+            $row['department'] ?? null,
+            $row['speciality'] ?? null,
+            $this->formatBool($row['requiresResus'] ?? null),
+            $this->formatBool($row['requiresCathlab'] ?? null),
+            $this->formatBool($row['isCPR'] ?? null),
+            $this->formatBool($row['isVentilated'] ?? null),
+            $this->formatBool($row['isShock'] ?? null),
+            $this->formatBool($row['isPregnant'] ?? null),
+            $this->formatBool($row['isWorkAccident'] ?? null),
+            $this->formatBool($row['isWithPhysician'] ?? null),
+            $row['infection'] ?? null,
+        ];
+    }
+
+    private function formatDateTime(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s');
+        }
+
+        return null === $value ? null : (string) $value;
+    }
+
+    private function formatEnum(mixed $value): ?string
+    {
+        if ($value instanceof \BackedEnum) {
+            return (string) $value->value;
+        }
+
+        return null === $value ? null : (string) $value;
+    }
+
+    private function formatBool(mixed $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+    }
+}

--- a/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
+++ b/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
@@ -18,8 +18,8 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
     /**
      * @var list<string>
      */
-    private const array CSV_HEADERS = [
-        'id',
+    private const array BASE_CSV_HEADERS = [
+        'row',
         'arrivalAt',
         'createdAt',
         'hospital',
@@ -30,9 +30,18 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
         'urgency',
         'transportType',
         'indicationNormalized',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const array TAIL_CSV_HEADERS = [
         'secondaryTransport',
         'department',
         'speciality',
+        'departmentWasClosed',
+        'assignment',
+        'occasion',
         'requiresResus',
         'requiresCathlab',
         'isCPR',
@@ -48,6 +57,7 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
         private ExportAccessService $exportAccessService,
         private OwnHospitalAllocationsExportQuery $exportQuery,
         private CsvStreamExportResponseFactory $csvStreamExportResponseFactory,
+        private AllocationExportValueFormatter $exportValueFormatter,
     ) {
     }
 
@@ -86,12 +96,12 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
     public function writeCsv(User $user, object $criteria, $stream): int
     {
         $filter = $this->assertFilter($criteria);
-        $this->csvStreamExportResponseFactory->writeRow($stream, self::CSV_HEADERS);
+        $this->csvStreamExportResponseFactory->writeRow($stream, $this->resolveCsvHeaders($filter));
 
         $written = 0;
         foreach ($this->exportQuery->iterateRows($this->resolveHospitalIdsForExport($user, $filter), $filter) as $row) {
-            $this->csvStreamExportResponseFactory->writeRow($stream, $this->formatRow($row));
             ++$written;
+            $this->csvStreamExportResponseFactory->writeRow($stream, $this->formatRow($written, $row, $filter));
         }
 
         return $written;
@@ -127,27 +137,50 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
     }
 
     /**
+     * @return list<string>
+     */
+    private function resolveCsvHeaders(OwnHospitalAllocationsExportFilter $filter): array
+    {
+        $headers = self::BASE_CSV_HEADERS;
+        if ($filter->includeIndicationRaw) {
+            $headers[] = 'indicationRaw';
+        }
+
+        return array_merge($headers, self::TAIL_CSV_HEADERS);
+    }
+
+    /**
      * @param array<string, mixed> $row
      *
      * @return list<string|int|float|null>
      */
-    private function formatRow(array $row): array
+    private function formatRow(int $rowNumber, array $row, OwnHospitalAllocationsExportFilter $filter): array
     {
-        return [
-            $row['id'] ?? null,
+        $values = [
+            $rowNumber,
             $this->formatDateTime($row['arrivalAt'] ?? null),
             $this->formatDateTime($row['createdAt'] ?? null),
             $row['hospital'] ?? null,
             $row['state'] ?? null,
             $row['dispatchArea'] ?? null,
-            $this->formatEnum($row['gender'] ?? null),
+            $this->exportValueFormatter->gender($row['gender'] ?? null),
             $row['age'] ?? null,
-            $this->formatEnum($row['urgency'] ?? null),
-            $this->formatEnum($row['transportType'] ?? null),
+            $this->exportValueFormatter->urgency($row['urgency'] ?? null),
+            $this->exportValueFormatter->transportType($row['transportType'] ?? null),
             $row['indicationNormalized'] ?? null,
+        ];
+
+        if ($filter->includeIndicationRaw) {
+            $values[] = $row['indicationRaw'] ?? null;
+        }
+
+        return array_merge($values, [
             $row['secondaryTransport'] ?? null,
             $row['department'] ?? null,
             $row['speciality'] ?? null,
+            $this->formatBool($row['departmentWasClosed'] ?? null),
+            $row['assignment'] ?? null,
+            $row['occasion'] ?? null,
             $this->formatBool($row['requiresResus'] ?? null),
             $this->formatBool($row['requiresCathlab'] ?? null),
             $this->formatBool($row['isCPR'] ?? null),
@@ -157,22 +190,13 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
             $this->formatBool($row['isWorkAccident'] ?? null),
             $this->formatBool($row['isWithPhysician'] ?? null),
             $row['infection'] ?? null,
-        ];
+        ]);
     }
 
     private function formatDateTime(mixed $value): ?string
     {
         if ($value instanceof \DateTimeInterface) {
             return $value->format('Y-m-d H:i:s');
-        }
-
-        return null === $value ? null : (string) $value;
-    }
-
-    private function formatEnum(mixed $value): ?string
-    {
-        if ($value instanceof \BackedEnum) {
-            return (string) $value->value;
         }
 
         return null === $value ? null : (string) $value;

--- a/src/Allocation/Domain/Enum/AllocationUrgency.php
+++ b/src/Allocation/Domain/Enum/AllocationUrgency.php
@@ -40,6 +40,11 @@ enum AllocationUrgency: int
         };
     }
 
+    public function skLabel(): string
+    {
+        return 'SK'.$this->value;
+    }
+
     public static function tryFromQueryValue(mixed $value): ?self
     {
         if (null === $value || '' === $value) {

--- a/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
+++ b/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Allocation\Infrastructure\Query;
 
+use App\Allocation\Application\Export\AllocationListFilterApplicator;
 use App\Allocation\Domain\Entity\Allocation;
 use App\Allocation\Domain\Entity\DispatchArea;
 use App\Allocation\Domain\Entity\Hospital;
@@ -12,11 +13,6 @@ use App\Allocation\Domain\Entity\IndicationRaw;
 use App\Allocation\Domain\Entity\Infection;
 use App\Allocation\Domain\Entity\SecondaryTransport;
 use App\Allocation\Domain\Entity\State;
-use App\Allocation\Domain\Enum\AllocationTransportType;
-use App\Allocation\Domain\Enum\AllocationUrgency;
-use App\Allocation\Domain\Enum\HospitalLocation;
-use App\Allocation\Domain\Enum\HospitalSize;
-use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
 use App\Shared\Infrastructure\Pagination\CursorCodec;
 use App\Shared\Infrastructure\Pagination\CursorPaginator;
@@ -29,6 +25,7 @@ final readonly class ListAllocationsQuery
     public function __construct(
         private EntityManagerInterface $entityManager,
         private CursorCodec $cursorCodec,
+        private AllocationListFilterApplicator $filterApplicator,
     ) {
     }
 
@@ -97,116 +94,13 @@ final readonly class ListAllocationsQuery
                 'a.secondaryIndicationNormalized = inor2.id'
             );
 
-        if (null !== $queryParametersDTO->importId) {
-            $qb->andWhere('a.import = :importId')
-            ->setParameter('importId', $queryParametersDTO->importId);
-        }
-
         $sortField = match ($queryParametersDTO->sortBy) {
             'arrivalAt' => 'a.arrivalAt',
             'age' => 'a.age',
             default => 'a.arrivalAt',
         };
 
-        if (null !== $queryParametersDTO->tier && '' !== $queryParametersDTO->tier) {
-            $qb->andWhere('h.tier = :tier')
-                ->setParameter('tier', HospitalTier::from($queryParametersDTO->tier));
-        }
-
-        if (null !== $queryParametersDTO->location && '' !== $queryParametersDTO->location) {
-            $qb->andWhere('h.location = :location')
-                ->setParameter('location', HospitalLocation::from($queryParametersDTO->location));
-        }
-
-        if (null !== $queryParametersDTO->size && '' !== $queryParametersDTO->size) {
-            $qb->andWhere('h.size = :size')
-                ->setParameter('size', HospitalSize::from($queryParametersDTO->size));
-        }
-
-        if (null !== $queryParametersDTO->urgency && '' !== $queryParametersDTO->urgency) {
-            $urgency = AllocationUrgency::tryFromQueryValue($queryParametersDTO->urgency);
-            if ($urgency instanceof AllocationUrgency) {
-                $qb->andWhere('a.urgency = :urgency')
-                    ->setParameter('urgency', $urgency->value);
-            }
-        }
-
-        if (null !== $queryParametersDTO->state) {
-            $qb->andWhere('s.id = :stateId')
-                ->setParameter('stateId', $queryParametersDTO->state);
-        }
-
-        if (null !== $queryParametersDTO->dispatchArea) {
-            $qb->andWhere('da.id = :dispatchAreaId')
-                ->setParameter('dispatchAreaId', $queryParametersDTO->dispatchArea);
-        }
-
-        if (null !== $queryParametersDTO->requiresResus) {
-            $qb->andWhere('a.requiresResus = :requiresResus')
-                ->setParameter(
-                    'requiresResus',
-                    filter_var($queryParametersDTO->requiresResus, FILTER_VALIDATE_BOOLEAN)
-                );
-        }
-
-        if (null !== $queryParametersDTO->requiresCathlab) {
-            $qb->andWhere('a.requiresCathlab = :requiresCathlab')
-                ->setParameter(
-                    'requiresCathlab',
-                    filter_var($queryParametersDTO->requiresCathlab, FILTER_VALIDATE_BOOLEAN)
-                );
-        }
-
-        foreach ([
-            'isVentilated' => 'a.isVentilated',
-            'isShock' => 'a.isShock',
-            'isCPR' => 'a.isCPR',
-            'isPregnant' => 'a.isPregnant',
-            'isWorkAccident' => 'a.isWorkAccident',
-        ] as $param => $booleanField) {
-            if (null !== $queryParametersDTO->{$param}) {
-                $qb->andWhere($booleanField.' = :'.$param)
-                    ->setParameter(
-                        $param,
-                        filter_var($queryParametersDTO->{$param}, FILTER_VALIDATE_BOOLEAN)
-                    );
-            }
-        }
-
-        if (null !== $queryParametersDTO->isInfectious) {
-            $isInfectious = filter_var($queryParametersDTO->isInfectious, FILTER_VALIDATE_BOOLEAN);
-            $qb->andWhere($isInfectious ? 'a.infection IS NOT NULL' : 'a.infection IS NULL');
-        }
-
-        if (null !== $queryParametersDTO->infection) {
-            $qb->andWhere('i.id = :infectionId')
-                ->setParameter('infectionId', $queryParametersDTO->infection);
-        }
-
-        if (null !== $queryParametersDTO->indication) {
-            $qb->andWhere('inor.code = :indication')
-                ->setParameter('indication', $queryParametersDTO->indication);
-        }
-
-        if (null !== $queryParametersDTO->secondaryTransport) {
-            $qb->andWhere('st.id = :secondaryTransportId')
-                ->setParameter('secondaryTransportId', $queryParametersDTO->secondaryTransport);
-        }
-
-        if (null !== $queryParametersDTO->department) {
-            $qb->andWhere('IDENTITY(a.department) = :departmentId')
-                ->setParameter('departmentId', $queryParametersDTO->department);
-        }
-
-        if (null !== $queryParametersDTO->speciality) {
-            $qb->andWhere('IDENTITY(a.speciality) = :specialityId')
-                ->setParameter('specialityId', $queryParametersDTO->speciality);
-        }
-
-        if (null !== $queryParametersDTO->transportType && '' !== $queryParametersDTO->transportType) {
-            $qb->andWhere('a.transportType = :transportType')
-                ->setParameter('transportType', AllocationTransportType::from($queryParametersDTO->transportType));
-        }
+        $this->filterApplicator->apply($qb, $queryParametersDTO->toListFilterCriteria());
 
         $estimatedNumResults = $this->estimateNumResults($qb);
 

--- a/src/Allocation/Infrastructure/Query/OwnHospitalAllocationsExportQuery.php
+++ b/src/Allocation/Infrastructure/Query/OwnHospitalAllocationsExportQuery.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Query;
+
+use App\Allocation\Application\Export\AllocationListFilterApplicator;
+use App\Allocation\Application\Export\DTO\ExportDateTimeRange;
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Department;
+use App\Allocation\Domain\Entity\DispatchArea;
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Allocation\Domain\Entity\Infection;
+use App\Allocation\Domain\Entity\SecondaryTransport;
+use App\Allocation\Domain\Entity\Speciality;
+use App\Allocation\Domain\Entity\State;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+
+final readonly class OwnHospitalAllocationsExportQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private AllocationListFilterApplicator $filterApplicator,
+        private ExportDateTimeRangeResolver $dateTimeRangeResolver,
+    ) {
+    }
+
+    /**
+     * @param list<int> $exportHospitalIds
+     */
+    public function count(array $exportHospitalIds, OwnHospitalAllocationsExportFilter $filter): int
+    {
+        if ([] === $exportHospitalIds) {
+            return 0;
+        }
+
+        $qb = $this->createBaseQueryBuilder($exportHospitalIds);
+        $this->applyFilter($qb, $filter);
+
+        return (int) $qb
+            ->select('COUNT(a.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @param list<int> $exportHospitalIds
+     *
+     * @return iterable<array<string, mixed>>
+     */
+    public function iterateRows(array $exportHospitalIds, OwnHospitalAllocationsExportFilter $filter): iterable
+    {
+        if ([] === $exportHospitalIds) {
+            return;
+        }
+
+        $qb = $this->createBaseQueryBuilder($exportHospitalIds);
+        $this->applyFilter($qb, $filter);
+        $qb->select($this->exportSelectFields())
+            ->orderBy('a.arrivalAt', 'ASC')
+            ->addOrderBy('a.id', 'ASC');
+
+        /** @var iterable<array<string, mixed>> $rows */
+        $rows = $qb->getQuery()->toIterable();
+
+        yield from $rows;
+    }
+
+    /**
+     * @param list<int> $exportHospitalIds
+     */
+    private function createBaseQueryBuilder(array $exportHospitalIds): QueryBuilder
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->from(Allocation::class, 'a')
+            ->leftJoin(State::class, 's', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.state = s.id')
+            ->leftJoin(DispatchArea::class, 'da', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.dispatchArea = da.id')
+            ->leftJoin(Hospital::class, 'h', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.hospital = h.id')
+            ->leftJoin(Infection::class, 'i', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.infection = i.id')
+            ->leftJoin(SecondaryTransport::class, 'st', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.secondaryTransport = st.id')
+            ->leftJoin(IndicationNormalized::class, 'inor', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.indicationNormalized = inor.id')
+            ->leftJoin(Department::class, 'dep', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.department = dep.id')
+            ->leftJoin(Speciality::class, 'spec', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.speciality = spec.id')
+            ->andWhere('h.id IN (:exportHospitalIds)')
+            ->setParameter('exportHospitalIds', $exportHospitalIds);
+
+        return $qb;
+    }
+
+    private function applyFilter(QueryBuilder $qb, OwnHospitalAllocationsExportFilter $filter): void
+    {
+        $range = $this->dateTimeRangeResolver->resolve(
+            $filter->dateFrom,
+            $filter->dateTo,
+            $filter->timeFrom,
+            $filter->timeTo,
+        );
+
+        $this->filterApplicator->applyArrivalAtRange($qb, $range);
+        $this->filterApplicator->apply($qb, $filter->toListFilterCriteria());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function exportSelectFields(): array
+    {
+        return [
+            'a.id',
+            'a.arrivalAt',
+            'a.createdAt',
+            'h.name as hospital',
+            's.name as state',
+            'da.name as dispatchArea',
+            'a.gender',
+            'a.age',
+            'a.urgency',
+            'a.transportType',
+            'inor.name as indicationNormalized',
+            'st.name as secondaryTransport',
+            'dep.name as department',
+            'spec.name as speciality',
+            'a.requiresResus',
+            'a.requiresCathlab',
+            'a.isCPR',
+            'a.isVentilated',
+            'a.isShock',
+            'a.isPregnant',
+            'a.isWorkAccident',
+            'a.isWithPhysician',
+            'i.name as infection',
+        ];
+    }
+
+    public function resolveDateTimeRange(OwnHospitalAllocationsExportFilter $filter): ExportDateTimeRange
+    {
+        return $this->dateTimeRangeResolver->resolve(
+            $filter->dateFrom,
+            $filter->dateTo,
+            $filter->timeFrom,
+            $filter->timeTo,
+        );
+    }
+}

--- a/src/Allocation/Infrastructure/Query/OwnHospitalAllocationsExportQuery.php
+++ b/src/Allocation/Infrastructure/Query/OwnHospitalAllocationsExportQuery.php
@@ -9,11 +9,14 @@ use App\Allocation\Application\Export\DTO\ExportDateTimeRange;
 use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
 use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
 use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Assignment;
 use App\Allocation\Domain\Entity\Department;
 use App\Allocation\Domain\Entity\DispatchArea;
 use App\Allocation\Domain\Entity\Hospital;
 use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Allocation\Domain\Entity\IndicationRaw;
 use App\Allocation\Domain\Entity\Infection;
+use App\Allocation\Domain\Entity\Occasion;
 use App\Allocation\Domain\Entity\SecondaryTransport;
 use App\Allocation\Domain\Entity\Speciality;
 use App\Allocation\Domain\Entity\State;
@@ -83,8 +86,11 @@ final readonly class OwnHospitalAllocationsExportQuery
             ->leftJoin(Infection::class, 'i', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.infection = i.id')
             ->leftJoin(SecondaryTransport::class, 'st', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.secondaryTransport = st.id')
             ->leftJoin(IndicationNormalized::class, 'inor', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.indicationNormalized = inor.id')
+            ->leftJoin(IndicationRaw::class, 'iraw', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.indicationRaw = iraw.id')
             ->leftJoin(Department::class, 'dep', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.department = dep.id')
             ->leftJoin(Speciality::class, 'spec', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.speciality = spec.id')
+            ->leftJoin(Assignment::class, 'asgn', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.assignment = asgn.id')
+            ->leftJoin(Occasion::class, 'occ', \Doctrine\ORM\Query\Expr\Join::WITH, 'a.occasion = occ.id')
             ->andWhere('h.id IN (:exportHospitalIds)')
             ->setParameter('exportHospitalIds', $exportHospitalIds);
 
@@ -110,7 +116,6 @@ final readonly class OwnHospitalAllocationsExportQuery
     private function exportSelectFields(): array
     {
         return [
-            'a.id',
             'a.arrivalAt',
             'a.createdAt',
             'h.name as hospital',
@@ -121,9 +126,13 @@ final readonly class OwnHospitalAllocationsExportQuery
             'a.urgency',
             'a.transportType',
             'inor.name as indicationNormalized',
+            'iraw.name as indicationRaw',
             'st.name as secondaryTransport',
             'dep.name as department',
             'spec.name as speciality',
+            'a.departmentWasClosed',
+            'asgn.name as assignment',
+            'occ.name as occasion',
             'a.requiresResus',
             'a.requiresCathlab',
             'a.isCPR',

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -263,6 +263,28 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
     }
 
     /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function findExportableHospitalSummaries(User $user): array
+    {
+        $rows = $this->getQueryBuilderForHospitalsWithPermission($user, HospitalPermission::Export)
+            ->select('h.id AS id', 'h.name AS name')
+            ->orderBy('h.name', 'ASC')
+            ->getQuery()
+            ->getArrayResult();
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = [
+                'id' => (int) $row['id'],
+                'name' => (string) $row['name'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
      * @return list<Hospital>
      */
     public function findParticipatingWithOwner(): array

--- a/src/Allocation/Infrastructure/Security/Voter/ExportVoter.php
+++ b/src/Allocation/Infrastructure/Security/Voter/ExportVoter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Security\Voter;
+
+use App\Allocation\Application\Export\ExportAccessService;
+use App\User\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<string, null>
+ */
+final class ExportVoter extends Voter
+{
+    public const string EXPORT = 'EXPORT';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private readonly ExportAccessService $exportAccessService,
+    ) {
+    }
+
+    #[\Override]
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return self::EXPORT === $attribute && null === $subject;
+    }
+
+    #[\Override]
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        $user = $token->getUser();
+
+        return $user instanceof User && $this->exportAccessService->canExport($user);
+    }
+}

--- a/src/Allocation/UI/Form/Model/OwnHospitalAllocationsExportFormData.php
+++ b/src/Allocation/UI/Form/Model/OwnHospitalAllocationsExportFormData.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form\Model;
+
+final class OwnHospitalAllocationsExportFormData
+{
+    public ?\DateTimeInterface $dateFrom = null;
+
+    public ?\DateTimeInterface $dateTo = null;
+
+    public ?\DateTimeInterface $timeFrom = null;
+
+    public ?\DateTimeInterface $timeTo = null;
+
+    /** @var list<int> */
+    public array $hospitals = [];
+
+    public ?string $urgency = null;
+
+    public ?int $indication = null;
+
+    public ?int $secondaryTransport = null;
+
+    public ?int $department = null;
+
+    public ?int $speciality = null;
+
+    public ?string $transportType = null;
+
+    public bool $requiresResus = false;
+
+    public bool $requiresCathlab = false;
+
+    public bool $isVentilated = false;
+
+    public bool $isShock = false;
+
+    public bool $isCPR = false;
+
+    public bool $isPregnant = false;
+
+    public bool $isWorkAccident = false;
+
+    public bool $isInfectious = false;
+
+    public ?int $infection = null;
+}

--- a/src/Allocation/UI/Form/Model/OwnHospitalAllocationsExportFormData.php
+++ b/src/Allocation/UI/Form/Model/OwnHospitalAllocationsExportFormData.php
@@ -27,6 +27,12 @@ final class OwnHospitalAllocationsExportFormData
 
     public ?int $speciality = null;
 
+    public ?int $assignment = null;
+
+    public ?int $occasion = null;
+
+    public bool $departmentWasClosed = false;
+
     public ?string $transportType = null;
 
     public bool $requiresResus = false;
@@ -46,4 +52,6 @@ final class OwnHospitalAllocationsExportFormData
     public bool $isInfectious = false;
 
     public ?int $infection = null;
+
+    public bool $includeIndicationRaw = false;
 }

--- a/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
+++ b/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form;
+
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Repository\DepartmentRepository;
+use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
+use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
+use App\Allocation\Infrastructure\Repository\SpecialityRepository;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @extends AbstractType<OwnHospitalAllocationsExportFormData>
+ */
+final class OwnHospitalAllocationsExportType extends AbstractType
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private readonly IndicationNormalizedRepository $indicationNormalizedRepository,
+        private readonly SecondaryTransportRepository $secondaryTransportRepository,
+        private readonly InfectionRepository $infectionRepository,
+        private readonly DepartmentRepository $departmentRepository,
+        private readonly SpecialityRepository $specialityRepository,
+    ) {
+    }
+
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('dateFrom', DateType::class, [
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'constraints' => [new Assert\NotNull()],
+            ])
+            ->add('dateTo', DateType::class, [
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'constraints' => [new Assert\NotNull()],
+            ])
+            ->add('timeFrom', TimeType::class, [
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'required' => false,
+                'with_seconds' => true,
+            ])
+            ->add('timeTo', TimeType::class, [
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'required' => false,
+                'with_seconds' => true,
+            ]);
+
+        if ([] !== $options['hospital_choices']) {
+            $builder->add('hospitals', ChoiceType::class, [
+                'choices' => $options['hospital_choices'],
+                'multiple' => true,
+                'expanded' => true,
+                'required' => false,
+                'label' => false,
+            ]);
+        }
+
+        $builder
+            ->add('urgency', ChoiceType::class, [
+                'choices' => $this->enumChoices(AllocationUrgency::cases()),
+                'required' => false,
+                'placeholder' => 'label.all_urgencies',
+            ])
+            ->add('transportType', ChoiceType::class, [
+                'choices' => $this->enumChoices(AllocationTransportType::cases()),
+                'required' => false,
+                'placeholder' => 'label.all_transport_types',
+            ])
+            ->add('indication', ChoiceType::class, [
+                'choices' => $this->indicationChoices(),
+                'required' => false,
+                'placeholder' => 'label.all_indications',
+            ])
+            ->add('secondaryTransport', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->secondaryTransportRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_secondary_transports',
+            ])
+            ->add('department', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->departmentRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_departments',
+            ])
+            ->add('speciality', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->specialityRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_specialities',
+            ])
+            ->add('requiresResus', CheckboxType::class, ['required' => false])
+            ->add('requiresCathlab', CheckboxType::class, ['required' => false])
+            ->add('isVentilated', CheckboxType::class, ['required' => false])
+            ->add('isShock', CheckboxType::class, ['required' => false])
+            ->add('isCPR', CheckboxType::class, ['required' => false])
+            ->add('isPregnant', CheckboxType::class, ['required' => false])
+            ->add('isWorkAccident', CheckboxType::class, ['required' => false])
+            ->add('isInfectious', CheckboxType::class, ['required' => false])
+            ->add('infection', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->infectionRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_infections',
+            ]);
+    }
+
+    #[\Override]
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['hospitals_section_label'] = $options['hospitals_section_label'];
+        $view->vars['hospitals_help'] = $options['hospitals_help'];
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => OwnHospitalAllocationsExportFormData::class,
+            'translation_domain' => 'messages',
+            'hospital_choices' => [],
+            'hospitals_section_label' => 'label.hospital',
+            'hospitals_help' => '',
+        ]);
+
+        $resolver->setAllowedTypes('hospital_choices', 'array');
+        $resolver->setAllowedTypes('hospitals_section_label', 'string');
+        $resolver->setAllowedTypes('hospitals_help', 'string');
+    }
+
+    /**
+     * @param list<\BackedEnum> $cases
+     *
+     * @return array<string, string>
+     */
+    private function enumChoices(array $cases): array
+    {
+        $choices = [];
+        foreach ($cases as $case) {
+            $choices[(string) $case->value] = (string) $case->value;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param list<object> $entities
+     *
+     * @return array<string, int>
+     */
+    private function entityIdChoices(array $entities): array
+    {
+        $choices = [];
+        foreach ($entities as $entity) {
+            if (!method_exists($entity, 'getId') || !method_exists($entity, 'getName')) {
+                continue;
+            }
+
+            $id = $entity->getId();
+            if (null === $id) {
+                continue;
+            }
+
+            $choices[(string) $entity->getName()] = (int) $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function indicationChoices(): array
+    {
+        $choices = [];
+        foreach ($this->indicationNormalizedRepository->findAll() as $indication) {
+            $code = $indication->getCode();
+            if (null === $code || $code <= 0) {
+                continue;
+            }
+
+            $choices[(string) $indication->getName()] = $code;
+        }
+
+        return $choices;
+    }
+}

--- a/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
+++ b/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
@@ -6,9 +6,11 @@ namespace App\Allocation\UI\Form;
 
 use App\Allocation\Domain\Enum\AllocationTransportType;
 use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Repository\AssignmentRepository;
 use App\Allocation\Infrastructure\Repository\DepartmentRepository;
 use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
 use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\OccasionRepository;
 use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
 use App\Allocation\Infrastructure\Repository\SpecialityRepository;
 use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
@@ -22,6 +24,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends AbstractType<OwnHospitalAllocationsExportFormData>
@@ -35,6 +38,9 @@ final class OwnHospitalAllocationsExportType extends AbstractType
         private readonly InfectionRepository $infectionRepository,
         private readonly DepartmentRepository $departmentRepository,
         private readonly SpecialityRepository $specialityRepository,
+        private readonly AssignmentRepository $assignmentRepository,
+        private readonly OccasionRepository $occasionRepository,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -77,12 +83,22 @@ final class OwnHospitalAllocationsExportType extends AbstractType
 
         $builder
             ->add('urgency', ChoiceType::class, [
-                'choices' => $this->enumChoices(AllocationUrgency::cases()),
+                'choices' => $this->urgencyChoices(),
                 'required' => false,
                 'placeholder' => 'label.all_urgencies',
             ])
+            ->add('assignment', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->assignmentRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_assignments',
+            ])
+            ->add('occasion', ChoiceType::class, [
+                'choices' => $this->entityIdChoices($this->occasionRepository->findBy([], ['name' => 'ASC'])),
+                'required' => false,
+                'placeholder' => 'label.all_occasions',
+            ])
             ->add('transportType', ChoiceType::class, [
-                'choices' => $this->enumChoices(AllocationTransportType::cases()),
+                'choices' => $this->transportTypeChoices(),
                 'required' => false,
                 'placeholder' => 'label.all_transport_types',
             ])
@@ -90,6 +106,11 @@ final class OwnHospitalAllocationsExportType extends AbstractType
                 'choices' => $this->indicationChoices(),
                 'required' => false,
                 'placeholder' => 'label.all_indications',
+            ])
+            ->add('includeIndicationRaw', CheckboxType::class, [
+                'required' => false,
+                'label' => 'field.includeIndicationRaw',
+                'help' => 'help.export.include_indication_raw',
             ])
             ->add('secondaryTransport', ChoiceType::class, [
                 'choices' => $this->entityIdChoices($this->secondaryTransportRepository->findBy([], ['name' => 'ASC'])),
@@ -105,6 +126,11 @@ final class OwnHospitalAllocationsExportType extends AbstractType
                 'choices' => $this->entityIdChoices($this->specialityRepository->findBy([], ['name' => 'ASC'])),
                 'required' => false,
                 'placeholder' => 'label.all_specialities',
+            ])
+            ->add('departmentWasClosed', CheckboxType::class, [
+                'required' => false,
+                'label' => 'field.departmentWasClosed',
+                'help' => 'help.export.department_was_closed_filter',
             ])
             ->add('requiresResus', CheckboxType::class, ['required' => false])
             ->add('requiresCathlab', CheckboxType::class, ['required' => false])
@@ -145,15 +171,44 @@ final class OwnHospitalAllocationsExportType extends AbstractType
     }
 
     /**
-     * @param list<\BackedEnum> $cases
-     *
      * @return array<string, string>
      */
-    private function enumChoices(array $cases): array
+    private function urgencyChoices(): array
     {
         $choices = [];
-        foreach ($cases as $case) {
-            $choices[(string) $case->value] = (string) $case->value;
+        foreach (AllocationUrgency::cases() as $case) {
+            $choices[$case->skLabel()] = (string) $case->value;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function transportTypeChoices(): array
+    {
+        $choices = [];
+        foreach (AllocationTransportType::cases() as $case) {
+            $choices[$this->translator->trans($case->label())] = $case->value;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function indicationChoices(): array
+    {
+        $choices = [];
+        foreach ($this->indicationNormalizedRepository->findAll() as $indication) {
+            $code = $indication->getCode();
+            if (null === $code || $code <= 0) {
+                continue;
+            }
+
+            $choices[(string) $indication->getName()] = $code;
         }
 
         return $choices;
@@ -178,24 +233,6 @@ final class OwnHospitalAllocationsExportType extends AbstractType
             }
 
             $choices[(string) $entity->getName()] = (int) $id;
-        }
-
-        return $choices;
-    }
-
-    /**
-     * @return array<string, int>
-     */
-    private function indicationChoices(): array
-    {
-        $choices = [];
-        foreach ($this->indicationNormalizedRepository->findAll() as $indication) {
-            $code = $indication->getCode();
-            if (null === $code || $code <= 0) {
-                continue;
-            }
-
-            $choices[(string) $indication->getName()] = $code;
         }
 
         return $choices;

--- a/src/Allocation/UI/Http/Controller/Export/DownloadAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/DownloadAllocationsExportController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Export;
+
+use App\Allocation\Application\Export\ExportHospitalFormOptionsProvider;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExportFilterMapper;
+use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
+use App\Allocation\UI\Form\OwnHospitalAllocationsExportType;
+use App\Shared\Application\Export\ExportBlockedException;
+use App\Shared\Application\Export\ExportOrchestrator;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+#[IsGranted(ExportVoter::EXPORT)]
+final class DownloadAllocationsExportController extends AbstractController
+{
+    private const string CSRF_TOKEN_ID = 'export_allocations_csv';
+
+    public function __construct(
+        private readonly ExportOrchestrator $exportOrchestrator,
+        private readonly OwnHospitalAllocationsExportFilterMapper $filterMapper,
+        private readonly ExportHospitalFormOptionsProvider $exportHospitalFormOptionsProvider,
+    ) {
+    }
+
+    #[Route('/hospitals/export/allocations/download', name: 'app_hospitals_export_allocations_download', methods: ['POST'])]
+    public function __invoke(Request $request, #[CurrentUser] User $user): \Symfony\Component\HttpFoundation\StreamedResponse
+    {
+        if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $request->request->getString('_token'))) {
+            throw new BadRequestHttpException('Invalid CSRF token.');
+        }
+
+        $form = $this->createForm(
+            OwnHospitalAllocationsExportType::class,
+            null,
+            $this->exportHospitalFormOptionsProvider->formOptionsFor($user, $request->getLocale()),
+        );
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            throw new BadRequestHttpException('Invalid export filter.');
+        }
+
+        $filter = $this->filterMapper->fromFormData($form->getData());
+
+        try {
+            return $this->exportOrchestrator->download(
+                $user,
+                OwnHospitalAllocationsExporter::KEY,
+                $filter,
+            );
+        } catch (ExportBlockedException) {
+            throw new BadRequestHttpException('Export exceeds the maximum row limit.');
+        }
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Export/EstimateAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/EstimateAllocationsExportController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Export;
+
+use App\Allocation\Application\Export\ExportHospitalFormOptionsProvider;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExportFilterMapper;
+use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
+use App\Allocation\UI\Form\OwnHospitalAllocationsExportType;
+use App\Shared\Application\Export\ExportOrchestrator;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+#[IsGranted(ExportVoter::EXPORT)]
+final class EstimateAllocationsExportController extends AbstractController
+{
+    public function __construct(
+        private readonly ExportOrchestrator $exportOrchestrator,
+        private readonly OwnHospitalAllocationsExportFilterMapper $filterMapper,
+        private readonly ExportHospitalFormOptionsProvider $exportHospitalFormOptionsProvider,
+    ) {
+    }
+
+    #[Route('/hospitals/export/allocations/estimate', name: 'app_hospitals_export_allocations_estimate', methods: ['POST'])]
+    public function __invoke(Request $request, #[CurrentUser] User $user): Response
+    {
+        $form = $this->createForm(
+            OwnHospitalAllocationsExportType::class,
+            null,
+            $this->exportHospitalFormOptionsProvider->formOptionsFor($user, $request->getLocale()),
+        );
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            return $this->render('@Allocation/export/_export_estimate_result.html.twig', [
+                'form' => $form,
+                'estimate' => null,
+                'error' => true,
+            ], new Response('', Response::HTTP_UNPROCESSABLE_ENTITY));
+        }
+
+        $filter = $this->filterMapper->fromFormData($form->getData());
+        $estimate = $this->exportOrchestrator->estimate(
+            $user,
+            OwnHospitalAllocationsExporter::KEY,
+            $filter,
+        );
+
+        return $this->render('@Allocation/export/_export_estimate_result.html.twig', [
+            'estimate' => $estimate,
+            'error' => false,
+        ]);
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Export/ShowAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/ShowAllocationsExportController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Http\Controller\Export;
+
+use App\Allocation\Application\Export\ExportHospitalFormOptionsProvider;
+use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use App\Allocation\UI\Form\OwnHospitalAllocationsExportType;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_PARTICIPANT')]
+#[IsGranted(ExportVoter::EXPORT)]
+final class ShowAllocationsExportController extends AbstractController
+{
+    public function __construct(
+        private readonly ExportHospitalFormOptionsProvider $exportHospitalFormOptionsProvider,
+    ) {
+    }
+
+    #[Route('/hospitals/export/allocations', name: 'app_hospitals_export_allocations', methods: ['GET'])]
+    public function __invoke(Request $request, #[CurrentUser] User $user): Response
+    {
+        $defaultData = new OwnHospitalAllocationsExportFormData();
+        $now = new \DateTimeImmutable('today');
+        $defaultData->dateFrom = $now->modify('first day of this month');
+        $defaultData->dateTo = $now;
+
+        $defaultData->hospitals = $this->exportHospitalFormOptionsProvider->defaultHospitalIdsFor($user);
+
+        $form = $this->createForm(
+            OwnHospitalAllocationsExportType::class,
+            $defaultData,
+            $this->exportHospitalFormOptionsProvider->formOptionsFor($user, $request->getLocale()),
+        );
+
+        return $this->render('@Allocation/export/allocations.html.twig', [
+            'form' => $form,
+        ]);
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Export/ShowAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/ShowAllocationsExportController.php
@@ -32,6 +32,8 @@ final class ShowAllocationsExportController extends AbstractController
         $now = new \DateTimeImmutable('today');
         $defaultData->dateFrom = $now->modify('first day of this month');
         $defaultData->dateTo = $now;
+        $defaultData->timeFrom = $now->setTime(0, 0, 0);
+        $defaultData->timeTo = $now->setTime(23, 59, 59);
 
         $defaultData->hospitals = $this->exportHospitalFormOptionsProvider->defaultHospitalIdsFor($user);
 

--- a/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
+++ b/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Allocation\UI\Http\DTO;
 
+use App\Allocation\Application\Export\DTO\AllocationListFilterCriteria;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final readonly class AllocationQueryParametersDTO
@@ -67,5 +68,32 @@ final readonly class AllocationQueryParametersDTO
 
         public ?string $transportType = null,
     ) {
+    }
+
+    public function toListFilterCriteria(): AllocationListFilterCriteria
+    {
+        return new AllocationListFilterCriteria(
+            importId: $this->importId,
+            tier: $this->tier,
+            location: $this->location,
+            size: $this->size,
+            urgency: $this->urgency,
+            dispatchArea: $this->dispatchArea,
+            state: $this->state,
+            requiresResus: $this->requiresResus,
+            requiresCathlab: $this->requiresCathlab,
+            indication: $this->indication,
+            secondaryTransport: $this->secondaryTransport,
+            isVentilated: $this->isVentilated,
+            isShock: $this->isShock,
+            isCPR: $this->isCPR,
+            isPregnant: $this->isPregnant,
+            isWorkAccident: $this->isWorkAccident,
+            isInfectious: $this->isInfectious,
+            infection: $this->infection,
+            department: $this->department,
+            speciality: $this->speciality,
+            transportType: $this->transportType,
+        );
     }
 }

--- a/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
@@ -1,0 +1,101 @@
+{% import '@Statistics/analysis_explorer/_edit_accordion_macros.html.twig' as editAccordion %}
+
+<div class="accordion accordion-flush" id="export-allocation-filter-accordion">
+    <div class="accordion-item">
+        {{ editAccordion.header(
+            'export-filter-period-heading',
+            'export-filter-period-panel',
+            'label.export.period'|trans,
+            'export-filter-section-period',
+            true,
+        ) }}
+        {{ editAccordion.panel_start('export-filter-period-panel', 'export-filter-period-heading', true) }}
+            <div class="accordion-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        {{ form_row(form.dateFrom) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.dateTo) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.timeFrom) }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_row(form.timeTo) }}
+                    </div>
+                </div>
+                <p class="text-muted small mb-0">{{ 'help.export.period'|trans }}</p>
+            </div>
+        {{ editAccordion.panel_end() }}
+    </div>
+
+    {% if form.hospitals is defined %}
+        <div class="accordion-item">
+            {{ editAccordion.header(
+                'export-filter-hospital-heading',
+                'export-filter-hospital-panel',
+                form.vars.hospitals_section_label,
+                'export-filter-section-hospital',
+                false,
+            ) }}
+            {{ editAccordion.panel_start('export-filter-hospital-panel', 'export-filter-hospital-heading', false) }}
+                <div class="accordion-body">
+                    <div class="row g-2">
+                        {% for hospitalField in form.hospitals %}
+                            <div class="col-md-6">{{ form_widget(hospitalField) }}</div>
+                        {% endfor %}
+                    </div>
+                    {% if form.vars.hospitals_help %}
+                        <p class="text-muted small mb-0 mt-2">{{ form.vars.hospitals_help }}</p>
+                    {% endif %}
+                </div>
+            {{ editAccordion.panel_end() }}
+        </div>
+    {% endif %}
+
+    <div class="accordion-item">
+        {{ editAccordion.header(
+            'export-filter-allocation-heading',
+            'export-filter-allocation-panel',
+            'label.allocation'|trans,
+            'export-filter-section-allocation',
+            false,
+        ) }}
+        {{ editAccordion.panel_start('export-filter-allocation-panel', 'export-filter-allocation-heading', false) }}
+            <div class="accordion-body row g-3">
+                <div class="col-md-6">{{ form_row(form.urgency) }}</div>
+                <div class="col-md-6">{{ form_row(form.transportType) }}</div>
+                <div class="col-md-6">{{ form_row(form.indication) }}</div>
+                <div class="col-md-6">{{ form_row(form.secondaryTransport) }}</div>
+                <div class="col-md-6">{{ form_row(form.department) }}</div>
+                <div class="col-md-6">{{ form_row(form.speciality) }}</div>
+            </div>
+        {{ editAccordion.panel_end() }}
+    </div>
+
+    <div class="accordion-item">
+        {{ editAccordion.header(
+            'export-filter-clinical-heading',
+            'export-filter-clinical-panel',
+            'stats.analysis_explorer.dimension_group.clinical_care'|trans,
+            'export-filter-section-clinical',
+            false,
+        ) }}
+        {{ editAccordion.panel_start('export-filter-clinical-panel', 'export-filter-clinical-heading', false) }}
+            <div class="accordion-body">
+                <div class="row g-2">
+                    <div class="col-md-6">{{ form_row(form.requiresResus) }}</div>
+                    <div class="col-md-6">{{ form_row(form.requiresCathlab) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isVentilated) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isShock) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isCPR) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isPregnant) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isWorkAccident) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isInfectious) }}</div>
+                    <div class="col-md-6">{{ form_row(form.infection) }}</div>
+                </div>
+            </div>
+        {{ editAccordion.panel_end() }}
+    </div>
+</div>

--- a/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
@@ -1,35 +1,6 @@
 {% import '@Statistics/analysis_explorer/_edit_accordion_macros.html.twig' as editAccordion %}
 
-<div class="accordion accordion-flush" id="export-allocation-filter-accordion">
-    <div class="accordion-item">
-        {{ editAccordion.header(
-            'export-filter-period-heading',
-            'export-filter-period-panel',
-            'label.export.period'|trans,
-            'export-filter-section-period',
-            true,
-        ) }}
-        {{ editAccordion.panel_start('export-filter-period-panel', 'export-filter-period-heading', true) }}
-            <div class="accordion-body">
-                <div class="row g-3">
-                    <div class="col-md-6">
-                        {{ form_row(form.dateFrom) }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ form_row(form.dateTo) }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ form_row(form.timeFrom) }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ form_row(form.timeTo) }}
-                    </div>
-                </div>
-                <p class="text-muted small mb-0">{{ 'help.export.period'|trans }}</p>
-            </div>
-        {{ editAccordion.panel_end() }}
-    </div>
-
+<div class="accordion accordion-flush export-filter-accordion" id="export-allocation-filter-accordion">
     {% if form.hospitals is defined %}
         <div class="accordion-item">
             {{ editAccordion.header(
@@ -37,9 +8,9 @@
                 'export-filter-hospital-panel',
                 form.vars.hospitals_section_label,
                 'export-filter-section-hospital',
-                false,
+                true,
             ) }}
-            {{ editAccordion.panel_start('export-filter-hospital-panel', 'export-filter-hospital-heading', false) }}
+            {{ editAccordion.panel_start('export-filter-hospital-panel', 'export-filter-hospital-heading', true) }}
                 <div class="accordion-body">
                     <div class="row g-2">
                         {% for hospitalField in form.hospitals %}
@@ -56,20 +27,60 @@
 
     <div class="accordion-item">
         {{ editAccordion.header(
+            'export-filter-period-heading',
+            'export-filter-period-panel',
+            'label.export.period'|trans,
+            'export-filter-section-period',
+            true,
+        ) }}
+        {{ editAccordion.panel_start('export-filter-period-panel', 'export-filter-period-heading', true) }}
+            <div class="accordion-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <div class="row g-2 align-items-end">
+                            <div class="col-7">{{ form_row(form.dateFrom) }}</div>
+                            <div class="col-5">{{ form_row(form.timeFrom) }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="row g-2 align-items-end">
+                            <div class="col-7">{{ form_row(form.dateTo) }}</div>
+                            <div class="col-5">{{ form_row(form.timeTo) }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {{ editAccordion.panel_end() }}
+    </div>
+
+    <div class="accordion-item">
+        {{ editAccordion.header(
             'export-filter-allocation-heading',
             'export-filter-allocation-panel',
             'label.allocation'|trans,
             'export-filter-section-allocation',
-            false,
+            true,
         ) }}
-        {{ editAccordion.panel_start('export-filter-allocation-panel', 'export-filter-allocation-heading', false) }}
-            <div class="accordion-body row g-3">
-                <div class="col-md-6">{{ form_row(form.urgency) }}</div>
-                <div class="col-md-6">{{ form_row(form.transportType) }}</div>
-                <div class="col-md-6">{{ form_row(form.indication) }}</div>
-                <div class="col-md-6">{{ form_row(form.secondaryTransport) }}</div>
-                <div class="col-md-6">{{ form_row(form.department) }}</div>
-                <div class="col-md-6">{{ form_row(form.speciality) }}</div>
+        {{ editAccordion.panel_start('export-filter-allocation-panel', 'export-filter-allocation-heading', true) }}
+            <div class="accordion-body d-flex flex-column gap-3">
+                <div class="row g-3">
+                    <div class="col-md-4">{{ form_row(form.urgency, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-4">{{ form_row(form.assignment, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-4">{{ form_row(form.occasion, {row_attr: {class: 'mb-0'}}) }}</div>
+                </div>
+                <div class="row g-3 align-items-center">
+                    <div class="col-md-6">{{ form_row(form.indication, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-6">{{ form_row(form.includeIndicationRaw, {row_attr: {class: 'mb-0 w-100'}}) }}</div>
+                </div>
+                <div class="row g-3">
+                    <div class="col-md-6">{{ form_row(form.transportType, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-6">{{ form_row(form.secondaryTransport, {row_attr: {class: 'mb-0'}}) }}</div>
+                </div>
+                <div class="row g-3 align-items-center mb-3">
+                    <div class="col-md-4">{{ form_row(form.speciality, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-4">{{ form_row(form.department, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-4">{{ form_row(form.departmentWasClosed, {row_attr: {class: 'mb-0 w-100'}}) }}</div>
+                </div>
             </div>
         {{ editAccordion.panel_end() }}
     </div>
@@ -80,19 +91,27 @@
             'export-filter-clinical-panel',
             'stats.analysis_explorer.dimension_group.clinical_care'|trans,
             'export-filter-section-clinical',
-            false,
+            true,
         ) }}
-        {{ editAccordion.panel_start('export-filter-clinical-panel', 'export-filter-clinical-heading', false) }}
-            <div class="accordion-body">
+        {{ editAccordion.panel_start('export-filter-clinical-panel', 'export-filter-clinical-heading', true) }}
+            <div class="accordion-body d-flex flex-column gap-2">
                 <div class="row g-2">
-                    <div class="col-md-6">{{ form_row(form.requiresResus) }}</div>
-                    <div class="col-md-6">{{ form_row(form.requiresCathlab) }}</div>
-                    <div class="col-md-6">{{ form_row(form.isVentilated) }}</div>
-                    <div class="col-md-6">{{ form_row(form.isShock) }}</div>
-                    <div class="col-md-6">{{ form_row(form.isCPR) }}</div>
-                    <div class="col-md-6">{{ form_row(form.isPregnant) }}</div>
+                    <div class="col-md-6">{{ form_row(form.requiresResus, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-6">{{ form_row(form.requiresCathlab, {row_attr: {class: 'mb-0'}}) }}</div>
+                </div>
+                <div class="row g-2">
+                    <div class="col-md-6">{{ form_row(form.isVentilated, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isShock, {row_attr: {class: 'mb-0'}}) }}</div>
+                </div>
+                <div class="row g-2">
+                    <div class="col-md-6">{{ form_row(form.isCPR, {row_attr: {class: 'mb-0'}}) }}</div>
+                    <div class="col-md-6">{{ form_row(form.isPregnant, {row_attr: {class: 'mb-0'}}) }}</div>
+                </div>
+                <div class="row g-2">
                     <div class="col-md-6">{{ form_row(form.isWorkAccident) }}</div>
-                    <div class="col-md-6">{{ form_row(form.isInfectious) }}</div>
+                </div>
+                <div class="row g-2 align-items-center">
+                    <div class="col-md-6">{{ form_row(form.isInfectious, {row_attr: {class: 'mb-0'}}) }}</div>
                     <div class="col-md-6">{{ form_row(form.infection) }}</div>
                 </div>
             </div>

--- a/src/Allocation/UI/Twig/templates/export/_export_estimate_result.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/_export_estimate_result.html.twig
@@ -1,0 +1,36 @@
+<turbo-frame id="export-estimate">
+    {% if error %}
+        <div class="alert alert-danger" role="alert" data-testid="export-estimate-error">
+            {{ 'error.export.invalid_filter'|trans }}
+        </div>
+    {% elseif estimate is not null %}
+        {% if estimate.blocked %}
+            <div class="alert alert-danger" role="alert" data-testid="export-estimate-blocked">
+                {{ 'error.export.too_many_rows'|trans({count: estimate.count}) }}
+            </div>
+        {% elseif estimate.warn %}
+            <div class="alert alert-warning" role="alert" data-testid="export-estimate-warning">
+                {{ 'warning.export.large_export'|trans({count: estimate.count}) }}
+            </div>
+        {% else %}
+            <div class="alert alert-info" role="alert" data-testid="export-estimate-ok">
+                {{ 'info.export.row_count'|trans({count: estimate.count}) }}
+            </div>
+        {% endif %}
+
+        {% if not estimate.blocked %}
+            <input type="hidden"
+                   form="export-allocations-form"
+                   name="_token"
+                   value="{{ csrf_token('export_allocations_csv') }}">
+            <button type="submit"
+                    class="btn btn-success"
+                    form="export-allocations-form"
+                    formaction="{{ path('app_hospitals_export_allocations_download') }}"
+                    data-turbo="false"
+                    data-testid="export-allocations-download">
+                {{ 'action.export.download_csv'|trans }}
+            </button>
+        {% endif %}
+    {% endif %}
+</turbo-frame>

--- a/src/Allocation/UI/Twig/templates/export/_export_estimate_result.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/_export_estimate_result.html.twig
@@ -1,34 +1,45 @@
-<turbo-frame id="export-estimate">
+<turbo-frame id="export-estimate" class="flex-grow-1 d-flex align-items-center gap-2 min-w-0">
     {% if error %}
-        <div class="alert alert-danger" role="alert" data-testid="export-estimate-error">
+        <div class="alert alert-danger mb-0 flex-grow-1 py-2" role="alert" data-testid="export-estimate-error">
             {{ 'error.export.invalid_filter'|trans }}
         </div>
     {% elseif estimate is not null %}
         {% if estimate.blocked %}
-            <div class="alert alert-danger" role="alert" data-testid="export-estimate-blocked">
+            <div class="alert alert-danger mb-0 flex-grow-1 py-2" role="alert" data-testid="export-estimate-blocked">
                 {{ 'error.export.too_many_rows'|trans({count: estimate.count}) }}
             </div>
         {% elseif estimate.warn %}
-            <div class="alert alert-warning" role="alert" data-testid="export-estimate-warning">
+            <div class="alert alert-warning mb-0 flex-grow-1 py-2" role="alert" data-testid="export-estimate-warning">
                 {{ 'warning.export.large_export'|trans({count: estimate.count}) }}
             </div>
-        {% else %}
-            <div class="alert alert-info" role="alert" data-testid="export-estimate-ok">
-                {{ 'info.export.row_count'|trans({count: estimate.count}) }}
-            </div>
-        {% endif %}
-
-        {% if not estimate.blocked %}
             <input type="hidden"
                    form="export-allocations-form"
                    name="_token"
                    value="{{ csrf_token('export_allocations_csv') }}">
             <button type="submit"
-                    class="btn btn-success"
+                    class="btn btn-success flex-shrink-0 d-inline-flex align-items-center gap-1"
                     form="export-allocations-form"
                     formaction="{{ path('app_hospitals_export_allocations_download') }}"
                     data-turbo="false"
                     data-testid="export-allocations-download">
+                <twig:ux:icon name="tabler:download" style="height: 1.1em;" aria-hidden="true" />
+                {{ 'action.export.download_csv'|trans }}
+            </button>
+        {% else %}
+            <div class="alert alert-info mb-0 flex-grow-1 py-2" role="alert" data-testid="export-estimate-ok">
+                {{ 'info.export.row_count'|trans({count: estimate.count}) }}
+            </div>
+            <input type="hidden"
+                   form="export-allocations-form"
+                   name="_token"
+                   value="{{ csrf_token('export_allocations_csv') }}">
+            <button type="submit"
+                    class="btn btn-success flex-shrink-0 d-inline-flex align-items-center gap-1"
+                    form="export-allocations-form"
+                    formaction="{{ path('app_hospitals_export_allocations_download') }}"
+                    data-turbo="false"
+                    data-testid="export-allocations-download">
+                <twig:ux:icon name="tabler:download" style="height: 1.1em;" aria-hidden="true" />
                 {{ 'action.export.download_csv'|trans }}
             </button>
         {% endif %}

--- a/src/Allocation/UI/Twig/templates/export/allocations.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/allocations.html.twig
@@ -1,0 +1,53 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'title.export.allocations'|trans }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    <div class="container-xl">
+        <twig:Breadcrumbs
+            :items="[
+                { label: 'title.export.allocations' }
+            ]"
+        />
+
+        <div class="page-header d-print-none">
+            <div class="row align-items-center">
+                <div class="col">
+                    <h2 class="page-title">{{ 'title.export.allocations'|trans }}</h2>
+                    <div class="text-body-secondary mt-1">
+                        {{ 'help.export.allocations'|trans }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block page_content %}
+    <div class="container-xl">
+        <div class="card">
+            <div class="card-body">
+                {{ form_start(form, {
+                    action: path('app_hospitals_export_allocations_estimate'),
+                    method: 'POST',
+                    attr: {
+                        id: 'export-allocations-form',
+                        'data-turbo-frame': 'export-estimate',
+                    },
+                }) }}
+                    {{ include('@Allocation/export/_export_allocation_filters.html.twig') }}
+
+                    <div class="d-flex justify-content-end mt-4">
+                        <button type="submit"
+                                class="btn btn-primary"
+                                data-testid="export-allocations-prepare">
+                            {{ 'action.export.prepare'|trans }}
+                        </button>
+                    </div>
+                {{ form_end(form) }}
+
+                <turbo-frame id="export-estimate" class="mt-4"></turbo-frame>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Allocation/UI/Twig/templates/export/allocations.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/allocations.html.twig
@@ -36,17 +36,17 @@
                     },
                 }) }}
                     {{ include('@Allocation/export/_export_allocation_filters.html.twig') }}
-
-                    <div class="d-flex justify-content-end mt-4">
-                        <button type="submit"
-                                class="btn btn-primary"
-                                data-testid="export-allocations-prepare">
-                            {{ 'action.export.prepare'|trans }}
-                        </button>
-                    </div>
                 {{ form_end(form) }}
-
-                <turbo-frame id="export-estimate" class="mt-4"></turbo-frame>
+            </div>
+            <div class="card-footer d-flex align-items-center gap-2">
+                <button type="submit"
+                        class="btn btn-primary flex-shrink-0 d-inline-flex align-items-center gap-1"
+                        form="export-allocations-form"
+                        data-testid="export-allocations-prepare">
+                    <twig:ux:icon name="tabler:calculator" style="height: 1.1em;" aria-hidden="true" />
+                    {{ 'action.export.prepare'|trans }}
+                </button>
+                {{ include('@Allocation/export/_export_estimate_result.html.twig', {estimate: null, error: false}, false) }}
             </div>
         </div>
     </div>

--- a/src/Shared/Application/Export/CsvStreamExportResponseFactory.php
+++ b/src/Shared/Application/Export/CsvStreamExportResponseFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class CsvStreamExportResponseFactory
+{
+    private const string UTF8_BOM = "\xEF\xBB\xBF";
+
+    /**
+     * @param callable(resource): int $writer receives php://output stream, returns row count
+     */
+    public function create(string $filename, callable $writer): StreamedResponse
+    {
+        return new StreamedResponse(
+            function () use ($writer): void {
+                $stream = fopen('php://output', 'w');
+                if (false === $stream) {
+                    throw new \RuntimeException('Cannot open output stream for CSV export.');
+                }
+
+                try {
+                    fwrite($stream, self::UTF8_BOM);
+                    $writer($stream);
+                } finally {
+                    fclose($stream);
+                }
+            },
+            StreamedResponse::HTTP_OK,
+            [
+                'Content-Type' => 'text/csv; charset=UTF-8',
+                'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
+            ],
+        );
+    }
+
+    /**
+     * @param resource                    $stream
+     * @param list<string|int|float|null> $cells
+     */
+    public function writeRow($stream, array $cells): void
+    {
+        fputcsv(
+            $stream,
+            array_map(static fn (string|int|float|null $value): string => match (true) {
+                null === $value => '',
+                \is_int($value) => (string) $value,
+                \is_float($value) => rtrim(rtrim(sprintf('%.10F', $value), '0'), '.'),
+                default => $value,
+            }, $cells),
+            ',',
+            '"',
+            '\\',
+        );
+    }
+}

--- a/src/Shared/Application/Export/ExportAuditLogger.php
+++ b/src/Shared/Application/Export/ExportAuditLogger.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ExportAuditLogger
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    /**
+     * @param list<int>            $hospitalIds
+     * @param array<string, mixed> $filters
+     */
+    public function log(
+        User $user,
+        string $exporterKey,
+        array $hospitalIds,
+        array $filters,
+        int $rowCount,
+        bool $blocked,
+        bool $success,
+    ): void {
+        $requestId = $this->auditContext->ensureRequestId(static fn (): string => bin2hex(random_bytes(16)));
+        $origin = $this->auditContext->getOrigin() ?? AuditContext::ORIGIN_HTTP;
+
+        $this->entityManager->persist(new AuditEntry(
+            new \DateTimeImmutable('now'),
+            $requestId,
+            $user,
+            $origin,
+            'export',
+            'data_export',
+            $exporterKey,
+            [],
+            [
+                'exporterKey' => $exporterKey,
+                'hospitalIds' => $hospitalIds,
+                'filters' => $filters,
+                'rowCount' => $rowCount,
+                'blocked' => $blocked,
+                'success' => $success,
+            ],
+        ));
+        $this->entityManager->flush();
+    }
+}

--- a/src/Shared/Application/Export/ExportBlockedException.php
+++ b/src/Shared/Application/Export/ExportBlockedException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+final class ExportBlockedException extends \RuntimeException
+{
+    public function __construct(
+        public readonly int $count,
+        public readonly string $exporterKey,
+    ) {
+        parent::__construct(sprintf(
+            'Export "%s" blocked: %d rows exceed the limit of %d.',
+            $exporterKey,
+            $count,
+            ExportLimits::MAX_EXPORT_ROWS,
+        ));
+    }
+}

--- a/src/Shared/Application/Export/ExportEstimate.php
+++ b/src/Shared/Application/Export/ExportEstimate.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+final readonly class ExportEstimate
+{
+    public function __construct(
+        public int $count,
+        public bool $blocked,
+        public bool $warn,
+        public string $exporterKey,
+    ) {
+    }
+}

--- a/src/Shared/Application/Export/ExportLimits.php
+++ b/src/Shared/Application/Export/ExportLimits.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+final class ExportLimits
+{
+    public const int MAX_EXPORT_ROWS = 50_000;
+
+    public const int WARN_EXPORT_ROWS = 40_000;
+}

--- a/src/Shared/Application/Export/ExportOrchestrator.php
+++ b/src/Shared/Application/Export/ExportOrchestrator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ExportOrchestrator
+{
+    public function __construct(
+        private readonly ExporterRegistry $exporterRegistry,
+        private readonly CsvStreamExportResponseFactory $csvStreamExportResponseFactory,
+        private readonly ExportAuditLogger $exportAuditLogger,
+    ) {
+    }
+
+    public function estimate(User $user, string $exporterKey, object $criteria): ExportEstimate
+    {
+        $exporter = $this->exporterRegistry->get($exporterKey);
+        $exporter->assertCanExport($user);
+
+        $count = $exporter->count($user, $criteria);
+        $blocked = $count > ExportLimits::MAX_EXPORT_ROWS;
+        $warn = !$blocked && $count >= ExportLimits::WARN_EXPORT_ROWS;
+
+        if ($blocked) {
+            $this->exportAuditLogger->log(
+                $user,
+                $exporterKey,
+                $exporter->resolveScopeHospitalIds($user),
+                $exporter->serializeCriteria($criteria),
+                $count,
+                true,
+                false,
+            );
+        }
+
+        return new ExportEstimate($count, $blocked, $warn, $exporterKey);
+    }
+
+    public function download(User $user, string $exporterKey, object $criteria): StreamedResponse
+    {
+        $exporter = $this->exporterRegistry->get($exporterKey);
+        $exporter->assertCanExport($user);
+
+        $count = $exporter->count($user, $criteria);
+        if ($count > ExportLimits::MAX_EXPORT_ROWS) {
+            $this->exportAuditLogger->log(
+                $user,
+                $exporterKey,
+                $exporter->resolveScopeHospitalIds($user),
+                $exporter->serializeCriteria($criteria),
+                $count,
+                true,
+                false,
+            );
+
+            throw new ExportBlockedException($count, $exporterKey);
+        }
+
+        $hospitalIds = $exporter->resolveScopeHospitalIds($user);
+        $filters = $exporter->serializeCriteria($criteria);
+
+        $this->exportAuditLogger->log(
+            $user,
+            $exporterKey,
+            $hospitalIds,
+            $filters,
+            $count,
+            false,
+            true,
+        );
+
+        return $this->csvStreamExportResponseFactory->create(
+            $exporter->buildFilename(),
+            static fn ($stream): int => $exporter->writeCsv($user, $criteria, $stream),
+        );
+    }
+}

--- a/src/Shared/Application/Export/ExporterInterface.php
+++ b/src/Shared/Application/Export/ExporterInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+use App\User\Domain\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exporter')]
+interface ExporterInterface
+{
+    public function key(): string;
+
+    public function assertCanExport(User $user): void;
+
+    /**
+     * @return list<int>
+     */
+    public function resolveScopeHospitalIds(User $user): array;
+
+    public function count(User $user, object $criteria): int;
+
+    /**
+     * @param resource $stream
+     *
+     * @return int number of data rows written (excluding header)
+     */
+    public function writeCsv(User $user, object $criteria, $stream): int;
+
+    public function buildFilename(): string;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function serializeCriteria(object $criteria): array;
+}

--- a/src/Shared/Application/Export/ExporterRegistry.php
+++ b/src/Shared/Application/Export/ExporterRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final readonly class ExporterRegistry
+{
+    /**
+     * @param iterable<ExporterInterface> $exporters
+     */
+    public function __construct(
+        #[AutowireIterator('app.exporter')]
+        private iterable $exporters,
+    ) {
+    }
+
+    public function get(string $key): ExporterInterface
+    {
+        foreach ($this->exporters as $exporter) {
+            if ($exporter->key() === $key) {
+                return $exporter;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown exporter key: %s', $key));
+    }
+}

--- a/src/Shared/UI/Twig/templates/_embeds/header.html.twig
+++ b/src/Shared/UI/Twig/templates/_embeds/header.html.twig
@@ -47,6 +47,16 @@
                                     </a>
                                 </li>
                             {% endif %}
+                            {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\ExportVoter::EXPORT')) %}
+                                <li class="nav-item {{ route starts with 'app_hospitals_export' ? 'active' : '' }}">
+                                    <a class="nav-link" href="{{ path('app_hospitals_export_allocations') }}">
+                                        <span class="nav-link-title">
+                                            <twig:ux:icon name="tabler:database-export" style="height: 1.5em;" />
+                                            {{ 'link.export'|trans }}
+                                        </span>
+                                    </a>
+                                </li>
+                            {% endif %}
                             <li class="nav-item {{ route starts with 'app_blog' ? 'active' : '' }}">
                                 <a class="nav-link" href="{{ path('app_blog_index') }}">
                                     <span class="nav-link-title">

--- a/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Functional\Controller\Export;
+
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Shared\Application\Export\ExportBlockedException;
+use App\Shared\Application\Export\ExportEstimate;
+use App\Shared\Application\Export\ExportLimits;
+use App\Shared\Application\Export\ExportOrchestrator;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AllocationsExportControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testNonParticipantCannotAccessExportPage(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+        $client->loginUser($user);
+
+        $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testParticipantWithoutExportScopeCannotAccessExportPage(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'participant-no-hospital']);
+        $client->loginUser($user);
+
+        $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testOwnerCanOpenExportPageAndSeesNavLink(): void
+    {
+        [$client] = $this->createOwnerClient();
+
+        $client->request(Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('a[href="/hospitals/export/allocations"]', 'Export');
+
+        $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="export-allocations-prepare"]');
+        self::assertSelectorExists('[data-testid="export-filter-section-hospital"]');
+        self::assertSelectorExists('input[type="checkbox"][name*="[hospitals]"]:checked');
+    }
+
+    public function testPrepareExportDoesNotDuplicateFilterFieldsInEstimateFrame(): void
+    {
+        [$client] = $this->createOwnerClient();
+
+        $this->submitEstimate($client);
+
+        self::assertSelectorExists('[data-testid="export-estimate-ok"]');
+        self::assertSelectorExists('[data-testid="export-allocations-download"]');
+        self::assertSelectorNotExists('#export-estimate select[name*="[urgency]"]');
+        self::assertSelectorNotExists('#export-estimate #export-allocations-download-form');
+    }
+
+    public function testParticipantWithoutHospitalDoesNotSeeNavLink(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'nav-no-export']);
+        $client->loginUser($user);
+
+        $crawler = $client->request(Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('a[href="/hospitals/export/allocations"]'));
+    }
+
+    public function testOwnerExportDownloadIsSuccessful(): void
+    {
+        [$client, $owner] = $this->createOwnerClient();
+        $other = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'other-owner']);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $ownedHospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Owned Hospital Export']);
+        $foreignHospital = HospitalFactory::createOne(['owner' => $other, 'name' => 'Foreign Hospital Export']);
+        $this->seedAllocationDependencies($ownedHospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $ownedHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'createdAt' => new \DateTimeImmutable('2026-01-15 09:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $foreignHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 11:00:00'),
+            'createdAt' => new \DateTimeImmutable('2026-01-15 09:30:00'),
+        ]);
+
+        $formValues = $this->submitEstimate($client);
+        self::assertSelectorExists('[data-testid="export-estimate-ok"]');
+
+        $this->submitDownload($client, $formValues);
+        self::assertResponseIsSuccessful();
+        self::assertSame('text/csv; charset=UTF-8', $client->getResponse()->headers->get('Content-Type'));
+        self::assertStringContainsString('attachment', (string) $client->getResponse()->headers->get('Content-Disposition'));
+    }
+
+    public function testGrantUserWithExportPermissionCanExportGrantHospital(): void
+    {
+        $client = self::createClient();
+
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-export-user']);
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grant-owner']);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Grant Hospital Export']);
+        $this->seedAllocationDependencies($hospital);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Export,
+            ]),
+        ]);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-20 12:00:00'),
+        ]);
+
+        $client->loginUser($grantee);
+
+        $formValues = $this->submitEstimate($client);
+        self::assertSelectorExists('[data-testid="export-estimate-ok"]');
+
+        $this->submitDownload($client, $formValues);
+        self::assertResponseIsSuccessful();
+        self::assertSame('text/csv; charset=UTF-8', $client->getResponse()->headers->get('Content-Type'));
+    }
+
+    public function testEstimateShowsWarningForLargeExport(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+        $this->mockOrchestratorEstimate(new ExportEstimate(
+            ExportLimits::WARN_EXPORT_ROWS,
+            false,
+            true,
+            OwnHospitalAllocationsExporter::KEY,
+        ));
+        $this->loginOwnerOnClient($client);
+
+        $this->submitEstimate($client);
+
+        self::assertSelectorExists('[data-testid="export-estimate-warning"]');
+        self::assertSelectorExists('[data-testid="export-allocations-download"]');
+    }
+
+    public function testEstimateBlocksWhenTooManyRows(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+        $this->mockOrchestratorEstimate(new ExportEstimate(
+            ExportLimits::MAX_EXPORT_ROWS + 1,
+            true,
+            false,
+            OwnHospitalAllocationsExporter::KEY,
+        ));
+        $this->loginOwnerOnClient($client);
+
+        $this->submitEstimate($client);
+
+        self::assertSelectorExists('[data-testid="export-estimate-blocked"]');
+        self::assertSelectorNotExists('[data-testid="export-allocations-download"]');
+    }
+
+    public function testDownloadRevalidatesRowLimit(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+
+        $mock = $this->createMock(ExportOrchestrator::class);
+        $mock->method('estimate')->willReturn(new ExportEstimate(100, false, false, OwnHospitalAllocationsExporter::KEY));
+        $mock->method('download')->willThrowException(new ExportBlockedException(ExportLimits::MAX_EXPORT_ROWS + 1, OwnHospitalAllocationsExporter::KEY));
+        self::getContainer()->set(ExportOrchestrator::class, $mock);
+
+        $this->loginOwnerOnClient($client);
+
+        $formValues = $this->submitEstimate($client);
+        $this->submitDownload($client, $formValues);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function testNavExportAppearsBetweenImportAndBlog(): void
+    {
+        [$client] = $this->createOwnerClient();
+
+        $crawler = $client->request(Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $navItems = $crawler->filter('#navbar-menu .nav-item .nav-link');
+        $labels = [];
+        foreach ($navItems as $item) {
+            $labels[] = trim(preg_replace('/\s+/', ' ', $item->textContent ?? '') ?? '');
+        }
+
+        $importIndex = array_search('Import', $labels, true);
+        $exportIndex = array_search('Export', $labels, true);
+        $blogIndex = array_search('Blog', $labels, true);
+
+        self::assertNotFalse($importIndex);
+        self::assertNotFalse($exportIndex);
+        self::assertNotFalse($blogIndex);
+        self::assertSame($importIndex + 1, $exportIndex);
+        self::assertSame($exportIndex + 1, $blogIndex);
+    }
+
+    /**
+     * @return array{0: KernelBrowser, 1: User}
+     */
+    private function createOwnerClient(): array
+    {
+        $client = self::createClient();
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'export-owner-'.bin2hex(random_bytes(4))]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+        $client->loginUser($owner);
+
+        return [$client, $owner];
+    }
+
+    private function loginOwnerOnClient(KernelBrowser $client): User
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'export-owner-'.bin2hex(random_bytes(4))]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+        $client->loginUser($owner);
+
+        return $owner;
+    }
+
+    private function seedAllocationDependencies(object $hospital): void
+    {
+        ImportFactory::createOne(['name' => 'Export Test Import', 'hospital' => $hospital]);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        OccasionFactory::createOne(['name' => 'Test Occasion']);
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+        InfectionFactory::createOne(['name' => 'Test Infection']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication Raw']);
+        IndicationNormalizedFactory::createOne(['name' => 'Test Indication']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function submitEstimate(KernelBrowser $client): array
+    {
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('#export-allocations-form')->form();
+        $form['own_hospital_allocations_export[dateFrom]'] = '2026-01-01';
+        $form['own_hospital_allocations_export[dateTo]'] = '2026-01-31';
+        $values = $form->getPhpValues();
+
+        $client->request(
+            Request::METHOD_POST,
+            '/hospitals/export/allocations/estimate',
+            $values,
+            [],
+            ['HTTP_TURBO_FRAME' => 'export-estimate'],
+        );
+        self::assertResponseIsSuccessful();
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $formValues
+     */
+    private function submitDownload(KernelBrowser $client, array $formValues): void
+    {
+        $formValues['_token'] = (string) $client->getCrawler()
+            ->filter('input[name="_token"]')
+            ->attr('value');
+
+        $client->request(
+            Request::METHOD_POST,
+            '/hospitals/export/allocations/download',
+            $formValues,
+        );
+    }
+
+    private function mockOrchestratorEstimate(ExportEstimate $estimate): void
+    {
+        $mock = $this->createMock(ExportOrchestrator::class);
+        $mock->method('estimate')->willReturn($estimate);
+        self::getContainer()->set(ExportOrchestrator::class, $mock);
+    }
+}

--- a/tests/Allocation/Integration/Export/ExportAccessServiceTest.php
+++ b/tests/Allocation/Integration/Export/ExportAccessServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Export;
+
+use App\Allocation\Application\Export\ExportAccessService;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ExportAccessServiceTest extends KernelTestCase
+{
+    use Factories;
+
+    private ExportAccessService $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->service = self::getContainer()->get(ExportAccessService::class);
+    }
+
+    public function testResolveEffectiveHospitalIdsReturnsAllWhenNoneSelected(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospitalA = HospitalFactory::createOne(['owner' => $owner]);
+        $hospitalB = HospitalFactory::createOne(['owner' => $owner]);
+
+        $allowed = $this->service->resolveExportHospitalIds($owner);
+        self::assertEqualsCanonicalizing(
+            [(int) $hospitalA->getId(), (int) $hospitalB->getId()],
+            $this->service->resolveEffectiveHospitalIds($owner, null),
+        );
+        self::assertEqualsCanonicalizing($allowed, $this->service->resolveEffectiveHospitalIds($owner, []));
+    }
+
+    public function testResolveEffectiveHospitalIdsIntersectsWithAllowed(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $other = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospitalA = HospitalFactory::createOne(['owner' => $owner]);
+        $hospitalB = HospitalFactory::createOne(['owner' => $owner]);
+        $foreign = HospitalFactory::createOne(['owner' => $other]);
+
+        self::assertSame(
+            [(int) $hospitalA->getId()],
+            $this->service->resolveEffectiveHospitalIds($owner, [(int) $hospitalA->getId(), (int) $foreign->getId()]),
+        );
+
+        self::assertSame(
+            [(int) $hospitalB->getId()],
+            $this->service->resolveEffectiveHospitalIds($owner, [(int) $hospitalB->getId()]),
+        );
+    }
+
+    public function testGrantUserCanOnlySelectGrantedHospital(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        HospitalFactory::createOne(['owner' => $owner]);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Export,
+            ]),
+        ]);
+
+        self::assertSame(
+            [(int) $hospital->getId()],
+            $this->service->resolveEffectiveHospitalIds($grantee, [(int) $hospital->getId()]),
+        );
+    }
+}

--- a/tests/Allocation/Integration/Export/ExportHospitalFormOptionsProviderTest.php
+++ b/tests/Allocation/Integration/Export/ExportHospitalFormOptionsProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Export;
+
+use App\Allocation\Application\Export\ExportHospitalFormOptionsProvider;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ExportHospitalFormOptionsProviderTest extends KernelTestCase
+{
+    use Factories;
+
+    private ExportHospitalFormOptionsProvider $provider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->provider = self::getContainer()->get(ExportHospitalFormOptionsProvider::class);
+    }
+
+    public function testSingleHospitalOwnerGetsVisibleChoicesAndDefaultSelection(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Solo Hospital']);
+
+        $options = $this->provider->optionsFor($owner, 'en');
+        $formOptions = $this->provider->formOptionsFor($owner, 'en');
+
+        self::assertCount(1, $options['hospital_choices']);
+        self::assertSame([(int) $hospital->getId()], $options['default_hospital_ids']);
+        self::assertArrayNotHasKey('default_hospital_ids', $formOptions);
+        self::assertSame('', $options['hospitals_help']);
+        self::assertSame('My hospitals', $options['hospitals_section_label']);
+    }
+
+    public function testAdminGetsHospitalsLabelAndHelpForMultipleChoices(): void
+    {
+        $admin = UserFactory::createOne(['roles' => [UserRole::ADMIN, 'ROLE_USER']]);
+        HospitalFactory::createOne(['name' => 'Hospital A']);
+        HospitalFactory::createOne(['name' => 'Hospital B']);
+
+        $options = $this->provider->optionsFor($admin, 'en');
+
+        self::assertGreaterThanOrEqual(2, \count($options['hospital_choices']));
+        self::assertNotSame('', $options['hospitals_help']);
+        self::assertSame('Hospitals', $options['hospitals_section_label']);
+    }
+}

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExportQueryTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExportQueryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Export;
+
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class OwnHospitalAllocationsExportQueryTest extends KernelTestCase
+{
+    use Factories;
+
+    private OwnHospitalAllocationsExportQuery $query;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->query = self::getContainer()->get(OwnHospitalAllocationsExportQuery::class);
+    }
+
+    public function testOwnerSeesOnlyOwnHospitalAllocations(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $other = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $ownedHospital = HospitalFactory::createOne(['owner' => $owner]);
+        $foreignHospital = HospitalFactory::createOne(['owner' => $other]);
+        $this->seedAllocationDependencies($ownedHospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $ownedHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'createdAt' => new \DateTimeImmutable('2026-01-15 09:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $foreignHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 11:00:00'),
+            'createdAt' => new \DateTimeImmutable('2026-01-15 09:30:00'),
+        ]);
+
+        $filter = $this->createJanuaryFilter();
+        $count = $this->query->count([(int) $ownedHospital->getId()], $filter);
+
+        self::assertSame(1, $count);
+    }
+
+    public function testArrivalAtIntervalExcludesOutsideRange(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-01 07:59:59'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-01 08:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-01 18:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-01 18:00:01'),
+        ]);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-01'),
+            timeFrom: new \DateTimeImmutable('1970-01-01 08:00:00'),
+            timeTo: new \DateTimeImmutable('1970-01-01 18:00:00'),
+        );
+
+        $count = $this->query->count([(int) $hospital->getId()], $filter);
+
+        self::assertSame(2, $count);
+    }
+
+    public function testGrantHospitalIncludedInScopeIds(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'], 'username' => 'grantee-export']);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Export,
+            ]),
+        ]);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-10 12:00:00'),
+        ]);
+
+        $filter = $this->createJanuaryFilter();
+        $count = $this->query->count([(int) $hospital->getId()], $filter);
+
+        self::assertSame(1, $count);
+    }
+
+    private function createJanuaryFilter(): OwnHospitalAllocationsExportFilter
+    {
+        return new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+    }
+
+    private function seedAllocationDependencies(object $hospital): void
+    {
+        ImportFactory::createOne(['name' => 'Export Test Import', 'hospital' => $hospital]);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        OccasionFactory::createOne(['name' => 'Test Occasion']);
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+        InfectionFactory::createOne(['name' => 'Test Infection']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication Raw']);
+        IndicationNormalizedFactory::createOne(['name' => 'Test Indication']);
+    }
+}

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExportQueryTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExportQueryTest.php
@@ -136,6 +136,53 @@ final class OwnHospitalAllocationsExportQueryTest extends KernelTestCase
         self::assertSame(1, $count);
     }
 
+    public function testFiltersByAssignmentOccasionAndDepartmentWasClosed(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        $assignmentA = AssignmentFactory::createOne(['name' => 'Assignment A']);
+        $assignmentB = AssignmentFactory::createOne(['name' => 'Assignment B']);
+        $occasionA = OccasionFactory::createOne(['name' => 'Occasion A']);
+        $occasionB = OccasionFactory::createOne(['name' => 'Occasion B']);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-10 12:00:00'),
+            'assignment' => $assignmentA,
+            'occasion' => $occasionA,
+            'departmentWasClosed' => true,
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-11 12:00:00'),
+            'assignment' => $assignmentB,
+            'occasion' => $occasionB,
+            'departmentWasClosed' => false,
+        ]);
+
+        $hospitalId = (int) $hospital->getId();
+
+        self::assertSame(1, $this->query->count([$hospitalId], new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+            assignment: (int) $assignmentA->getId(),
+        )));
+        self::assertSame(1, $this->query->count([$hospitalId], new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+            occasion: (int) $occasionA->getId(),
+        )));
+        self::assertSame(1, $this->query->count([$hospitalId], new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+            departmentWasClosed: 1,
+        )));
+    }
+
     private function createJanuaryFilter(): OwnHospitalAllocationsExportFilter
     {
         return new OwnHospitalAllocationsExportFilter(

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Export;
+
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class OwnHospitalAllocationsExporterTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testWriteCsvIncludesHeaderAndScopedRows(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $other = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        $ownedHospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'CSV Owned Hospital']);
+        $foreignHospital = HospitalFactory::createOne(['owner' => $other, 'name' => 'CSV Foreign Hospital']);
+        $this->seedAllocationDependencies($ownedHospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $ownedHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $foreignHospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 11:00:00'),
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $stream = fopen('php://temp', 'w+');
+        self::assertIsResource($stream);
+
+        $written = $exporter->writeCsv($owner, $filter, $stream);
+        rewind($stream);
+        $csv = stream_get_contents($stream) ?: '';
+        fclose($stream);
+
+        self::assertSame(1, $written);
+        self::assertStringContainsString('arrivalAt', $csv);
+        self::assertStringContainsString('dispatchArea', $csv);
+        self::assertStringContainsString('CSV Owned Hospital', $csv);
+        self::assertStringNotContainsString('CSV Foreign Hospital', $csv);
+    }
+
+    public function testWriteCsvRespectsSelectedHospitalIds(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+
+        $hospitalA = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Hospital Alpha']);
+        $hospitalB = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Hospital Beta']);
+        $this->seedAllocationDependencies($hospitalA);
+        $this->seedAllocationDependencies($hospitalB);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospitalA,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospitalB,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 11:00:00'),
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+            hospitalIds: [(int) $hospitalA->getId()],
+        );
+
+        $stream = fopen('php://temp', 'w+');
+        self::assertIsResource($stream);
+
+        $written = $exporter->writeCsv($owner, $filter, $stream);
+        rewind($stream);
+        $csv = stream_get_contents($stream) ?: '';
+        fclose($stream);
+
+        self::assertSame(1, $written);
+        self::assertStringContainsString('Hospital Alpha', $csv);
+        self::assertStringNotContainsString('Hospital Beta', $csv);
+    }
+
+    private function seedAllocationDependencies(object $hospital): void
+    {
+        ImportFactory::createOne(['name' => 'CSV Export Import', 'hospital' => $hospital]);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        OccasionFactory::createOne(['name' => 'Test Occasion']);
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+        InfectionFactory::createOne(['name' => 'Test Infection']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication Raw']);
+        IndicationNormalizedFactory::createOne(['name' => 'Test Indication']);
+    }
+}

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
@@ -6,6 +6,9 @@ namespace App\Tests\Allocation\Integration\Export;
 
 use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
 use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Infrastructure\Factory\AllocationFactory;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
@@ -60,19 +63,163 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
             dateTo: new \DateTimeImmutable('2026-01-31'),
         );
 
-        $stream = fopen('php://temp', 'w+');
-        self::assertIsResource($stream);
+        $csv = $this->exportCsv($exporter, $owner, $filter);
 
-        $written = $exporter->writeCsv($owner, $filter, $stream);
-        rewind($stream);
-        $csv = stream_get_contents($stream) ?: '';
-        fclose($stream);
-
-        self::assertSame(1, $written);
         self::assertStringContainsString('arrivalAt', $csv);
         self::assertStringContainsString('dispatchArea', $csv);
         self::assertStringContainsString('CSV Owned Hospital', $csv);
         self::assertStringNotContainsString('CSV Foreign Hospital', $csv);
+    }
+
+    public function testWriteCsvUsesReadableEnumValues(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'Chest pain raw text']);
+        IndicationNormalizedFactory::createOne(['name' => 'Chest pain normalized']);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::AIR,
+            'indicationRaw' => $indicationRaw,
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+
+        self::assertStringContainsString('Male', $csv);
+        self::assertStringContainsString('SK2', $csv);
+        self::assertStringContainsString('Air', $csv);
+        self::assertStringNotContainsString(',M,', $csv);
+        self::assertStringNotContainsString(',A,', $csv);
+    }
+
+    public function testWriteCsvCanIncludeIndicationRawColumn(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'Original indication text']);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'indicationRaw' => $indicationRaw,
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filterWithoutRaw = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+        $filterWithRaw = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+            includeIndicationRaw: true,
+        );
+
+        $csvWithoutRaw = $this->exportCsv($exporter, $owner, $filterWithoutRaw);
+        $csvWithRaw = $this->exportCsv($exporter, $owner, $filterWithRaw);
+
+        self::assertStringNotContainsString('indicationRaw', $csvWithoutRaw);
+        self::assertStringContainsString('indicationRaw', $csvWithRaw);
+        self::assertStringContainsString('Original indication text', $csvWithRaw);
+    }
+
+    public function testWriteCsvIncludesAssignmentOccasionAndDepartmentWasClosedColumns(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        $assignment = AssignmentFactory::createOne(['name' => 'Emergency assignment']);
+        $occasion = OccasionFactory::createOne(['name' => 'Holiday occasion']);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'assignment' => $assignment,
+            'occasion' => $occasion,
+            'departmentWasClosed' => true,
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+
+        self::assertStringContainsString('departmentWasClosed', $csv);
+        self::assertStringContainsString('assignment', $csv);
+        self::assertStringContainsString('occasion', $csv);
+        self::assertStringContainsString('Emergency assignment', $csv);
+        self::assertStringContainsString('Holiday occasion', $csv);
+        self::assertMatchesRegularExpression('/,1,/', $csv);
+    }
+
+    public function testWriteCsvUsesSequentialRowNumbers(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+        ]);
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-16 10:00:00'),
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+        $lines = array_values(array_filter(explode("\n", trim($csv))));
+
+        self::assertSame('row', str_getcsv($lines[0], escape: '\\')[0]);
+        self::assertSame('1', str_getcsv($lines[1], escape: '\\')[0]);
+        self::assertSame('2', str_getcsv($lines[2], escape: '\\')[0]);
     }
 
     public function testWriteCsvRespectsSelectedHospitalIds(): void
@@ -107,17 +254,23 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
             hospitalIds: [(int) $hospitalA->getId()],
         );
 
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+
+        self::assertStringContainsString('Hospital Alpha', $csv);
+        self::assertStringNotContainsString('Hospital Beta', $csv);
+    }
+
+    private function exportCsv(OwnHospitalAllocationsExporter $exporter, object $user, OwnHospitalAllocationsExportFilter $filter): string
+    {
         $stream = fopen('php://temp', 'w+');
         self::assertIsResource($stream);
 
-        $written = $exporter->writeCsv($owner, $filter, $stream);
+        $exporter->writeCsv($user, $filter, $stream);
         rewind($stream);
         $csv = stream_get_contents($stream) ?: '';
         fclose($stream);
 
-        self::assertSame(1, $written);
-        self::assertStringContainsString('Hospital Alpha', $csv);
-        self::assertStringNotContainsString('Hospital Beta', $csv);
+        return $csv;
     }
 
     private function seedAllocationDependencies(object $hospital): void

--- a/tests/Allocation/Unit/Export/AllocationExportValueFormatterTest.php
+++ b/tests/Allocation/Unit/Export/AllocationExportValueFormatterTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Export;
+
+use App\Allocation\Application\Export\AllocationExportValueFormatter;
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AllocationExportValueFormatterTest extends TestCase
+{
+    private AllocationExportValueFormatter $formatter;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'label.gender.male' => 'Male',
+                'label.transportType.ground' => 'Ground',
+                'label.transportType.air' => 'Air',
+                default => $id,
+            },
+        );
+
+        $this->formatter = new AllocationExportValueFormatter($translator);
+    }
+
+    public function testFormatsGenderTransportAndUrgencyForExport(): void
+    {
+        self::assertSame('Male', $this->formatter->gender(AllocationGender::MALE));
+        self::assertSame('SK1', $this->formatter->urgency(AllocationUrgency::EMERGENCY));
+        self::assertSame('Ground', $this->formatter->transportType(AllocationTransportType::GROUND));
+        self::assertSame('Air', $this->formatter->transportType('A'));
+    }
+}

--- a/tests/Allocation/Unit/Export/ExportDateTimeRangeResolverTest.php
+++ b/tests/Allocation/Unit/Export/ExportDateTimeRangeResolverTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Export;
+
+use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ExportDateTimeRangeResolverTest extends TestCase
+{
+    private ExportDateTimeRangeResolver $resolver;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->resolver = new ExportDateTimeRangeResolver();
+    }
+
+    public function testDefaultsMissingTimesToDayStartAndEnd(): void
+    {
+        $range = $this->resolver->resolve(
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+        );
+
+        self::assertSame('2026-01-01 00:00:00', $range->from->format('Y-m-d H:i:s'));
+        self::assertSame('2026-01-31 23:59:59', $range->to->format('Y-m-d H:i:s'));
+    }
+
+    public function testCombinesDateAndTimeIntoSingleInterval(): void
+    {
+        $range = $this->resolver->resolve(
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-31'),
+            new \DateTimeImmutable('1970-01-01 08:00:00'),
+            new \DateTimeImmutable('1970-01-01 18:00:00'),
+        );
+
+        self::assertSame('2026-01-01 08:00:00', $range->from->format('Y-m-d H:i:s'));
+        self::assertSame('2026-01-31 18:00:00', $range->to->format('Y-m-d H:i:s'));
+    }
+
+    public function testIntervalIsNotDailyWindowAcrossDays(): void
+    {
+        $range = $this->resolver->resolve(
+            new \DateTimeImmutable('2026-01-01'),
+            new \DateTimeImmutable('2026-01-03'),
+            new \DateTimeImmutable('1970-01-01 08:00:00'),
+            new \DateTimeImmutable('1970-01-01 18:00:00'),
+        );
+
+        self::assertSame('2026-01-01 08:00:00', $range->from->format('Y-m-d H:i:s'));
+        self::assertSame('2026-01-03 18:00:00', $range->to->format('Y-m-d H:i:s'));
+    }
+
+    #[DataProvider('invalidRangeProvider')]
+    public function testRejectsStartAfterEnd(\DateTimeInterface $from, \DateTimeInterface $to): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->resolver->resolve($from, $to);
+    }
+
+    /**
+     * @return iterable<string, array{\DateTimeInterface, \DateTimeInterface}>
+     */
+    public static function invalidRangeProvider(): iterable
+    {
+        yield 'dates reversed' => [
+            new \DateTimeImmutable('2026-02-01'),
+            new \DateTimeImmutable('2026-01-01'),
+        ];
+    }
+}

--- a/tests/Allocation/Unit/Export/ExportOrchestratorTest.php
+++ b/tests/Allocation/Unit/Export/ExportOrchestratorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Export;
+
+use App\Allocation\Application\Export\DTO\OwnHospitalAllocationsExportFilter;
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use App\Shared\Application\Export\ExporterInterface;
+use App\Shared\Application\Export\ExporterRegistry;
+use App\Shared\Application\Export\ExportLimits;
+use App\Shared\Application\Export\ExportOrchestrator;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class ExportOrchestratorTest extends TestCase
+{
+    public function testEstimateBlocksAboveMaxRows(): void
+    {
+        $user = new User();
+        $criteria = $this->createFilter();
+        $exporter = $this->createExporterMock(count: ExportLimits::MAX_EXPORT_ROWS + 1);
+
+        $orchestrator = $this->createOrchestrator($exporter);
+
+        $estimate = $orchestrator->estimate($user, OwnHospitalAllocationsExporter::KEY, $criteria);
+
+        self::assertTrue($estimate->blocked);
+        self::assertFalse($estimate->warn);
+    }
+
+    public function testEstimateWarnsBetweenThresholds(): void
+    {
+        $user = new User();
+        $criteria = $this->createFilter();
+        $exporter = $this->createExporterMock(count: ExportLimits::WARN_EXPORT_ROWS);
+
+        $orchestrator = $this->createOrchestrator($exporter);
+
+        $estimate = $orchestrator->estimate($user, OwnHospitalAllocationsExporter::KEY, $criteria);
+
+        self::assertFalse($estimate->blocked);
+        self::assertTrue($estimate->warn);
+    }
+
+    public function testEstimateAllowsBelowWarnThreshold(): void
+    {
+        $user = new User();
+        $criteria = $this->createFilter();
+        $exporter = $this->createExporterMock(count: ExportLimits::WARN_EXPORT_ROWS - 1);
+
+        $orchestrator = $this->createOrchestrator($exporter);
+
+        $estimate = $orchestrator->estimate($user, OwnHospitalAllocationsExporter::KEY, $criteria);
+
+        self::assertFalse($estimate->blocked);
+        self::assertFalse($estimate->warn);
+    }
+
+    private function createOrchestrator(ExporterInterface $exporter): ExportOrchestrator
+    {
+        return new ExportOrchestrator(
+            new ExporterRegistry([$exporter]),
+            new \App\Shared\Application\Export\CsvStreamExportResponseFactory(),
+            $this->createMock(\App\Shared\Application\Export\ExportAuditLogger::class),
+        );
+    }
+
+    private function createExporterMock(int $count): ExporterInterface
+    {
+        $exporter = $this->createMock(ExporterInterface::class);
+        $exporter->method('key')->willReturn(OwnHospitalAllocationsExporter::KEY);
+        $exporter->method('count')->willReturn($count);
+        $exporter->method('resolveScopeHospitalIds')->willReturn([1]);
+        $exporter->method('serializeCriteria')->willReturn([]);
+
+        return $exporter;
+    }
+
+    private function createFilter(): OwnHospitalAllocationsExportFilter
+    {
+        return new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+    }
+}

--- a/tests/Allocation/Unit/Export/OwnHospitalAllocationsExportFilterMapperTest.php
+++ b/tests/Allocation/Unit/Export/OwnHospitalAllocationsExportFilterMapperTest.php
@@ -34,6 +34,35 @@ final class OwnHospitalAllocationsExportFilterMapperTest extends TestCase
         self::assertSame([3, 5], $filter->hospitalIds);
         self::assertSame('red', $filter->urgency);
         self::assertSame(1, $filter->requiresResus);
+        self::assertFalse($filter->includeIndicationRaw);
+    }
+
+    public function testIncludeIndicationRawFlagIsMapped(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-31');
+        $data->includeIndicationRaw = true;
+
+        $filter = $this->mapper->fromFormData($data);
+
+        self::assertTrue($filter->includeIndicationRaw);
+    }
+
+    public function testMapsAssignmentOccasionAndDepartmentWasClosed(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-31');
+        $data->assignment = 7;
+        $data->occasion = 9;
+        $data->departmentWasClosed = true;
+
+        $filter = $this->mapper->fromFormData($data);
+
+        self::assertSame(7, $filter->assignment);
+        self::assertSame(9, $filter->occasion);
+        self::assertSame(1, $filter->departmentWasClosed);
     }
 
     public function testEmptyHospitalSelectionMapsToNull(): void

--- a/tests/Allocation/Unit/Export/OwnHospitalAllocationsExportFilterMapperTest.php
+++ b/tests/Allocation/Unit/Export/OwnHospitalAllocationsExportFilterMapperTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Export;
+
+use App\Allocation\Application\Export\OwnHospitalAllocationsExportFilterMapper;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use PHPUnit\Framework\TestCase;
+
+final class OwnHospitalAllocationsExportFilterMapperTest extends TestCase
+{
+    private OwnHospitalAllocationsExportFilterMapper $mapper;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->mapper = new OwnHospitalAllocationsExportFilterMapper();
+    }
+
+    public function testMapsFormDataToFilterWithHospitalSelection(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-31');
+        $data->hospitals = [3, 5, 3];
+        $data->urgency = 'red';
+        $data->requiresResus = true;
+
+        $filter = $this->mapper->fromFormData($data);
+
+        self::assertSame('2026-01-01', $filter->dateFrom->format('Y-m-d'));
+        self::assertSame('2026-01-31', $filter->dateTo->format('Y-m-d'));
+        self::assertSame([3, 5], $filter->hospitalIds);
+        self::assertSame('red', $filter->urgency);
+        self::assertSame(1, $filter->requiresResus);
+    }
+
+    public function testEmptyHospitalSelectionMapsToNull(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-31');
+
+        $filter = $this->mapper->fromFormData($data);
+
+        self::assertNull($filter->hospitalIds);
+    }
+
+    public function testMissingDatesThrow(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->mapper->fromFormData(new OwnHospitalAllocationsExportFormData());
+    }
+}

--- a/tests/Shared/Unit/Export/CsvStreamExportResponseFactoryTest.php
+++ b/tests/Shared/Unit/Export/CsvStreamExportResponseFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Export;
+
+use App\Shared\Application\Export\CsvStreamExportResponseFactory;
+use PHPUnit\Framework\TestCase;
+
+final class CsvStreamExportResponseFactoryTest extends TestCase
+{
+    public function testWriteRowWritesCsvLine(): void
+    {
+        $factory = new CsvStreamExportResponseFactory();
+        $stream = fopen('php://temp', 'w+');
+        self::assertIsResource($stream);
+
+        $factory->writeRow($stream, ['id', 'name', null, 42]);
+        rewind($stream);
+        $line = stream_get_contents($stream) ?: '';
+        fclose($stream);
+
+        self::assertSame("id,name,,42\n", $line);
+    }
+}

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -1205,6 +1205,18 @@
         <source>label.all_specialities</source>
         <target>Alle Fachrichtungen</target>
       </trans-unit>
+      <trans-unit id="lblAllAssignmentsDe" resname="label.all_assignments">
+        <source>label.all_assignments</source>
+        <target>Alle Zuweisungen</target>
+      </trans-unit>
+      <trans-unit id="lblAllOccasionsDe" resname="label.all_occasions">
+        <source>label.all_occasions</source>
+        <target>Alle Anlässe</target>
+      </trans-unit>
+      <trans-unit id="ExpFldDe02" resname="field.departmentWasClosed">
+        <source>field.departmentWasClosed</source>
+        <target>Fachbereich war abgemeldet</target>
+      </trans-unit>
       <trans-unit id="lblAllTiersDe" resname="label.all_tiers">
         <source>label.all_tiers</source>
         <target>Alle Versorgungsstufen</target>
@@ -1448,6 +1460,18 @@
       <trans-unit id="ExpHlpDe03" resname="help.export.hospitals">
         <source>help.export.hospitals</source>
         <target>Alle zugänglichen Krankenhäuser sind standardmäßig ausgewählt. Deaktivieren Sie ein Krankenhaus, um es vom Export auszuschließen.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpDe04" resname="help.export.include_indication_raw">
+        <source>help.export.include_indication_raw</source>
+        <target>Fügt eine zusätzliche Spalte mit dem ursprünglichen Indikationstext aus dem Import hinzu.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpDe05" resname="help.export.department_was_closed_filter">
+        <source>help.export.department_was_closed_filter</source>
+        <target>Nur Zuweisungen exportieren, bei denen der Fachbereich abgemeldet war.</target>
+      </trans-unit>
+      <trans-unit id="ExpFldDe01" resname="field.includeIndicationRaw">
+        <source>field.includeIndicationRaw</source>
+        <target>Roh-Indikation mit exportieren</target>
       </trans-unit>
       <trans-unit id="ExpLblDe01" resname="label.export.period">
         <source>label.export.period</source>

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -1429,6 +1429,54 @@
         <source>flash.indication.review.matched_and_approved</source>
         <target>Match gesetzt und freigegeben. Zuweisungen werden im Hintergrund aktualisiert.</target>
       </trans-unit>
+      <trans-unit id="ExpLnkDe01" resname="link.export">
+        <source>link.export</source>
+        <target>Export</target>
+      </trans-unit>
+      <trans-unit id="ExpTitDe01" resname="title.export.allocations">
+        <source>title.export.allocations</source>
+        <target>Allocations exportieren</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpDe01" resname="help.export.allocations">
+        <source>help.export.allocations</source>
+        <target>Exportieren Sie Einsatzdaten Ihrer Krankenhäuser als CSV. Der Zeitraum wird als zusammenhängendes Intervall gefiltert.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpDe02" resname="help.export.period">
+        <source>help.export.period</source>
+        <target>Ohne Uhrzeit gilt Tagesbeginn (00:00:00) bzw. Tagesende (23:59:59). Datum und Uhrzeit bilden ein durchgängiges Intervall.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpDe03" resname="help.export.hospitals">
+        <source>help.export.hospitals</source>
+        <target>Alle zugänglichen Krankenhäuser sind standardmäßig ausgewählt. Deaktivieren Sie ein Krankenhaus, um es vom Export auszuschließen.</target>
+      </trans-unit>
+      <trans-unit id="ExpLblDe01" resname="label.export.period">
+        <source>label.export.period</source>
+        <target>Zeitraum</target>
+      </trans-unit>
+      <trans-unit id="ExpActDe01" resname="action.export.prepare">
+        <source>action.export.prepare</source>
+        <target>Export vorbereiten</target>
+      </trans-unit>
+      <trans-unit id="ExpActDe02" resname="action.export.download_csv">
+        <source>action.export.download_csv</source>
+        <target>CSV herunterladen</target>
+      </trans-unit>
+      <trans-unit id="ExpInfDe01" resname="info.export.row_count">
+        <source>info.export.row_count</source>
+        <target>{count, number} Datensätze werden exportiert.</target>
+      </trans-unit>
+      <trans-unit id="ExpWrnDe01" resname="warning.export.large_export">
+        <source>warning.export.large_export</source>
+        <target>Der Export ist groß ({count, number} Datensätze). Bitte prüfen Sie die Filter vor dem Download.</target>
+      </trans-unit>
+      <trans-unit id="ExpErrDe01" resname="error.export.too_many_rows">
+        <source>error.export.too_many_rows</source>
+        <target>Export blockiert: {count, number} Datensätze überschreiten das Limit. Bitte Filter enger setzen.</target>
+      </trans-unit>
+      <trans-unit id="ExpErrDe02" resname="error.export.invalid_filter">
+        <source>error.export.invalid_filter</source>
+        <target>Bitte prüfen Sie die Export-Filter.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -1433,6 +1433,10 @@
         <source>link.import</source>
         <target>Import</target>
       </trans-unit>
+      <trans-unit id="ExpLnkEn01" resname="link.export">
+        <source>link.export</source>
+        <target>Export</target>
+      </trans-unit>
       <trans-unit id="4wLkxRO" resname="link.imports">
         <source>link.imports</source>
         <target>Imports</target>
@@ -8450,6 +8454,50 @@
       <trans-unit id="statsAexHp09" resname="stats.analysis_explorer.edit.additional_table_metrics_help">
         <source>stats.analysis_explorer.edit.additional_table_metrics_help</source>
         <target>Optional extra columns in the results table. The chart always uses the chart metric above.</target>
+      </trans-unit>
+      <trans-unit id="ExpTitEn01" resname="title.export.allocations">
+        <source>title.export.allocations</source>
+        <target>Export allocations</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpEn01" resname="help.export.allocations">
+        <source>help.export.allocations</source>
+        <target>Export allocation data from your hospitals as CSV. The period is filtered as one continuous interval.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpEn02" resname="help.export.period">
+        <source>help.export.period</source>
+        <target>Without a time, day start (00:00:00) or day end (23:59:59) applies. Date and time form one continuous interval.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpEn03" resname="help.export.hospitals">
+        <source>help.export.hospitals</source>
+        <target>All accessible hospitals are selected by default. Uncheck any to exclude them from the export.</target>
+      </trans-unit>
+      <trans-unit id="ExpLblEn01" resname="label.export.period">
+        <source>label.export.period</source>
+        <target>Period</target>
+      </trans-unit>
+      <trans-unit id="ExpActEn01" resname="action.export.prepare">
+        <source>action.export.prepare</source>
+        <target>Prepare export</target>
+      </trans-unit>
+      <trans-unit id="ExpActEn02" resname="action.export.download_csv">
+        <source>action.export.download_csv</source>
+        <target>Download CSV</target>
+      </trans-unit>
+      <trans-unit id="ExpInfEn01" resname="info.export.row_count">
+        <source>info.export.row_count</source>
+        <target>{count, number} records will be exported.</target>
+      </trans-unit>
+      <trans-unit id="ExpWrnEn01" resname="warning.export.large_export">
+        <source>warning.export.large_export</source>
+        <target>This export is large ({count, number} records). Review your filters before downloading.</target>
+      </trans-unit>
+      <trans-unit id="ExpErrEn01" resname="error.export.too_many_rows">
+        <source>error.export.too_many_rows</source>
+        <target>Export blocked: {count, number} records exceed the limit. Narrow your filters.</target>
+      </trans-unit>
+      <trans-unit id="ExpErrEn02" resname="error.export.invalid_filter">
+        <source>error.export.invalid_filter</source>
+        <target>Please check the export filters.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -305,6 +305,10 @@
         <source>field.requiresResus</source>
         <target>Requires Resus</target>
       </trans-unit>
+      <trans-unit id="ExpFldEn01" resname="field.includeIndicationRaw">
+        <source>field.includeIndicationRaw</source>
+        <target>Include raw indication</target>
+      </trans-unit>
       <trans-unit id="d833nvj" resname="field.transportType">
         <source>field.transportType</source>
         <target>Transport Type</target>
@@ -696,6 +700,18 @@
       <trans-unit id="allocAllSpec" resname="label.all_specialities">
         <source>label.all_specialities</source>
         <target>All specialities</target>
+      </trans-unit>
+      <trans-unit id="allocAllAsgn" resname="label.all_assignments">
+        <source>label.all_assignments</source>
+        <target>All assignments</target>
+      </trans-unit>
+      <trans-unit id="allocAllOcc" resname="label.all_occasions">
+        <source>label.all_occasions</source>
+        <target>All occasions</target>
+      </trans-unit>
+      <trans-unit id="ExpFldEn02" resname="field.departmentWasClosed">
+        <source>field.departmentWasClosed</source>
+        <target>Department was closed</target>
       </trans-unit>
       <trans-unit id="allocAllTt" resname="label.all_transport_types">
         <source>label.all_transport_types</source>
@@ -8470,6 +8486,14 @@
       <trans-unit id="ExpHlpEn03" resname="help.export.hospitals">
         <source>help.export.hospitals</source>
         <target>All accessible hospitals are selected by default. Uncheck any to exclude them from the export.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpEn04" resname="help.export.include_indication_raw">
+        <source>help.export.include_indication_raw</source>
+        <target>Adds an extra column with the original indication text from the import.</target>
+      </trans-unit>
+      <trans-unit id="ExpHlpEn05" resname="help.export.department_was_closed_filter">
+        <source>help.export.department_was_closed_filter</source>
+        <target>Include only allocations where the department was closed.</target>
       </trans-unit>
       <trans-unit id="ExpLblEn01" resname="label.export.period">
         <source>label.export.period</source>


### PR DESCRIPTION
## Summary

This PR adds a CSV export for hospital allocations scoped to the hospitals a participant owns (or is granted export access to). The feature follows a reusable export pipeline (`ExportOrchestrator`, `ExporterInterface`, audit logging, row limits) and ships with a dedicated export page at `/hospitals/export/allocations`.

Participants can filter exports by hospital, date/time range, allocation attributes, and clinical flags. The workflow is two-step: **Prepare export** estimates the row count (with warning/block thresholds), then **Download CSV** streams the result without duplicating form fields.

### Highlights

- **Scoped access**: Export respects hospital ownership and `Export` grants via `ExportAccessService` / `ExportVoter`.
- **Rich CSV output**: Includes hospital, geography (`state`, `dispatchArea`), allocation, department/speciality, assignment, occasion, clinical care fields, and optional raw indication text.
- **Human-readable values**: Gender, urgency (SK1–SK3), and transport type are formatted for CSV consumers via `AllocationExportValueFormatter`.
- **Sequential row numbers**: The first column (`row`) is a 1-based export index, not the database ID.
- **Shared filter logic**: Export filters reuse `AllocationListFilterApplicator`, aligned with the allocation list query refactor.
- **UX**: Accordion-based filter form, card footer with prepare/download actions and inline estimate feedback, default period (month-to-date) and times (`00:00:00` / `23:59:59`).

### New filters & columns

| Filter | CSV column |
|---|---|
| Assignment | `assignment` |
| Occasion | `occasion` |
| Department was closed | `departmentWasClosed` |
| Include raw indication (checkbox) | `indicationRaw` (optional) |

Closes #234.