### PR TITLE
fix: Widgets are displaying less recent blogposts then expected

### DIFF
--- a/src/Content/Infrastructure/Repository/PostRepository.php
+++ b/src/Content/Infrastructure/Repository/PostRepository.php
@@ -78,9 +78,8 @@ final class PostRepository extends ServiceEntityRepository implements PostSlugEx
     public function findPublishedForIndex(?int $limit = null): array
     {
         $qb = $this->createQueryBuilder('p')
-            ->addSelect('c', 't')
+            ->addSelect('c')
             ->leftJoin('p.category', 'c')
-            ->leftJoin('p.tags', 't')
             ->andWhere('p.status = :status')
             ->andWhere('p.publishedAt <= :now')
             ->setParameter('status', PostStatus::PUBLISHED)

--- a/tests/Content/Integration/Repository/PostRepositoryFindPublishedForIndexTest.php
+++ b/tests/Content/Integration/Repository/PostRepositoryFindPublishedForIndexTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Repository;
+
+use App\Content\Domain\Enum\PostStatus;
+use App\Content\Infrastructure\Factory\PostCategoryFactory;
+use App\Content\Infrastructure\Factory\PostFactory;
+use App\Content\Infrastructure\Factory\PostTagFactory;
+use App\Content\Infrastructure\Repository\PostRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class PostRepositoryFindPublishedForIndexTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testFindPublishedForIndexReturnsFewerPostsWhenTagsMultiplyJoinedRows(): void
+    {
+        self::bootKernel();
+
+        $category = PostCategoryFactory::createOne(['name' => 'News', 'slug' => 'news']);
+        $manyTags = PostTagFactory::createMany(3);
+        $singleTag = PostTagFactory::createOne(['name' => 'Solo', 'slug' => 'solo']);
+
+        PostFactory::createOne([
+            'title' => 'Post Newest',
+            'slug' => 'post-newest',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-1 hour'),
+            'category' => $category,
+            'tags' => $manyTags,
+        ]);
+        PostFactory::createOne([
+            'title' => 'Post Middle',
+            'slug' => 'post-middle',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-2 hours'),
+            'category' => $category,
+            'tags' => $manyTags,
+        ]);
+        PostFactory::createOne([
+            'title' => 'Post Oldest',
+            'slug' => 'post-oldest',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-3 hours'),
+            'category' => $category,
+            'tags' => [$singleTag],
+        ]);
+
+        $repository = self::getContainer()->get(PostRepository::class);
+        $posts = $repository->findPublishedForIndex(5);
+
+        self::assertCount(
+            3,
+            $posts,
+            'Expected all 3 published posts; tag join + SQL LIMIT can return fewer unique posts.',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an issue where the dashboard and blog sidebar showed fewer recent posts than expected in production (e.g. 2 instead of 3).

## Problem

`PostRepository::findPublishedForIndex()` loaded post tags via a `leftJoin` and applied `setMaxResults()` on the query. Because each tag creates an extra SQL row, the database `LIMIT` was applied to joined rows, not to distinct posts. Posts with multiple tags could “consume” several limit slots, so fewer unique posts were returned after hydration.

This only showed up reliably in production, where posts tend to have more tags than in local/test data.

## Solution

Remove the unnecessary tag join from `findPublishedForIndex()`. Category is still joined (needed for display); tags are not used in the dashboard, sidebar, or RSS feed.

Added an integration test that reproduces the bug with multi-tag posts and asserts all published posts are returned.