### PR TITLE
feat(ops): backup and restore tooling for beta readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = help
-.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules
+.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules backup backup-db backup-files restore-db verify-restore-baseline verify-restore
 
 # Executables
 COMPOSER      = composer
@@ -106,6 +106,26 @@ compile: ## Execute some tasks before deployment
 
 consume: ## Consume messages from symfony messenger
 	@$(CONSOLE) messenger:consume async_priority_high async_priority_low scheduler_default -vv
+
+## —— Backups 💾 ———————————————————————————————————————————————————————————————
+backup-db: ## PostgreSQL dump to var/backups (uses Docker database service when running)
+	@./bin/ops/backup-database.sh
+
+backup-files: ## Archive var/imports and public/uploads/media to var/backups
+	@./bin/ops/backup-files.sh
+
+backup: backup-db backup-files ## Full backup (database + files)
+
+restore-db: ## Restore DB from BACKUP_FILE=var/backups/....dump RESTORE_CONFIRM=yes
+	@if [ -z "$(BACKUP_FILE)" ]; then echo "Set BACKUP_FILE=var/backups/ivena-stats-db-....dump" >&2; exit 1; fi
+	@if [ "$(RESTORE_CONFIRM)" != "yes" ]; then echo "Set RESTORE_CONFIRM=yes to confirm destructive restore." >&2; exit 1; fi
+	@RESTORE_CONFIRM=yes BACKUP_FILE="$(BACKUP_FILE)" ./bin/ops/restore-database.sh
+
+verify-restore-baseline: ## Save DB metrics snapshot for restore drill
+	@./bin/ops/verify-restore.sh baseline
+
+verify-restore: ## Compare current DB metrics with saved baseline (exit 1 on mismatch)
+	@./bin/ops/verify-restore.sh verify
 
 fixtures: ## Load dev demo fixtures (replaces existing fixture data)
 	@$(SYMFONY) composer load-fixtures

--- a/bin/ops/_lib.sh
+++ b/bin/ops/_lib.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Shared helpers for backup/restore scripts. Source from other bin/ops/*.sh scripts.
+
+set -euo pipefail
+
+ops_script_dir() {
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+ops_project_root() {
+    cd "$(ops_script_dir)/../.." && pwd
+}
+
+ops_timestamp() {
+    date -u +%Y%m%d-%H%M%S
+}
+
+ops_backup_dir() {
+    local root
+    root="$(ops_project_root)"
+    echo "${BACKUP_DIR:-$root/var/backups}"
+}
+
+ops_ensure_backup_dir() {
+    local dir
+    dir="$(ops_backup_dir)"
+    mkdir -p "$dir"
+    echo "$dir"
+}
+
+ops_load_database_url() {
+    if [[ -n "${DATABASE_URL:-}" ]]; then
+        export DATABASE_URL
+        return 0
+    fi
+
+    local root file line
+    root="$(ops_project_root)"
+
+    for file in "$root/.env.local" "$root/.env"; do
+        [[ -f "$file" ]] || continue
+        line="$(grep -E '^DATABASE_URL=' "$file" | grep -v '^#' | tail -1 || true)"
+        if [[ -n "$line" ]]; then
+            DATABASE_URL="${line#DATABASE_URL=}"
+            DATABASE_URL="${DATABASE_URL%\"}"
+            DATABASE_URL="${DATABASE_URL#\"}"
+            DATABASE_URL="${DATABASE_URL%\'}"
+            DATABASE_URL="${DATABASE_URL#\'}"
+            export DATABASE_URL
+            return 0
+        fi
+    done
+
+    echo "DATABASE_URL is not set and was not found in .env.local or .env." >&2
+    return 1
+}
+
+ops_database_url_without_query() {
+    ops_load_database_url
+    echo "${DATABASE_URL%%\?*}"
+}
+
+ops_docker_compose_available() {
+    command -v docker >/dev/null 2>&1 \
+        && docker compose version >/dev/null 2>&1
+}
+
+ops_docker_database_running() {
+    ops_docker_compose_available || return 1
+    local root
+    root="$(ops_project_root)"
+    (
+        cd "$root"
+        docker compose ps --status running --services 2>/dev/null | grep -qx 'database'
+    )
+}
+
+ops_log() {
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+ops_die() {
+    ops_log "ERROR: $*" >&2
+    exit 1
+}
+
+ops_psql_scalar() {
+    local sql="$1"
+
+    if ops_docker_database_running; then
+        docker compose exec -T database \
+            psql -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" -t -A -c "$sql"
+        return
+    fi
+
+    if command -v psql >/dev/null 2>&1; then
+        local url
+        url="$(ops_database_url_without_query)"
+        psql "$url" -t -A -c "$sql"
+        return
+    fi
+
+    ops_die "No running Docker database service and psql not on PATH."
+}

--- a/bin/ops/backup-database.sh
+++ b/bin/ops/backup-database.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=bin/ops/_lib.sh
+source "$ROOT/bin/ops/_lib.sh"
+
+cd "$ROOT"
+
+BACKUP_DIR="$(ops_ensure_backup_dir)"
+TIMESTAMP="$(ops_timestamp)"
+OUTPUT_FILE="${BACKUP_FILE:-$BACKUP_DIR/ivena-stats-db-$TIMESTAMP.dump}"
+
+ops_log "Database backup starting → $OUTPUT_FILE"
+
+if ops_docker_database_running; then
+    ops_log "Using Docker Compose service 'database' (pg_dump inside container)"
+    docker compose exec -T database \
+        pg_dump -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" -Fc \
+        >"$OUTPUT_FILE"
+elif command -v pg_dump >/dev/null 2>&1; then
+    DATABASE_URL_CLEAN="$(ops_database_url_without_query)"
+    ops_log "Using local pg_dump with DATABASE_URL"
+    pg_dump "$DATABASE_URL_CLEAN" -Fc -f "$OUTPUT_FILE"
+else
+    ops_die "Neither a running Docker database service nor pg_dump on PATH is available."
+fi
+
+if [[ ! -s "$OUTPUT_FILE" ]]; then
+    rm -f "$OUTPUT_FILE"
+    ops_die "Backup file is empty: $OUTPUT_FILE"
+fi
+
+BYTES="$(wc -c <"$OUTPUT_FILE" | tr -d ' ')"
+ops_log "Database backup completed ($BYTES bytes): $OUTPUT_FILE"

--- a/bin/ops/backup-files.sh
+++ b/bin/ops/backup-files.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=bin/ops/_lib.sh
+source "$ROOT/bin/ops/_lib.sh"
+
+cd "$ROOT"
+
+IMPORTS_DIR="${IMPORTS_DIR:-$ROOT/var/imports}"
+MEDIA_DIR="${MEDIA_DIR:-$ROOT/public/uploads/media}"
+BACKUP_DIR="$(ops_ensure_backup_dir)"
+TIMESTAMP="$(ops_timestamp)"
+OUTPUT_FILE="${BACKUP_FILE:-$BACKUP_DIR/ivena-stats-files-$TIMESTAMP.tar.gz}"
+
+ops_log "File backup starting → $OUTPUT_FILE"
+ops_log "  imports: $IMPORTS_DIR"
+ops_log "  media:   $MEDIA_DIR"
+
+TAR_PATHS=()
+
+ops_add_directory_to_tar() {
+    local path="$1"
+    if [[ ! -d "$path" ]]; then
+        ops_log "WARN: directory missing, skipping: $path"
+        return 0
+    fi
+
+    local parent base
+    parent="$(cd "$(dirname "$path")" && pwd)"
+    base="$(basename "$path")"
+    TAR_PATHS+=(-C "$parent" "$base")
+}
+
+ops_add_directory_to_tar "$IMPORTS_DIR"
+ops_add_directory_to_tar "$MEDIA_DIR"
+
+if [[ ${#TAR_PATHS[@]} -eq 0 ]]; then
+    ops_die "No directories to back up (imports and media both missing)."
+fi
+
+tar -czf "$OUTPUT_FILE" "${TAR_PATHS[@]}"
+
+BYTES="$(wc -c <"$OUTPUT_FILE" | tr -d ' ')"
+ops_log "File backup completed ($BYTES bytes): $OUTPUT_FILE"

--- a/bin/ops/restore-database.sh
+++ b/bin/ops/restore-database.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=bin/ops/_lib.sh
+source "$ROOT/bin/ops/_lib.sh"
+
+usage() {
+    cat <<'EOF'
+Restore a PostgreSQL backup created by bin/ops/backup-database.sh.
+
+Usage:
+  RESTORE_CONFIRM=yes BACKUP_FILE=var/backups/ivena-stats-db-....dump ./bin/ops/restore-database.sh
+  RESTORE_CONFIRM=yes ./bin/ops/restore-database.sh var/backups/ivena-stats-db-....dump
+
+Environment:
+  BACKUP_FILE       Path to .dump file (custom format from pg_dump -Fc)
+  RESTORE_CONFIRM   Must be "yes" to proceed (safety gate)
+  DATABASE_URL      Target database (from env or .env.local / .env)
+
+This replaces objects in the target database. Use only on dev/staging or after
+a confirmed incident on production.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+BACKUP_FILE="${BACKUP_FILE:-${1:-}}"
+if [[ -z "$BACKUP_FILE" ]]; then
+    usage >&2
+    ops_die "BACKUP_FILE is required."
+fi
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+    ops_die "Backup file not found: $BACKUP_FILE"
+fi
+
+if [[ "${RESTORE_CONFIRM:-}" != "yes" ]]; then
+    ops_die 'Set RESTORE_CONFIRM=yes to run restore (this overwrites database objects).'
+fi
+
+cd "$ROOT"
+
+ops_log "Database restore starting from $BACKUP_FILE"
+
+if ops_docker_database_running; then
+    ops_log "Using Docker Compose service 'database' (pg_restore inside container)"
+    docker compose exec -T database \
+        pg_restore --clean --if-exists --no-owner --no-acl \
+        -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" \
+        <"$BACKUP_FILE"
+elif command -v pg_restore >/dev/null 2>&1; then
+    DATABASE_URL_CLEAN="$(ops_database_url_without_query)"
+    ops_log "Using local pg_restore with DATABASE_URL"
+    pg_restore --clean --if-exists --no-owner --no-acl -d "$DATABASE_URL_CLEAN" "$BACKUP_FILE"
+else
+    ops_die "Neither a running Docker database service nor pg_restore on PATH is available."
+fi
+
+ops_log "Database restore finished. Run: php bin/console cache:clear"

--- a/bin/ops/verify-restore.sh
+++ b/bin/ops/verify-restore.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=bin/ops/_lib.sh
+source "$ROOT/bin/ops/_lib.sh"
+
+BASELINE_FILE="${BASELINE_FILE:-$ROOT/var/backups/restore-baseline-latest.txt}"
+
+usage() {
+    cat <<'EOF'
+Capture or verify database metrics for a restore drill.
+
+Usage:
+  ./bin/ops/verify-restore.sh show
+  ./bin/ops/verify-restore.sh baseline
+  ./bin/ops/verify-restore.sh verify [baseline-file]
+
+Commands:
+  show      Print current row counts and migration version
+  baseline  Save current metrics to var/backups/restore-baseline-latest.txt
+  verify    Compare current metrics with a saved baseline (exit 1 on mismatch)
+
+Environment:
+  BASELINE_FILE   Override baseline path (default: var/backups/restore-baseline-latest.txt)
+
+Requires a running Docker database service or psql + DATABASE_URL.
+EOF
+}
+
+ops_migration_version() {
+    (
+        cd "$ROOT"
+        php bin/console doctrine:migrations:current --no-ansi 2>/dev/null \
+            | head -1 \
+            | grep -oE 'Version[0-9]+' \
+            | head -1 \
+            || echo "unknown"
+    )
+}
+
+ops_collect_metrics() {
+    local allocation_count import_count user_count hospital_count migration_version
+
+    allocation_count="$(ops_psql_scalar "SELECT COUNT(*) FROM allocation;")"
+    import_count="$(ops_psql_scalar "SELECT COUNT(*) FROM import;")"
+    user_count="$(ops_psql_scalar 'SELECT COUNT(*) FROM "user";')"
+    hospital_count="$(ops_psql_scalar "SELECT COUNT(*) FROM hospital;")"
+    migration_version="$(ops_migration_version)"
+
+    cat <<EOF
+allocation_count=${allocation_count}
+import_count=${import_count}
+user_count=${user_count}
+hospital_count=${hospital_count}
+migration_version=${migration_version}
+captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+}
+
+cmd_show() {
+    ops_collect_metrics
+}
+
+cmd_baseline() {
+    local dir
+    dir="$(ops_ensure_backup_dir)"
+    BASELINE_FILE="${BASELINE_FILE:-$dir/restore-baseline-latest.txt}"
+
+    ops_collect_metrics >"$BASELINE_FILE"
+    ops_log "Baseline saved: $BASELINE_FILE"
+    cat "$BASELINE_FILE"
+}
+
+cmd_verify() {
+    local file="${1:-$BASELINE_FILE}"
+
+    if [[ ! -f "$file" ]]; then
+        ops_die "Baseline file not found: $file (run: ./bin/ops/verify-restore.sh baseline)"
+    fi
+
+    local exp_allocation exp_import exp_user exp_hospital exp_migration
+    # shellcheck disable=SC1090
+    source "$file"
+    exp_allocation="${allocation_count:-}"
+    exp_import="${import_count:-}"
+    exp_user="${user_count:-}"
+    exp_hospital="${hospital_count:-}"
+    exp_migration="${migration_version:-}"
+
+    local got_allocation got_import got_user got_hospital got_migration
+    got_allocation="$(ops_psql_scalar "SELECT COUNT(*) FROM allocation;")"
+    got_import="$(ops_psql_scalar "SELECT COUNT(*) FROM import;")"
+    got_user="$(ops_psql_scalar 'SELECT COUNT(*) FROM "user";')"
+    got_hospital="$(ops_psql_scalar "SELECT COUNT(*) FROM hospital;")"
+    got_migration="$(ops_migration_version)"
+
+    local failed=0
+
+    ops_compare() {
+        local label="$1"
+        local got="$2"
+        local want="$3"
+
+        if [[ "$got" == "$want" ]]; then
+            ops_log "OK   $label: $got"
+        else
+            ops_log "FAIL $label: expected $want, got $got"
+            failed=1
+        fi
+    }
+
+    ops_log "Verifying against baseline: $file"
+    ops_compare "allocation_count" "$got_allocation" "$exp_allocation"
+    ops_compare "import_count" "$got_import" "$exp_import"
+    ops_compare "user_count" "$got_user" "$exp_user"
+    ops_compare "hospital_count" "$got_hospital" "$exp_hospital"
+    ops_compare "migration_version" "$got_migration" "$exp_migration"
+
+    if [[ "$failed" -ne 0 ]]; then
+        ops_die "Verification failed."
+    fi
+
+    ops_log "Verification passed."
+}
+
+COMMAND="${1:-}"
+shift || true
+
+case "$COMMAND" in
+    show)
+        cmd_show
+        ;;
+    baseline)
+        cmd_baseline
+        ;;
+    verify)
+        cmd_verify "${1:-}"
+        ;;
+    -h|--help|help|'')
+        usage
+        [[ -n "$COMMAND" ]] || exit 0
+        ;;
+    *)
+        usage >&2
+        ops_die "Unknown command: $COMMAND"
+        ;;
+esac

--- a/docs/Backup-restore.md
+++ b/docs/Backup-restore.md
@@ -1,0 +1,250 @@
+# Backup & restore
+
+Operational guide for PostgreSQL, import files, and media uploads.
+
+## Scope
+
+| Asset | Default path (local) | Production (Deployer shared) |
+|-------|----------------------|------------------------------|
+| PostgreSQL database | from `DATABASE_URL` | from `shared/.env.local` → `DATABASE_URL` |
+| Import uploads | `var/imports/` | `~/www/shared/var/imports/` (adjust to your `deploy_path`) |
+| Media uploads | `public/uploads/media/` | `~/www/shared/public/uploads/media/` |
+| Secrets | `.env.local` | `~/www/shared/.env.local` — **back up separately**, never inside DB dumps |
+
+Backups are written to `var/backups/` locally (override with `BACKUP_DIR`).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `bin/ops/backup-database.sh` | `pg_dump` custom format (`.dump`) |
+| `bin/ops/backup-files.sh` | `tar.gz` of imports + media |
+| `bin/ops/restore-database.sh` | `pg_restore` from `.dump` (requires `RESTORE_CONFIRM=yes`) |
+| `bin/ops/verify-restore.sh` | Capture/compare row counts for restore drills |
+
+### Make targets
+
+```bash
+make backup-db      # database only
+make backup-files   # imports + media only
+make backup         # both
+make restore-db BACKUP_FILE=var/backups/ivena-stats-db-....dump RESTORE_CONFIRM=yes
+make verify-restore-baseline   # save metrics snapshot
+make verify-restore            # compare after restore
+```
+
+## Local development (Docker PostgreSQL)
+
+### Restore drill (recommended)
+
+Use `verify-restore.sh` to prove backup + restore round-trip without hand-written SQL.
+Symfony provides `dbal:run-sql` (not `doctrine:query:sql`) if you need ad-hoc queries.
+
+1. Start the database:
+
+   ```bash
+   docker compose up -d database
+   ```
+
+2. Ensure meaningful data exists (skip if your DB is already populated):
+
+   ```bash
+   make reset
+   ```
+
+3. Save a baseline snapshot:
+
+   ```bash
+   make verify-restore-baseline
+   ```
+
+4. Create a database backup:
+
+   ```bash
+   make backup-db
+   ls -lh var/backups/ivena-stats-db-*.dump
+   ```
+
+5. Destroy data (pick one):
+
+   ```bash
+   make purge          # empty DB + runtime files
+   # or only DB:
+   symfony composer setup-database
+   ```
+
+6. Confirm data is gone:
+
+   ```bash
+   ./bin/ops/verify-restore.sh show
+   ```
+
+   Counts should be `0` or much lower than the baseline.
+
+7. Restore from the dump:
+
+   ```bash
+   make restore-db BACKUP_FILE=var/backups/ivena-stats-db-YYYYMMDD-HHMMSS.dump RESTORE_CONFIRM=yes
+   php bin/console cache:clear
+   ```
+
+8. Verify metrics match the baseline:
+
+   ```bash
+   make verify-restore
+   ```
+
+   Exit code `0` means all counts and migration version match.
+
+9. Optional app smoke test: login, `/explore/allocation`, statistics dashboard.
+
+### Quick backup only
+
+1. Start the database:
+
+   ```bash
+   docker compose up -d database
+   ```
+
+2. Create a backup (uses `docker compose exec` when the `database` service is running):
+
+   ```bash
+   make backup-db
+   ```
+
+3. Optional file backup:
+
+   ```bash
+   make backup-files
+   ```
+
+### Ad-hoc SQL (optional)
+
+```bash
+php bin/console dbal:run-sql "SELECT COUNT(*) FROM allocation"
+docker compose exec database psql -U app -d app -c 'SELECT COUNT(*) FROM "user";'
+```
+
+If `pg_dump` / `pg_restore` is installed on the host and Docker is not running, the backup scripts fall back to `DATABASE_URL` from the environment or `.env.local`.
+
+## Production (Uberspace)
+
+Deployer keeps persistent data outside release directories ([Deployment.md](Deployment.md)):
+
+- `shared/.env.local`
+- `shared/var/imports`
+- `shared/public/uploads/media`
+
+### Manual backup commands
+
+From the project root on the server (`~/www/current` or similar):
+
+```bash
+# Database (requires pg_dump on PATH and DATABASE_URL in environment)
+cd ~/www/current
+set -a && source ../shared/.env.local && set +a
+BACKUP_DIR=~/backups ./bin/ops/backup-database.sh
+
+# Files (shared paths)
+BACKUP_DIR=~/backups \
+  IMPORTS_DIR=~/www/shared/var/imports \
+  MEDIA_DIR=~/www/shared/public/uploads/media \
+  ./bin/ops/backup-files.sh
+
+# Secrets (store encrypted or offline — not in the git repo)
+cp ~/www/shared/.env.local ~/backups/env-local-$(date -u +%Y%m%d).bak
+chmod 600 ~/backups/env-local-*.bak
+```
+
+Store backups **outside** the Deployer `releases/` tree (for example `~/backups/`) so deploys cannot delete them.
+
+### Cron (operator-managed)
+
+Schedule regular backups on the server (example — adjust paths and times):
+
+```cron
+# Daily database dump at 03:00 UTC
+0 3 * * * cd ~/www/current && set -a && source ../shared/.env.local && set +a && BACKUP_DIR=~/backups ./bin/ops/backup-database.sh >> ~/backups/backup.log 2>&1
+
+# Weekly file archive on Sunday 04:00 UTC
+0 4 * * 0 BACKUP_DIR=~/backups IMPORTS_DIR=~/www/shared/var/imports MEDIA_DIR=~/www/shared/public/uploads/media ~/www/current/bin/ops/backup-files.sh >> ~/backups/backup.log 2>&1
+
+# Retention: delete dumps older than 30 days
+15 5 * * * find ~/backups -name 'ivena-stats-*' -mtime +30 -delete
+```
+
+Cron is configured on Uberspace outside this repository.
+
+### Suggested retention
+
+| Type | Suggestion |
+|------|------------|
+| Daily DB dumps | keep 7 |
+| Weekly DB dumps | keep 4 |
+| Weekly file archives | keep 4 |
+| `.env.local` copies | keep 4 (secure storage) |
+
+## Restore runbook
+
+### 1. Database
+
+1. Stop the Messenger worker to avoid writes during restore:
+
+   ```bash
+   systemctl --user stop messenger
+   ```
+
+2. Restore from the latest good `.dump`:
+
+   ```bash
+   cd ~/www/current
+   set -a && source ../shared/.env.local && set +a
+   RESTORE_CONFIRM=yes BACKUP_FILE=~/backups/ivena-stats-db-YYYYMMDD-HHMMSS.dump ./bin/ops/restore-database.sh
+   ```
+
+3. Clear cache and restart the worker:
+
+   ```bash
+   php bin/console cache:clear --env=prod
+   systemctl --user start messenger
+   ```
+
+4. Smoke test: login, import list, statistics dashboard. When available, `GET /health`.
+
+`pg_restore --clean --if-exists` drops and recreates objects from the dump. Schema drift after restore is unlikely if the dump matches the deployed code version; if not, run `php bin/console doctrine:migrations:status`.
+
+### 2. Import and media files
+
+```bash
+cd ~/www
+tar -xzf ~/backups/ivena-stats-files-YYYYMMDD-HHMMSS.tar.gz -C ~/www/shared
+# archives contain paths relative to their source roots (var/imports, public/uploads/media)
+```
+
+Verify permissions on `shared/var/imports` and `shared/public/uploads/media` (writable by the web user).
+
+### 3. Secrets (`.env.local`)
+
+Only if the secrets file was lost or corrupted:
+
+```bash
+cp ~/backups/env-local-YYYYMMDD.bak ~/www/shared/.env.local
+chmod 600 ~/www/shared/.env.local
+systemctl --user restart messenger
+```
+
+Rotate `APP_SECRET` if there is any chance the backup was exposed.
+
+## Restore test log
+
+Record each restore drill (recommended before beta):
+
+| Date | Environment | Backup file | Duration | Result | Notes |
+|------|-------------|-------------|----------|--------|-------|
+| | local Docker | | | | |
+
+## Related docs
+
+- [Deployment.md](Deployment.md) — Deployer, shared directories, worker
+- [Configuration.md](Configuration.md) — `DATABASE_URL` and env variables
+- [Troubleshooting.md](Troubleshooting.md) — runtime diagnostics

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -40,6 +40,7 @@ vendor/bin/dep content:analyze-page-images coishub.uber.space -o content_analyze
 
 Related docs:
 - Configuration details: [Configuration.md](Configuration.md)
+- Backups and restore: [Backup-restore.md](Backup-restore.md)
 - Runtime issues and diagnostics: [Troubleshooting.md](Troubleshooting.md)
 - Import-specific operations: [Import-workflow.md](Import-workflow.md), [Import-batch-requeue.md](Import-batch-requeue.md)
 
@@ -336,6 +337,28 @@ above) or set `messenger_restart_on_deploy: false` in `hosts.yaml` until the wor
 | Queue stats | `cd ~/html/current && php bin/console messenger:stats` |
 | Failed messages | `php bin/console messenger:failed:show` |
 | Retry failed | `php bin/console messenger:failed:retry` |
+
+### Backups
+
+Database and file backups are documented in [Backup-restore.md](Backup-restore.md).
+
+Quick reference on the server:
+
+```bash
+cd ~/www/current
+set -a && source ../shared/.env.local && set +a
+BACKUP_DIR=~/backups ./bin/ops/backup-database.sh
+BACKUP_DIR=~/backups IMPORTS_DIR=~/www/shared/var/imports MEDIA_DIR=~/www/shared/public/uploads/media ./bin/ops/backup-files.sh
+```
+
+Schedule cron jobs on Uberspace separately (see Backup-restore.md for examples).
+
+Local development with Docker:
+
+```bash
+docker compose up -d database
+make backup-db
+```
 
 Local development uses `make consume` (same transports, verbose). Mail is sent synchronously in `dev`; production 
 requires the worker for queued mail.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -14,6 +14,7 @@ Entry point for project documentation.
 | Fixtures | [Development-fixtures.md](Development-fixtures.md) | Reference YAML, fixture groups, synthetic allocations |
 | Testing | [Testing.md](Testing.md)                           | Local test runs and CI-relevant checks |
 | Deployment | [Deployment.md](Deployment.md)                     | Deployer, worker, ops commands |
+| Backups | [Backup-restore.md](Backup-restore.md)             | Database/file backup and restore |
 | Troubleshooting | [Troubleshooting.md](Troubleshooting.md)           | Common problems and quick diagnosis |
 | Glossary | [Glossary.md](Glossary.md)                         | Project terms and abbreviations |
 | i18n glossary (DE) | [Glossary-i18n-de.md](Glossary-i18n-de.md)       | EN↔DE UI terms, translation rules, open decisions |


### PR DESCRIPTION
## Summary

- Add `bin/ops/` shell scripts for PostgreSQL backups (`pg_dump`), file archives (imports + media), `pg_restore`, and restore-drill verification via row-count snapshots.
- Scripts work with Docker Compose locally or native `pg_dump`/`psql` on the server via `DATABASE_URL`.
- Document the full backup/restore runbook in `docs/Backup-restore.md`, including Uberspace examples and Makefile targets (`backup-db`, `backup-files`, `restore-db`, `verify-restore-baseline`, `verify-restore`).

Part of the beta-readiness audit **P0-1** (backup & restore strategy). Restore round-trip was verified locally with `make verify-restore`.

## Test plan

- [x] `make backup-db` against Docker PostgreSQL
- [x] `make backup-files`
- [x] Restore drill: baseline → `make purge` → `make restore-db` → `make verify-restore` (all metrics OK)
- [ ] CI passes on PR