### PR TITLE
fix(engagement): send monthly reminder in hospital owner locale

### DIFF
--- a/src/DataFixtures/Content/DemoContentLoader.php
+++ b/src/DataFixtures/Content/DemoContentLoader.php
@@ -317,6 +317,7 @@ Germany</pre><p><strong>Contact:</strong> <a href="mailto:demo@example.org">demo
                     'post' => $post,
                     'content' => 'Thanks for the update — great to see steady progress on the platform.',
                     'author' => $foo,
+                    'createdBy' => $admin,
                 ]);
             }
         }

--- a/src/DataFixtures/Reference/AreaReferenceFixture.php
+++ b/src/DataFixtures/Reference/AreaReferenceFixture.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\DataFixtures\Reference;
 
-use App\DataFixtures\Content\ContentScenarioFixture;
+use App\DataFixtures\UserFixtures;
 use App\User\Domain\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
@@ -31,7 +31,7 @@ final class AreaReferenceFixture extends Fixture implements DependentFixtureInte
     #[\Override]
     public function getDependencies(): array
     {
-        return [ContentScenarioFixture::class];
+        return [UserFixtures::class];
     }
 
     /**

--- a/src/Engagement/Application/MonthlyReminderContentBuilder.php
+++ b/src/Engagement/Application/MonthlyReminderContentBuilder.php
@@ -48,9 +48,13 @@ final readonly class MonthlyReminderContentBuilder
     ) {
     }
 
-    public function build(Hospital $hospital, ?\DateTimeImmutable $referenceDate = null): MonthlyReminderContent
+    public function build(Hospital $hospital, ?\DateTimeImmutable $referenceDate, string $locale): MonthlyReminderContent
     {
         $period = $this->periodResolver->resolve($referenceDate);
+        $chartLabels = array_map(
+            fn (string $monthKey): string => $this->formatChartMonthLabel($monthKey, $locale),
+            $period['chartMonthKeys'],
+        );
         $hospitalId = (int) $hospital->getId();
         $hospitalIds = [$hospitalId];
 
@@ -105,7 +109,7 @@ final readonly class MonthlyReminderContentBuilder
 
         $chartBars = $this->chartBuilder->build(
             $period['chartMonthKeys'],
-            $period['chartLabels'],
+            $chartLabels,
             $chartAllocationRows,
             $reportingKey,
         );
@@ -155,8 +159,8 @@ final readonly class MonthlyReminderContentBuilder
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
 
-        $baselinePeriodLabel = $this->translator->trans('monthly_reminder.baseline.period_label');
-        $reportingPeriodLabel = $this->formatMonthYear($period['reportingYear'], $period['reportingMonth']);
+        $baselinePeriodLabel = $this->trans('monthly_reminder.baseline.period_label', [], $locale);
+        $reportingPeriodLabel = $this->formatMonthYear($period['reportingYear'], $period['reportingMonth'], $locale);
 
         $allocationMom = $this->chartBuilder->percentChange($reportingAllocations, $previousAllocations);
         $allocationYoy = $this->chartBuilder->percentChange($reportingAllocations, $yearAgoAllocations);
@@ -171,8 +175,9 @@ final readonly class MonthlyReminderContentBuilder
                 $selfBenchmarkUrl,
                 $baselinePeriodLabel,
                 $reportingPeriodLabel,
+                $locale,
             )
-            : $this->fallbackInsights($benchmarkingUrl);
+            : $this->fallbackInsights($benchmarkingUrl, $locale);
 
         $platformData = $isPersonalized ? [] : $this->platformFallbackData(
             $period,
@@ -180,14 +185,14 @@ final readonly class MonthlyReminderContentBuilder
             $previousReportingKey,
         );
 
-        $uploadMonthLabel = $this->formatMonthYear($period['uploadYear'], $period['uploadMonth']);
+        $uploadMonthLabel = $this->formatMonthYear($period['uploadYear'], $period['uploadMonth'], $locale);
 
-        $preheader = $this->translator->trans('monthly_reminder.preheader', [
+        $preheader = $this->trans('monthly_reminder.preheader', [
             'period' => $reportingPeriodLabel,
             'count' => $reportingAllocations,
             'delta' => null !== $allocationMom ? $this->formatSignedPercent($allocationMom) : '—',
             'upload_month' => $uploadMonthLabel,
-        ]);
+        ], $locale);
 
         return new MonthlyReminderContent(
             hospitalName: (string) $hospital->getName(),
@@ -197,32 +202,34 @@ final readonly class MonthlyReminderContentBuilder
             isPersonalized: $isPersonalized,
             allocationCount: $reportingAllocations,
             allocationMomPercent: $allocationMom,
-            lastImportLabel: $this->formatLastImportLabel($latestImport),
+            lastImportLabel: $this->formatLastImportLabel($latestImport, $locale),
             lastImportStale: $isStaleImport,
             withPhysicianPercent: $withPhysicianPercent,
             withPhysicianBaselineDeltaPp: $physicianMetric?->absoluteDelta,
             baselinePeriodLabel: $baselinePeriodLabel,
             medianTransportMinutes: $transportMetric instanceof \App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric ? $transportMetric->primaryValue : 0.0,
             medianTransportBaselineDeltaMinutes: $transportMetric?->absoluteDelta,
-            trendSummary: '' !== $trendKey ? $this->translator->trans($trendKey, [
+            trendSummary: '' !== $trendKey ? $this->trans($trendKey, [
                 'percent' => number_format(abs($this->averageMonthlyChange($allocationSeries)), 1, '.', ''),
-            ]) : '',
+            ], $locale) : '',
             chartBars: $chartBars,
             urgencySegments: $this->distributionSegments->urgencySegments(
                 $overviewMetrics->urgencyCounts,
                 $overviewMetrics->scopedTotal,
+                $locale,
             ),
-            urgencyBenchmarkNote: $this->urgencyBenchmarkNote($selfReport, $baselinePeriodLabel),
+            urgencyBenchmarkNote: $this->urgencyBenchmarkNote($selfReport, $baselinePeriodLabel, $locale),
             genderSegments: $this->distributionSegments->genderSegments(
                 $overviewMetrics->genderCounts,
                 $overviewMetrics->scopedTotal,
+                $locale,
             ),
             insights: $insights,
             submissionMonthsCompleted: $completedMonths,
             submissionMonthsTotal: $totalMonths,
             submissionProgressPercent: $totalMonths > 0 ? (int) round(100 * $completedMonths / $totalMonths) : 0,
             submissionMonths: $submissionMonths,
-            longestSubmissionGapLabel: $this->longestGapLabel($submissionMonths, $period['chartMonthKeys']),
+            longestSubmissionGapLabel: $this->longestGapLabel($submissionMonths, $period['chartMonthKeys'], $locale),
             importCreateUrl: $importCreateUrl,
             statisticsDashboardUrl: $statisticsUrl,
             benchmarkingUrl: $benchmarkingUrl,
@@ -258,26 +265,41 @@ final readonly class MonthlyReminderContentBuilder
         return (int) $createdAt->diff($referenceDate)->days;
     }
 
-    private function formatLastImportLabel(?Import $import): string
+    private function formatLastImportLabel(?Import $import, string $locale): string
     {
         $createdAt = $import?->getCreatedAt();
         if (!$createdAt instanceof \DateTimeImmutable) {
-            return $this->translator->trans('monthly_reminder.kpi.last_import.none');
+            return $this->trans('monthly_reminder.kpi.last_import.none', [], $locale);
         }
 
-        return $this->translator->trans('monthly_reminder.kpi.last_import.date', [
-            'date' => $this->formatMonthYear((int) $createdAt->format('Y'), (int) $createdAt->format('n')),
-        ]);
+        return $this->trans('monthly_reminder.kpi.last_import.date', [
+            'date' => $this->formatMonthYear((int) $createdAt->format('Y'), (int) $createdAt->format('n'), $locale),
+        ], $locale);
     }
 
-    private function formatMonthYear(int $year, int $month): string
+    private function formatMonthYear(int $year, int $month, string $locale): string
     {
         $date = new \DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month));
+        $formatted = \IntlDateFormatter::formatObject($date, 'LLLL yyyy', $locale);
 
-        return $this->translator->trans('monthly_reminder.month_year', [
-            'month' => $date->format('F'),
-            'year' => $year,
-        ]);
+        return false !== $formatted ? $formatted : sprintf('%04d-%02d', $year, $month);
+    }
+
+    private function formatChartMonthLabel(string $monthKey, string $locale): string
+    {
+        [$year, $month] = explode('-', $monthKey);
+        $date = new \DateTimeImmutable(sprintf('%04d-%02d-01', (int) $year, (int) $month));
+        $formatted = \IntlDateFormatter::formatObject($date, 'MMM', $locale);
+
+        return false !== $formatted ? $formatted : $monthKey;
+    }
+
+    /**
+     * @param array<string, string|int|float> $parameters
+     */
+    private function trans(string $id, array $parameters, string $locale): string
+    {
+        return $this->translator->trans($id, $parameters, null, $locale);
     }
 
     private function formatSignedPercent(float $value): string
@@ -307,6 +329,7 @@ final readonly class MonthlyReminderContentBuilder
     private function urgencyBenchmarkNote(
         \App\Statistics\Benchmarking\Application\DTO\BenchmarkReport $report,
         string $baselinePeriodLabel,
+        string $locale,
     ): ?string {
         foreach ($report->urgency->buckets as $bucket) {
             if ('1' !== $bucket->key && 'urgency_1' !== $bucket->key) {
@@ -316,12 +339,12 @@ final readonly class MonthlyReminderContentBuilder
                 return null;
             }
 
-            return $this->translator->trans('monthly_reminder.urgency.benchmark', [
-                'urgency' => $this->translator->trans(AllocationUrgency::EMERGENCY->label()),
+            return $this->trans('monthly_reminder.urgency.benchmark', [
+                'urgency' => $this->trans(AllocationUrgency::EMERGENCY->label(), [], $locale),
                 'percent' => number_format($bucket->primaryShare, 1, '.', ''),
                 'delta' => $this->formatSignedPercent($bucket->primaryShare - $bucket->comparisonShare),
                 'baseline' => $baselinePeriodLabel,
-            ]);
+            ], $locale);
         }
 
         return null;
@@ -331,7 +354,7 @@ final readonly class MonthlyReminderContentBuilder
      * @param array<string, string> $submissionMonths
      * @param list<string>          $monthKeys
      */
-    private function longestGapLabel(array $submissionMonths, array $monthKeys): ?string
+    private function longestGapLabel(array $submissionMonths, array $monthKeys, string $locale): ?string
     {
         $longest = 0;
         $gapStart = null;
@@ -368,34 +391,34 @@ final readonly class MonthlyReminderContentBuilder
             return null;
         }
 
-        return $this->translator->trans('monthly_reminder.submission.gap', [
+        return $this->trans('monthly_reminder.submission.gap', [
             'months' => $longest,
-            'from' => $this->formatMonthKey($gapStart),
-            'to' => $this->formatMonthKey($gapEnd),
-        ]);
+            'from' => $this->formatMonthKey($gapStart, $locale),
+            'to' => $this->formatMonthKey($gapEnd, $locale),
+        ], $locale);
     }
 
-    private function formatMonthKey(string $key): string
+    private function formatMonthKey(string $key, string $locale): string
     {
         [$year, $month] = explode('-', $key);
 
-        return $this->formatMonthYear((int) $year, (int) $month);
+        return $this->formatMonthYear((int) $year, (int) $month, $locale);
     }
 
     /**
      * @return list<HospitalInsight>
      */
-    private function fallbackInsights(string $benchmarkingUrl): array
+    private function fallbackInsights(string $benchmarkingUrl, string $locale): array
     {
         return [
             new HospitalInsight(
-                $this->translator->trans('monthly_reminder.fallback.insight.upload.title'),
-                $this->translator->trans('monthly_reminder.fallback.insight.upload.body'),
+                $this->trans('monthly_reminder.fallback.insight.upload.title', [], $locale),
+                $this->trans('monthly_reminder.fallback.insight.upload.body', [], $locale),
                 HospitalInsightTrend::Neutral,
             ),
             new HospitalInsight(
-                $this->translator->trans('monthly_reminder.fallback.insight.platform.title'),
-                $this->translator->trans('monthly_reminder.fallback.insight.platform.body'),
+                $this->trans('monthly_reminder.fallback.insight.platform.title', [], $locale),
+                $this->trans('monthly_reminder.fallback.insight.platform.body', [], $locale),
                 HospitalInsightTrend::Neutral,
                 $benchmarkingUrl,
             ),

--- a/src/Engagement/Application/MonthlyReminderDistributionSegments.php
+++ b/src/Engagement/Application/MonthlyReminderDistributionSegments.php
@@ -21,7 +21,7 @@ final readonly class MonthlyReminderDistributionSegments
      *
      * @return list<MonthlyReminderSegment>
      */
-    public function genderSegments(array $genderCounts, int $total): array
+    public function genderSegments(array $genderCounts, int $total, string $locale): array
     {
         $colors = [
             AllocationGender::MALE->value => '#206bc4',
@@ -33,7 +33,7 @@ final readonly class MonthlyReminderDistributionSegments
         foreach (AllocationGender::cases() as $case) {
             $count = $genderCounts[$case->value] ?? 0;
             $segments[] = new MonthlyReminderSegment(
-                $this->translator->trans($case->label()),
+                $this->translator->trans($case->label(), [], null, $locale),
                 $total > 0 ? round(100 * $count / $total, 1) : 0.0,
                 $colors[$case->value] ?? '#667382',
             );
@@ -47,7 +47,7 @@ final readonly class MonthlyReminderDistributionSegments
      *
      * @return list<MonthlyReminderSegment>
      */
-    public function urgencySegments(array $urgencyCounts, int $total): array
+    public function urgencySegments(array $urgencyCounts, int $total, string $locale): array
     {
         $colors = [
             AllocationUrgency::EMERGENCY->value => '#d63939',
@@ -59,7 +59,7 @@ final readonly class MonthlyReminderDistributionSegments
         foreach (AllocationUrgency::cases() as $case) {
             $count = $urgencyCounts[$case->value] ?? 0;
             $segments[] = new MonthlyReminderSegment(
-                $this->translator->trans($case->label()),
+                $this->translator->trans($case->label(), [], null, $locale),
                 $total > 0 ? round(100 * $count / $total, 1) : 0.0,
                 $colors[$case->value] ?? '#667382',
             );

--- a/src/Engagement/Application/MonthlyReminderMailer.php
+++ b/src/Engagement/Application/MonthlyReminderMailer.php
@@ -22,7 +22,7 @@ final readonly class MonthlyReminderMailer
     ) {
     }
 
-    public function send(string $recipientEmail, MonthlyReminderContent $content): void
+    public function send(string $recipientEmail, MonthlyReminderContent $content, string $locale): void
     {
         $email = new TemplatedEmail()
             ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
@@ -30,7 +30,8 @@ final readonly class MonthlyReminderMailer
             ->subject($this->translator->trans('monthly_reminder.subject', [
                 'hospital' => $content->hospitalName,
                 'period' => $content->reportingPeriodLabel,
-            ]))
+            ], null, $locale))
+            ->locale($locale)
             ->htmlTemplate('@Engagement/email/monthly_submission_reminder.html.twig')
             ->context([
                 'content' => $content,

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -8,6 +8,7 @@ use App\Allocation\Domain\Entity\Hospital;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
 use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
 use Symfony\Component\Lock\LockFactory;
@@ -21,6 +22,7 @@ final readonly class MonthlyReminderSender
         private MonthlyReminderMailer $mailer,
         private MonthlyReminderPeriodResolver $periodResolver,
         private MonthlyReminderDispatchRepository $dispatchRepository,
+        private LocaleResolver $localeResolver,
         private AuditContext $auditContext,
         private LockFactory $lockFactory,
     ) {
@@ -83,7 +85,8 @@ final readonly class MonthlyReminderSender
             return ['monthly_reminder.error.already_sent_for_period'];
         }
 
-        $content = $this->contentBuilder->build($hospital, $referenceDate);
+        $ownerLocale = $this->localeResolver->resolveForUser($owner);
+        $content = $this->contentBuilder->build($hospital, $referenceDate, $ownerLocale);
         $reportingMonth = $content->reportingPeriodLabel;
 
         $this->auditContext->beginIntent('hospital.reminder_sent', [
@@ -91,9 +94,10 @@ final readonly class MonthlyReminderSender
             'owner_id' => $owner->getId(),
             'reporting_period' => $reportingMonth,
             'trigger' => $trigger->value,
+            'owner_locale' => $ownerLocale,
         ]);
         try {
-            $this->mailer->send($email, $content);
+            $this->mailer->send($email, $content, $ownerLocale);
 
             if (MonthlyReminderTrigger::Scheduler === $trigger) {
                 $this->dispatchRepository->save(new MonthlyReminderDispatch(

--- a/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
+++ b/src/Engagement/UI/Console/Command/MonthlyReminderPreviewCommand.php
@@ -10,13 +10,15 @@ use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\MonthlyReminderContentBuilder;
 use App\Engagement\Application\MonthlyReminderSender;
 use App\Engagement\UI\Console\Input\MonthlyReminderPreviewInput;
+use App\Shared\Application\Locale\LocaleResolver;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mime\BodyRendererInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment;
 
 #[AsCommand(
     name: 'app:reminder:preview',
@@ -27,7 +29,8 @@ final readonly class MonthlyReminderPreviewCommand
     public function __construct(
         private HospitalRepository $hospitalRepository,
         private MonthlyReminderContentBuilder $contentBuilder,
-        private Environment $twig,
+        private BodyRendererInterface $bodyRenderer,
+        private LocaleResolver $localeResolver,
         private MonthlyReminderSender $reminderSender,
         private TranslatorInterface $translator,
         #[Autowire('%env(MAILER_DSN)%')] private string $mailerDsn,
@@ -53,12 +56,19 @@ final readonly class MonthlyReminderPreviewCommand
         }
 
         $referenceDate = $input->date;
+        $owner = $hospital->getOwner();
+        $ownerLocale = $this->localeResolver->resolveForUser($owner);
 
-        $content = $this->contentBuilder->build($hospital, $referenceDate);
-        $html = $this->twig->render('@Engagement/email/monthly_submission_reminder.html.twig', [
-            'content' => $content,
-            'app_title' => 'Preview',
-        ]);
+        $content = $this->contentBuilder->build($hospital, $referenceDate, $ownerLocale);
+        $previewEmail = new TemplatedEmail()
+            ->locale($ownerLocale)
+            ->htmlTemplate('@Engagement/email/monthly_submission_reminder.html.twig')
+            ->context([
+                'content' => $content,
+                'app_title' => 'Preview',
+            ]);
+        $this->bodyRenderer->render($previewEmail);
+        $html = (string) $previewEmail->getHtmlBody();
 
         $outputPath = $input->output;
         $shouldSend = $input->send;

--- a/src/Shared/Application/Locale/LocaleResolver.php
+++ b/src/Shared/Application/Locale/LocaleResolver.php
@@ -41,6 +41,11 @@ final readonly class LocaleResolver
         return $this->resolveFromAcceptLanguage($request->headers->get('Accept-Language'));
     }
 
+    public function resolveForUser(?User $user): string
+    {
+        return $this->resolveFromUser($user) ?? SupportedLocales::DEFAULT;
+    }
+
     private function resolveFromUser(?User $user): ?string
     {
         if (!$user instanceof User || !$user->hasExplicitLocale()) {

--- a/src/Statistics/Application/Insights/HospitalInsightSelector.php
+++ b/src/Statistics/Application/Insights/HospitalInsightSelector.php
@@ -38,23 +38,24 @@ final readonly class HospitalInsightSelector
         string $benchmarkingUrl,
         string $baselinePeriodLabel,
         string $reportingPeriodLabel,
+        ?string $locale = null,
     ): array {
         $candidates = [];
 
         if (null !== $allocationYoyPercent && abs($allocationYoyPercent) >= self::VOLUME_CHANGE_THRESHOLD) {
             $candidates[] = new HospitalInsight(
-                $this->translator->trans('monthly_reminder.insight.volume_yoy.title'),
-                $this->translator->trans('monthly_reminder.insight.volume_yoy.body', [
+                $this->trans('monthly_reminder.insight.volume_yoy.title', [], $locale),
+                $this->trans('monthly_reminder.insight.volume_yoy.body', [
                     'percent' => $this->formatSignedPercent($allocationYoyPercent),
-                ]),
+                ], $locale),
                 $allocationYoyPercent >= 0 ? HospitalInsightTrend::Up : HospitalInsightTrend::Down,
             );
         } elseif (null !== $allocationMomPercent && abs($allocationMomPercent) >= self::VOLUME_CHANGE_THRESHOLD) {
             $candidates[] = new HospitalInsight(
-                $this->translator->trans('monthly_reminder.insight.volume_mom.title'),
-                $this->translator->trans('monthly_reminder.insight.volume_mom.body', [
+                $this->trans('monthly_reminder.insight.volume_mom.title', [], $locale),
+                $this->trans('monthly_reminder.insight.volume_mom.body', [
                     'percent' => $this->formatSignedPercent($allocationMomPercent),
-                ]),
+                ], $locale),
                 $allocationMomPercent >= 0 ? HospitalInsightTrend::Up : HospitalInsightTrend::Down,
             );
         }
@@ -65,6 +66,7 @@ final readonly class HospitalInsightSelector
                 $benchmarkingUrl,
                 $baselinePeriodLabel,
                 $reportingPeriodLabel,
+                $locale,
             );
             if ($insight instanceof HospitalInsight) {
                 $candidates[] = $insight;
@@ -76,6 +78,7 @@ final readonly class HospitalInsightSelector
             $benchmarkingUrl,
             $baselinePeriodLabel,
             $reportingPeriodLabel,
+            $locale,
         );
         if ($indicationInsight instanceof HospitalInsight) {
             $candidates[] = $indicationInsight;
@@ -83,10 +86,10 @@ final readonly class HospitalInsightSelector
 
         if (null !== $rejectionRateDeltaPp && $rejectionRateDeltaPp <= -1.0) {
             $candidates[] = new HospitalInsight(
-                $this->translator->trans('monthly_reminder.insight.quality.title'),
-                $this->translator->trans('monthly_reminder.insight.quality.body', [
+                $this->trans('monthly_reminder.insight.quality.title', [], $locale),
+                $this->trans('monthly_reminder.insight.quality.body', [
                     'delta' => number_format(abs($rejectionRateDeltaPp), 1, '.', ''),
-                ]),
+                ], $locale),
                 HospitalInsightTrend::Up,
             );
         }
@@ -99,6 +102,7 @@ final readonly class HospitalInsightSelector
         string $benchmarkingUrl,
         string $baselinePeriodLabel,
         string $reportingPeriodLabel,
+        ?string $locale,
     ): ?HospitalInsight {
         if (BenchmarkMetricFormat::Percent !== $metric->format) {
             return null;
@@ -116,14 +120,14 @@ final readonly class HospitalInsightSelector
         };
 
         return new HospitalInsight(
-            $this->translator->trans($key.'.title'),
-            $this->translator->trans($key.'.body', [
+            $this->trans($key.'.title', [], $locale),
+            $this->trans($key.'.body', [
                 'period' => $reportingPeriodLabel,
                 'primary_percent' => number_format($metric->primaryValue, 1, '.', ''),
                 'baseline_percent' => number_format($metric->comparisonValue, 1, '.', ''),
                 'delta_pp' => $this->formatSignedPercent($metric->absoluteDelta),
                 'baseline' => $baselinePeriodLabel,
-            ]),
+            ], $locale),
             $metric->absoluteDelta >= 0 ? HospitalInsightTrend::Up : HospitalInsightTrend::Down,
             $benchmarkingUrl,
         );
@@ -134,6 +138,7 @@ final readonly class HospitalInsightSelector
         string $benchmarkingUrl,
         string $baselinePeriodLabel,
         string $reportingPeriodLabel,
+        ?string $locale,
     ): ?HospitalInsight {
         $top = null;
         $maxDeviation = 0.0;
@@ -150,20 +155,32 @@ final readonly class HospitalInsightSelector
         }
 
         return new HospitalInsight(
-            $this->translator->trans('monthly_reminder.insight.indication.title'),
-            $this->translator->trans('monthly_reminder.insight.indication.body', [
+            $this->trans('monthly_reminder.insight.indication.title', [], $locale),
+            $this->trans('monthly_reminder.insight.indication.body', [
                 'period' => $reportingPeriodLabel,
                 'indication' => $top->label,
                 'primary_percent' => number_format($top->primaryShare, 1, '.', ''),
                 'baseline_percent' => number_format($top->comparisonShare, 1, '.', ''),
                 'delta_pp' => $this->formatSignedPercent($top->primaryShare - $top->comparisonShare),
                 'baseline' => $baselinePeriodLabel,
-            ]),
+            ], $locale),
             $top->primaryShare >= $top->comparisonShare
                 ? HospitalInsightTrend::Up
                 : HospitalInsightTrend::Down,
             $benchmarkingUrl,
         );
+    }
+
+    /**
+     * @param array<string, string|int|float> $parameters
+     */
+    private function trans(string $id, array $parameters = [], ?string $locale = null): string
+    {
+        if (null !== $locale) {
+            return $this->translator->trans($id, $parameters, null, $locale);
+        }
+
+        return $this->translator->trans($id, $parameters);
     }
 
     private function formatSignedPercent(float $value): string

--- a/src/User/UI/Http/Controller/RegistrationController.php
+++ b/src/User/UI/Http/Controller/RegistrationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\UI\Http\Controller;
 
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Application\Event\UserRegistered;
 use App\User\Domain\Entity\User;
@@ -28,6 +29,7 @@ final class RegistrationController extends AbstractController
         private readonly EmailVerifier $emailVerifier,
         private readonly AuditContext $auditContext,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly LocaleResolver $localeResolver,
     ) {
     }
 
@@ -53,7 +55,8 @@ final class RegistrationController extends AbstractController
             $user = new User()
                 ->setUsername($data['username'])
                 ->setEmail($data['email'])
-                ->setIsVerified(false);
+                ->setIsVerified(false)
+                ->setLocale($this->localeResolver->resolve($request, null));
 
             $user->setPassword($this->passwordHasher->hashPassword($user, $plainPassword));
 

--- a/tests/Engagement/Functional/Command/MonthlyReminderPreviewCommandTest.php
+++ b/tests/Engagement/Functional/Command/MonthlyReminderPreviewCommandTest.php
@@ -46,6 +46,35 @@ final class MonthlyReminderPreviewCommandTest extends DatabaseKernelTestCase
         self::assertStringContainsString('<!DOCTYPE html>', $tester->getDisplay());
     }
 
+    public function testPreviewRendersGermanTemplateForGermanOwner(): void
+    {
+        self::bootKernel();
+        $owner = UserFactory::createOne([
+            'email' => sprintf('preview-de-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+            'locale' => 'de',
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'name' => 'Deutsches Testkrankenhaus',
+        ]);
+        $tester = new CommandTester(self::getContainer()->get(MonthlyReminderPreviewCommand::class));
+
+        self::assertSame(Command::SUCCESS, $tester->execute([
+            '--hospital' => (string) $hospital->getId(),
+            '--date' => '2026-06-17',
+        ]));
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Monatsübersicht: Deutsches Testkrankenhaus', $output);
+        self::assertStringContainsString('Mai 2026', $output);
+    }
+
     public function testSendFailsForOptedOutOwnerAndShowsHint(): void
     {
         self::bootKernel();

--- a/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
@@ -42,7 +42,7 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
         $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
         $hospital = $this->seedHospital();
 
-        $content = $this->builder->build($hospital, $referenceDate);
+        $content = $this->builder->build($hospital, $referenceDate, 'en');
 
         self::assertFalse($content->isPersonalized);
         self::assertSame(0, $content->allocationCount);
@@ -93,7 +93,7 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
             5,
         );
 
-        $content = $this->builder->build($hospital, $referenceDate);
+        $content = $this->builder->build($hospital, $referenceDate, 'en');
 
         self::assertTrue($content->isPersonalized);
         self::assertGreaterThanOrEqual(20, $content->allocationCount);
@@ -101,6 +101,18 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
         self::assertGreaterThan(0, $content->submissionMonthsTotal);
         self::assertNotEmpty($content->chartBars);
         self::assertNull($content->platformAllocationCount);
+    }
+
+    public function testBuildUsesGermanPeriodLabelsForGermanLocale(): void
+    {
+        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $hospital = $this->seedHospital();
+
+        $content = $this->builder->build($hospital, $referenceDate, 'de');
+
+        self::assertStringContainsString('Mai 2026', $content->reportingPeriodLabel);
+        self::assertStringContainsString('Juni 2026', $content->uploadMonthLabel);
+        self::assertStringNotContainsString('May 2026', $content->reportingPeriodLabel);
     }
 
     private function seedHospital(): mixed

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -13,10 +13,13 @@ use App\Engagement\Application\MonthlyReminderSender;
 use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Tests\Support\Foundry\DatabaseKernelTestCase;
 use App\User\Domain\Factory\UserFactory;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Component\Lock\LockFactory;
 
 final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
 {
+    use MailerAssertionsTrait;
     private MonthlyReminderSender $sender;
 
     protected function setUp(): void
@@ -176,6 +179,54 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
 
         self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
         self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
+    }
+
+    public function testSendUsesOwnerGermanLocale(): void
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('de-owner-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+            'locale' => 'de',
+        ]);
+        $hospital = $this->createHospital(optedOut: false, owner: $owner);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
+
+        self::assertQueuedEmailCount(1);
+        $email = $this->findReminderEmail();
+        self::assertSame('de', $email->getLocale());
+        self::assertEmailSubjectContains($email, 'Monatsübersicht');
+    }
+
+    public function testSendUsesOwnerEnglishLocaleWhenExplicit(): void
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('en-owner-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+            'receivesMonthlySubmissionReminder' => true,
+            'locale' => 'en',
+        ]);
+        $hospital = $this->createHospital(optedOut: false, owner: $owner);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
+
+        self::assertQueuedEmailCount(1);
+        $email = $this->findReminderEmail();
+        self::assertSame('en', $email->getLocale());
+        self::assertEmailSubjectContains($email, 'Monthly overview');
+        self::assertEmailSubjectNotContains($email, 'Monatsübersicht');
+    }
+
+    private function findReminderEmail(): TemplatedEmail
+    {
+        foreach (self::getMailerMessages() as $message) {
+            if ($message instanceof TemplatedEmail) {
+                return $message;
+            }
+        }
+
+        self::fail('Expected monthly reminder TemplatedEmail to be queued.');
     }
 
     private function createHospital(

--- a/tests/Engagement/Unit/Application/MonthlyReminderDistributionSegmentsTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderDistributionSegmentsTest.php
@@ -17,12 +17,12 @@ final class MonthlyReminderDistributionSegmentsTest extends TestCase
         $genderSegments = $segments->genderSegments([
             'M' => 30,
             'F' => 70,
-        ], 100);
+        ], 100, 'de');
         $urgencySegments = $segments->urgencySegments([
             1 => 10,
             2 => 20,
             3 => 70,
-        ], 100);
+        ], 100, 'de');
 
         self::assertCount(3, $genderSegments);
         self::assertSame(30.0, $genderSegments[0]->percent);

--- a/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
@@ -15,15 +15,21 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class MonthlyReminderMailerTest extends TestCase
 {
-    public function testSendUsesConfiguredSenderSubjectAndTemplate(): void
+    public function testSendUsesConfiguredSenderSubjectTemplateAndLocale(): void
     {
         $content = $this->content();
+        $capturedLocale = null;
 
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
-            static fn (string $id, array $parameters = []): string => match ($id) {
-                'monthly_reminder.subject' => sprintf('Reminder for %s (%s)', $parameters['hospital'], $parameters['period']),
-                default => $id,
+            static function (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null) use (&$capturedLocale): string {
+                if ('monthly_reminder.subject' === $id) {
+                    $capturedLocale = $locale;
+
+                    return sprintf('Reminder for %s (%s)', $parameters['hospital'], $parameters['period']);
+                }
+
+                return $id;
             },
         );
 
@@ -39,6 +45,7 @@ final class MonthlyReminderMailerTest extends TestCase
                 ));
                 self::assertSame('Reminder for Test Hospital (May 2026)', $email->getSubject());
                 self::assertSame('@Engagement/email/monthly_submission_reminder.html.twig', $email->getHtmlTemplate());
+                self::assertSame('de', $email->getLocale());
                 self::assertSame('IVENA Stats', $email->getContext()['app_title'] ?? null);
 
                 return true;
@@ -57,7 +64,9 @@ final class MonthlyReminderMailerTest extends TestCase
             ),
             $translator,
             $logger,
-        )->send('owner@example.test', $content);
+        )->send('owner@example.test', $content, 'de');
+
+        self::assertSame('de', $capturedLocale);
     }
 
     public function testReplyToIsAppliedWhenConfigured(): void
@@ -87,7 +96,7 @@ final class MonthlyReminderMailerTest extends TestCase
             ),
             $translator,
             $this->createMock(LoggerInterface::class),
-        )->send('owner@example.test', $this->content());
+        )->send('owner@example.test', $this->content(), 'en');
     }
 
     private function content(): MonthlyReminderContent

--- a/tests/Shared/Unit/Locale/LocaleResolverTest.php
+++ b/tests/Shared/Unit/Locale/LocaleResolverTest.php
@@ -86,6 +86,21 @@ final class LocaleResolverTest extends TestCase
         self::assertSame('en', $this->resolver->resolve($request, $user));
     }
 
+    public function testResolveForUserReturnsExplicitLocale(): void
+    {
+        self::assertSame('de', $this->resolver->resolveForUser($this->createUserWithLocale('de')));
+    }
+
+    public function testResolveForUserFallsBackToDefaultWhenLocaleNotExplicit(): void
+    {
+        self::assertSame('en', $this->resolver->resolveForUser($this->createUserWithLocale(null)));
+    }
+
+    public function testResolveForUserFallsBackToDefaultForNullUser(): void
+    {
+        self::assertSame('en', $this->resolver->resolveForUser(null));
+    }
+
     private function createUserWithLocale(?string $locale): User
     {
         $user = new User();

--- a/tests/Statistics/Unit/Application/Insights/HospitalInsightSelectorTest.php
+++ b/tests/Statistics/Unit/Application/Insights/HospitalInsightSelectorTest.php
@@ -191,6 +191,38 @@ final class HospitalInsightSelectorTest extends TestCase
         self::assertStringContainsString('Chest pain', $insights[0]->body);
     }
 
+    public function testSelectPassesExplicitLocaleToTranslator(): void
+    {
+        $capturedLocale = null;
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static function (
+                string $id,
+                array $parameters = [],
+                ?string $domain = null,
+                ?string $locale = null,
+            ) use (&$capturedLocale): string {
+                $capturedLocale = $locale;
+
+                return $id;
+            },
+        );
+
+        new HospitalInsightSelector($translator)->select(
+            10.0,
+            null,
+            [],
+            new BenchmarkDistribution(BenchmarkMetricKey::IndicationMix, []),
+            null,
+            'https://example.test/stats',
+            'your last 12 months',
+            'May 2026',
+            'de',
+        );
+
+        self::assertSame('de', $capturedLocale);
+    }
+
     private function translator(): TranslatorInterface
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -13,6 +13,7 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Email;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
@@ -26,6 +27,55 @@ final class RegistrationControllerTest extends WebTestCase
     use Factories;
     use HasBrowser;
     use MailerAssertionsTrait;
+
+    public function testRegistrationStoresResolvedGermanLocaleFromCookie(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('register-locale-de-%s', $suffix);
+        $email = sprintf('register-locale-de-%s@example.test', $suffix);
+
+        $this->browser()
+            ->visit('/locale/switch/de?_target_path=/register')
+            ->visit('/register')
+            ->fillField('Username', $username)
+            ->fillField('Email', $email)
+            ->fillField('Plain password', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
+            ->click('Registrieren')
+            ->assertSuccessful()
+            ->assertSeeIn('h2', 'E-Mail prüfen')
+        ;
+
+        UserFactory::assert()->exists([
+            'username' => $username,
+            'locale' => 'de',
+        ]);
+    }
+
+    public function testRegistrationStoresEnglishLocaleWhenBrowserLanguageIsNotGerman(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('register-locale-en-%s', $suffix);
+        $email = sprintf('register-locale-en-%s@example.test', $suffix);
+
+        $client = self::createClient();
+        $client->setServerParameter('HTTP_Accept-Language', 'fr-FR,fr;q=0.9');
+        $client->request(Request::METHOD_GET, '/register');
+        self::assertResponseIsSuccessful();
+
+        $client->submitForm('Register', [
+            'registration_form[username]' => $username,
+            'registration_form[email]' => $email,
+            'registration_form[plainPassword]' => 'super-secret-password',
+            'registration_form[acceptTerms]' => true,
+        ]);
+        self::assertResponseRedirects('/register/check-email');
+
+        UserFactory::assert()->exists([
+            'username' => $username,
+            'locale' => 'en',
+        ]);
+    }
 
     public function testRegistrationSendsAdminNotificationToNotificationRecipients(): void
     {


### PR DESCRIPTION
## Summary

- Fix monthly submission reminders being sent in English regardless of the hospital owner's language preference ([#247](https://github.com/nplhse/collaborative-ivena-statistics/issues/247))
- Resolve owner locale centrally in `MonthlyReminderSender` via new `LocaleResolver::resolveForUser()` (explicit DB locale → fallback `en`)
- Apply Symfony's two-layer localization pattern:
  - **Mailer:** `TemplatedEmail::locale()` for Twig `|trans` (works in async Messenger workers)
  - **PHP content:** explicit `translator->trans(..., null, $locale)` for pre-rendered DTO strings
- Localize month labels with `IntlDateFormatter` instead of `DateTime::format('F')` / `format('M')`
- Update CLI preview to render via `BodyRendererInterface` + `TemplatedEmail::locale()` so preview matches the sent email

## Changes by area

| Area | What changed |
|------|--------------|
| `LocaleResolver` | `resolveForUser()` for off-request contexts (scheduler, CLI, Messenger) |
| `MonthlyReminderContentBuilder` | `build(..., $locale)`; all pre-rendered strings use explicit locale |
| `MonthlyReminderMailer` | Subject + template locale from owner |
| `MonthlyReminderSender` | Resolves owner locale; passes through to builder and mailer |
| `MonthlyReminderPreviewCommand` | Preview uses same locale rendering as production send |
| `HospitalInsightSelector` | Optional `$locale` parameter (Overview HTTP flow unchanged) |

## Test plan

- [x] `LocaleResolver::resolveForUser()` — explicit `de`, implicit → `en`
- [x] Owner `locale=de` → German subject (`Monatsübersicht`) and `TemplatedEmail::locale() === 'de'`
- [x] Owner `locale=en` → English subject; no German leakage
- [x] German period labels in content (`Mai 2026`, not `May 2026`)
- [x] CLI preview renders German template for German owner
- [x] All engagement tests pass
- [x] `make static-analysis` passes

## Out of scope

- Locale for other transactional emails (verification, password reset)
- Locale fallback from cookie/browser without a stored user preference