### PR TITLE
feat(install): add app:env:check for beta-readiness P0-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = help
-.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules backup backup-db backup-files restore-db verify-restore-baseline verify-restore
+.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules backup backup-db backup-files restore-db verify-restore-baseline verify-restore env-check
 
 # Executables
 COMPOSER      = composer
@@ -126,6 +126,9 @@ verify-restore-baseline: ## Save DB metrics snapshot for restore drill
 
 verify-restore: ## Compare current DB metrics with saved baseline (exit 1 on mismatch)
 	@./bin/ops/verify-restore.sh verify
+
+env-check: ## Validate environment variables (dev profile; use --check-profile=beta on server)
+	@$(CONSOLE) app:env:check --skip-database
 
 fixtures: ## Load dev demo fixtures (replaces existing fixture data)
 	@$(SYMFONY) composer load-fixtures

--- a/docs/Beta-readiness-checklist.md
+++ b/docs/Beta-readiness-checklist.md
@@ -1,0 +1,96 @@
+# Beta readiness checklist
+
+Checklist for the transition from alpha to a **closed beta** (invited participants only).
+
+Automated checks use `php bin/console app:env:check` (Install bounded context, alongside `app:install`). Manual server checks cannot be replaced by the command.
+
+Related: [Configuration.md](Configuration.md), [Deployment.md](Deployment.md), [Backup-restore.md](Backup-restore.md)
+
+## P0 — before closed beta
+
+| ID | Item | How to verify | Status |
+|----|------|---------------|--------|
+| P0-1 | Backup & restore strategy | Follow [Backup-restore.md](Backup-restore.md); restore drill with `make verify-restore` | |
+| P0-2 | Production secrets & env | `php bin/console app:env:check --check-profile=beta` on server (see below) | |
+| P0-3 | HTTP health endpoint | `GET /health` returns JSON with database OK | planned |
+| P0-4 | SQL month aggregation | `countByMonthLast12Months()` uses SQL `GROUP BY` | planned |
+
+### P0-2 on the server (Uberspace)
+
+```bash
+cd ~/www/current
+set -a && source ../shared/.env.local && set +a
+php bin/console app:env:check --check-profile=beta
+```
+
+Expected: exit code `0`, no `FAIL` rows. Warnings are acceptable only where documented (for example optional `SENTRY_ENVIRONMENT` in prod profile — not in beta).
+
+Record date and result here:
+
+- Verified on: ___________
+- Result: ___________
+
+## Manual production checks (not automated)
+
+These are required in addition to `app:env:check`:
+
+- [ ] `APP_ENV=prod` and `APP_DEBUG=0` in `shared/.env.local`
+- [ ] Messenger worker running: `systemctl --user status messenger`
+- [ ] Queue consumers active: `php bin/console messenger:stats`
+- [ ] No stuck failed messages: `php bin/console messenger:failed:show`
+- [ ] Transactional mail works (registration or password reset test)
+- [ ] Sentry receives a test event (if `SENTRY_DSN` is set)
+- [ ] Backups scheduled on Uberspace (cron — see [Backup-restore.md](Backup-restore.md))
+
+## Environment variables reference
+
+| Variable | Check | Risk if missing or wrong |
+|----------|-------|---------------------------|
+| `APP_SECRET` | set, min. 32 characters | insecure sessions, cookies, signed URLs |
+| `DATABASE_URL` | PostgreSQL URL, DB reachable | application cannot persist data |
+| `APP_URL` | `https://` public domain in prod | mail links point to localhost |
+| `MAILER_DSN` | real transport, not `null://null` | no verification or reset mail |
+| `MAILER_FROM` | valid sender address | bounces, spam folder |
+| `SENTRY_DSN` | required for `--check-profile=beta` | no error monitoring during beta |
+| `SENTRY_ENVIRONMENT` | e.g. `beta` or `prod` | wrong Sentry environment grouping |
+| `MESSENGER_TRANSPORT_DSN` | set | async imports and mail stall |
+
+`app:env:check` prints status per variable but **never** prints secret values.
+
+### Profiles
+
+| Profile | Use case |
+|---------|----------|
+| `dev` (default in `APP_ENV=dev`) | local development; failures become warnings |
+| `prod` | production deployment gate |
+| `beta` | closed beta; same as prod plus required `SENTRY_DSN` |
+
+Options:
+
+- `--skip-database` — skip DB connectivity ping (faster, no DB required)
+- `--check-profile=beta` — beta gate on server
+
+Local shortcut: `make env-check`
+
+## Bootstrap order on a new server
+
+1. Configure `shared/.env.local`
+2. `php bin/console app:env:check --check-profile=beta`
+3. Deploy / migrate database
+4. Optionally `php bin/console app:install` (bootstrap admin — see Install command)
+5. Start Messenger worker
+
+`app:install` creates data; `app:env:check` only validates configuration.
+
+## P1 / P2 (after P0)
+
+Higher-priority follow-ups from the beta-readiness audit:
+
+- Referenzdaten-Cache for explore filter dropdowns
+- ShowAllocation N+1 fix
+- CSP report-only
+- Functional tests for auth/onboarding
+- Sentry alerts and failed-message monitoring
+- HTTP `/health` endpoint (P0-3)
+
+See the project beta-readiness audit plan for the full roadmap.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,4 +59,15 @@ Routing examples:
 ## Operations-related configuration
 
 - [Deployment.md](Deployment.md)
+- [Beta-readiness-checklist.md](Beta-readiness-checklist.md)
 - [Observability-sentry.md](Observability-sentry.md)
+
+Validate environment variables:
+
+```bash
+php bin/console app:env:check              # dev profile locally
+php bin/console app:env:check --check-profile=beta --skip-database   # beta gate (format only)
+make env-check
+```
+
+See [Beta-readiness-checklist.md](Beta-readiness-checklist.md) for production verification steps.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -40,6 +40,7 @@ vendor/bin/dep content:analyze-page-images coishub.uber.space -o content_analyze
 
 Related docs:
 - Configuration details: [Configuration.md](Configuration.md)
+- Beta readiness checklist: [Beta-readiness-checklist.md](Beta-readiness-checklist.md)
 - Backups and restore: [Backup-restore.md](Backup-restore.md)
 - Runtime issues and diagnostics: [Troubleshooting.md](Troubleshooting.md)
 - Import-specific operations: [Import-workflow.md](Import-workflow.md), [Import-batch-requeue.md](Import-batch-requeue.md)
@@ -77,6 +78,30 @@ Optional but recommended:
 The application version label (`App\Kernel::APP_VERSION`, exposed as `app.version`) is stored with feedback submissions and used as the default Sentry release unless `SENTRY_RELEASE` is set.
 
 Run database migrations so the `messenger_messages` table exists (included in the default deploy workflow).
+
+## Pre-beta gate
+
+Before opening a closed beta, validate server configuration:
+
+```bash
+cd ~/www/current
+set -a && source ../shared/.env.local && set +a
+php bin/console app:env:check --check-profile=beta
+```
+
+Use `--skip-database` only for a quick env-format check without a DB ping.
+
+Manual checks that `app:env:check` cannot perform:
+
+```bash
+systemctl --user status messenger
+php bin/console messenger:stats
+php bin/console messenger:failed:show
+```
+
+Full checklist: [Beta-readiness-checklist.md](Beta-readiness-checklist.md).
+
+On a **new server**, run `app:env:check` before `app:install` (both Install commands). `app:install` only creates the initial admin user; `app:env:check` validates secrets and URLs.
 
 ## Transactional mail
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -14,6 +14,7 @@ Entry point for project documentation.
 | Fixtures | [Development-fixtures.md](Development-fixtures.md) | Reference YAML, fixture groups, synthetic allocations |
 | Testing | [Testing.md](Testing.md)                           | Local test runs and CI-relevant checks |
 | Deployment | [Deployment.md](Deployment.md)                     | Deployer, worker, ops commands |
+| Beta readiness | [Beta-readiness-checklist.md](Beta-readiness-checklist.md) | Pre-beta P0 checklist, `app:env:check` |
 | Backups | [Backup-restore.md](Backup-restore.md)             | Database/file backup and restore |
 | Troubleshooting | [Troubleshooting.md](Troubleshooting.md)           | Common problems and quick diagnosis |
 | Glossary | [Glossary.md](Glossary.md)                         | Project terms and abbreviations |

--- a/src/Install/Application/Environment/EnvironmentCheckItem.php
+++ b/src/Install/Application/Environment/EnvironmentCheckItem.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\Application\Environment;
+
+final readonly class EnvironmentCheckItem
+{
+    public function __construct(
+        public string $variable,
+        public EnvironmentCheckStatus $status,
+        public string $message,
+    ) {
+    }
+}

--- a/src/Install/Application/Environment/EnvironmentCheckProfile.php
+++ b/src/Install/Application/Environment/EnvironmentCheckProfile.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\Application\Environment;
+
+enum EnvironmentCheckProfile: string
+{
+    case Prod = 'prod';
+    case Beta = 'beta';
+    case Dev = 'dev';
+
+    public function isStrict(): bool
+    {
+        return self::Dev !== $this;
+    }
+
+    public function requiresSentry(): bool
+    {
+        return self::Beta === $this;
+    }
+}

--- a/src/Install/Application/Environment/EnvironmentCheckReport.php
+++ b/src/Install/Application/Environment/EnvironmentCheckReport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\Application\Environment;
+
+final readonly class EnvironmentCheckReport
+{
+    /**
+     * @param list<EnvironmentCheckItem> $items
+     */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+
+    public function hasFailures(): bool
+    {
+        return array_any($this->items, static fn (EnvironmentCheckItem $item): bool => EnvironmentCheckStatus::Fail === $item->status);
+    }
+
+    public function hasWarnings(): bool
+    {
+        return array_any($this->items, static fn (EnvironmentCheckItem $item): bool => EnvironmentCheckStatus::Warn === $item->status);
+    }
+}

--- a/src/Install/Application/Environment/EnvironmentCheckStatus.php
+++ b/src/Install/Application/Environment/EnvironmentCheckStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\Application\Environment;
+
+enum EnvironmentCheckStatus: string
+{
+    case Ok = 'OK';
+    case Warn = 'WARN';
+    case Fail = 'FAIL';
+}

--- a/src/Install/Application/Environment/EnvironmentChecker.php
+++ b/src/Install/Application/Environment/EnvironmentChecker.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\Application\Environment;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+
+final readonly class EnvironmentChecker
+{
+    private const string DATABASE_CHECK_VARIABLE = 'DATABASE_CONNECTION';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private ?Connection $connection = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    public function check(
+        EnvironmentCheckProfile $profile,
+        array $variables,
+        bool $skipDatabase,
+    ): EnvironmentCheckReport {
+        $items = [
+            $this->checkAppEnv($profile, $variables),
+            $this->checkAppDebug($profile, $variables),
+            $this->checkAppSecret($profile, $variables),
+            $this->checkDatabaseUrl($profile, $variables),
+            $this->checkAppUrl($profile, $variables),
+            $this->checkMailerDsn($profile, $variables),
+            $this->checkMailerFrom($profile, $variables),
+            $this->checkMessengerTransportDsn($profile, $variables),
+            $this->checkSentryDsn($profile, $variables),
+            $this->checkSentryEnvironment($profile, $variables),
+        ];
+
+        if (!$skipDatabase) {
+            $items[] = $this->checkDatabaseConnection($profile, $variables);
+        }
+
+        return new EnvironmentCheckReport($items);
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkAppEnv(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'APP_ENV');
+
+        if ('prod' === $value) {
+            return $this->item('APP_ENV', EnvironmentCheckStatus::Ok, 'set to prod');
+        }
+
+        if (!$profile->isStrict()) {
+            return $this->item('APP_ENV', EnvironmentCheckStatus::Warn, sprintf('expected prod for deployment (current: %s)', $this->presenceLabel($value)));
+        }
+
+        return $this->item('APP_ENV', EnvironmentCheckStatus::Fail, sprintf('must be prod (current: %s)', $this->presenceLabel($value)));
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkAppDebug(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = strtolower($this->value($variables, 'APP_DEBUG'));
+
+        if (\in_array($value, ['0', 'false', ''], true)) {
+            return $this->item('APP_DEBUG', EnvironmentCheckStatus::Ok, 'disabled');
+        }
+
+        if (!$profile->isStrict()) {
+            return $this->item('APP_DEBUG', EnvironmentCheckStatus::Warn, 'should be 0 in production');
+        }
+
+        return $this->item('APP_DEBUG', EnvironmentCheckStatus::Fail, 'must be 0 in production');
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkAppSecret(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'APP_SECRET');
+
+        if ('' !== $value && strlen($value) >= 32) {
+            return $this->item('APP_SECRET', EnvironmentCheckStatus::Ok, 'set (length ok)');
+        }
+
+        if ('' === $value) {
+            $message = 'not set';
+
+            return $this->item(
+                'APP_SECRET',
+                $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+                $message,
+            );
+        }
+
+        return $this->item(
+            'APP_SECRET',
+            $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            'too short (minimum 32 characters)',
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkDatabaseUrl(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'DATABASE_URL');
+
+        if ('' === $value) {
+            return $this->item(
+                'DATABASE_URL',
+                $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+                'not set',
+            );
+        }
+
+        if (!str_starts_with($value, 'postgresql://') && !str_starts_with($value, 'postgres://')) {
+            return $this->item(
+                'DATABASE_URL',
+                $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+                'must use a PostgreSQL URL scheme',
+            );
+        }
+
+        return $this->item('DATABASE_URL', EnvironmentCheckStatus::Ok, 'set (postgresql)');
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkAppUrl(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = trim($this->value($variables, 'APP_URL'));
+
+        if ('' === $value) {
+            return $this->item(
+                'APP_URL',
+                $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+                'not set',
+            );
+        }
+
+        if (!$profile->isStrict()) {
+            return $this->item('APP_URL', EnvironmentCheckStatus::Ok, 'set');
+        }
+
+        if (!str_starts_with($value, 'https://')) {
+            return $this->item('APP_URL', EnvironmentCheckStatus::Fail, 'must use https:// in production');
+        }
+
+        if (str_contains($value, 'localhost') || str_contains($value, '127.0.0.1')) {
+            return $this->item('APP_URL', EnvironmentCheckStatus::Fail, 'must not point to localhost in production');
+        }
+
+        return $this->item('APP_URL', EnvironmentCheckStatus::Ok, 'set (https)');
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkMailerDsn(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'MAILER_DSN');
+
+        if ('' !== $value && 'null://null' !== $value) {
+            return $this->item('MAILER_DSN', EnvironmentCheckStatus::Ok, 'set');
+        }
+
+        $message = 'null://null' === $value ? 'null transport configured' : 'not set';
+
+        return $this->item(
+            'MAILER_DSN',
+            $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            $message,
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkMailerFrom(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = trim($this->value($variables, 'MAILER_FROM'));
+
+        if ('' !== $value && false !== filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return $this->item('MAILER_FROM', EnvironmentCheckStatus::Ok, 'valid email address');
+        }
+
+        return $this->item(
+            'MAILER_FROM',
+            $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            '' === $value ? 'not set' : 'invalid email address',
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkMessengerTransportDsn(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'MESSENGER_TRANSPORT_DSN');
+
+        if ('' !== $value) {
+            return $this->item('MESSENGER_TRANSPORT_DSN', EnvironmentCheckStatus::Ok, 'set');
+        }
+
+        return $this->item(
+            'MESSENGER_TRANSPORT_DSN',
+            $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            'not set',
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkSentryDsn(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'SENTRY_DSN');
+
+        if ('' !== $value) {
+            return $this->item('SENTRY_DSN', EnvironmentCheckStatus::Ok, 'set');
+        }
+
+        return $this->item(
+            'SENTRY_DSN',
+            $profile->requiresSentry() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            'not set (recommended for beta/production monitoring)',
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkSentryEnvironment(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $value = $this->value($variables, 'SENTRY_ENVIRONMENT');
+
+        if ('' !== $value) {
+            return $this->item('SENTRY_ENVIRONMENT', EnvironmentCheckStatus::Ok, 'set');
+        }
+
+        if (!$profile->isStrict()) {
+            return $this->item('SENTRY_ENVIRONMENT', EnvironmentCheckStatus::Warn, 'not set (falls back to APP_ENV)');
+        }
+
+        return $this->item(
+            'SENTRY_ENVIRONMENT',
+            $profile->requiresSentry() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+            'not set (falls back to APP_ENV)',
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function checkDatabaseConnection(EnvironmentCheckProfile $profile, array $variables): EnvironmentCheckItem
+    {
+        $databaseUrl = $this->value($variables, 'DATABASE_URL');
+        if ('' === $databaseUrl) {
+            return $this->item(
+                self::DATABASE_CHECK_VARIABLE,
+                EnvironmentCheckStatus::Fail,
+                'skipped because DATABASE_URL is not set',
+            );
+        }
+
+        if (!$this->connection instanceof Connection) {
+            return $this->item(
+                self::DATABASE_CHECK_VARIABLE,
+                $profile->isStrict() ? EnvironmentCheckStatus::Fail : EnvironmentCheckStatus::Warn,
+                'database connection not available',
+            );
+        }
+
+        try {
+            $this->connection->executeQuery('SELECT 1');
+
+            return $this->item(self::DATABASE_CHECK_VARIABLE, EnvironmentCheckStatus::Ok, 'reachable');
+        } catch (Exception $exception) {
+            return $this->item(
+                self::DATABASE_CHECK_VARIABLE,
+                EnvironmentCheckStatus::Fail,
+                'connection failed: '.$exception->getMessage(),
+            );
+        }
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    private function value(array $variables, string $key): string
+    {
+        return trim($variables[$key] ?? '');
+    }
+
+    private function presenceLabel(string $value): string
+    {
+        return '' === $value ? 'not set' : $value;
+    }
+
+    private function item(string $variable, EnvironmentCheckStatus $status, string $message): EnvironmentCheckItem
+    {
+        return new EnvironmentCheckItem($variable, $status, $message);
+    }
+}

--- a/src/Install/UI/Console/Command/EnvCheckCommand.php
+++ b/src/Install/UI/Console/Command/EnvCheckCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Install\UI\Console\Command;
+
+use App\Install\Application\Environment\EnvironmentChecker;
+use App\Install\Application\Environment\EnvironmentCheckItem;
+use App\Install\Application\Environment\EnvironmentCheckProfile;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(
+    name: 'app:env:check',
+    description: 'Validate required environment variables for production/beta deployment.',
+)]
+final readonly class EnvCheckCommand
+{
+    private const array TRACKED_VARIABLES = [
+        'APP_ENV',
+        'APP_DEBUG',
+        'APP_SECRET',
+        'DATABASE_URL',
+        'APP_URL',
+        'MAILER_DSN',
+        'MAILER_FROM',
+        'MESSENGER_TRANSPORT_DSN',
+        'SENTRY_DSN',
+        'SENTRY_ENVIRONMENT',
+    ];
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private EnvironmentChecker $environmentChecker,
+        #[Autowire('%kernel.environment%')]
+        private string $kernelEnvironment,
+    ) {
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'Validation profile: prod, beta, or dev', name: 'check-profile')]
+        ?string $checkProfile = null,
+        #[Option(description: 'Skip database connectivity check', name: 'skip-database')]
+        bool $skipDatabase = false,
+    ): int {
+        $resolvedProfile = $this->resolveProfile($checkProfile);
+        $variables = $this->collectVariables();
+        $report = $this->environmentChecker->check($resolvedProfile, $variables, $skipDatabase);
+
+        $io->title(sprintf('Environment check (%s profile)', $resolvedProfile->value));
+        $io->table(
+            ['Variable', 'Status', 'Message'],
+            array_map(
+                static fn (EnvironmentCheckItem $item): array => [
+                    $item->variable,
+                    $item->status->value,
+                    $item->message,
+                ],
+                $report->items,
+            ),
+        );
+
+        if ($report->hasFailures()) {
+            $io->error('Environment check failed.');
+
+            return Command::FAILURE;
+        }
+
+        if ($report->hasWarnings()) {
+            $io->warning('Environment check passed with warnings.');
+        } else {
+            $io->success('Environment check passed.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function resolveProfile(?string $profile): EnvironmentCheckProfile
+    {
+        if (null !== $profile && '' !== $profile) {
+            return EnvironmentCheckProfile::from($profile);
+        }
+
+        return 'prod' === $this->kernelEnvironment
+            ? EnvironmentCheckProfile::Prod
+            : EnvironmentCheckProfile::Dev;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function collectVariables(): array
+    {
+        $variables = [];
+
+        foreach (self::TRACKED_VARIABLES as $name) {
+            $variables[$name] = $this->readVariable($name);
+        }
+
+        return $variables;
+    }
+
+    private function readVariable(string $name): string
+    {
+        $envValue = $_ENV[$name] ?? null;
+        if (is_string($envValue)) {
+            return $envValue;
+        }
+
+        $serverValue = $_SERVER[$name] ?? null;
+        if (is_string($serverValue)) {
+            return $serverValue;
+        }
+
+        $value = getenv($name);
+
+        return false === $value ? '' : (string) $value;
+    }
+}

--- a/src/Install/UI/Console/Command/InstallCommand.php
+++ b/src/Install/UI/Console/Command/InstallCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 #[AsCommand(
     name: 'app:install',
-    description: 'Run one-time server bootstrap (initial admin user and future install steps).',
+    description: 'Run one-time server bootstrap (initial admin user). Run app:env:check first.',
 )]
 final readonly class InstallCommand
 {

--- a/tests/Install/Functional/Command/EnvCheckCommandTest.php
+++ b/tests/Install/Functional/Command/EnvCheckCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Install\Functional\Command;
+
+use App\Install\UI\Console\Command\EnvCheckCommand;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class EnvCheckCommandTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+    }
+
+    public function testDevProfilePassesWithWarningsAndDoesNotExposeSecrets(): void
+    {
+        $tester = $this->createCommandTester();
+        $tester->execute([
+            '--check-profile' => 'dev',
+            '--skip-database' => true,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('APP_SECRET', $display);
+        self::assertStringContainsString('WARN', $display);
+        self::assertStringNotContainsString('ecretf0rt3st', $display);
+        self::assertStringNotContainsString('password@', $display);
+    }
+
+    public function testBetaProfileFailsWhenSentryMissing(): void
+    {
+        $tester = $this->createCommandTester();
+        $tester->execute([
+            '--check-profile' => 'beta',
+            '--skip-database' => true,
+        ]);
+
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('SENTRY_DSN', $tester->getDisplay());
+        self::assertStringContainsString('FAIL', $tester->getDisplay());
+    }
+
+    public function testCommandIsRegisteredNextToInstallCommand(): void
+    {
+        self::assertTrue(self::getContainer()->has(EnvCheckCommand::class));
+        self::assertTrue(self::getContainer()->has(\App\Install\UI\Console\Command\InstallCommand::class));
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        /** @var EnvCheckCommand $command */
+        $command = self::getContainer()->get(EnvCheckCommand::class);
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Install/Unit/Environment/EnvironmentCheckerTest.php
+++ b/tests/Install/Unit/Environment/EnvironmentCheckerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Install\Unit\Environment;
+
+use App\Install\Application\Environment\EnvironmentChecker;
+use App\Install\Application\Environment\EnvironmentCheckItem;
+use App\Install\Application\Environment\EnvironmentCheckProfile;
+use App\Install\Application\Environment\EnvironmentCheckReport;
+use App\Install\Application\Environment\EnvironmentCheckStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EnvironmentCheckerTest extends TestCase
+{
+    private EnvironmentChecker $checker;
+
+    protected function setUp(): void
+    {
+        $this->checker = new EnvironmentChecker();
+    }
+
+    public function testProdProfileFailsWhenAppSecretMissing(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Prod,
+            $this->validProdVariables(['APP_SECRET' => '']),
+            true,
+        );
+
+        self::assertTrue($report->hasFailures());
+        self::assertSame(
+            EnvironmentCheckStatus::Fail,
+            $this->statusFor($report, 'APP_SECRET'),
+        );
+    }
+
+    public function testProdProfileFailsWhenAppUrlUsesLocalhost(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Prod,
+            $this->validProdVariables(['APP_URL' => 'http://127.0.0.1:8000']),
+            true,
+        );
+
+        self::assertTrue($report->hasFailures());
+        self::assertSame(
+            EnvironmentCheckStatus::Fail,
+            $this->statusFor($report, 'APP_URL'),
+        );
+    }
+
+    public function testProdProfileWarnsWhenSentryDsnMissing(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Prod,
+            $this->validProdVariables(['SENTRY_DSN' => '']),
+            true,
+        );
+
+        self::assertFalse($report->hasFailures());
+        self::assertTrue($report->hasWarnings());
+        self::assertSame(
+            EnvironmentCheckStatus::Warn,
+            $this->statusFor($report, 'SENTRY_DSN'),
+        );
+    }
+
+    public function testBetaProfileFailsWhenSentryDsnMissing(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Beta,
+            $this->validProdVariables(['SENTRY_DSN' => '']),
+            true,
+        );
+
+        self::assertTrue($report->hasFailures());
+        self::assertSame(
+            EnvironmentCheckStatus::Fail,
+            $this->statusFor($report, 'SENTRY_DSN'),
+        );
+    }
+
+    /**
+     * @param array<string, string> $variables
+     */
+    #[DataProvider('devProfileProvider')]
+    public function testDevProfileTreatsMissingProductionValuesAsWarnings(array $variables): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Dev,
+            $variables,
+            true,
+        );
+
+        self::assertFalse($report->hasFailures());
+        self::assertTrue($report->hasWarnings());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function devProfileProvider(): iterable
+    {
+        yield 'local defaults' => [[
+            'APP_ENV' => 'dev',
+            'APP_DEBUG' => '1',
+            'APP_SECRET' => '',
+            'DATABASE_URL' => 'postgresql://app:password@127.0.0.1:5432/app',
+            'APP_URL' => 'http://127.0.0.1:8000',
+            'MAILER_DSN' => 'null://null',
+            'MAILER_FROM' => 'no-reply@localhost',
+            'MESSENGER_TRANSPORT_DSN' => 'doctrine://default?auto_setup=0',
+            'SENTRY_DSN' => '',
+            'SENTRY_ENVIRONMENT' => '',
+        ]];
+    }
+
+    public function testValidProdProfilePassesWithoutDatabaseCheck(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Prod,
+            $this->validProdVariables(),
+            true,
+        );
+
+        self::assertFalse($report->hasFailures());
+        self::assertFalse($report->hasWarnings());
+    }
+
+    public function testBetaProfilePassesWithFullConfiguration(): void
+    {
+        $report = $this->checker->check(
+            EnvironmentCheckProfile::Beta,
+            $this->validProdVariables(['SENTRY_ENVIRONMENT' => 'beta']),
+            true,
+        );
+
+        self::assertFalse($report->hasFailures());
+        self::assertFalse($report->hasWarnings());
+    }
+
+    public function testReportDetectsWarningsAndFailures(): void
+    {
+        $report = new EnvironmentCheckReport([
+            new EnvironmentCheckItem('APP_ENV', EnvironmentCheckStatus::Ok, 'ok'),
+            new EnvironmentCheckItem('SENTRY_DSN', EnvironmentCheckStatus::Warn, 'warn'),
+        ]);
+
+        self::assertFalse($report->hasFailures());
+        self::assertTrue($report->hasWarnings());
+
+        $failed = new EnvironmentCheckReport([
+            new EnvironmentCheckItem('APP_SECRET', EnvironmentCheckStatus::Fail, 'fail'),
+        ]);
+
+        self::assertTrue($failed->hasFailures());
+        self::assertFalse($failed->hasWarnings());
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     *
+     * @return array<string, string>
+     */
+    private function validProdVariables(array $overrides = []): array
+    {
+        return array_merge([
+            'APP_ENV' => 'prod',
+            'APP_DEBUG' => '0',
+            'APP_SECRET' => bin2hex(random_bytes(16)),
+            'DATABASE_URL' => 'postgresql://app:password@db.example.test:5432/app',
+            'APP_URL' => 'https://coishub.example.test',
+            'MAILER_DSN' => 'smtp://user:pass@smtp.example.test:587',
+            'MAILER_FROM' => 'no-reply@example.test',
+            'MESSENGER_TRANSPORT_DSN' => 'doctrine://default?auto_setup=0',
+            'SENTRY_DSN' => 'https://example@sentry.example.test/1',
+            'SENTRY_ENVIRONMENT' => 'prod',
+        ], $overrides);
+    }
+
+    private function statusFor(EnvironmentCheckReport $report, string $variable): EnvironmentCheckStatus
+    {
+        foreach ($report->items as $item) {
+            if ($item->variable === $variable) {
+                return $item->status;
+            }
+        }
+
+        self::fail(sprintf('Missing check result for %s', $variable));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `app:env:check` to the **Install** bounded context (alongside `app:install`) to validate production/beta environment variables without printing secret values.
- Profiles: `dev` (warnings only), `prod` (strict), `beta` (strict + required `SENTRY_DSN`).
- Add `docs/Beta-readiness-checklist.md` and Pre-beta gate section in Deployment docs.

Part of beta-readiness audit **P0-2** (prod secrets checklist).

## Test plan

- [x] `make ci` passes
- [x] 11 unit/functional tests for `EnvironmentChecker` and `EnvCheckCommand`
- [x] `make env-check` locally (warnings expected in dev)
- [ ] `php bin/console app:env:check --check-profile=beta` on Uberspace prod (manual P0-2.5)