### PR TITLE
fix(statistics): restore heatmap mode toggle on overview and benchmarking charts

### DIFF
--- a/assets/controllers/benchmarking-charts_controller.js
+++ b/assets/controllers/benchmarking-charts_controller.js
@@ -121,14 +121,12 @@ export default class extends Controller {
     }
 
     setHeatmapMode(event) {
-        this.heatmapModeValue = event.params.mode;
-    }
-
-    heatmapModeValueChanged() {
-        if (!this.isConnected) {
+        const mode = event.params.mode;
+        if (!mode || mode === this.heatmapModeValue) {
             return;
         }
 
+        this.heatmapModeValue = mode;
         this._renderGeneration = (this._renderGeneration ?? 0) + 1;
         void this.renderHeatmapOnly(this._renderGeneration);
     }

--- a/assets/controllers/indication-dashboard-charts_controller.js
+++ b/assets/controllers/indication-dashboard-charts_controller.js
@@ -85,7 +85,14 @@ export default class extends Controller {
     }
 
     setHeatmapMode(event) {
-        this.heatmapModeValue = event.params.mode;
+        const mode = event.params.mode;
+        if (!mode || mode === this.heatmapModeValue) {
+            return;
+        }
+
+        this.heatmapModeValue = mode;
+        this._renderGeneration = (this._renderGeneration ?? 0) + 1;
+        void this.renderHeatmapOnly(this._renderGeneration);
     }
 
     async renderHeatmapOnly(generation) {
@@ -97,15 +104,6 @@ export default class extends Controller {
         const payload = this.payloadValue ?? {};
         this.renderHeatmap(ApexCharts, this.currentHeatmapPayload(payload), generation);
         this.syncHeatmapModeButtons();
-    }
-
-    heatmapModeValueChanged() {
-        if (!this.isConnected) {
-            return;
-        }
-
-        this._renderGeneration = (this._renderGeneration ?? 0) + 1;
-        void this.renderHeatmapOnly(this._renderGeneration);
     }
 
     currentHeatmapPayload(payload) {

--- a/tests/Statistics/Functional/Controller/DashboardControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerTest.php
@@ -329,6 +329,35 @@ final class DashboardControllerTest extends WebTestCase
         $this->assertStringContainsString('scope=public', $location);
     }
 
+    public function testOverviewHeatmapToggleMarkupAndPayload(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/statistics/?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $shiftButton = $crawler->filter('[data-testid="stats-overview-heatmap"] [data-indication-dashboard-charts-target="heatmapModeShift"]');
+        self::assertSame(1, $shiftButton->count());
+        self::assertSame(
+            'indication-dashboard-charts#setHeatmapMode',
+            $shiftButton->attr('data-action'),
+        );
+        self::assertSame('shift', $shiftButton->attr('data-indication-dashboard-charts-mode-param'));
+
+        $payloadRaw = (string) $crawler->filter('[data-testid="stats-charts"]')->attr('data-indication-dashboard-charts-payload-value');
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode(html_entity_decode($payloadRaw, ENT_QUOTES), true, flags: JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('heatmapDayTime', $payload);
+        self::assertArrayHasKey('heatmapShift', $payload);
+        self::assertNotSame(
+            $payload['heatmapDayTime']['columnLabels'] ?? [],
+            $payload['heatmapShift']['columnLabels'] ?? [],
+        );
+    }
+
     public function testScopeSidebarShowsHospitalCohortGroup(): void
     {
         $client = $this->createClientAsRoleUser();

--- a/tests/Statistics/Functional/Controller/DashboardControllerTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerTest.php
@@ -340,7 +340,7 @@ final class DashboardControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
 
         $shiftButton = $crawler->filter('[data-testid="stats-overview-heatmap"] [data-indication-dashboard-charts-target="heatmapModeShift"]');
-        self::assertSame(1, $shiftButton->count());
+        $this->assertCount(1, $shiftButton);
         self::assertSame(
             'indication-dashboard-charts#setHeatmapMode',
             $shiftButton->attr('data-action'),


### PR DESCRIPTION
## Summary

- Fix the case distribution heatmap toggle on the statistics overview (`/statistics/`) so switching between day-time buckets and shift model updates the chart again.
- Render the heatmap directly from `setHeatmapMode` instead of relying solely on the Stimulus `heatmapModeValueChanged` callback, which no longer triggered a reliable re-render after a recent lifecycle refactor.
- Apply the same fix to the benchmarking and indication compare chart controllers for consistency.
- Add a functional test that verifies the overview heatmap toggle markup, Stimulus action wiring, and distinct day-time vs. shift payloads.

## Test plan

- [x] Open `/statistics/?period=all` and toggle between **Day time** and **Shift model** — the heatmap columns should change (e.g. Morning/Afternoon/Evening vs. Early/Late/Night shift).
- [x] Confirm the active button state updates correctly.
- [x] Repeat on `/statistics/benchmarking` and `/statistics/indication/compare` if those pages are in use.
- [x] Run `php bin/phpunit tests/Statistics/Functional/Controller/DashboardControllerTest.php --filter testOverviewHeatmapToggleMarkupAndPayload`