### PR TITLE
refactor(allocation): SQL GROUP BY for countByMonthLast12Months (P0-4)

### DIFF
--- a/docs/Beta-readiness-checklist.md
+++ b/docs/Beta-readiness-checklist.md
@@ -13,7 +13,7 @@ Related: [Configuration.md](Configuration.md), [Deployment.md](Deployment.md), [
 | P0-1 | Backup & restore strategy | Follow [Backup-restore.md](Backup-restore.md); restore drill with `make verify-restore` | done |
 | P0-2 | Production secrets & env | `php bin/console app:env:check --check-profile=beta` on server (see below) | done |
 | P0-3 | HTTP health endpoint | `curl -sS https://<host>/health` returns JSON with `checks.database: ok` | done |
-| P0-4 | SQL month aggregation | `countByMonthLast12Months()` uses SQL `GROUP BY` | planned |
+| P0-4 | SQL month aggregation | `countByMonthLast12Months()` uses SQL `GROUP BY` (see repository integration tests) | done |
 
 ### P0-2 on the server (Uberspace)
 

--- a/src/Allocation/Infrastructure/Repository/AllocationRepository.php
+++ b/src/Allocation/Infrastructure/Repository/AllocationRepository.php
@@ -9,6 +9,7 @@ use App\Allocation\Domain\Enum\AllocationGender;
 use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Import\Domain\Entity\Import;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -33,7 +34,7 @@ final class AllocationRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array<int, array{year: int, month: int, count: int}>
+     * @return list<array{year: int, month: int, count: int}>
      */
     public function countByMonthLast12Months(): array
     {
@@ -41,45 +42,7 @@ final class AllocationRepository extends ServiceEntityRepository
             ->modify('-11 months')
             ->setTime(0, 0, 0);
 
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        $buckets = [];
-
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $key = $createdAt->format('Y-m');
-
-            if (!isset($buckets[$key])) {
-                $buckets[$key] = 0;
-            }
-
-            ++$buckets[$key];
-        }
-
-        $result = [];
-        foreach ($buckets as $key => $count) {
-            [$year, $month] = explode('-', $key);
-
-            $result[] = [
-                'year' => (int) $year,
-                'month' => (int) $month,
-                'count' => $count,
-            ];
-        }
-
-        usort($result, static fn (array $a, array $b): int => [$a['year'], $a['month']] <=> [$b['year'], $b['month']]);
-
-        return $result;
+        return $this->aggregateCountByMonthSince($from, null);
     }
 
     /**
@@ -87,7 +50,7 @@ final class AllocationRepository extends ServiceEntityRepository
      *
      * @param list<int> $hospitalIds
      *
-     * @return array<int, array{year: int, month: int, count: int}>
+     * @return list<array{year: int, month: int, count: int}>
      */
     public function countByMonthLast12MonthsForHospitals(array $hospitalIds): array
     {
@@ -99,42 +62,56 @@ final class AllocationRepository extends ServiceEntityRepository
             ->modify('-11 months')
             ->setTime(0, 0, 0);
 
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->andWhere('a.hospital IN (:hospitalIds)')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->setParameter('hospitalIds', $hospitalIds)
-            ->orderBy('a.createdAt', 'ASC');
+        return $this->aggregateCountByMonthSince($from, $hospitalIds);
+    }
 
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return list<array{year: int, month: int, count: int}>
+     */
+    private function aggregateCountByMonthSince(\DateTimeImmutable $from, ?array $hospitalIds): array
+    {
+        $sql = <<<'SQL'
+SELECT EXTRACT(YEAR FROM created_at)::INT AS year,
+       EXTRACT(MONTH FROM created_at)::INT AS month,
+       COUNT(id)::INT AS count
+FROM allocation
+WHERE created_at >= :from
+  AND created_at IS NOT NULL
+SQL;
+        $params = ['from' => $from];
+        $types = ['from' => Types::DATETIME_IMMUTABLE];
 
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-            $key = $createdAt->format('Y-m');
-            if (!isset($buckets[$key])) {
-                $buckets[$key] = 0;
-            }
-            ++$buckets[$key];
+        if (null !== $hospitalIds) {
+            $sql .= ' AND hospital_id IN (:hospitalIds)';
+            $params['hospitalIds'] = $hospitalIds;
+            $types['hospitalIds'] = ArrayParameterType::INTEGER;
         }
 
-        $result = [];
-        foreach ($buckets as $key => $count) {
-            [$year, $month] = explode('-', $key);
-            $result[] = [
-                'year' => (int) $year,
-                'month' => (int) $month,
-                'count' => $count,
-            ];
-        }
+        $sql .= ' GROUP BY 1, 2 ORDER BY 1 ASC, 2 ASC';
 
-        usort($result, static fn (array $a, array $b): int => [$a['year'], $a['month']] <=> [$b['year'], $b['month']]);
+        /** @var list<array{year:numeric-string|int,month:numeric-string|int,count:numeric-string|int}> $raw */
+        $raw = $this->getEntityManager()->getConnection()->fetchAllAssociative($sql, $params, $types);
 
-        return $result;
+        return $this->mapMonthCountRows($raw);
+    }
+
+    /**
+     * @param list<array{year:numeric-string|int,month:numeric-string|int,count:numeric-string|int}> $raw
+     *
+     * @return list<array{year: int, month: int, count: int}>
+     */
+    private function mapMonthCountRows(array $raw): array
+    {
+        return array_map(
+            static fn (array $row): array => [
+                'year' => (int) $row['year'],
+                'month' => (int) $row['month'],
+                'count' => (int) $row['count'],
+            ],
+            $raw,
+        );
     }
 
     public function countAll(): int

--- a/src/Import/Infrastructure/Repository/ImportRepository.php
+++ b/src/Import/Infrastructure/Repository/ImportRepository.php
@@ -23,7 +23,7 @@ final class ImportRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array<int, array{year: int, month: int, count: int}>
+     * @return list<array{year: int, month: int, count: int}>
      */
     public function countByMonthLast12Months(): array
     {
@@ -31,41 +31,41 @@ final class ImportRepository extends ServiceEntityRepository
             ->modify('-11 months')
             ->setTime(0, 0, 0);
 
-        $qb = $this->createQueryBuilder('i')
-            ->where('i.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('i.createdAt', 'ASC');
+        $sql = <<<'SQL'
+SELECT EXTRACT(YEAR FROM created_at)::INT AS year,
+       EXTRACT(MONTH FROM created_at)::INT AS month,
+       COUNT(id)::INT AS count
+FROM import
+WHERE created_at >= :from
+GROUP BY 1, 2
+ORDER BY 1 ASC, 2 ASC
+SQL;
 
-        /** @var Import[] $rows */
-        $rows = $qb->getQuery()->getResult();
+        /** @var list<array{year:numeric-string|int,month:numeric-string|int,count:numeric-string|int}> $raw */
+        $raw = $this->getEntityManager()->getConnection()->fetchAllAssociative(
+            $sql,
+            ['from' => $from],
+            ['from' => Types::DATETIME_IMMUTABLE],
+        );
 
-        $buckets = [];
+        return $this->mapMonthCountRows($raw);
+    }
 
-        foreach ($rows as $import) {
-            $createdAt = $import->getCreatedAt();
-            $key = $createdAt->format('Y-m');
-
-            if (!isset($buckets[$key])) {
-                $buckets[$key] = 0;
-            }
-
-            ++$buckets[$key];
-        }
-
-        $result = [];
-        foreach ($buckets as $key => $count) {
-            [$year, $month] = explode('-', $key);
-
-            $result[] = [
-                'year' => (int) $year,
-                'month' => (int) $month,
-                'count' => $count,
-            ];
-        }
-
-        usort($result, static fn (array $a, array $b): int => [$a['year'], $a['month']] <=> [$b['year'], $b['month']]);
-
-        return $result;
+    /**
+     * @param list<array{year:numeric-string|int,month:numeric-string|int,count:numeric-string|int}> $raw
+     *
+     * @return list<array{year: int, month: int, count: int}>
+     */
+    private function mapMonthCountRows(array $raw): array
+    {
+        return array_map(
+            static fn (array $row): array => [
+                'year' => (int) $row['year'],
+                'month' => (int) $row['month'],
+                'count' => (int) $row['count'],
+            ],
+            $raw,
+        );
     }
 
     /**

--- a/tests/Allocation/Integration/Repository/AllocationRepositoryMonthAggregationTest.php
+++ b/tests/Allocation/Integration/Repository/AllocationRepositoryMonthAggregationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Repository\AllocationRepository;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AllocationRepositoryMonthAggregationTest extends KernelTestCase
+{
+    use Factories;
+
+    private AllocationRepository $repository;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->repository = self::getContainer()->get(AllocationRepository::class);
+    }
+
+    public function testCountByMonthLast12MonthsAggregatesInWindowOnly(): void
+    {
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        $monthA = $from->modify('+10 days');
+        $monthB = $from->modify('+1 month +10 days');
+        $outOfWindow = $from->modify('-1 day');
+
+        $import = $this->seedAllocationGraph();
+
+        AllocationFactory::createOne(['createdAt' => $monthA, 'import' => $import]);
+        AllocationFactory::createOne(['createdAt' => $monthA->modify('+2 days'), 'import' => $import]);
+        AllocationFactory::createOne(['createdAt' => $monthB, 'import' => $import]);
+        AllocationFactory::createOne(['createdAt' => $outOfWindow, 'import' => $import]);
+
+        $rows = $this->repository->countByMonthLast12Months();
+
+        self::assertSame([
+            ['year' => (int) $monthA->format('Y'), 'month' => (int) $monthA->format('n'), 'count' => 2],
+            ['year' => (int) $monthB->format('Y'), 'month' => (int) $monthB->format('n'), 'count' => 1],
+        ], $rows);
+    }
+
+    public function testCountByMonthLast12MonthsForHospitalsFiltersByHospital(): void
+    {
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+        $inWindow = $from->modify('+10 days');
+
+        $import = $this->seedAllocationGraph();
+        $hospitalA = HospitalFactory::createOne();
+        $hospitalB = HospitalFactory::createOne();
+
+        AllocationFactory::createOne(['createdAt' => $inWindow, 'hospital' => $hospitalA, 'import' => $import]);
+        AllocationFactory::createOne(['createdAt' => $inWindow, 'hospital' => $hospitalB, 'import' => $import]);
+
+        $rows = $this->repository->countByMonthLast12MonthsForHospitals([(int) $hospitalA->getId()]);
+
+        self::assertSame([
+            ['year' => (int) $inWindow->format('Y'), 'month' => (int) $inWindow->format('n'), 'count' => 1],
+        ], $rows);
+    }
+
+    public function testCountByMonthLast12MonthsForHospitalsReturnsEmptyForNoIds(): void
+    {
+        self::assertSame([], $this->repository->countByMonthLast12MonthsForHospitals([]));
+    }
+
+    private function seedAllocationGraph(): object
+    {
+        UserFactory::createOne();
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne();
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        AssignmentFactory::createOne();
+        OccasionFactory::createOne();
+        InfectionFactory::createOne();
+        IndicationRawFactory::createOne();
+        IndicationNormalizedFactory::createOne();
+
+        return ImportFactory::createOne();
+    }
+}

--- a/tests/Import/Integration/Repository/ImportRepositoryMonthAggregationTest.php
+++ b/tests/Import/Integration/Repository/ImportRepositoryMonthAggregationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+
+final class ImportRepositoryMonthAggregationTest extends DatabaseKernelTestCase
+{
+    private ImportRepository $repository;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->repository = self::getContainer()->get(ImportRepository::class);
+    }
+
+    public function testCountByMonthLast12MonthsAggregatesInWindowOnly(): void
+    {
+        [$hospital, $user] = $this->seedHospital();
+
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        $monthA = $from->modify('+10 days');
+        $monthB = $from->modify('+1 month +10 days');
+        $outOfWindow = $from->modify('-1 day');
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => $monthA,
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => $monthA->modify('+3 days'),
+            'status' => ImportStatus::COMPLETED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => $monthB,
+            'status' => ImportStatus::FAILED,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'createdAt' => $outOfWindow,
+            'status' => ImportStatus::COMPLETED,
+        ]);
+
+        $rows = $this->repository->countByMonthLast12Months();
+
+        self::assertSame([
+            ['year' => (int) $monthA->format('Y'), 'month' => (int) $monthA->format('n'), 'count' => 2],
+            ['year' => (int) $monthB->format('Y'), 'month' => (int) $monthB->format('n'), 'count' => 1],
+        ], $rows);
+    }
+
+    /**
+     * @return array{0: object, 1: object}
+     */
+    private function seedHospital(): array
+    {
+        $user = UserFactory::createOne([
+            'email' => sprintf('import-month-agg-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $user,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        return [$hospital, $user];
+    }
+}


### PR DESCRIPTION
## Summary

- Replace PHP entity bucketing in `countByMonthLast12Months()` with PostgreSQL `EXTRACT` + `GROUP BY` via DBAL
- **AllocationRepository:** `countByMonthLast12Months()` and `countByMonthLast12MonthsForHospitals()` share a private `aggregateCountByMonthSince()` helper
- **ImportRepository:** `countByMonthLast12Months()` — production hot path for the statistics overview import timeline
- Return shape and rolling 12-month window unchanged; months with zero rows are still omitted
- DQL `YEAR`/`MONTH` is not available in this project, so DBAL raw SQL was used (same pattern as other statistics queries)
- Add integration tests for allocation (window, hospital filter, empty IDs) and import month aggregation
- Mark **P0-4** as done in the beta readiness checklist — **all P0 beta blockers are now complete**

## Context

Previously these methods loaded all matching entities with `getResult()` and counted months in PHP. Under growing data volumes this risks memory pressure and slow overview/dashboard paths. Allocation counts on the overview dashboard already use `ProjectionTimeSeriesQuery`; this change fixes the remaining import timeline path and aligns unused allocation repository methods for consistency.

## Test plan

- [x] `make ci` passes
- [x] `php bin/phpunit tests/Allocation/Integration/Repository/AllocationRepositoryMonthAggregationTest.php`
- [x] `php bin/phpunit tests/Import/Integration/Repository/ImportRepositoryMonthAggregationTest.php`
- [x] `php bin/phpunit tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php` (regression)
- [ ] After merge: smoke-test `/statistics/` overview charts with real data on staging/prod

## After merge

P0 is complete. Before inviting the first closed-beta participant, run the manual server checks in [docs/Beta-readiness-checklist.md](docs/Beta-readiness-checklist.md) (env check, messenger, backups, Sentry uptime on `/health`)