### PR TITLE
feat(allocations): Add explore allocation filters and closed-department highlighting

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -4,6 +4,11 @@
     border-bottom: none !important;
 }
 
+.allocation-row-department-closed > td,
+.allocation-row-department-closed > th {
+    background-color: var(--tblr-red-lt) !important;
+}
+
 /* Hide CSV item in the ApexCharts export menu */
 .apexcharts-menu-item.exportCSV {
     display: none;

--- a/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
+++ b/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
@@ -32,7 +32,7 @@ final readonly class ListAllocationsQuery
     public function getPaginator(AllocationQueryParametersDTO $queryParametersDTO): CursorPaginator
     {
         $qb = $this->entityManager->createQueryBuilder();
-        $qb->select('a.id, a.createdAt, a.arrivalAt, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
+        $qb->select('a.id, a.createdAt, a.arrivalAt, a.departmentWasClosed, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
                 h.id as hospital_id, h.name as hospital, h.tier, h.size, h.location, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock,
                 a.isPregnant, a.isWorkAccident, a.isWithPhysician, a.urgency, i.name as infection, iraw.name as indicationRawName, iraw.code indicationRawCode,
                 inor.name as indicationNormalizedName, inor.code as indicationNormalizedCode,

--- a/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
+++ b/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
@@ -10,10 +10,12 @@ use App\Allocation\Domain\Enum\HospitalLocation;
 use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\Infrastructure\Query\ListAllocationsQuery;
+use App\Allocation\Infrastructure\Repository\AssignmentRepository;
 use App\Allocation\Infrastructure\Repository\DepartmentRepository;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
 use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
 use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\OccasionRepository;
 use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
 use App\Allocation\Infrastructure\Repository\SpecialityRepository;
 use App\Allocation\Infrastructure\Repository\StateRepository;
@@ -35,6 +37,8 @@ final class ListAllocationsController extends AbstractController
         private readonly InfectionRepository $infectionRepository,
         private readonly DepartmentRepository $departmentRepository,
         private readonly SpecialityRepository $specialityRepository,
+        private readonly AssignmentRepository $assignmentRepository,
+        private readonly OccasionRepository $occasionRepository,
     ) {
     }
 
@@ -61,6 +65,8 @@ final class ListAllocationsController extends AbstractController
             'infections' => $this->infectionRepository->findBy([], ['name' => 'ASC']),
             'departments' => $this->departmentRepository->findBy([], ['name' => 'ASC']),
             'specialities' => $this->specialityRepository->findBy([], ['name' => 'ASC']),
+            'assignments' => $this->assignmentRepository->findBy([], ['name' => 'ASC']),
+            'occasions' => $this->occasionRepository->findBy([], ['name' => 'ASC']),
             'transportTypes' => AllocationTransportType::cases(),
         ]);
     }
@@ -78,6 +84,9 @@ final class ListAllocationsController extends AbstractController
             'secondaryTransport',
             'department',
             'speciality',
+            'assignment',
+            'occasion',
+            'departmentWasClosed',
             'transportType',
             'dispatchArea',
             'state',

--- a/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
+++ b/src/Allocation/UI/Http/DTO/AllocationQueryParametersDTO.php
@@ -66,6 +66,12 @@ final readonly class AllocationQueryParametersDTO
 
         public ?int $speciality = null,
 
+        public ?int $assignment = null,
+
+        public ?int $occasion = null,
+
+        public ?int $departmentWasClosed = null,
+
         public ?string $transportType = null,
     ) {
     }
@@ -93,6 +99,9 @@ final readonly class AllocationQueryParametersDTO
             infection: $this->infection,
             department: $this->department,
             speciality: $this->speciality,
+            assignment: $this->assignment,
+            occasion: $this->occasion,
+            departmentWasClosed: $this->departmentWasClosed,
             transportType: $this->transportType,
         );
     }

--- a/src/Allocation/UI/Twig/templates/allocations/_allocation_filter_drawer.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/_allocation_filter_drawer.html.twig
@@ -10,6 +10,9 @@
     or filters.secondaryTransport is not null
     or filters.department is not null
     or filters.speciality is not null
+    or filters.assignment is not null
+    or filters.occasion is not null
+    or filters.departmentWasClosed is not null
     or filters.transportType is not empty %}
 {% set clinicalActive = filters.requiresResus is not null
     or filters.requiresCathlab is not null
@@ -149,6 +152,28 @@
                                     </select>
                                 </div>
                                 <div class="col-12">
+                                    <label class="form-label">{{ 'label.assignment'|trans }}</label>
+                                    <select name="assignment" class="form-select">
+                                        <option value="">{{ 'label.all_assignments'|trans }}</option>
+                                        {% for assignment in assignments %}
+                                            <option value="{{ assignment.id }}" {{ filters.assignment == assignment.id ? 'selected' }}>
+                                                {{ assignment.name }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label">{{ 'label.occasion'|trans }}</label>
+                                    <select name="occasion" class="form-select">
+                                        <option value="">{{ 'label.all_occasions'|trans }}</option>
+                                        {% for occasion in occasions %}
+                                            <option value="{{ occasion.id }}" {{ filters.occasion == occasion.id ? 'selected' }}>
+                                                {{ occasion.name }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div class="col-12">
                                     <label class="form-label">{{ 'stats.analysis_explorer.dimension.transport_type'|trans }}</label>
                                     <select name="transportType" class="form-select">
                                         <option value="">{{ 'label.all_transport_types'|trans }}</option>
@@ -204,6 +229,18 @@
                                             </option>
                                         {% endfor %}
                                     </select>
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-check form-switch mb-0">
+                                        <input class="form-check-input"
+                                               type="checkbox"
+                                               name="departmentWasClosed"
+                                               value="1"
+                                               data-testid="allocation-filter-department-was-closed"
+                                               {{ filters.departmentWasClosed ? 'checked' }}>
+                                        <span class="form-check-label">{{ 'field.departmentWasClosed'|trans }}</span>
+                                    </label>
+                                    <div class="form-text">{{ 'help.export.department_was_closed_filter'|trans }}</div>
                                 </div>
                             </div>
                         </div>

--- a/src/Allocation/UI/Twig/templates/allocations/_department_was_closed_indicator.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/_department_was_closed_indicator.html.twig
@@ -1,0 +1,17 @@
+{% set compact = compact|default(false) %}
+
+{% if compact %}
+    <span class="d-inline-flex align-items-center text-red"
+          title="{{ 'field.departmentWasClosed'|trans }}"
+          aria-label="{{ 'field.departmentWasClosed'|trans }}"
+          data-testid="department-was-closed-indicator">
+        <twig:ux:icon name="tabler:door-off" class="w-3 h-3" />
+    </span>
+{% else %}
+    <span class="badge bg-red-lt text-red ms-2 d-inline-flex align-items-center"
+          title="{{ 'field.departmentWasClosed'|trans }}"
+          data-testid="department-was-closed-indicator">
+        <twig:ux:icon name="tabler:alert-square-rounded" class="w-3 h-3 me-1" />
+        {{ 'abbr.department_was_closed'|trans }}
+    </span>
+{% endif %}

--- a/src/Allocation/UI/Twig/templates/allocations/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/list.html.twig
@@ -68,7 +68,7 @@
         {% if activeFilterCount > 0 %}
             <div class="alert alert-info" role="alert">
                 <strong class="text-info">{{ 'label.filters.active'|trans }}:</strong>
-                {{ activeFilters.allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections, departments, specialities, transportTypes) }}
+                {{ activeFilters.allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections, departments, specialities, transportTypes, assignments, occasions) }}
             </div>
         {% endif %}
 
@@ -120,7 +120,7 @@
                 </thead>
                 <tbody>
                 {% for allocation in paginator.results %}
-                    <tr>
+                    <tr{% if allocation.departmentWasClosed %} class="allocation-row-department-closed"{% endif %}>
                         <td>
                             <twig:ux:icon name="tabler:clock-play" class="w-3 h-3" /> {{ allocation.createdAt|date('d.m.Y H:i') }}<br/>
                             <twig:ux:icon name="tabler:clock-check" class="w-3 h-3" /> {{ allocation.arrivalAt|date('d.m.Y H:i') }}
@@ -166,6 +166,9 @@
                         </td>
                         <td>
                             <span class="text-danger fw-bold">
+                                {% if allocation.departmentWasClosed %}
+                                    {{ include('@Allocation/allocations/_department_was_closed_indicator.html.twig', {compact: true}) }}
+                                {% endif %}
                                 {% if allocation.infection is not null %}
                                     <span class="badge bg-orange text-orange-fg">{{ allocation.infection }}</span>
                                 {% endif %}

--- a/src/Allocation/UI/Twig/templates/allocations/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/show.html.twig
@@ -64,9 +64,7 @@
                             <span class="text-muted">({{ allocation.speciality }})</span>
 
                             {% if allocation.departmentWasClosed %}
-                                <span class="badge bg-red-lt text-red ms-2 d-inline-flex align-items-center" title="Department was closed">
-                                    <twig:ux:icon name="tabler:alert-square-rounded" class="w-3 h-3" /> closed
-                                </span>
+                                {{ include('@Allocation/allocations/_department_was_closed_indicator.html.twig') }}
                             {% endif %}
                         </div>
                     </div>

--- a/src/Shared/UI/Twig/templates/_macros/filters.html.twig
+++ b/src/Shared/UI/Twig/templates/_macros/filters.html.twig
@@ -1,4 +1,4 @@
-{% macro allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections, departments, specialities, transportTypes) %}
+{% macro allocation_filter_badges(filters, states, dispatchAreas, indications, secondaryTransports, infections, departments, specialities, transportTypes, assignments, occasions) %}
     {% set rawFilters = [] %}
 
     {# --- Simple string filters --- #}
@@ -58,6 +58,10 @@
 
     {% if filters.isInfectious is not null %}
         {% set rawFilters = rawFilters|merge([{key: 'label.is_infectious', value: filters.isInfectious ? 'Yes' : 'No'}]) %}
+    {% endif %}
+
+    {% if filters.departmentWasClosed is not null %}
+        {% set rawFilters = rawFilters|merge([{key: 'field.departmentWasClosed', value: filters.departmentWasClosed ? 'Yes' : 'No'}]) %}
     {% endif %}
 
     {# --- Lookup: State (id → name) --- #}
@@ -135,6 +139,32 @@
         {% endfor %}
         {% if specialityName is not null %}
             {% set rawFilters = rawFilters|merge([{key: 'label.speciality', value: specialityName}]) %}
+        {% endif %}
+    {% endif %}
+
+    {# --- Lookup: Assignment (id → name) --- #}
+    {% if filters.assignment is not null and assignments is defined %}
+        {% set assignmentName = null %}
+        {% for assignment in assignments %}
+            {% if assignmentName is null and assignment.id == filters.assignment %}
+                {% set assignmentName = assignment.name %}
+            {% endif %}
+        {% endfor %}
+        {% if assignmentName is not null %}
+            {% set rawFilters = rawFilters|merge([{key: 'label.assignment', value: assignmentName}]) %}
+        {% endif %}
+    {% endif %}
+
+    {# --- Lookup: Occasion (id → name) --- #}
+    {% if filters.occasion is not null and occasions is defined %}
+        {% set occasionName = null %}
+        {% for occasion in occasions %}
+            {% if occasionName is null and occasion.id == filters.occasion %}
+                {% set occasionName = occasion.name %}
+            {% endif %}
+        {% endfor %}
+        {% if occasionName is not null %}
+            {% set rawFilters = rawFilters|merge([{key: 'label.occasion', value: occasionName}]) %}
         {% endif %}
     {% endif %}
 

--- a/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
@@ -217,6 +217,67 @@ final class ListAllocationsControllerTest extends WebTestCase
         self::assertSame([(int) $matchingAllocation->getId()], $ids);
     }
 
+    public function testAssignmentOccasionAndDepartmentWasClosedFilters(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedDependencies();
+
+        $assignment = AssignmentFactory::find(['name' => 'Test Assignment']);
+        $occasion = OccasionFactory::find(['name' => 'Test Occasion']);
+
+        $matchingAllocation = AllocationFactory::createOne([
+            'assignment' => $assignment,
+            'occasion' => $occasion,
+            'departmentWasClosed' => true,
+        ]);
+        AllocationFactory::createOne([
+            'departmentWasClosed' => false,
+        ]);
+
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            sprintf(
+                '/explore/allocation?assignment=%d&occasion=%d&departmentWasClosed=1&limit=50',
+                $assignment->getId(),
+                $occasion->getId(),
+            )
+        );
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('select[name="assignment"]');
+        self::assertSelectorExists('select[name="occasion"]');
+        self::assertSelectorExists('[data-testid="allocation-filter-department-was-closed"]');
+        $ids = $this->extractAllocationIds($crawler);
+        self::assertSame([(int) $matchingAllocation->getId()], $ids);
+        self::assertSelectorExists('.alert.alert-info');
+        self::assertSelectorTextContains('.alert.alert-info', 'Test Assignment');
+        self::assertSelectorTextContains('.alert.alert-info', 'Test Occasion');
+    }
+
+    public function testDepartmentWasClosedAllocationShowsRowHighlightAndIndicator(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedDependencies();
+
+        AllocationFactory::createOne(['departmentWasClosed' => true]);
+        AllocationFactory::createOne(['departmentWasClosed' => false]);
+
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/explore/allocation?limit=50'
+        );
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('tr.allocation-row-department-closed');
+        self::assertSelectorExists('[data-testid="department-was-closed-indicator"]');
+        self::assertCount(1, $crawler->filter('tr.allocation-row-department-closed'));
+        self::assertCount(
+            0,
+            $crawler->filter('[data-testid="department-was-closed-indicator"] .w-3.h-3 + *'),
+            'Properties indicator should render icon only without trailing text.',
+        );
+    }
+
     private function seedDependencies(): void
     {
         UserFactory::createOne(['username' => 'area-user']);

--- a/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
@@ -118,6 +118,50 @@ final class ShowAllocationControllerTest extends WebTestCase
         self::assertStringContainsString(HospitalTier::cases()[0]->value, $pageText);
     }
 
+    public function testShowDisplaysDepartmentWasClosedIndicator(): void
+    {
+        $client = $this->createClientAsParticipant();
+
+        $owner = UserFactory::createOne(['username' => 'owner-user']);
+        $createdBy = UserFactory::createOne(['username' => 'area-user']);
+        $state = StateFactory::createOne(['name' => 'Hessen']);
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Dispatch Area', 'state' => $state]);
+        $department = DepartmentFactory::createOne(['name' => 'Closed Department']);
+        $speciality = SpecialityFactory::createOne(['name' => 'Closed Speciality']);
+        $assignment = AssignmentFactory::createOne();
+        $indicationRaw = IndicationRawFactory::createOne(['name' => 'Test Indication']);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'Test Indication']);
+        $hospital = HospitalFactory::createOne([
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+            'createdBy' => $createdBy,
+            'owner' => $owner,
+        ]);
+        $import = ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $createdBy,
+        ]);
+        $allocation = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'dispatchArea' => $dispatch,
+            'state' => $state,
+            'assignment' => $assignment,
+            'department' => $department,
+            'speciality' => $speciality,
+            'indicationRaw' => $indicationRaw,
+            'indicationNormalized' => $indicationNormalized,
+            'occasion' => OccasionFactory::createOne(),
+            'departmentWasClosed' => true,
+        ]);
+
+        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getId());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('.department-line [data-testid="department-was-closed-indicator"]');
+        self::assertSelectorTextContains('.department-line', 'Closed');
+    }
+
     public function testShowRejectsPostMethod(): void
     {
         $client = $this->createClientAsParticipant();

--- a/tests/Allocation/Integration/Query/ListAllocationsAssignmentOccasionDepartmentWasClosedFilterTest.php
+++ b/tests/Allocation/Integration/Query/ListAllocationsAssignmentOccasionDepartmentWasClosedFilterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Query;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Query\ListAllocationsQuery;
+use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ListAllocationsAssignmentOccasionDepartmentWasClosedFilterTest extends KernelTestCase
+{
+    use Factories;
+
+    private ListAllocationsQuery $query;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->query = self::getContainer()->get(ListAllocationsQuery::class);
+    }
+
+    public function testFiltersByAssignmentOccasionAndDepartmentWasClosed(): void
+    {
+        $shared = $this->seedAllocationGraph();
+
+        $assignmentA = AssignmentFactory::createOne(['name' => 'Assignment A']);
+        $assignmentB = AssignmentFactory::createOne(['name' => 'Assignment B']);
+        $occasionA = OccasionFactory::createOne(['name' => 'Occasion A']);
+        $occasionB = OccasionFactory::createOne(['name' => 'Occasion B']);
+
+        AllocationFactory::createOne([
+            'assignment' => $assignmentA,
+            'occasion' => $occasionA,
+            'departmentWasClosed' => true,
+        ] + $shared);
+        AllocationFactory::createOne([
+            'assignment' => $assignmentB,
+            'occasion' => $occasionB,
+            'departmentWasClosed' => false,
+        ] + $shared);
+
+        $assignmentResults = iterator_to_array($this->query->getPaginator(new AllocationQueryParametersDTO(
+            assignment: (int) $assignmentA->getId(),
+        ))->getResults());
+        self::assertCount(1, $assignmentResults);
+
+        $occasionResults = iterator_to_array($this->query->getPaginator(new AllocationQueryParametersDTO(
+            occasion: (int) $occasionA->getId(),
+        ))->getResults());
+        self::assertCount(1, $occasionResults);
+
+        $closedResults = iterator_to_array($this->query->getPaginator(new AllocationQueryParametersDTO(
+            departmentWasClosed: 1,
+        ))->getResults());
+        self::assertCount(1, $closedResults);
+        self::assertTrue($closedResults[0]['departmentWasClosed']);
+
+        $combinedResults = iterator_to_array($this->query->getPaginator(new AllocationQueryParametersDTO(
+            assignment: (int) $assignmentA->getId(),
+            occasion: (int) $occasionA->getId(),
+            departmentWasClosed: 1,
+        ))->getResults());
+        self::assertCount(1, $combinedResults);
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    private function seedAllocationGraph(): array
+    {
+        $user = UserFactory::createOne();
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne(['state' => $state, 'dispatchArea' => $dispatchArea]);
+        $import = ImportFactory::createOne(['hospital' => $hospital, 'createdBy' => $user]);
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        IndicationRawFactory::createOne();
+
+        return [
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ];
+    }
+}

--- a/tests/Allocation/Unit/UI/Http/DTO/AllocationQueryParametersDTOTest.php
+++ b/tests/Allocation/Unit/UI/Http/DTO/AllocationQueryParametersDTOTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\UI\Http\DTO;
+
+use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
+use PHPUnit\Framework\TestCase;
+
+final class AllocationQueryParametersDTOTest extends TestCase
+{
+    public function testToListFilterCriteriaMapsAssignmentOccasionAndDepartmentWasClosed(): void
+    {
+        $dto = new AllocationQueryParametersDTO(
+            assignment: 11,
+            occasion: 22,
+            departmentWasClosed: 1,
+        );
+
+        $criteria = $dto->toListFilterCriteria();
+
+        self::assertSame(11, $criteria->assignment);
+        self::assertSame(22, $criteria->occasion);
+        self::assertSame(1, $criteria->departmentWasClosed);
+    }
+}

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -1217,6 +1217,10 @@
         <source>field.departmentWasClosed</source>
         <target>Fachbereich war abgemeldet</target>
       </trans-unit>
+      <trans-unit id="abbrDeptClosedDe" resname="abbr.department_was_closed">
+        <source>abbr.department_was_closed</source>
+        <target>Abgm.</target>
+      </trans-unit>
       <trans-unit id="lblAllTiersDe" resname="label.all_tiers">
         <source>label.all_tiers</source>
         <target>Alle Versorgungsstufen</target>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -713,6 +713,10 @@
         <source>field.departmentWasClosed</source>
         <target>Department was closed</target>
       </trans-unit>
+      <trans-unit id="abbrDeptClosedEn" resname="abbr.department_was_closed">
+        <source>abbr.department_was_closed</source>
+        <target>Closed</target>
+      </trans-unit>
       <trans-unit id="allocAllTt" resname="label.all_transport_types">
         <source>label.all_transport_types</source>
         <target>All transport types</target>


### PR DESCRIPTION
## Summary

- Add **Assignment**, **Occasion**, and **Department was closed** filters to the Explore allocations filter drawer, reusing the same filter semantics already used for CSV export.
- Wire the new query parameters through `AllocationQueryParametersDTO` into the shared `AllocationListFilterApplicator`.
- Show active filter badges for the new fields in the allocations list.
- Visually highlight allocations where the department was closed:
  - light red row background in the list
  - compact icon-only indicator in the Properties column (tooltip via `field.departmentWasClosed`)
  - translated badge next to the department in the detail view

## Test plan

- [x] Integration test for assignment / occasion / `departmentWasClosed` filtering
- [x] Unit test for `AllocationQueryParametersDTO::toListFilterCriteria()`
- [x] Functional tests for filter drawer fields, active filter badges, and filtered results
- [x] Functional tests for closed-department row styling and detail indicator
- [x] `make ci` passes locally