### PR TITLE
feat: Refresh overview materialized views only on structural projection changes

### DIFF
--- a/docs/Statistics-projection-materialized-views.md
+++ b/docs/Statistics-projection-materialized-views.md
@@ -36,7 +36,26 @@ Typical flow:
 3. Dashboard and overview queries often read from the views for performance.
 4. Deeper or legacy comparisons may still use `AllocationStatsProjectionScopeQuery`, which queries `allocation_stats_projection` directly.
 
-Because of this split, **the projection table and the materialized views can disagree** until a refresh runs. That is expected; only the projection is updated automatically on import rebuild.
+Because of this split, **the projection table and the materialized views can disagree** until a refresh runs. The application refreshes overview materialized views automatically when structural projection changes occur (see below). Routine re-imports of existing hospitals do not trigger a refresh.
+
+## Automatic materialized view refresh
+
+Overview materialized views are refreshed automatically when the hospital structure in `allocation_stats_projection` changes:
+
+| Trigger | Refresh? | Implementation |
+|---------|----------|----------------|
+| First import for a hospital (new `hospital_id` in projection) | Yes | `RebuildAllocationStatsProjectionHandler` after `rebuildForImport()` |
+| Re-import of an existing hospital | No | Hospital already present in projection |
+| Import deletion removing a hospital's last projection rows | Yes | `ImportRelatedDataCleanupService` after cleanup |
+| Bulk rebuild (`app:statistics:rebuild-projection`) | Yes (always) | Command refreshes overview views at the end |
+
+Detection uses `ProjectionOverviewChangeDetector` (cheap `EXISTS` queries on `allocation` / `allocation_stats_projection`).
+
+Manual refresh remains available for repair:
+
+```bash
+php bin/console app:statistics:refresh-mviews --overview
+```
 
 ## Production and development operations
 
@@ -48,13 +67,13 @@ After imports or loading allocation fixtures:
 php bin/console app:statistics:rebuild-projection
 ```
 
-Or rely on the async handler that calls `AllocationStatsProjectionRebuilder::rebuildForImport()` per import.
+Or rely on the async handler that calls `AllocationStatsProjectionRebuilder::rebuildForImport()` per import. When a hospital appears in the projection for the first time, the handler also refreshes overview materialized views.
 
-Rebuilding the projection **does not** refresh materialized views.
+Rebuilding the projection via the bulk command refreshes overview materialized views at the end. Per-import rebuilds refresh materialized views only when a new hospital enters the projection.
 
-### Refresh materialized views
+### Refresh materialized views (manual)
 
-After bulk projection changes:
+For repair or after unusual operations (e.g. direct SQL on the projection table):
 
 ```bash
 # All registered groups (currently: overview)
@@ -82,7 +101,7 @@ Implications for materialized views:
 
 - **Schema reset** (drop + recreate + MV install) runs **once per PHPUnit process** when the first `#[ResetDatabase]` test class starts — not before every test method.
 - **MV data** refreshed inside a test (via `RefreshesStatisticsMaterializedViewsTrait`) is rolled back with the test transaction; the view definitions persist.
-- **MV refresh after projection rebuild remains mandatory** when assertions use MV-backed queries or `StatisticsFilterFactory` scope rules.
+- **MV refresh after projection rebuild** is required in tests that call `AllocationStatsProjectionRebuilder` directly without going through `RebuildAllocationStatsProjectionHandler`. Tests that use the handler for first-import scenarios get automatic refresh when a new hospital enters the projection.
 
 Configuration: `config/packages/dama_doctrine_test_bundle.yaml`, PHPUnit extension in `phpunit.dist.xml`.
 
@@ -161,9 +180,11 @@ self::getContainer()
 | Drop before reset | `StatisticsMaterializedViewDropper` | Test reset hook (DBAL) |
 | Foundry decorator | `App\Tests\Support\Foundry\MaterializedViewAwareOrmResetter` | Test env only |
 | Install / refresh helper | `OverviewMaterializedViewsInstaller` | Test install + `refreshIfInstalled()` |
-| Refresh service | `MaterializedViewRefresher` | Used by console command and test trait |
-| Console command | `app:statistics:refresh-mviews` | Production refresh |
-| Projection rebuilder | `AllocationStatsProjectionRebuilder` | Does not refresh MVs |
+| Refresh service | `MaterializedViewRefresher` | Used by console command, handler, import cleanup, and test trait |
+| Structural change detector | `ProjectionOverviewChangeDetector` | Decides when handler/cleanup should refresh overview MVs |
+| Detector / refresher contracts | `ProjectionOverviewChangeDetectorInterface`, `MaterializedViewRefresherInterface` | Autowired into handler and import cleanup |
+| Console command | `app:statistics:refresh-mviews` | Manual repair refresh |
+| Projection rebuilder | `AllocationStatsProjectionRebuilder` | Does not refresh MVs by itself; use handler or bulk command |
 | Test trait | `RefreshesStatisticsMaterializedViewsTrait` | `tests/Support/MaterializedView/` |
 
 ## Related documentation

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -22,7 +22,7 @@ journalctl --user -u messenger -f
 | Imports/mail stuck in queue | Worker not running | Start/restart worker and inspect queue |
 | `import.failed.precondition` | Missing CSV or invalid path | Verify import file path and file availability |
 | Requeue exits with code `2` | Critical error / retry limit | Fix affected import, retry |
-| Statistics look outdated | Materialized views not refreshed | Run `app:statistics:refresh-mviews` |
+| Statistics look outdated | Messenger worker not processing projection rebuild, manual projection SQL, or hospital metadata changed without re-import | Check worker queue; run `app:statistics:refresh-mviews` if projection was changed outside the app |
 | Feedback saved, no admin mail | No eligible recipients | Check Admin + Receives Feedback roles |
 | Mail links point to `localhost` | Missing/wrong `APP_URL` in prod | Fix `APP_URL`, clear cache, restart worker |
 

--- a/src/Import/Application/Service/ImportRelatedDataCleanupService.php
+++ b/src/Import/Application/Service/ImportRelatedDataCleanupService.php
@@ -9,6 +9,9 @@ use App\Allocation\Infrastructure\Repository\MciCaseRepository;
 use App\Import\Domain\Entity\Import;
 use App\Import\Infrastructure\Repository\ImportRejectRepository;
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\Contract\MaterializedViewRefresherInterface;
+use App\Statistics\Application\Contract\ProjectionOverviewChangeDetectorInterface;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -24,6 +27,8 @@ final readonly class ImportRelatedDataCleanupService
         private AllocationRepository $allocationRepository,
         private MciCaseRepository $mciCaseRepository,
         private AllocationStatsProjectionRebuildInterface $statsProjectionRebuilder,
+        private ProjectionOverviewChangeDetectorInterface $projectionOverviewChangeDetector,
+        private MaterializedViewRefresherInterface $materializedViewRefresher,
         private LoggerInterface $importLogger,
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
@@ -33,6 +38,7 @@ final readonly class ImportRelatedDataCleanupService
     public function removeAll(Import $import): void
     {
         $importId = (int) $import->getId();
+        $needsMaterializedViewRefresh = $this->projectionOverviewChangeDetector->willRemoveHospitalsFromProjection($importId);
 
         $counts = $this->em->wrapInTransaction(function () use ($import, $importId): array {
             $assessmentIds = $this->collectAssessmentIdsForImport($importId);
@@ -45,6 +51,14 @@ final readonly class ImportRelatedDataCleanupService
                 'mci_cases' => $this->mciCaseRepository->deleteByImport($import),
             ];
         });
+
+        if ($needsMaterializedViewRefresh) {
+            $this->materializedViewRefresher->refresh([StatisticsMaterializedViewGroups::OVERVIEW]);
+            $this->importLogger->info('statistics_materialized_view.refreshed_after_structural_change', [
+                'import_id' => $importId,
+                'reason' => 'hospital_removed',
+            ]);
+        }
 
         $this->logCleanup(
             $importId,

--- a/src/Statistics/Application/Contract/MaterializedViewRefresherInterface.php
+++ b/src/Statistics/Application/Contract/MaterializedViewRefresherInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Contract;
+
+interface MaterializedViewRefresherInterface
+{
+    /**
+     * @param list<string> $groups empty = all registered groups
+     *
+     * @return list<array{view: string, success: bool, message: string}>
+     */
+    public function refresh(array $groups = [], ?bool $concurrently = null): array;
+}

--- a/src/Statistics/Application/Contract/ProjectionOverviewChangeDetectorInterface.php
+++ b/src/Statistics/Application/Contract/ProjectionOverviewChangeDetectorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Contract;
+
+interface ProjectionOverviewChangeDetectorInterface
+{
+    public function willIntroduceNewHospitals(int $importId): bool;
+
+    public function willRemoveHospitalsFromProjection(int $importId): bool;
+}

--- a/src/Statistics/Application/MessageHandler/RebuildAllocationStatsProjectionHandler.php
+++ b/src/Statistics/Application/MessageHandler/RebuildAllocationStatsProjectionHandler.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace App\Statistics\Application\MessageHandler;
 
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\Contract\MaterializedViewRefresherInterface;
+use App\Statistics\Application\Contract\ProjectionOverviewChangeDetectorInterface;
 use App\Statistics\Application\Message\RebuildAllocationStatsProjection;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -13,11 +17,27 @@ final readonly class RebuildAllocationStatsProjectionHandler
 {
     public function __construct(
         private AllocationStatsProjectionRebuildInterface $rebuilder,
+        private ProjectionOverviewChangeDetectorInterface $changeDetector,
+        private MaterializedViewRefresherInterface $materializedViewRefresher,
+        private LoggerInterface $logger,
     ) {
     }
 
     public function __invoke(RebuildAllocationStatsProjection $message): void
     {
+        $needsRefresh = $this->changeDetector->willIntroduceNewHospitals($message->importId);
+
         $this->rebuilder->rebuildForImport($message->importId);
+
+        if (!$needsRefresh) {
+            return;
+        }
+
+        $this->materializedViewRefresher->refresh([StatisticsMaterializedViewGroups::OVERVIEW]);
+
+        $this->logger->info('statistics_materialized_view.refreshed_after_structural_change', [
+            'import_id' => $message->importId,
+            'reason' => 'new_hospital',
+        ]);
     }
 }

--- a/src/Statistics/Infrastructure/MaterializedView/MaterializedViewRefresher.php
+++ b/src/Statistics/Infrastructure/MaterializedView/MaterializedViewRefresher.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace App\Statistics\Infrastructure\MaterializedView;
 
+use App\Statistics\Application\Contract\MaterializedViewRefresherInterface;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-final readonly class MaterializedViewRefresher
+final readonly class MaterializedViewRefresher implements MaterializedViewRefresherInterface
 {
     public function __construct(
         private Connection $connection,
         private LoggerInterface $logger,
+        #[Autowire('%kernel.environment%')]
+        private string $kernelEnvironment,
     ) {
     }
 
@@ -20,8 +24,11 @@ final readonly class MaterializedViewRefresher
      *
      * @return list<array{view: string, success: bool, message: string}>
      */
-    public function refresh(array $groups = [], bool $concurrently = true): array
+    #[\Override]
+    public function refresh(array $groups = [], ?bool $concurrently = null): array
     {
+        $concurrently ??= 'test' !== $this->kernelEnvironment;
+
         $results = [];
         foreach (StatisticsMaterializedViewGroups::viewsForGroups($groups) as $viewName) {
             $results[] = $this->refreshView($viewName, $concurrently);

--- a/src/Statistics/Infrastructure/Projection/ProjectionOverviewChangeDetector.php
+++ b/src/Statistics/Infrastructure/Projection/ProjectionOverviewChangeDetector.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Projection;
+
+use App\Statistics\Application\Contract\ProjectionOverviewChangeDetectorInterface;
+use Doctrine\DBAL\Connection;
+
+final readonly class ProjectionOverviewChangeDetector implements ProjectionOverviewChangeDetectorInterface
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    #[\Override]
+    public function willIntroduceNewHospitals(int $importId): bool
+    {
+        return (bool) $this->connection->fetchOne(
+            <<<'SQL'
+SELECT EXISTS (
+    SELECT 1
+    FROM allocation a
+    WHERE a.import_id = :importId
+      AND NOT EXISTS (
+          SELECT 1
+          FROM allocation_stats_projection p
+          WHERE p.hospital_id = a.hospital_id
+      )
+)
+SQL,
+            ['importId' => $importId],
+        );
+    }
+
+    #[\Override]
+    public function willRemoveHospitalsFromProjection(int $importId): bool
+    {
+        return (bool) $this->connection->fetchOne(
+            <<<'SQL'
+SELECT EXISTS (
+    SELECT 1
+    FROM allocation_stats_projection p
+    WHERE p.import_id = :importId
+      AND NOT EXISTS (
+          SELECT 1
+          FROM allocation_stats_projection p2
+          WHERE p2.hospital_id = p.hospital_id
+            AND p2.import_id <> :importId
+      )
+)
+SQL,
+            ['importId' => $importId],
+        );
+    }
+}

--- a/src/Statistics/UI/Console/Command/RebuildAllocationStatsProjectionCommand.php
+++ b/src/Statistics/UI/Console/Command/RebuildAllocationStatsProjectionCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Statistics\UI\Console\Command;
 
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -25,6 +27,7 @@ final readonly class RebuildAllocationStatsProjectionCommand
         private Connection $connection,
         private EntityManagerInterface $entityManager,
         private AllocationStatsProjectionRebuildInterface $rebuilder,
+        private MaterializedViewRefresher $materializedViewRefresher,
     ) {
     }
 
@@ -40,7 +43,10 @@ final readonly class RebuildAllocationStatsProjectionCommand
 
             $importIds = $this->fetchImportIdsFromAllocations();
             if ([] === $importIds) {
-                $io->success('No allocations found. Projection table remains empty.');
+                $io->writeln('<info>No allocations found. Refreshing materialized views for empty projection.</info>');
+                $this->refreshOverviewMaterializedViews($io);
+
+                $io->success('Projection table remains empty. Materialized views refreshed.');
 
                 return Command::SUCCESS;
             }
@@ -59,6 +65,13 @@ final readonly class RebuildAllocationStatsProjectionCommand
 
             $progress->finish();
             $output->writeln('');
+
+            $io->section('Refreshing materialized views');
+            if ($this->refreshOverviewMaterializedViews($io)) {
+                $io->warning('Projection rebuild completed but some materialized view refreshes failed.');
+
+                return Command::FAILURE;
+            }
         } catch (\Throwable $e) {
             $io->error(sprintf('Projection rebuild failed: %s', $e->getMessage()));
 
@@ -91,5 +104,20 @@ final readonly class RebuildAllocationStatsProjectionCommand
             ->fetchFirstColumn('SELECT DISTINCT import_id FROM allocation ORDER BY import_id ASC');
 
         return array_map(static fn (int|string $value): int => (int) $value, $rows);
+    }
+
+    private function refreshOverviewMaterializedViews(SymfonyStyle $io): bool
+    {
+        $failed = false;
+        foreach ($this->materializedViewRefresher->refresh([StatisticsMaterializedViewGroups::OVERVIEW]) as $refreshResult) {
+            if ($refreshResult['success']) {
+                $io->success($refreshResult['message']);
+            } else {
+                $failed = true;
+                $io->error($refreshResult['message']);
+            }
+        }
+
+        return $failed;
     }
 }

--- a/tests/Import/Integration/Service/ImportDeletionServiceTest.php
+++ b/tests/Import/Integration/Service/ImportDeletionServiceTest.php
@@ -24,7 +24,10 @@ use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\Import\Infrastructure\Repository\ImportRepository;
-use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\Message\RebuildAllocationStatsProjection;
+use App\Statistics\Application\MessageHandler\RebuildAllocationStatsProjectionHandler;
+use App\Statistics\Infrastructure\Entity\ProjectionHospitalDimension;
+use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
 use App\User\Domain\Factory\UserFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -82,10 +85,53 @@ final class ImportDeletionServiceTest extends KernelTestCase
         }
     }
 
+    public function testDeleteLastImportRefreshesMaterializedViews(): void
+    {
+        ['import' => $import, 'csvPath' => $csvPath, 'importId' => $importId, 'hospitalId' => $hospitalId] = $this->arrangeImportWithAllocation();
+
+        try {
+            self::assertInstanceOf(
+                ProjectionHospitalDimension::class,
+                $this->em->find(ProjectionHospitalDimension::class, $hospitalId),
+            );
+
+            $this->deletionService->delete($import);
+
+            $this->em->clear();
+            self::assertNull($this->em->find(ProjectionHospitalDimension::class, $hospitalId));
+        } finally {
+            if (\is_file($csvPath)) {
+                @unlink($csvPath);
+            }
+        }
+    }
+
+    public function testDeleteImportKeepsHospitalInMaterializedViewsWhenOtherImportsExist(): void
+    {
+        ['import' => $firstImport, 'hospitalId' => $hospitalId] = $this->arrangeImportWithAllocation('DeleteKeepA');
+        $secondImport = $this->arrangeSecondImportForSameHospital($firstImport);
+
+        try {
+            $this->deletionService->delete($firstImport);
+
+            $this->em->clear();
+            self::assertInstanceOf(
+                ProjectionHospitalDimension::class,
+                $this->em->find(ProjectionHospitalDimension::class, $hospitalId),
+            );
+            self::assertNotNull($this->imports->find((int) $secondImport->getId()));
+        } finally {
+            $csvPath = $secondImport->getFilePath();
+            if (\is_string($csvPath) && '' !== $csvPath && \is_file($csvPath)) {
+                @unlink($csvPath);
+            }
+        }
+    }
+
     /**
-     * @return array{import: Import, importId: int, csvPath: string}
+     * @return array{import: Import, importId: int, csvPath: string, hospitalId: int}
      */
-    private function arrangeImportWithAllocation(): array
+    private function arrangeImportWithAllocation(string $namePrefix = 'DeleteService'): array
     {
         UserFactory::createOne();
         $state = StateFactory::createOne();
@@ -99,7 +145,7 @@ final class ImportDeletionServiceTest extends KernelTestCase
         file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
 
         $importProxy = ImportFactory::createOne([
-            'name' => 'Delete Service IT',
+            'name' => $namePrefix.' IT',
             'hospital' => $hospital,
             'type' => ImportType::ALLOCATION,
             'status' => ImportStatus::COMPLETED,
@@ -132,12 +178,56 @@ final class ImportDeletionServiceTest extends KernelTestCase
         ]);
 
         $importId = (int) $importProxy->getId();
-        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($importId);
+        self::getContainer()->get(OverviewMaterializedViewsInstaller::class)->ensureInstalled();
+        self::getContainer()->get(RebuildAllocationStatsProjectionHandler::class)
+            ->__invoke(new RebuildAllocationStatsProjection($importId));
 
         /** @var Import $import */
         $import = $this->imports->find($importId);
 
-        return ['import' => $import, 'importId' => $importId, 'csvPath' => $csvPath];
+        return ['import' => $import, 'importId' => $importId, 'csvPath' => $csvPath, 'hospitalId' => (int) $hospital->getId()];
+    }
+
+    private function arrangeSecondImportForSameHospital(Import $firstImport): Import
+    {
+        $hospital = $firstImport->getHospital();
+        self::assertNotNull($hospital);
+
+        $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
+        file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+
+        $importProxy = ImportFactory::createOne([
+            'name' => 'DeleteKeepB IT',
+            'hospital' => $hospital,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::COMPLETED,
+            'filePath' => $csvPath,
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => (int) filesize($csvPath),
+            'rowCount' => 1,
+            'rowsPassed' => 1,
+            'rowsRejected' => 0,
+            'runCount' => 1,
+            'runTime' => 50,
+        ]);
+
+        AllocationFactory::createOne([
+            'import' => $importProxy,
+            'hospital' => $hospital,
+            'dispatchArea' => $hospital->getDispatchArea(),
+            'state' => $hospital->getState(),
+        ]);
+
+        $importId = (int) $importProxy->getId();
+        self::getContainer()->get(RebuildAllocationStatsProjectionHandler::class)
+            ->__invoke(new RebuildAllocationStatsProjection($importId));
+
+        /** @var Import $import */
+        $import = $this->imports->find($importId);
+        self::assertInstanceOf(Import::class, $import);
+
+        return $import;
     }
 
     private function countAllocationsForImport(int $importId): int

--- a/tests/Statistics/Functional/Command/RebuildAllocationStatsProjectionCommandTest.php
+++ b/tests/Statistics/Functional/Command/RebuildAllocationStatsProjectionCommandTest.php
@@ -76,6 +76,7 @@ final class RebuildAllocationStatsProjectionCommandTest extends KernelTestCase
 
         $display = $tester->getDisplay();
         self::assertStringContainsString('Projection table truncated.', $display);
+        self::assertStringContainsString('Refreshing materialized views', $display);
         self::assertStringContainsString('Projection rebuild finished. Imports processed: 2', $display);
     }
 
@@ -91,7 +92,7 @@ final class RebuildAllocationStatsProjectionCommandTest extends KernelTestCase
         $tester->assertCommandIsSuccessful();
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('No allocations found. Projection table remains empty.', $tester->getDisplay());
+        self::assertStringContainsString('Projection table remains empty. Materialized views refreshed.', $tester->getDisplay());
     }
 
     #[Test]

--- a/tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderTest.php
+++ b/tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderTest.php
@@ -118,7 +118,6 @@ final class StatisticsFilterFormChoiceProviderTest extends KernelTestCase
             'dispatchArea' => $emptyDispatchArea,
             'owner' => $user,
         ]);
-        $this->refreshStatisticsMaterializedViews();
 
         $registeredDispatchId = (string) $emptyDispatchArea->getId();
         self::assertArrayNotHasKey(

--- a/tests/Statistics/Integration/MessageHandler/RebuildAllocationStatsProjectionHandlerIntegrationTest.php
+++ b/tests/Statistics/Integration/MessageHandler/RebuildAllocationStatsProjectionHandlerIntegrationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\MessageHandler;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Message\RebuildAllocationStatsProjection;
+use App\Statistics\Application\MessageHandler\RebuildAllocationStatsProjectionHandler;
+use App\Statistics\Infrastructure\Entity\ProjectionStateHospitalCount;
+use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class RebuildAllocationStatsProjectionHandlerIntegrationTest extends KernelTestCase
+{
+    use Factories;
+
+    private RebuildAllocationStatsProjectionHandler $projectionHandler;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->projectionHandler = $container->get(RebuildAllocationStatsProjectionHandler::class);
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+        $container->get(OverviewMaterializedViewsInstaller::class)->ensureInstalled();
+    }
+
+    public function testFirstImportRefreshesMaterializedViewsWithoutManualRefresh(): void
+    {
+        $importId = $this->seedImport('HandlerFirstImport');
+        $stateId = $this->stateIdForImport($importId);
+
+        ($this->projectionHandler)(new RebuildAllocationStatsProjection($importId));
+
+        $row = $this->entityManager->find(ProjectionStateHospitalCount::class, $stateId);
+        self::assertInstanceOf(ProjectionStateHospitalCount::class, $row);
+        self::assertSame(1, $row->getHospitalCount());
+    }
+
+    public function testReimportKeepsMaterializedViewCountsStable(): void
+    {
+        $importId = $this->seedImport('HandlerReimport');
+        $stateId = $this->stateIdForImport($importId);
+
+        ($this->projectionHandler)(new RebuildAllocationStatsProjection($importId));
+        ($this->projectionHandler)(new RebuildAllocationStatsProjection($importId));
+
+        $row = $this->entityManager->find(ProjectionStateHospitalCount::class, $stateId);
+        self::assertInstanceOf(ProjectionStateHospitalCount::class, $row);
+        self::assertSame(1, $row->getHospitalCount());
+    }
+
+    private function seedImport(string $prefix): int
+    {
+        $user = UserFactory::createOne(['username' => strtolower($prefix).'-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => $prefix.'State']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => $prefix.'Dispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => $prefix.'Hospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+            'owner' => $user,
+        ]);
+        $import = ImportFactory::createOne([
+            'name' => $prefix.'Import',
+            'hospital' => $hospital,
+            'createdBy' => $user,
+        ]);
+
+        SpecialityFactory::createOne(['name' => $prefix.'Speciality']);
+        DepartmentFactory::createOne(['name' => $prefix.'Department']);
+        AssignmentFactory::createOne(['name' => $prefix.'Assignment']);
+        IndicationRawFactory::createOne(['name' => $prefix.'Indication', 'code' => random_int(900_000, 999_999)]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'createdAt' => new \DateTimeImmutable('2025-06-01 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-01 10:20:00'),
+        ]);
+
+        return (int) $import->getId();
+    }
+
+    private function stateIdForImport(int $importId): int
+    {
+        $stateId = self::getContainer()->get(\Doctrine\DBAL\Connection::class)->fetchOne(
+            'SELECT state_id FROM allocation WHERE import_id = :importId LIMIT 1',
+            ['importId' => $importId],
+        );
+
+        self::assertNotFalse($stateId);
+
+        return (int) $stateId;
+    }
+}

--- a/tests/Statistics/Integration/Projection/ProjectionOverviewChangeDetectorTest.php
+++ b/tests/Statistics/Integration/Projection/ProjectionOverviewChangeDetectorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Projection;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Infrastructure\Projection\ProjectionOverviewChangeDetector;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ProjectionOverviewChangeDetectorTest extends KernelTestCase
+{
+    use Factories;
+
+    private ProjectionOverviewChangeDetector $detector;
+
+    private AllocationStatsProjectionRebuildInterface $rebuilder;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $this->detector = $container->get(ProjectionOverviewChangeDetector::class);
+        $this->rebuilder = $container->get(AllocationStatsProjectionRebuildInterface::class);
+    }
+
+    public function testWillIntroduceNewHospitalsIsTrueForFirstImport(): void
+    {
+        $importId = $this->seedImportWithAllocation('DetectorFirstImport');
+
+        self::assertTrue($this->detector->willIntroduceNewHospitals($importId));
+    }
+
+    public function testWillIntroduceNewHospitalsIsFalseAfterProjectionRebuild(): void
+    {
+        $importId = $this->seedImportWithAllocation('DetectorReimport');
+        $this->rebuilder->rebuildForImport($importId);
+
+        self::assertFalse($this->detector->willIntroduceNewHospitals($importId));
+    }
+
+    public function testWillIntroduceNewHospitalsIsFalseWhenHospitalExistsFromOtherImport(): void
+    {
+        $user = UserFactory::createOne(['username' => 'detector-other-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DetectorOtherState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'DetectorOtherDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'DetectorSharedHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'owner' => $user,
+        ]);
+
+        $firstImportId = $this->seedImportWithAllocation('DetectorOtherA', $hospital, $user, $state, $dispatchArea);
+        $this->rebuilder->rebuildForImport($firstImportId);
+
+        $secondImport = ImportFactory::createOne([
+            'name' => 'DetectorOtherB',
+            'hospital' => $hospital,
+            'createdBy' => $user,
+        ]);
+        $secondImportId = (int) $secondImport->getId();
+        $this->seedAllocation($secondImport, $hospital, $state, $dispatchArea);
+
+        self::assertFalse($this->detector->willIntroduceNewHospitals($secondImportId));
+    }
+
+    public function testWillRemoveHospitalsFromProjectionIsTrueForOnlyImport(): void
+    {
+        $importId = $this->seedImportWithAllocation('DetectorDeleteOnly');
+        $this->rebuilder->rebuildForImport($importId);
+
+        self::assertTrue($this->detector->willRemoveHospitalsFromProjection($importId));
+    }
+
+    public function testWillRemoveHospitalsFromProjectionIsFalseWhenHospitalHasOtherImports(): void
+    {
+        $user = UserFactory::createOne(['username' => 'detector-delete-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DetectorDeleteState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'DetectorDeleteDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'DetectorDeleteHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'owner' => $user,
+        ]);
+
+        $firstImportId = $this->seedImportWithAllocation('DetectorDeleteA', $hospital, $user, $state, $dispatchArea);
+        $secondImport = ImportFactory::createOne([
+            'name' => 'DetectorDeleteB',
+            'hospital' => $hospital,
+            'createdBy' => $user,
+        ]);
+        $secondImportId = (int) $secondImport->getId();
+        $this->seedAllocation($secondImport, $hospital, $state, $dispatchArea);
+
+        $this->rebuilder->rebuildForImport($firstImportId);
+        $this->rebuilder->rebuildForImport($secondImportId);
+
+        self::assertFalse($this->detector->willRemoveHospitalsFromProjection($firstImportId));
+    }
+
+    private function seedImportWithAllocation(
+        string $prefix,
+        ?\App\Allocation\Domain\Entity\Hospital $hospital = null,
+        ?\App\User\Domain\Entity\User $user = null,
+        ?\App\Allocation\Domain\Entity\State $state = null,
+        ?\App\Allocation\Domain\Entity\DispatchArea $dispatchArea = null,
+    ): int {
+        $user ??= UserFactory::createOne(['username' => strtolower($prefix).'-'.bin2hex(random_bytes(4))]);
+        $state ??= StateFactory::createOne(['name' => $prefix.'State']);
+        $dispatchArea ??= DispatchAreaFactory::createOne(['name' => $prefix.'Dispatch', 'state' => $state]);
+        $hospital ??= HospitalFactory::createOne([
+            'name' => $prefix.'Hospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'owner' => $user,
+        ]);
+
+        $import = ImportFactory::createOne([
+            'name' => $prefix.'Import',
+            'hospital' => $hospital,
+            'createdBy' => $user,
+        ]);
+        $this->seedAllocation($import, $hospital, $state, $dispatchArea);
+
+        return (int) $import->getId();
+    }
+
+    private function seedAllocation(
+        \App\Import\Domain\Entity\Import $import,
+        \App\Allocation\Domain\Entity\Hospital $hospital,
+        \App\Allocation\Domain\Entity\State $state,
+        \App\Allocation\Domain\Entity\DispatchArea $dispatchArea,
+    ): void {
+        SpecialityFactory::createOne(['name' => $import->getName().'Speciality']);
+        DepartmentFactory::createOne(['name' => $import->getName().'Department']);
+        AssignmentFactory::createOne(['name' => $import->getName().'Assignment']);
+        IndicationRawFactory::createOne(['name' => $import->getName().'Indication', 'code' => random_int(900_000, 999_999)]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'createdAt' => new \DateTimeImmutable('2025-06-01 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-01 10:20:00'),
+        ]);
+    }
+}

--- a/tests/Statistics/Support/Benchmarking/EligibleBenchmarkScopeTrait.php
+++ b/tests/Statistics/Support/Benchmarking/EligibleBenchmarkScopeTrait.php
@@ -20,15 +20,14 @@ use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Infrastructure\Factory\ImportFactory;
-use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
-use App\Tests\Support\MaterializedView\RefreshesStatisticsMaterializedViewsTrait;
+use App\Statistics\Application\Message\RebuildAllocationStatsProjection;
+use App\Statistics\Application\MessageHandler\RebuildAllocationStatsProjectionHandler;
 use App\User\Domain\Entity\User;
 use Zenstruck\Foundry\Test\Factories;
 
 trait EligibleBenchmarkScopeTrait
 {
     use Factories;
-    use RefreshesStatisticsMaterializedViewsTrait;
 
     /**
      * @return array{state: State, dispatchArea: DispatchArea, hospitalA: Hospital, hospitalB: Hospital}
@@ -83,10 +82,9 @@ trait EligibleBenchmarkScopeTrait
             'arrivalAt' => new \DateTimeImmutable('2025-06-02 11:20:00'),
         ]);
 
-        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
-        $rebuilder->rebuildForImport($importA->getId());
-        $rebuilder->rebuildForImport($importB->getId());
-        $this->refreshStatisticsMaterializedViews();
+        $rebuilder = self::getContainer()->get(RebuildAllocationStatsProjectionHandler::class);
+        $rebuilder(new RebuildAllocationStatsProjection($importA->getId()));
+        $rebuilder(new RebuildAllocationStatsProjection($importB->getId()));
 
         return [
             'state' => $state,

--- a/tests/Statistics/Unit/MessageHandler/RebuildAllocationStatsProjectionHandlerTest.php
+++ b/tests/Statistics/Unit/MessageHandler/RebuildAllocationStatsProjectionHandlerTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\Statistics\Unit\MessageHandler;
 
 use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\Contract\MaterializedViewRefresherInterface;
+use App\Statistics\Application\Contract\ProjectionOverviewChangeDetectorInterface;
 use App\Statistics\Application\Message\RebuildAllocationStatsProjection;
 use App\Statistics\Application\MessageHandler\RebuildAllocationStatsProjectionHandler;
+use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 final class RebuildAllocationStatsProjectionHandlerTest extends TestCase
 {
-    public function testInvokesRebuilderWithImportId(): void
+    public function testInvokesRebuilderWithoutRefreshWhenNoStructuralChange(): void
     {
         $importId = 901;
 
@@ -20,7 +24,59 @@ final class RebuildAllocationStatsProjectionHandlerTest extends TestCase
             ->method('rebuildForImport')
             ->with($importId);
 
-        $handler = new RebuildAllocationStatsProjectionHandler($rebuilder);
+        $changeDetector = $this->createMock(ProjectionOverviewChangeDetectorInterface::class);
+        $changeDetector->expects($this->once())
+            ->method('willIntroduceNewHospitals')
+            ->with($importId)
+            ->willReturn(false);
+
+        $materializedViewRefresher = $this->createMock(MaterializedViewRefresherInterface::class);
+        $materializedViewRefresher->expects($this->never())->method('refresh');
+
+        $handler = new RebuildAllocationStatsProjectionHandler(
+            $rebuilder,
+            $changeDetector,
+            $materializedViewRefresher,
+            $this->createMock(LoggerInterface::class),
+        );
+        $handler(new RebuildAllocationStatsProjection($importId));
+    }
+
+    public function testRefreshesMaterializedViewsWhenNewHospitalIntroduced(): void
+    {
+        $importId = 902;
+
+        $rebuilder = $this->createMock(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->expects($this->once())
+            ->method('rebuildForImport')
+            ->with($importId);
+
+        $changeDetector = $this->createMock(ProjectionOverviewChangeDetectorInterface::class);
+        $changeDetector->expects($this->once())
+            ->method('willIntroduceNewHospitals')
+            ->with($importId)
+            ->willReturn(true);
+
+        $materializedViewRefresher = $this->createMock(MaterializedViewRefresherInterface::class);
+        $materializedViewRefresher->expects($this->once())
+            ->method('refresh')
+            ->with([StatisticsMaterializedViewGroups::OVERVIEW])
+            ->willReturn([]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                'statistics_materialized_view.refreshed_after_structural_change',
+                ['import_id' => $importId, 'reason' => 'new_hospital'],
+            );
+
+        $handler = new RebuildAllocationStatsProjectionHandler(
+            $rebuilder,
+            $changeDetector,
+            $materializedViewRefresher,
+            $logger,
+        );
         $handler(new RebuildAllocationStatsProjection($importId));
     }
 }


### PR DESCRIPTION
## Summary

Statistics scope filters (state, dispatch area, hospital cohorts) read from overview **materialized views** (`mv_projection_*`). Those views are derived from `allocation_stats_projection`, which is rebuilt automatically after each import — but until now, the materialized views were only refreshed manually via `app:statistics:refresh-mviews`.

That gap caused a real UX problem: when a hospital completed its **first import**, the projection was up to date, but filter options and scope validation still read **stale MV data**. New participants could not see the statistics scopes they were entitled to until someone ran a manual refresh.

This PR adds **conditional, automatic MV refresh** when the hospital structure in the projection actually changes — without refreshing on every routine re-import.

## What changed

### `ProjectionOverviewChangeDetector`
A small SQL-based detector answers two questions:
- **`willIntroduceNewHospitals(importId)`** — will this import bring at least one `hospital_id` into the projection for the first time?
- **`willRemoveHospitalsFromProjection(importId)`** — will deleting this import remove a hospital entirely from the projection?

### Automatic refresh triggers

| Event | MV refresh? |
|-------|-------------|
| First import for a hospital | Yes |
| Re-import of an existing hospital (e.g. new quarter) | No |
| Deleting a hospital's last import | Yes |
| Deleting an import while the hospital has other imports | No |
| `app:statistics:rebuild-projection` (bulk) | Yes (always at end) |

Refresh runs **synchronously in the same handler/cleanup path** after the projection change, so there is no window where the projection is fresh but the MVs are still stale within a single operation.

### Other notes
- `MaterializedViewRefresher` uses non-concurrent refresh in `test` by default (DAMA transaction compatibility).
- `app:statistics:refresh-mviews` remains available as a manual repair command.
- Marking a hospital as `isParticipating` alone still does not affect statistics scopes — a successful import is still required. This PR only fixes the lag **after** that first import.

## Why not refresh on every import?

Routine quarterly re-imports add allocation rows but do not change `COUNT(DISTINCT hospital_id)` per state, dispatch area, or cohort. Refreshing three materialized views on every import would add unnecessary overhead. Structural changes (new or removed hospitals) are rare and are exactly when filter eligibility changes.

## Test plan

- [x] Detector integration tests (first import, re-import, shared hospital, deletion edge cases)
- [x] Handler unit + integration tests (refresh on first import, stable on re-import)
- [x] Import deletion keeps/removes hospital in `mv_projection_hospital_dimensions` as expected
- [x] Bulk rebuild command refreshes MVs and reports success in output
- [x] `make ci` passes (PHPStan, Psalm, formatters)
