### PR TITLE
chore(deps): fix Dependabot Composer updates and tune schedule (#267)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,24 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+          day: "sunday"
+      open-pull-requests-limit: 10
+      groups:
+          symfony:
+              patterns:
+                  - "symfony/*"
+          doctrine:
+              patterns:
+                  - "doctrine/*"
+      ignore:
+          - dependency-name: "roave/security-advisories"
 
     # Enable version updates for npm (JS dev tooling)
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
           interval: "weekly"
+          day: "sunday"
       groups:
           eslint:
               patterns:
@@ -25,15 +37,9 @@ updates:
                   - "globals"
                   - "prettier"
 
-    # Enable version updates for Docker
-    - package-ecosystem: "docker"
-      directory: "/"
-      schedule:
-          interval: "weekly"
-
     # Enable version updates for GitHub Actions
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          # Check for updates to GitHub Actions every week
           interval: "weekly"
+          day: "sunday"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL = help
-.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules backup backup-db backup-files restore-db verify-restore-baseline verify-restore env-check
+.PHONY        : help purge-runtime setup-dev setup-prod upgrade-dev upgrade-prod install prod warmup purge reset load-fixtures upgrade node_modules backup backup-db backup-files restore-db verify-restore-baseline verify-restore env-check update-security-advisories
 
 # Executables
 COMPOSER      = composer
@@ -77,6 +77,9 @@ warmup: ## Warm cache and compiled assets only (does not touch the database)
 ## —— Composer 🧙 ——————————————————————————————————————————————————————————————
 vendor: composer.lock ## Install vendors according to the current composer.lock file
 	@$(COMPOSER) install --prefer-dist --no-dev --no-progress --no-interaction
+
+update-security-advisories: ## Refresh roave/security-advisories (ignored by Dependabot)
+	@$(COMPOSER) update roave/security-advisories --no-interaction
 
 ## —— Node / npm 📦 ———————————————————————————————————————————————————————————
 node_modules: package-lock.json ## Install npm dev dependencies according to package-lock.json

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "azuyalabs/yasumi": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf88d14075811c788422756887d3567c",
+    "content-hash": "dcd111fa2fc358f049d53eccc350c61f",
     "packages": [
         {
             "name": "azuyalabs/yasumi",
@@ -17818,7 +17818,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },


### PR DESCRIPTION
## Summary

- Raise the minimum PHP constraint from `>=8.4` to `>=8.4.1` so Dependabot can resolve Symfony 8.1 dependencies (Dependabot simulates `config.platform.php` from the minimum PHP version; `>=8.4` becomes `8.4.0`, which fails Symfony’s `>=8.4.1` requirement).
- Update Dependabot config for Composer: Symfony and Doctrine groups, ignore `roave/security-advisories`, and a higher open PR limit.
- Align all Dependabot ecosystems on a weekly Sunday schedule.
- Remove the Docker ecosystem entry (no fixed image tag in `compose.yaml`, so updates were ineffective).
- Add `make update-security-advisories` for manually refreshing the Roave security blocklist.

Fixes #267

## Context

Dependabot was creating PRs for GitHub Actions and npm, but essentially no Composer PRs. Dependabot logs showed repeated `No update possible` errors caused by a PHP platform mismatch, not by missing Composer configuration.

## Test plan

- [x] `composer validate --strict`
- [x] `composer install --dry-run` with platform PHP `8.4.1`
- [ ] After merge: confirm Dependabot opens Composer PRs (e.g. grouped Symfony patch updates)
- [ ] Periodically run `make update-security-advisories` for Roave advisories