### PR TITLE
chore: Block wordpress scanner requests

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -340,6 +340,18 @@ above) or set `messenger_restart_on_deploy: false` in `hosts.yaml` until the wor
 Local development uses `make consume` (same transports, verbose). Mail is sent synchronously in `dev`; production 
 requires the worker for queued mail.
 
+### Scanner path blocking (Apache)
+
+`public/.htaccess` returns **403 Forbidden** for common WordPress scanner and exploit probe paths (for example `/wp-login.php`, `/xmlrpc.php`, `/.env`) before requests reach Symfony. This applies on production (Uberspace/Apache) only; local development with `symfony server` does not use `.htaccess`.
+
+After deploy, verify with:
+
+```bash
+curl -sI https://<host>/wp-login.php | head -1   # expect HTTP/1.1 403 Forbidden
+curl -sI https://<host>/.env | head -1           # expect HTTP/1.1 403 Forbidden
+curl -sI https://<host>/ | head -1               # expect HTTP/1.1 200 or 302
+```
+
 ## Troubleshooting
 
 | Symptom | Likely cause |

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -24,6 +24,10 @@ DirectoryIndex index.php
 
     RewriteEngine On
 
+    # Block common WordPress scanner and exploit probe paths before Symfony boots.
+    RewriteRule ^(wp-admin|wp-login\.php|xmlrpc\.php|wp-content|wp-includes|wp-json|wordpress|wp-config\.php)(/.*)?$ - [F,L,NC]
+    RewriteRule ^(\.env|vendor/phpunit|phpunit|setup\.php|config\.php|composer\.(json|lock))$ - [F,L,NC]
+
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the
     # project in a subdirectory, the base path will be prepended to allow proper


### PR DESCRIPTION
## Summary

- Block common WordPress scanner and exploit probe paths in `public/.htaccess` with **403 Forbidden** before requests reach Symfony’s front controller.
- Document the Apache-level behavior and post-deploy verification steps in `docs/Deployment.md`.

Closes #237.

## Motivation

Automated bots regularly probe production for paths such as `/wp-login.php`, `/wp-admin`, `/xmlrpc.php`, and `/.env`. These requests are unrelated to this application but still bootstrap Symfony, adding unnecessary overhead and noise in monitoring.

Although `NotFoundHttpException` is already ignored in Sentry, handling these requests at the Apache layer avoids PHP/Symfony startup entirely.

## Changes

### `public/.htaccess`

Added two rewrite rules immediately after `RewriteEngine On`:

- WordPress-related paths: `wp-admin`, `wp-login.php`, `xmlrpc.php`, `wp-content`, `wp-includes`, `wp-json`, `wordpress`, `wp-config.php`
- Common exploit probes: `.env`, `vendor/phpunit`, `phpunit`, `setup.php`, `config.php`, `composer.json`, `composer.lock`

Blocked paths return **403 Forbidden** via `[F,L,NC]`.

Intentionally **not** blocked:

- `.well-known/` (may be needed for ACME, `security.txt`, etc.)
- generic `/vendor/` paths (only the specific `vendor/phpunit` probe is blocked)

### `docs/Deployment.md`

Added a short section describing:

- that blocking applies on production/Uberspace (Apache), not local `symfony server`
- `curl` checks to run after deploy

## Test plan

- [x] Local Apache verification (Docker, `mod_rewrite` enabled):
  - `/wp-login.php` → `403 Forbidden`
  - `/.env` → `403 Forbidden`
  - `/xmlrpc.php` → `403 Forbidden`
  - `/` → `200 OK`
- [x] After deploy to production:
  ```bash
  curl -sI https://<host>/wp-login.php | head -1   # expect 403
  curl -sI https://<host>/.env | head -1           # expect 403
  curl -sI https://<host>/ | head -1               # expect 200 or 302
  ```