### PR TITLE
feat(shared): add GET /health endpoint for beta monitoring

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -52,6 +52,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/health, roles: PUBLIC_ACCESS }
         - { path: ^/_error_preview, roles: PUBLIC_ACCESS }
         - { path: ^/_error/, roles: PUBLIC_ACCESS }
         - { path: ^/admin, roles: ROLE_ADMIN }

--- a/docs/Backup-restore.md
+++ b/docs/Backup-restore.md
@@ -209,7 +209,7 @@ Cron is configured on Uberspace outside this repository.
    systemctl --user start messenger
    ```
 
-4. Smoke test: login, import list, statistics dashboard. When available, `GET /health`.
+4. Smoke test: `curl -sS https://<host>/health | jq` (expect HTTP 200, `checks.database: ok`), then login, import list, statistics dashboard.
 
 `pg_restore --clean --if-exists` drops and recreates objects from the dump. Schema drift after restore is unlikely if the dump matches the deployed code version; if not, run `php bin/console doctrine:migrations:status`.
 

--- a/docs/Beta-readiness-checklist.md
+++ b/docs/Beta-readiness-checklist.md
@@ -10,9 +10,9 @@ Related: [Configuration.md](Configuration.md), [Deployment.md](Deployment.md), [
 
 | ID | Item | How to verify | Status |
 |----|------|---------------|--------|
-| P0-1 | Backup & restore strategy | Follow [Backup-restore.md](Backup-restore.md); restore drill with `make verify-restore` | |
-| P0-2 | Production secrets & env | `php bin/console app:env:check --check-profile=beta` on server (see below) | |
-| P0-3 | HTTP health endpoint | `GET /health` returns JSON with database OK | planned |
+| P0-1 | Backup & restore strategy | Follow [Backup-restore.md](Backup-restore.md); restore drill with `make verify-restore` | done |
+| P0-2 | Production secrets & env | `php bin/console app:env:check --check-profile=beta` on server (see below) | done |
+| P0-3 | HTTP health endpoint | `curl -sS https://<host>/health` returns JSON with `checks.database: ok` | done |
 | P0-4 | SQL month aggregation | `countByMonthLast12Months()` uses SQL `GROUP BY` | planned |
 
 ### P0-2 on the server (Uberspace)
@@ -41,6 +41,7 @@ These are required in addition to `app:env:check`:
 - [ ] Transactional mail works (registration or password reset test)
 - [ ] Sentry receives a test event (if `SENTRY_DSN` is set)
 - [ ] Backups scheduled on Uberspace (cron — see [Backup-restore.md](Backup-restore.md))
+- [ ] Sentry Uptime Monitor on `GET /health` (see [Observability-sentry.md](Observability-sentry.md#uptime-monitoring))
 
 ## Environment variables reference
 
@@ -91,6 +92,5 @@ Higher-priority follow-ups from the beta-readiness audit:
 - CSP report-only
 - Functional tests for auth/onboarding
 - Sentry alerts and failed-message monitoring
-- HTTP `/health` endpoint (P0-3)
 
 See the project beta-readiness audit plan for the full roadmap.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -363,6 +363,24 @@ above) or set `messenger_restart_on_deploy: false` in `hosts.yaml` until the wor
 | Failed messages | `php bin/console messenger:failed:show` |
 | Retry failed | `php bin/console messenger:failed:retry` |
 
+### Health check
+
+`GET /health` is public (no login) and returns JSON with runtime status:
+
+| `status` | HTTP | Meaning |
+|--------|------|---------|
+| `healthy` | 200 | Database reachable, no failed Messenger messages |
+| `degraded` | 200 | Database OK, failed queue has messages — check `messenger:failed:show` |
+| `unhealthy` | 503 | Database unreachable |
+
+Example after deploy:
+
+```bash
+curl -sS https://<host>/health | jq
+```
+
+For external uptime monitoring (Sentry Uptime or similar), point the monitor at the same URL and expect HTTP **200**. A `degraded` response still returns 200 by design so failed messages do not page on-call; investigate via the checklist and `messenger:failed:show`. Details: [Observability-sentry.md](Observability-sentry.md#uptime-monitoring).
+
 ### Backups
 
 Database and file backups are documented in [Backup-restore.md](Backup-restore.md).

--- a/docs/Observability-sentry.md
+++ b/docs/Observability-sentry.md
@@ -57,3 +57,26 @@ In `dev` or `staging`, with a DSN configured, `GET /_debug/sentry/test` triggers
 2. **Logs:** Explore -> Logs with filters such as `message:import.summary` or `level:error`.
 3. **Performance:** HTTP requests, Messenger jobs, and Doctrine queries appear as automatic transactions and spans.
 4. **Privacy:** event and log details should not include request bodies or unnecessary personal data.
+
+## Uptime monitoring
+
+The Symfony SDK (`sentry/sentry-symfony`) sends errors, logs, and traces **from the app to Sentry**. It does **not** poll URLs. For reachability checks, configure **Sentry Uptime Monitoring** (or another external HTTP monitor) in the Sentry UI — no application code required.
+
+### Setup (Sentry UI)
+
+1. Open **Alerts** → **Uptime Monitors** → create monitor.
+2. URL: `https://<APP_URL>/health` (same value as `APP_URL` in `shared/.env.local`).
+3. Interval: e.g. every 5 minutes.
+4. Expected HTTP status: **200**.
+
+### What triggers an alert
+
+| Condition | Uptime alert |
+|-----------|--------------|
+| Timeout or connection failure | yes |
+| HTTP **503** (`unhealthy`, database down) | yes |
+| HTTP **200** with `"status": "degraded"` (failed Messenger messages) | no (by design) |
+
+`degraded` means the app is up but the failed queue has messages. Use `php bin/console messenger:failed:show` and the [beta readiness checklist](Beta-readiness-checklist.md) — Sentry Uptime does not parse JSON response bodies.
+
+Related: [Deployment.md](Deployment.md#health-check) (`GET /health` response format).

--- a/src/Shared/Application/Health/HealthCheckReport.php
+++ b/src/Shared/Application/Health/HealthCheckReport.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Health;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class HealthCheckReport
+{
+    /**
+     * @param array<string, string> $checks
+     */
+    public function __construct(
+        public HealthCheckStatus $status,
+        public string $version,
+        public array $checks,
+    ) {
+    }
+
+    public function httpStatusCode(): int
+    {
+        return HealthCheckStatus::Unhealthy === $this->status
+            ? Response::HTTP_SERVICE_UNAVAILABLE
+            : Response::HTTP_OK;
+    }
+
+    /**
+     * @return array{status: string, version: string, checks: array<string, string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'version' => $this->version,
+            'checks' => $this->checks,
+        ];
+    }
+}

--- a/src/Shared/Application/Health/HealthCheckService.php
+++ b/src/Shared/Application/Health/HealthCheckService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Health;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class HealthCheckService
+{
+    private const string FAILED_QUEUE_NAME = 'failed';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private Connection $connection,
+        #[Autowire('%app.version%')]
+        private string $appVersion,
+    ) {
+    }
+
+    public function check(): HealthCheckReport
+    {
+        try {
+            $this->connection->executeQuery('SELECT 1');
+        } catch (Exception) {
+            return new HealthCheckReport(
+                HealthCheckStatus::Unhealthy,
+                $this->appVersion,
+                [
+                    'database' => 'unreachable',
+                    'messenger_failed' => 'skipped',
+                ],
+            );
+        }
+
+        $checks = ['database' => 'ok'];
+        $failedCount = $this->countFailedMessages();
+
+        if ($failedCount > 0) {
+            $checks['messenger_failed'] = sprintf('%d failed message(s)', $failedCount);
+
+            return new HealthCheckReport(
+                HealthCheckStatus::Degraded,
+                $this->appVersion,
+                $checks,
+            );
+        }
+
+        $checks['messenger_failed'] = 'ok';
+
+        return new HealthCheckReport(
+            HealthCheckStatus::Healthy,
+            $this->appVersion,
+            $checks,
+        );
+    }
+
+    private function countFailedMessages(): int
+    {
+        $result = $this->connection->executeQuery(
+            'SELECT COUNT(*) FROM messenger_messages WHERE queue_name = :queue',
+            ['queue' => self::FAILED_QUEUE_NAME],
+        );
+
+        return (int) $result->fetchOne();
+    }
+}

--- a/src/Shared/Application/Health/HealthCheckStatus.php
+++ b/src/Shared/Application/Health/HealthCheckStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Health;
+
+enum HealthCheckStatus: string
+{
+    case Healthy = 'healthy';
+    case Degraded = 'degraded';
+    case Unhealthy = 'unhealthy';
+}

--- a/src/Shared/UI/Http/Controller/HealthCheckController.php
+++ b/src/Shared/UI/Http/Controller/HealthCheckController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Http\Controller;
+
+use App\Shared\Application\Health\HealthCheckService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final readonly class HealthCheckController
+{
+    public function __construct(
+        private HealthCheckService $healthCheckService,
+    ) {
+    }
+
+    #[Route('/health', name: 'app_health', methods: [Request::METHOD_GET])]
+    public function __invoke(): JsonResponse
+    {
+        $report = $this->healthCheckService->check();
+
+        return new JsonResponse(
+            $report->toArray(),
+            $report->httpStatusCode(),
+        );
+    }
+}

--- a/tests/Shared/Functional/Controller/HealthCheckControllerTest.php
+++ b/tests/Shared/Functional/Controller/HealthCheckControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Functional\Controller;
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class HealthCheckControllerTest extends WebTestCase
+{
+    public function testHealthEndpointIsPublicAndReturnsJson(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/health');
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('status', $payload);
+        self::assertArrayHasKey('version', $payload);
+        self::assertArrayHasKey('checks', $payload);
+        self::assertSame(Kernel::APP_VERSION, $payload['version']);
+        self::assertSame('ok', $payload['checks']['database']);
+        self::assertContains($payload['status'], ['healthy', 'degraded']);
+    }
+}

--- a/tests/Shared/Unit/Health/HealthCheckServiceTest.php
+++ b/tests/Shared/Unit/Health/HealthCheckServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Health;
+
+use App\Shared\Application\Health\HealthCheckService;
+use App\Shared\Application\Health\HealthCheckStatus;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\TestCase;
+
+final class HealthCheckServiceTest extends TestCase
+{
+    private const string APP_VERSION = 'v0.0.4-alpha';
+
+    public function testReturnsHealthyWhenDatabaseOkAndNoFailedMessages(): void
+    {
+        $connection = $this->createConnectionMock(failedCount: 0);
+
+        $service = new HealthCheckService($connection, self::APP_VERSION);
+        $report = $service->check();
+
+        self::assertSame(HealthCheckStatus::Healthy, $report->status);
+        self::assertSame(self::APP_VERSION, $report->version);
+        self::assertSame('ok', $report->checks['database']);
+        self::assertSame('ok', $report->checks['messenger_failed']);
+        self::assertSame(200, $report->httpStatusCode());
+    }
+
+    public function testReturnsDegradedWhenFailedMessagesExist(): void
+    {
+        $connection = $this->createConnectionMock(failedCount: 3);
+
+        $service = new HealthCheckService($connection, self::APP_VERSION);
+        $report = $service->check();
+
+        self::assertSame(HealthCheckStatus::Degraded, $report->status);
+        self::assertSame('ok', $report->checks['database']);
+        self::assertSame('3 failed message(s)', $report->checks['messenger_failed']);
+        self::assertSame(200, $report->httpStatusCode());
+    }
+
+    public function testReturnsUnhealthyWhenDatabaseUnreachable(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects(self::once())
+            ->method('executeQuery')
+            ->with('SELECT 1')
+            ->willThrowException($this->createMock(Exception::class));
+
+        $service = new HealthCheckService($connection, self::APP_VERSION);
+        $report = $service->check();
+
+        self::assertSame(HealthCheckStatus::Unhealthy, $report->status);
+        self::assertSame('unreachable', $report->checks['database']);
+        self::assertSame('skipped', $report->checks['messenger_failed']);
+        self::assertSame(503, $report->httpStatusCode());
+    }
+
+    private function createConnectionMock(int $failedCount): Connection
+    {
+        $failedResult = $this->createMock(Result::class);
+        $failedResult->method('fetchOne')->willReturn($failedCount);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects(self::exactly(2))
+            ->method('executeQuery')
+            ->willReturnCallback(static function (string $sql) use ($failedResult): \PHPUnit\Framework\MockObject\MockObject {
+                if ('SELECT 1' === $sql) {
+                    return $failedResult;
+                }
+
+                if (str_contains($sql, 'messenger_messages')) {
+                    return $failedResult;
+                }
+
+                self::fail('Unexpected SQL: '.$sql);
+            });
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
## Summary

- Add public `GET /health` JSON endpoint for uptime monitoring and post-restore smoke tests
- Check database connectivity (`SELECT 1`) and Messenger failed queue (`messenger_messages` where `queue_name = failed`)
- Return `healthy` / `degraded` (HTTP 200) / `unhealthy` (HTTP 503); `degraded` when failed messages exist but DB is up
- Expose route without authentication via `PUBLIC_ACCESS` in `security.yaml`
- Add unit tests (all service paths) and a functional test (public access + JSON shape)
- Document health check in Deployment, Sentry Uptime setup in Observability-sentry, and mark P0-1/2/3 done in the beta readiness checklist

## Test plan

- [x] `make ci` passes
- [x] `php bin/phpunit tests/Shared/Unit/Health/ tests/Shared/Functional/Controller/HealthCheckControllerTest.php`
- [x] `php bin/console router:match /health`
- [ ] After deploy: `curl -sS https://<host>/health | jq` (expect HTTP 200, `checks.database: ok`)
- [ ] Optional: configure Sentry Uptime Monitor on `https://<APP_URL>/health`