### PR TITLE
fix(mail): localize transactional and admin notification emails

### DIFF
--- a/src/Shared/Application/Locale/LocaleResolver.php
+++ b/src/Shared/Application/Locale/LocaleResolver.php
@@ -46,6 +46,30 @@ final readonly class LocaleResolver
         return $this->resolveFromUser($user) ?? SupportedLocales::DEFAULT;
     }
 
+    /**
+     * @param iterable<User> $users
+     *
+     * @return array<string, list<string>>
+     */
+    public function groupEmailsByLocale(iterable $users): array
+    {
+        $grouped = [];
+        foreach ($users as $user) {
+            $email = $user->getEmail();
+            if (null === $email || '' === trim($email)) {
+                continue;
+            }
+
+            $locale = $this->resolveForUser($user);
+            $normalizedEmail = mb_strtolower(trim($email));
+            if (!\in_array($normalizedEmail, $grouped[$locale] ?? [], true)) {
+                $grouped[$locale][] = $normalizedEmail;
+            }
+        }
+
+        return $grouped;
+    }
+
     private function resolveFromUser(?User $user): ?string
     {
         if (!$user instanceof User || !$user->hasExplicitLocale()) {

--- a/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
+++ b/src/Shared/Infrastructure/Mail/AdminNotificationSender.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Mail;
 
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Application\Notification\AdminNotification;
 use App\Shared\Application\Notification\AdminNotificationSenderInterface;
 use App\Shared\Application\Notification\AdminNotificationType;
@@ -25,6 +26,7 @@ final readonly class AdminNotificationSender implements AdminNotificationSenderI
         private MailConfig $mailConfig,
         private NotificationRecipientEmailResolver $notificationRecipientResolver,
         private TranslatorInterface $translator,
+        private LocaleResolver $localeResolver,
         private LoggerInterface $logger,
     ) {
     }
@@ -32,8 +34,10 @@ final readonly class AdminNotificationSender implements AdminNotificationSenderI
     #[\Override]
     public function send(AdminNotification $notification): void
     {
-        $recipients = $this->notificationRecipientResolver->resolveRecipientEmails();
-        if ([] === $recipients) {
+        $recipientsByLocale = $this->localeResolver->groupEmailsByLocale(
+            $this->notificationRecipientResolver->resolveRecipientUsers(),
+        );
+        if ([] === $recipientsByLocale) {
             $this->logger->info('admin_notification.skipped', [
                 'reason' => 'no_notification_recipients',
                 'type' => $notification->type->value,
@@ -43,18 +47,20 @@ final readonly class AdminNotificationSender implements AdminNotificationSenderI
             return;
         }
 
-        $email = $this->createTemplatedEmail()
-            ->to(...$recipients)
-            ->subject($this->buildSubject($notification->type))
-            ->htmlTemplate($this->resolveTemplate($notification->type))
-            ->context($notification->templateContext);
+        foreach ($recipientsByLocale as $locale => $recipients) {
+            $email = $this->createTemplatedEmail($locale)
+                ->to(...$recipients)
+                ->subject($this->buildSubject($notification->type, $locale))
+                ->htmlTemplate($this->resolveTemplate($notification->type))
+                ->context($notification->templateContext);
 
-        $this->mailer->send($email);
+            $this->mailer->send($email);
+        }
     }
 
-    private function buildSubject(AdminNotificationType $type): string
+    private function buildSubject(AdminNotificationType $type, string $locale): string
     {
-        $label = $this->translator->trans($type->subjectTranslationKey());
+        $label = $this->translator->trans($type->subjectTranslationKey(), [], null, $locale);
 
         return sprintf('[%s] %s', $this->mailConfig->appName, $label);
     }
@@ -67,10 +73,11 @@ final readonly class AdminNotificationSender implements AdminNotificationSenderI
         };
     }
 
-    private function createTemplatedEmail(): TemplatedEmail
+    private function createTemplatedEmail(string $locale): TemplatedEmail
     {
         $email = new TemplatedEmail()
-            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName));
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
+            ->locale($locale);
 
         $replyTo = $this->mailConfig->replyTo();
         if (null !== $replyTo) {

--- a/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
@@ -6,6 +6,7 @@ namespace App\Shared\Infrastructure\Mail;
 
 use App\Feedback\Domain\Entity\Feedback;
 use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Shared\Application\Locale\LocaleResolver;
 use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
@@ -13,22 +14,21 @@ use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 
 /** @psalm-suppress UnusedClass */
 #[AsAlias(TransactionalMailer::class)]
 final readonly class SymfonyTransactionalMailer implements TransactionalMailer
 {
-    private const string SUBJECT_VERIFICATION = 'Please confirm your email address';
-
-    private const string SUBJECT_PASSWORD_RESET = 'Your password reset request';
-
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private MailerInterface $mailer,
         private MailConfig $mailConfig,
         private FeedbackRecipientEmailResolver $feedbackRecipientResolver,
         private UrlGeneratorInterface $urlGenerator,
+        private TranslatorInterface $translator,
+        private LocaleResolver $localeResolver,
         private LoggerInterface $logger,
     ) {
     }
@@ -43,10 +43,11 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
         string $expiresAtMessageKey,
         array $expiresAtMessageData,
         string $homepageUrl,
+        string $locale,
     ): void {
-        $email = $this->createTemplatedEmail()
+        $email = $this->createTemplatedEmail($locale)
             ->to($recipientEmail)
-            ->subject(self::SUBJECT_VERIFICATION)
+            ->subject($this->translator->trans('email.verify.title', [], null, $locale))
             ->htmlTemplate('@User/registration/confirmation_email.html.twig')
             ->context([
                 'signedUrl' => $signedUrl,
@@ -62,10 +63,11 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
     public function sendPasswordResetEmail(
         string $recipientEmail,
         ResetPasswordToken $resetToken,
+        string $locale,
     ): void {
-        $email = $this->createTemplatedEmail()
+        $email = $this->createTemplatedEmail($locale)
             ->to($recipientEmail)
-            ->subject(self::SUBJECT_PASSWORD_RESET)
+            ->subject($this->translator->trans('email.reset_password.title', [], null, $locale))
             ->htmlTemplate('@User/reset_password/email.html.twig')
             ->context([
                 'resetToken' => $resetToken,
@@ -85,8 +87,10 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
         FeedbackCategory $category,
         string $contextJsonPreview,
     ): void {
-        $recipients = $this->feedbackRecipientResolver->resolveRecipientEmails();
-        if ([] === $recipients) {
+        $recipientsByLocale = $this->localeResolver->groupEmailsByLocale(
+            $this->feedbackRecipientResolver->resolveRecipientUsers(),
+        );
+        if ([] === $recipientsByLocale) {
             $this->logger->info('feedback.admin_mail_skipped', [
                 'reason' => 'no_feedback_recipients',
                 'feedback_id' => $feedback->getId(),
@@ -95,23 +99,31 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
             return;
         }
 
-        $email = $this->createTemplatedEmail()
-            ->to(...$recipients)
-            ->subject(sprintf('[%s] Feedback (%s)', $this->mailConfig->appName, $category->value))
-            ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
-            ->context([
-                'feedback' => $feedback,
-                'categoryLabel' => $category->value,
-                'contextJson' => $contextJsonPreview,
-            ]);
+        foreach ($recipientsByLocale as $locale => $recipients) {
+            $email = $this->createTemplatedEmail($locale)
+                ->to(...$recipients)
+                ->subject(sprintf(
+                    '[%s] %s (%s)',
+                    $this->mailConfig->appName,
+                    $this->translator->trans('feedback.email.title', [], null, $locale),
+                    $category->value,
+                ))
+                ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
+                ->context([
+                    'feedback' => $feedback,
+                    'categoryLabel' => $category->value,
+                    'contextJson' => $contextJsonPreview,
+                ]);
 
-        $this->mailer->send($email);
+            $this->mailer->send($email);
+        }
     }
 
-    private function createTemplatedEmail(): TemplatedEmail
+    private function createTemplatedEmail(string $locale): TemplatedEmail
     {
         $email = new TemplatedEmail()
-            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName));
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
+            ->locale($locale);
 
         $replyTo = $this->mailConfig->replyTo();
         if (null !== $replyTo) {

--- a/src/Shared/Infrastructure/Mail/TransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/TransactionalMailer.php
@@ -19,11 +19,13 @@ interface TransactionalMailer
         string $expiresAtMessageKey,
         array $expiresAtMessageData,
         string $homepageUrl,
+        string $locale,
     ): void;
 
     public function sendPasswordResetEmail(
         string $recipientEmail,
         ResetPasswordToken $resetToken,
+        string $locale,
     ): void;
 
     public function sendAdminFeedbackEmail(

--- a/src/User/Infrastructure/Security/EmailVerifier.php
+++ b/src/User/Infrastructure/Security/EmailVerifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,6 +18,7 @@ final readonly class EmailVerifier
         private VerifyEmailHelperInterface $verifyEmailHelper,
         private TransactionalMailer $transactionalMailer,
         private UrlGeneratorInterface $urlGenerator,
+        private LocaleResolver $localeResolver,
     ) {
     }
 
@@ -40,6 +42,7 @@ final readonly class EmailVerifier
             $signatureComponents->getExpirationMessageKey(),
             $signatureComponents->getExpirationMessageData(),
             $this->urlGenerator->generate('app_default', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            $this->localeResolver->resolveForUser($user),
         );
     }
 

--- a/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\User\Domain\Entity\User;
+
 interface FeedbackRecipientEmailResolver
 {
+    /**
+     * @return list<User>
+     */
+    public function resolveRecipientUsers(): array;
+
     /**
      * @return list<string>
      */

--- a/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
@@ -19,18 +20,25 @@ final readonly class FeedbackRecipientResolver implements FeedbackRecipientEmail
     }
 
     /**
+     * @return list<User>
+     */
+    #[\Override]
+    public function resolveRecipientUsers(): array
+    {
+        return $this->userRepository->findEnabledVerifiedUsersWithRoles([
+            UserRole::ADMIN,
+            UserRole::FEEDBACK_RECIPIENT,
+        ]);
+    }
+
+    /**
      * @return list<string>
      */
     #[\Override]
     public function resolveRecipientEmails(): array
     {
-        $candidates = $this->userRepository->findEnabledVerifiedUsersWithRoles([
-            UserRole::ADMIN,
-            UserRole::FEEDBACK_RECIPIENT,
-        ]);
-
         $emails = [];
-        foreach ($candidates as $user) {
+        foreach ($this->resolveRecipientUsers() as $user) {
             $email = $user->getEmail();
             if (null === $email || '' === trim($email)) {
                 continue;

--- a/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\Security;
 
+use App\User\Domain\Entity\User;
+
 interface NotificationRecipientEmailResolver
 {
+    /**
+     * @return list<User>
+     */
+    public function resolveRecipientUsers(): array;
+
     /**
      * @return list<string>
      */

--- a/src/User/Infrastructure/Security/NotificationRecipientResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientResolver.php
@@ -20,17 +20,24 @@ final readonly class NotificationRecipientResolver implements NotificationRecipi
     }
 
     /**
+     * @return list<User>
+     */
+    #[\Override]
+    public function resolveRecipientUsers(): array
+    {
+        return $this->userRepository->findEnabledVerifiedUsersWithRoles([
+            UserRole::ADMIN,
+            UserRole::RECEIVES_NOTIFICATION,
+        ]);
+    }
+
+    /**
      * @return list<string>
      */
     #[\Override]
     public function resolveRecipientEmails(): array
     {
-        $candidates = $this->userRepository->findEnabledVerifiedUsersWithRoles([
-            UserRole::ADMIN,
-            UserRole::RECEIVES_NOTIFICATION,
-        ]);
-
-        return $this->extractUniqueEmails($candidates);
+        return $this->extractUniqueEmails($this->resolveRecipientUsers());
     }
 
     /**

--- a/src/User/UI/Http/Controller/ResetPasswordController.php
+++ b/src/User/UI/Http/Controller/ResetPasswordController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\UI\Http\Controller;
 
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
@@ -31,6 +32,7 @@ final class ResetPasswordController extends AbstractController
         private readonly TransactionalMailer $transactionalMailer,
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly AuditContext $auditContext,
+        private readonly LocaleResolver $localeResolver,
     ) {
     }
 
@@ -143,7 +145,11 @@ final class ResetPasswordController extends AbstractController
             return $this->redirectToRoute('app_check_email');
         }
 
-        $this->transactionalMailer->sendPasswordResetEmail((string) $user->getEmail(), $resetToken);
+        $this->transactionalMailer->sendPasswordResetEmail(
+            (string) $user->getEmail(),
+            $resetToken,
+            $this->localeResolver->resolveForUser($user),
+        );
 
         $this->setTokenObjectInSession($resetToken);
 

--- a/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Tests\Shared\Unit\Infrastructure\Mail;
 
+use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Application\Notification\AdminNotification;
 use App\Shared\Application\Notification\AdminNotificationType;
+use App\Shared\Infrastructure\Locale\LocaleCookieManager;
 use App\Shared\Infrastructure\Mail\AdminNotificationSender;
 use App\Shared\Infrastructure\Mail\MailConfig;
+use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\NotificationRecipientEmailResolver;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -17,16 +20,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AdminNotificationSenderTest extends TestCase
 {
-    public function testSendUsesResolvedRecipientsAndTemplate(): void
+    public function testSendUsesResolvedRecipientsTemplateAndLocale(): void
     {
+        $adminA = $this->createAdminUser('admin-a@example.test', 'de');
+        $adminB = $this->createAdminUser('admin-b@example.test', 'de');
+
         $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientEmails')->willReturn([
-            'admin-a@example.test',
-            'admin-b@example.test',
-        ]);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([$adminA, $adminB]);
 
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->method('trans')->willReturn('New user registration');
+        $translator->method('trans')->willReturn('Neue Benutzerregistrierung');
 
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
@@ -36,7 +39,8 @@ final class AdminNotificationSenderTest extends TestCase
                     ['admin-a@example.test', 'admin-b@example.test'],
                     array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
                 );
-                self::assertSame('[Test App] New user registration', $email->getSubject());
+                self::assertSame('[Test App] Neue Benutzerregistrierung', $email->getSubject());
+                self::assertSame('de', $email->getLocale());
                 self::assertSame('@Shared/email/admin_notification/user_registered.html.twig', $email->getHtmlTemplate());
                 self::assertSame('new-user', $email->getContext()['username'] ?? null);
 
@@ -52,7 +56,9 @@ final class AdminNotificationSenderTest extends TestCase
     public function testSendUsesImportFailedTemplate(): void
     {
         $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientEmails')->willReturn(['admin@example.test']);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([
+            $this->createAdminUser('admin@example.test', 'en'),
+        ]);
 
         $translator = $this->createMock(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Import failed');
@@ -66,6 +72,7 @@ final class AdminNotificationSenderTest extends TestCase
                     $email->getTo(),
                 ));
                 self::assertSame('[Test App] Import failed', $email->getSubject());
+                self::assertSame('en', $email->getLocale());
                 self::assertSame('@Shared/email/admin_notification/import_failed.html.twig', $email->getHtmlTemplate());
                 self::assertSame('Broken import', $email->getContext()['importName'] ?? null);
                 self::assertSame('Missing header row', $email->getContext()['reason'] ?? null);
@@ -86,7 +93,7 @@ final class AdminNotificationSenderTest extends TestCase
     public function testSendSkipsWhenNoRecipients(): void
     {
         $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientEmails')->willReturn([]);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
 
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::never())->method('send');
@@ -122,7 +129,19 @@ final class AdminNotificationSenderTest extends TestCase
             ),
             $recipientResolver,
             $translator ?? $this->createMock(TranslatorInterface::class),
+            new LocaleResolver(new LocaleCookieManager()),
             $logger ?? $this->createMock(LoggerInterface::class),
         );
+    }
+
+    private function createAdminUser(string $email, string $locale): User
+    {
+        $user = new User();
+        $user->setUsername(str_replace('@', '-', $email));
+        $user->setEmail($email);
+        $user->setPassword('hashed');
+        $user->setLocale($locale);
+
+        return $user;
     }
 }

--- a/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
@@ -6,20 +6,25 @@ namespace App\Tests\Shared\Unit\Infrastructure\Mail;
 
 use App\Feedback\Domain\Entity\Feedback;
 use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Shared\Application\Locale\LocaleResolver;
+use App\Shared\Infrastructure\Locale\LocaleCookieManager;
 use App\Shared\Infrastructure\Mail\MailConfig;
 use App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer;
+use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 
 final class SymfonyTransactionalMailerTest extends TestCase
 {
-    public function testSendVerificationEmailUsesConfiguredSenderAndRecipient(): void
+    public function testSendVerificationEmailUsesConfiguredSenderRecipientAndLocale(): void
     {
+        $translator = $this->createTranslatorMock();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -30,22 +35,24 @@ final class SymfonyTransactionalMailerTest extends TestCase
                     static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
                     $email->getTo(),
                 ));
-                self::assertSame('Please confirm your email address', $email->getSubject());
+                self::assertSame('E-Mail-Adresse bestätigen', $email->getSubject());
+                self::assertSame('de', $email->getLocale());
                 self::assertSame('@User/registration/confirmation_email.html.twig', $email->getHtmlTemplate());
 
                 return true;
             }));
 
-        $this->createMailer($mailer)->sendVerificationEmail(
+        $this->createMailer($mailer, translator: $translator)->sendVerificationEmail(
             'user@example.test',
             'https://example.test/verify',
             'key',
             ['%count%' => 1],
             'https://example.test/',
+            'de',
         );
     }
 
-    public function testSendPasswordResetEmailUsesConfiguredSenderAndAbsoluteResetUrl(): void
+    public function testSendPasswordResetEmailUsesConfiguredSenderAbsoluteResetUrlAndLocale(): void
     {
         $resetToken = new ResetPasswordToken(
             'selector_verifier',
@@ -63,6 +70,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
             )
             ->willReturn('https://example.test/reset-password/reset/selector_verifier');
 
+        $translator = $this->createTranslatorMock();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -72,7 +80,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
                     static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
                     $email->getTo(),
                 ));
-                self::assertSame('Your password reset request', $email->getSubject());
+                self::assertSame('Reset your password', $email->getSubject());
+                self::assertSame('en', $email->getLocale());
                 self::assertSame('@User/reset_password/email.html.twig', $email->getHtmlTemplate());
                 self::assertInstanceOf(ResetPasswordToken::class, $email->getContext()['resetToken'] ?? null);
                 self::assertSame(
@@ -83,22 +92,27 @@ final class SymfonyTransactionalMailerTest extends TestCase
                 return true;
             }));
 
-        $this->createMailer($mailer, urlGenerator: $urlGenerator)->sendPasswordResetEmail('reset@example.test', $resetToken);
+        $this->createMailer($mailer, urlGenerator: $urlGenerator, translator: $translator)->sendPasswordResetEmail(
+            'reset@example.test',
+            $resetToken,
+            'en',
+        );
     }
 
-    public function testSendAdminFeedbackEmailUsesAllResolvedRecipients(): void
+    public function testSendAdminFeedbackEmailUsesAllResolvedRecipientsGroupedByLocale(): void
     {
         $feedback = new Feedback()
             ->setCategory(FeedbackCategory::BUG)
             ->setMessage('Broken filter')
             ->setPageUrl('https://example.test/page');
 
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientEmails')->willReturn([
-            'admin-a@example.test',
-            'admin-b@example.test',
-        ]);
+        $adminA = $this->createAdminUser('admin-a@example.test', 'de');
+        $adminB = $this->createAdminUser('admin-b@example.test', 'de');
 
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([$adminA, $adminB]);
+
+        $translator = $this->createTranslatorMock();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -108,12 +122,46 @@ final class SymfonyTransactionalMailerTest extends TestCase
                     array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
                 );
                 self::assertSame('[Test App] Feedback (bug)', $email->getSubject());
+                self::assertSame('de', $email->getLocale());
                 self::assertSame('@Feedback/email/admin_feedback_notification.html.twig', $email->getHtmlTemplate());
 
                 return true;
             }));
 
-        $this->createMailer($mailer, $recipientResolver)->sendAdminFeedbackEmail(
+        $this->createMailer($mailer, $recipientResolver, translator: $translator)->sendAdminFeedbackEmail(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    public function testSendAdminFeedbackEmailSendsSeparateMailsPerLocale(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([
+            $this->createAdminUser('de-admin@example.test', 'de'),
+            $this->createAdminUser('en-admin@example.test', 'en'),
+        ]);
+
+        $localeResolver = new LocaleResolver(new LocaleCookieManager());
+
+        $translator = $this->createTranslatorMock();
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::exactly(2))
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                $locale = $email->getLocale();
+                self::assertContains($locale, ['de', 'en']);
+
+                return true;
+            }));
+
+        $this->createMailer($mailer, $recipientResolver, translator: $translator, localeResolver: $localeResolver)->sendAdminFeedbackEmail(
             $feedback,
             FeedbackCategory::BUG,
             '{}',
@@ -128,7 +176,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
             ->setPageUrl('https://example.test/page');
 
         $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientEmails')->willReturn([]);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
 
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::never())->method('send');
@@ -174,6 +222,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
             $mailConfig,
             $this->createMock(FeedbackRecipientEmailResolver::class),
             $this->createMock(UrlGeneratorInterface::class),
+            $this->createTranslatorMock(),
+            new LocaleResolver(new LocaleCookieManager()),
             $this->createMock(LoggerInterface::class),
         )->sendVerificationEmail(
             'user@example.test',
@@ -181,6 +231,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
             'key',
             [],
             'https://example.test/',
+            'en',
         );
     }
 
@@ -189,6 +240,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
         ?FeedbackRecipientEmailResolver $recipientResolver = null,
         ?LoggerInterface $logger = null,
         ?UrlGeneratorInterface $urlGenerator = null,
+        ?TranslatorInterface $translator = null,
+        ?LocaleResolver $localeResolver = null,
     ): SymfonyTransactionalMailer {
         return new SymfonyTransactionalMailer(
             $mailer,
@@ -200,7 +253,35 @@ final class SymfonyTransactionalMailerTest extends TestCase
             ),
             $recipientResolver ?? $this->createMock(FeedbackRecipientEmailResolver::class),
             $urlGenerator ?? $this->createMock(UrlGeneratorInterface::class),
+            $translator ?? $this->createTranslatorMock(),
+            $localeResolver ?? new LocaleResolver(new LocaleCookieManager()),
             $logger ?? $this->createMock(LoggerInterface::class),
         );
+    }
+
+    private function createTranslatorMock(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string => match ($id) {
+                'email.verify.title' => 'de' === $locale ? 'E-Mail-Adresse bestätigen' : 'Confirm your email address',
+                'email.reset_password.title' => 'de' === $locale ? 'Passwort zurücksetzen' : 'Reset your password',
+                'feedback.email.title' => 'Feedback',
+                default => $id,
+            },
+        );
+
+        return $translator;
+    }
+
+    private function createAdminUser(string $email, string $locale): User
+    {
+        $user = new User();
+        $user->setUsername(str_replace('@', '-', $email));
+        $user->setEmail($email);
+        $user->setPassword('hashed');
+        $user->setLocale($locale);
+
+        return $user;
     }
 }

--- a/tests/Shared/Unit/Locale/LocaleResolverTest.php
+++ b/tests/Shared/Unit/Locale/LocaleResolverTest.php
@@ -101,6 +101,43 @@ final class LocaleResolverTest extends TestCase
         self::assertSame('en', $this->resolver->resolveForUser(null));
     }
 
+    public function testGroupEmailsByLocaleGroupsUsersByExplicitLocale(): void
+    {
+        $deUser = $this->createUserWithLocale('de');
+        $deUser->setEmail('de-admin@example.test');
+        $enUser = $this->createUserWithLocale('en');
+        $enUser->setEmail('en-admin@example.test');
+        $defaultUser = $this->createUserWithLocale(null);
+        $defaultUser->setEmail('default-admin@example.test');
+
+        $grouped = $this->resolver->groupEmailsByLocale([$deUser, $enUser, $defaultUser]);
+
+        self::assertSame(['de-admin@example.test'], $grouped['de']);
+        self::assertSame(['en-admin@example.test', 'default-admin@example.test'], $grouped['en']);
+    }
+
+    public function testGroupEmailsByLocaleDeduplicatesEmailsWithinLocale(): void
+    {
+        $userA = $this->createUserWithLocale('de');
+        $userA->setEmail('DUPLICATE@example.test');
+        $userB = $this->createUserWithLocale('de');
+        $userB->setEmail('duplicate@example.test');
+
+        $grouped = $this->resolver->groupEmailsByLocale([$userA, $userB]);
+
+        self::assertSame(['duplicate@example.test'], $grouped['de']);
+    }
+
+    public function testGroupEmailsByLocaleSkipsUsersWithoutEmail(): void
+    {
+        $user = new User();
+        $user->setUsername('no-email-user');
+        $user->setPassword('hashed');
+        $user->setLocale('de');
+
+        self::assertSame([], $this->resolver->groupEmailsByLocale([$user]));
+    }
+
     private function createUserWithLocale(?string $locale): User
     {
         $user = new User();

--- a/tests/User/Integration/Infrastructure/Security/FeedbackRecipientResolverTest.php
+++ b/tests/User/Integration/Infrastructure/Security/FeedbackRecipientResolverTest.php
@@ -42,6 +42,8 @@ final class FeedbackRecipientResolverTest extends KernelTestCase
         $resolver = self::getContainer()->get(FeedbackRecipientResolver::class);
 
         self::assertSame(['recipient@example.test'], $resolver->resolveRecipientEmails());
+        self::assertCount(1, $resolver->resolveRecipientUsers());
+        self::assertSame('recipient@example.test', $resolver->resolveRecipientUsers()[0]->getEmail());
     }
 
     public function testDeduplicatesEmails(): void

--- a/tests/User/Integration/Infrastructure/Security/NotificationRecipientResolverTest.php
+++ b/tests/User/Integration/Infrastructure/Security/NotificationRecipientResolverTest.php
@@ -42,6 +42,8 @@ final class NotificationRecipientResolverTest extends KernelTestCase
         $resolver = self::getContainer()->get(NotificationRecipientResolver::class);
 
         self::assertSame(['notify@example.test'], $resolver->resolveRecipientEmails());
+        self::assertCount(1, $resolver->resolveRecipientUsers());
+        self::assertSame('notify@example.test', $resolver->resolveRecipientUsers()[0]->getEmail());
     }
 
     public function testDeduplicatesEmails(): void


### PR DESCRIPTION
## Summary

- Set `TemplatedEmail::locale()` on all previously English-only outgoing emails so existing Twig `|trans` keys and German XLF translations are actually used (including in async Messenger workers). Closes #253 
- Pass `user.locale` into verification and password-reset emails via `LocaleResolver::resolveForUser()`.
- Localize admin notifications and feedback emails per recipient locale, grouping admins by language to avoid duplicate sends.
- Replace hardcoded English subjects with translated keys (`email.verify.title`, `email.reset_password.title`, `feedback.email.title`, existing admin subject keys).

Closes #253.

## Changes

**User-facing emails**
- Verification and password-reset mails now respect `user.locale` (fallback: `en`).
- Subjects are translated via `TranslatorInterface` instead of hardcoded strings.

**Admin emails**
- `NotificationRecipientResolver` and `FeedbackRecipientResolver` expose `resolveRecipientUsers()`.
- `LocaleResolver::groupEmailsByLocale()` groups recipient emails by admin locale.
- One localized email is sent per locale group.

**Reference pattern:** same approach as `MonthlyReminderMailer` (`->locale($locale)` + `translator->trans(..., $locale)`).

## Test plan

- [x] `make ci` passes
- [x] `make test` passes (2179 tests)
- [x] Unit tests cover `de` and `en` locales for transactional and admin mailers
- [x] Integration tests cover `resolveRecipientUsers()`
- [ ] Manual: register with `de` locale → verification email subject/body in German
- [ ] Manual: password reset for `de` user → email in German
- [ ] Manual: admin with `de` locale receives localized admin notification