### PR TITLE
refactor: Create dedicated ImportFileStorage service to centralize logic

### DIFF
--- a/docs/Import-workflow.md
+++ b/docs/Import-workflow.md
@@ -38,6 +38,20 @@ Source: CSV files uploaded through the import UI.
 - Row-level business errors become rejects
 - Critical errors are logged as import failures
 
+## Deletion cleanup
+
+When an import is deleted (UI or admin), `ImportDeletionService` removes:
+
+- The import database record
+- Related allocations, assessments, MCI cases, and projection rows
+- Batch-run history entries for that import
+- The uploaded source file under `var/imports/...`
+- The reject CSV file, if one was written during processing
+
+Reimports intentionally keep the source file; only result data from the previous run is cleared. See [Import-batch-requeue.md](Import-batch-requeue.md).
+
+File paths are resolved and removed through `ImportFileStorage` (Symfony `Filesystem::remove()`). Failed deletions are logged as `import.file.delete_failed`.
+
 ## Test locally
 
 ```bash

--- a/docs/Observability-sentry.md
+++ b/docs/Observability-sentry.md
@@ -38,6 +38,8 @@ For alpha deployments, set a DSN, `SENTRY_ENVIRONMENT=alpha`, and `SENTRY_TRACES
 | `import.abort.flush_failed` | yes |
 | `import.rejects.cleared` | yes |
 | `import.reject_file.deleted` | yes |
+| `import.source_file.deleted` | yes |
+| `import.file.delete_failed` | yes |
 | `reject.row_rejected` | no (local only) |
 | `reject.row_type_unknown` | no (local only) |
 

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -15,6 +15,7 @@ use App\Import\Application\Factory\RejectWriterFactory;
 use App\Import\Application\Factory\RowReaderFactory;
 use App\Import\Application\Message\ImportAllocationsMessage;
 use App\Import\Application\Service\ImportAllocationDeduplicationService;
+use App\Import\Application\Service\ImportFileStorage;
 use App\Import\Application\Service\ImportPreviousRunCleanupService;
 use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
@@ -24,8 +25,6 @@ use App\Shared\Infrastructure\Audit\AuditContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -45,8 +44,7 @@ final readonly class ImportAllocationsMessageHandler
         private ImportAllocationDeduplicationService $deduplicationService,
         private AuditContext $auditContext,
         private ManagerRegistry $managerRegistry,
-        #[Autowire('%kernel.project_dir%')]
-        private string $projectDir,
+        private ImportFileStorage $fileStorage,
     ) {
     }
 
@@ -67,7 +65,7 @@ final readonly class ImportAllocationsMessageHandler
             return;
         }
 
-        $filePath = $this->resolvePath($filePath);
+        $filePath = $this->fileStorage->resolve($filePath);
         if (!\is_file($filePath)) {
             $reason = 'CSV not found: '.$filePath;
             $this->markFailed($import, $reason);
@@ -126,8 +124,7 @@ final readonly class ImportAllocationsMessageHandler
 
             $absRejectPath = $writer->getPath();
             if ($summary->rejected > 0 && \is_string($absRejectPath) && '' !== $absRejectPath) {
-                $rel = Path::makeRelative($absRejectPath, $this->projectDir);
-                $fresh->setRejectFilePath(\str_replace('\\', '/', $rel));
+                $fresh->setRejectFilePath($this->fileStorage->toRelative($absRejectPath));
             }
 
             $dedupResult = $this->deduplicationService->deduplicateForImport($fresh);
@@ -254,27 +251,5 @@ final readonly class ImportAllocationsMessageHandler
     private function cleanupPreviousRun(Import $import): void
     {
         $this->previousRunCleanupService->cleanup($import);
-    }
-
-    private function resolvePath(string $stored): string
-    {
-        if ($this->isAbsolutePath($stored)) {
-            return $stored;
-        }
-
-        return Path::join($this->projectDir, $stored);
-    }
-
-    private function isAbsolutePath(string $path): bool
-    {
-        if ('' === $path) {
-            return false;
-        }
-
-        if (DIRECTORY_SEPARATOR === $path[0]) {
-            return true;
-        }
-
-        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
     }
 }

--- a/src/Import/Application/Service/FileChecksumCalculator.php
+++ b/src/Import/Application/Service/FileChecksumCalculator.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Path;
-
 /** @psalm-suppress ClassMustBeFinal */
 final readonly class FileChecksumCalculator
 {
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
-        #[Autowire('%kernel.project_dir%')]
-        private string $projectDir,
+        private ImportFileStorage $fileStorage,
         private string $algorithm = 'sha256',
     ) {
     }
@@ -21,7 +17,7 @@ final readonly class FileChecksumCalculator
     /** @return non-empty-string */
     public function forPath(string $path): string
     {
-        $abs = $this->resolvePath($path);
+        $abs = $this->fileStorage->resolve($path);
 
         $hash = @\hash_file($this->algorithm, $abs);
 
@@ -30,29 +26,5 @@ final readonly class FileChecksumCalculator
         }
 
         return $hash;
-    }
-
-    private function resolvePath(string $stored): string
-    {
-        if ($this->isAbsolutePath($stored)) {
-            return $stored;
-        }
-
-        return Path::join($this->projectDir, $stored);
-    }
-
-    private function isAbsolutePath(string $path): bool
-    {
-        if ('' === $path) {
-            return false;
-        }
-
-        // Unix: starts with /
-        if (DIRECTORY_SEPARATOR === $path[0]) {
-            return true;
-        }
-
-        // Windows: drive letter + colon
-        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
     }
 }

--- a/src/Import/Application/Service/FileUploader.php
+++ b/src/Import/Application/Service/FileUploader.php
@@ -20,7 +20,7 @@ final readonly class FileUploader
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         #[Autowire(param: 'app.imports_base_dir')] private string $baseDir,
-        #[Autowire('%kernel.project_dir%')] private string $projectDir,
+        private ImportFileStorage $fileStorage,
         private LoggerInterface $logger,
         private Filesystem $filesystem,
     ) {
@@ -42,8 +42,7 @@ final readonly class FileUploader
 
             $file->move($absDir, $fileName);
 
-            $relative = Path::makeRelative($targetAbs, $this->projectDir);
-            $relative = str_replace('\\', '/', $relative);
+            $relative = $this->fileStorage->toRelative($targetAbs);
 
             $this->logger->info('upload.success', [
                 'target_rel' => $relative,
@@ -55,7 +54,7 @@ final readonly class FileUploader
             return $relative;
         } catch (FileException $e) {
             $this->logger->error('upload.failed', [
-                'target_rel' => Path::makeRelative($targetAbs, $this->projectDir),
+                'target_rel' => $this->fileStorage->toRelative($targetAbs),
                 'error' => $e->getMessage(),
                 'orig' => $file->getClientOriginalName(),
             ]);

--- a/src/Import/Application/Service/ImportFileStorage.php
+++ b/src/Import/Application/Service/ImportFileStorage.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+final readonly class ImportFileStorage
+{
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private string $projectDir,
+        private Filesystem $filesystem,
+        private LoggerInterface $importLogger,
+    ) {
+    }
+
+    public function resolve(string $storedPath): string
+    {
+        if ($this->isAbsolutePath($storedPath)) {
+            return $storedPath;
+        }
+
+        return Path::join($this->projectDir, $storedPath);
+    }
+
+    public function toRelative(string $absolutePath): string
+    {
+        $relative = Path::makeRelative($absolutePath, $this->projectDir);
+
+        return str_replace('\\', '/', $relative);
+    }
+
+    public function delete(?string $storedPath, string $logEvent, int $importId): void
+    {
+        if (null === $storedPath || '' === $storedPath) {
+            return;
+        }
+
+        $absPath = $this->resolve($storedPath);
+        if (!$this->filesystem->exists($absPath)) {
+            return;
+        }
+
+        try {
+            $this->filesystem->remove($absPath);
+        } catch (IOException $e) {
+            $this->importLogger->warning('import.file.delete_failed', [
+                'import_id' => $importId,
+                'path' => $absPath,
+                'event' => $logEvent,
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $this->importLogger->info($logEvent, [
+            'import_id' => $importId,
+            'path' => $absPath,
+        ]);
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        if (DIRECTORY_SEPARATOR === $path[0]) {
+            return true;
+        }
+
+        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
+    }
+}

--- a/src/Import/Application/Service/ImportRelatedDataCleanupService.php
+++ b/src/Import/Application/Service/ImportRelatedDataCleanupService.php
@@ -15,8 +15,6 @@ use App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGro
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Path;
 
 final readonly class ImportRelatedDataCleanupService
 {
@@ -30,8 +28,7 @@ final readonly class ImportRelatedDataCleanupService
         private ProjectionOverviewChangeDetectorInterface $projectionOverviewChangeDetector,
         private MaterializedViewRefresherInterface $materializedViewRefresher,
         private LoggerInterface $importLogger,
-        #[Autowire('%kernel.project_dir%')]
-        private string $projectDir,
+        private ImportFileStorage $fileStorage,
     ) {
     }
 
@@ -72,12 +69,20 @@ final readonly class ImportRelatedDataCleanupService
 
     public function deleteRejectFile(Import $import): void
     {
-        $this->deleteStoredFile($import->getRejectFilePath(), 'import.reject_file.deleted', $import);
+        $this->fileStorage->delete(
+            $import->getRejectFilePath(),
+            'import.reject_file.deleted',
+            (int) $import->getId(),
+        );
     }
 
     public function deleteSourceFile(Import $import): void
     {
-        $this->deleteStoredFile($import->getFilePath(), 'import.source_file.deleted', $import);
+        $this->fileStorage->delete(
+            $import->getFilePath(),
+            'import.source_file.deleted',
+            (int) $import->getId(),
+        );
     }
 
     /** @return list<int> */
@@ -109,46 +114,6 @@ SQL,
             'DELETE FROM assessment WHERE id IN ('.$placeholders.')',
             $assessmentIds,
         );
-    }
-
-    private function deleteStoredFile(?string $storedPath, string $logEvent, Import $import): void
-    {
-        if (null === $storedPath || '' === $storedPath) {
-            return;
-        }
-
-        $absPath = $this->resolvePath($storedPath);
-        if (!\is_file($absPath)) {
-            return;
-        }
-
-        @\unlink($absPath);
-        $this->importLogger->info($logEvent, [
-            'import_id' => $import->getId(),
-            'path' => $absPath,
-        ]);
-    }
-
-    private function resolvePath(string $stored): string
-    {
-        if ($this->isAbsolutePath($stored)) {
-            return $stored;
-        }
-
-        return Path::join($this->projectDir, $stored);
-    }
-
-    private function isAbsolutePath(string $path): bool
-    {
-        if ('' === $path) {
-            return false;
-        }
-
-        if (DIRECTORY_SEPARATOR === $path[0]) {
-            return true;
-        }
-
-        return (bool) \preg_match('#^[A-Za-z]:[\\\\/]#', $path);
     }
 
     private function logCleanup(

--- a/src/Shared/Infrastructure/Monitoring/Sentry/SentryLogScrubber.php
+++ b/src/Shared/Infrastructure/Monitoring/Sentry/SentryLogScrubber.php
@@ -19,6 +19,7 @@ final readonly class SentryLogScrubber
         'import.rejects.cleared',
         'import.reject_file.deleted',
         'import.source_file.deleted',
+        'import.file.delete_failed',
     ];
 
     /** @psalm-suppress PossiblyUnusedMethod */

--- a/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/FeedbackRecipientEmailResolver.php
@@ -15,6 +15,8 @@ interface FeedbackRecipientEmailResolver
 
     /**
      * @return list<string>
+     *
+     * @psalm-suppress PossiblyUnusedMethod
      */
     public function resolveRecipientEmails(): array;
 }

--- a/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
+++ b/src/User/Infrastructure/Security/NotificationRecipientEmailResolver.php
@@ -15,6 +15,8 @@ interface NotificationRecipientEmailResolver
 
     /**
      * @return list<string>
+     *
+     * @psalm-suppress PossiblyUnusedMethod
      */
     public function resolveRecipientEmails(): array;
 }

--- a/tests/Import/Integration/Service/FileChecksumCalculatorTest.php
+++ b/tests/Import/Integration/Service/FileChecksumCalculatorTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Import\Integration\Service;
 
 use App\Import\Application\Service\FileChecksumCalculator;
+use App\Import\Application\Service\ImportFileStorage;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -41,7 +43,7 @@ final class FileChecksumCalculatorTest extends TestCase
         $rel = Path::makeRelative($abs, $this->projectDir);
         $rel = str_replace('\\', '/', $rel);
 
-        $calc = new FileChecksumCalculator($this->projectDir, 'sha256');
+        $calc = new FileChecksumCalculator($this->createFileStorage(), 'sha256');
 
         // Act
         $hash = $calc->forPath($rel);
@@ -56,7 +58,7 @@ final class FileChecksumCalculatorTest extends TestCase
         $abs = Path::join($this->projectDir, 'file.csv');
         file_put_contents($abs, 'data');
 
-        $calc = new FileChecksumCalculator($this->projectDir, 'sha256');
+        $calc = new FileChecksumCalculator($this->createFileStorage(), 'sha256');
 
         // Act
         $hash = $calc->forPath($abs);
@@ -68,11 +70,16 @@ final class FileChecksumCalculatorTest extends TestCase
     public function testThrowsOnMissingFile(): void
     {
         // Arrange
-        $calc = new FileChecksumCalculator($this->projectDir, 'sha256');
+        $calc = new FileChecksumCalculator($this->createFileStorage(), 'sha256');
         $rel = 'var/imports/missing.csv';
 
         // Act + Assert
         $this->expectException(\RuntimeException::class);
         $calc->forPath($rel);
+    }
+
+    private function createFileStorage(): ImportFileStorage
+    {
+        return new ImportFileStorage($this->projectDir, $this->fs, $this->createMock(LoggerInterface::class));
     }
 }

--- a/tests/Import/Integration/Service/FileUploaderTest.php
+++ b/tests/Import/Integration/Service/FileUploaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Import\Integration\Service;
 
 use App\Import\Application\Service\FileUploader;
+use App\Import\Application\Service\ImportFileStorage;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -67,7 +68,7 @@ final class FileUploaderTest extends TestCase
 
         $uploader = new FileUploader(
             $this->baseDir,
-            $this->projectDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -105,7 +106,7 @@ final class FileUploaderTest extends TestCase
 
         $uploader = new FileUploader(
             $this->baseDir,
-            $this->projectDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -127,7 +128,7 @@ final class FileUploaderTest extends TestCase
 
         $uploader = new FileUploader(
             $this->baseDir,
-            $this->projectDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -160,7 +161,7 @@ final class FileUploaderTest extends TestCase
 
         $uploader = new FileUploader(
             $this->baseDir,
-            $this->projectDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -180,7 +181,7 @@ final class FileUploaderTest extends TestCase
 
         $uploader = new FileUploader(
             $this->baseDir,
-            $this->projectDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -213,8 +214,8 @@ final class FileUploaderTest extends TestCase
             ->method('error');
 
         $uploader = new FileUploader(
-            $this->projectDir,
             $this->baseDir,
+            $this->createFileStorage(),
             $this->logger,
             $this->filesystem,
         );
@@ -222,6 +223,11 @@ final class FileUploaderTest extends TestCase
         // Act + Assert
         $this->expectException(FileException::class);
         $uploader->upload($file);
+    }
+
+    private function createFileStorage(): ImportFileStorage
+    {
+        return new ImportFileStorage($this->projectDir, $this->filesystem, $this->logger);
     }
 
     /**

--- a/tests/Import/Integration/Service/ImportDeletionServiceTest.php
+++ b/tests/Import/Integration/Service/ImportDeletionServiceTest.php
@@ -115,6 +115,41 @@ final class ImportDeletionServiceTest extends KernelTestCase
         }
     }
 
+    public function testDeleteRemovesRejectFile(): void
+    {
+        $projectDir = (string) self::getContainer()->getParameter('kernel.project_dir');
+        $filesystem = new Filesystem();
+        $sourcePath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
+        file_put_contents($sourcePath, "header1;header2\nvalue1;value2\n");
+
+        $rejectRelativePath = 'var/imports/rejects/delete-reject-'.bin2hex(random_bytes(4)).'.csv';
+        $rejectAbsolutePath = Path::join($projectDir, $rejectRelativePath);
+        $filesystem->mkdir(\dirname($rejectAbsolutePath));
+        file_put_contents($rejectAbsolutePath, "row;reason\n1;invalid\n");
+
+        ['import' => $import, 'importId' => $importId] = $this->arrangeImportWithAllocation(
+            namePrefix: 'DeleteReject',
+            filePath: $sourcePath,
+            rejectFilePath: $rejectRelativePath,
+        );
+
+        try {
+            self::assertFileExists($rejectAbsolutePath);
+
+            $this->deletionService->delete($import);
+
+            self::assertNull($this->imports->find($importId));
+            self::assertFileDoesNotExist($rejectAbsolutePath);
+        } finally {
+            if (\is_file($sourcePath)) {
+                @unlink($sourcePath);
+            }
+            if ($filesystem->exists($rejectAbsolutePath)) {
+                $filesystem->remove($rejectAbsolutePath);
+            }
+        }
+    }
+
     public function testDeleteLastImportRefreshesMaterializedViews(): void
     {
         ['import' => $import, 'csvPath' => $csvPath, 'importId' => $importId, 'hospitalId' => $hospitalId] = $this->arrangeImportWithAllocation();
@@ -161,8 +196,11 @@ final class ImportDeletionServiceTest extends KernelTestCase
     /**
      * @return array{import: Import, importId: int, csvPath: string, hospitalId: int}
      */
-    private function arrangeImportWithAllocation(string $namePrefix = 'DeleteService', ?string $filePath = null): array
-    {
+    private function arrangeImportWithAllocation(
+        string $namePrefix = 'DeleteService',
+        ?string $filePath = null,
+        ?string $rejectFilePath = null,
+    ): array {
         UserFactory::createOne();
         $state = StateFactory::createOne();
         $dispatch = DispatchAreaFactory::createOne(['state' => $state]);
@@ -186,12 +224,13 @@ final class ImportDeletionServiceTest extends KernelTestCase
             'filePath' => $csvPath,
             'fileExtension' => 'csv',
             'fileMimeType' => 'text/csv',
-            'fileSize' => (int) filesize($csvPath),
+            'fileSize' => (int) filesize($this->resolveFileSizePath($csvPath, $filePath)),
             'rowCount' => 1,
             'rowsPassed' => 1,
-            'rowsRejected' => 0,
+            'rowsRejected' => null !== $rejectFilePath ? 1 : 0,
             'runCount' => 1,
             'runTime' => 50,
+            'rejectFilePath' => $rejectFilePath,
         ]);
 
         SpecialityFactory::createOne(['name' => 'Delete Speciality']);
@@ -289,5 +328,14 @@ final class ImportDeletionServiceTest extends KernelTestCase
             'SELECT COUNT(*) FROM import_batch_run_item WHERE import_id = :importId',
             ['importId' => $importId],
         );
+    }
+
+    private function resolveFileSizePath(string $storedPath, ?string $originalFilePath): string
+    {
+        if (null !== $originalFilePath && !Path::isAbsolute($originalFilePath)) {
+            return Path::join((string) self::getContainer()->getParameter('kernel.project_dir'), $storedPath);
+        }
+
+        return $storedPath;
     }
 }

--- a/tests/Import/Integration/Service/ImportDeletionServiceTest.php
+++ b/tests/Import/Integration/Service/ImportDeletionServiceTest.php
@@ -32,6 +32,8 @@ use App\User\Domain\Factory\UserFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
 
@@ -85,6 +87,34 @@ final class ImportDeletionServiceTest extends KernelTestCase
         }
     }
 
+    public function testDeleteRemovesRelativeImportFilePath(): void
+    {
+        $projectDir = (string) self::getContainer()->getParameter('kernel.project_dir');
+        $filesystem = new Filesystem();
+        $relativePath = 'var/imports/delete-relative-'.bin2hex(random_bytes(4)).'.csv';
+        $absolutePath = Path::join($projectDir, $relativePath);
+        $filesystem->mkdir(\dirname($absolutePath));
+        file_put_contents($absolutePath, "header1;header2\nvalue1;value2\n");
+
+        ['import' => $import, 'importId' => $importId] = $this->arrangeImportWithAllocation(
+            namePrefix: 'DeleteRelative',
+            filePath: $relativePath,
+        );
+
+        try {
+            self::assertFileExists($absolutePath);
+
+            $this->deletionService->delete($import);
+
+            self::assertNull($this->imports->find($importId));
+            self::assertFileDoesNotExist($absolutePath);
+        } finally {
+            if ($filesystem->exists($absolutePath)) {
+                $filesystem->remove($absolutePath);
+            }
+        }
+    }
+
     public function testDeleteLastImportRefreshesMaterializedViews(): void
     {
         ['import' => $import, 'csvPath' => $csvPath, 'importId' => $importId, 'hospitalId' => $hospitalId] = $this->arrangeImportWithAllocation();
@@ -131,7 +161,7 @@ final class ImportDeletionServiceTest extends KernelTestCase
     /**
      * @return array{import: Import, importId: int, csvPath: string, hospitalId: int}
      */
-    private function arrangeImportWithAllocation(string $namePrefix = 'DeleteService'): array
+    private function arrangeImportWithAllocation(string $namePrefix = 'DeleteService', ?string $filePath = null): array
     {
         UserFactory::createOne();
         $state = StateFactory::createOne();
@@ -141,8 +171,12 @@ final class ImportDeletionServiceTest extends KernelTestCase
             'dispatchArea' => $dispatch,
         ]);
 
-        $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
-        file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+        if (null === $filePath) {
+            $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
+            file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+        } else {
+            $csvPath = $filePath;
+        }
 
         $importProxy = ImportFactory::createOne([
             'name' => $namePrefix.' IT',

--- a/tests/Import/Unit/Application/Service/ImportFileStorageTest.php
+++ b/tests/Import/Unit/Application/Service/ImportFileStorageTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Import\Application\Service\ImportFileStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+final class ImportFileStorageTest extends TestCase
+{
+    private string $projectDir;
+    private Filesystem $filesystem;
+    /** @var MockObject&LoggerInterface */
+    private MockObject $logger;
+    private ImportFileStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/import-storage-'.bin2hex(random_bytes(4));
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir($this->projectDir, 0775);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->storage = new ImportFileStorage($this->projectDir, $this->filesystem, $this->logger);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->filesystem->exists($this->projectDir)) {
+            $this->filesystem->remove($this->projectDir);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testResolveJoinsRelativePathWithProjectDir(): void
+    {
+        self::assertSame(
+            Path::join($this->projectDir, 'var/imports/file.csv'),
+            $this->storage->resolve('var/imports/file.csv'),
+        );
+    }
+
+    public function testResolveReturnsAbsolutePathUnchanged(): void
+    {
+        $abs = Path::join($this->projectDir, 'absolute.csv');
+        self::assertSame($abs, $this->storage->resolve($abs));
+    }
+
+    public function testToRelativeReturnsForwardSlashes(): void
+    {
+        $abs = Path::join($this->projectDir, 'var', 'imports', 'file.csv');
+        self::assertSame('var/imports/file.csv', $this->storage->toRelative($abs));
+    }
+
+    public function testDeleteRemovesExistingFileAndLogsSuccess(): void
+    {
+        $rel = 'var/imports/delete-me.csv';
+        $abs = Path::join($this->projectDir, $rel);
+        $this->filesystem->mkdir(\dirname($abs));
+        file_put_contents($abs, 'data');
+
+        $this->logger
+            ->expects($this->once())
+            ->method('info')
+            ->with('import.source_file.deleted', $this->callback(static fn (array $context): bool => 42 === $context['import_id'] && $abs === $context['path']));
+
+        $this->storage->delete($rel, 'import.source_file.deleted', 42);
+
+        self::assertFileDoesNotExist($abs);
+    }
+
+    public function testDeleteIgnoresMissingFile(): void
+    {
+        $this->logger->expects($this->never())->method('info');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->storage->delete('var/imports/missing.csv', 'import.source_file.deleted', 1);
+    }
+
+    public function testDeleteIgnoresEmptyPath(): void
+    {
+        $this->logger->expects($this->never())->method('info');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->storage->delete(null, 'import.source_file.deleted', 1);
+        $this->storage->delete('', 'import.source_file.deleted', 1);
+    }
+
+    public function testDeleteLogsWarningWhenRemovalFails(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(true);
+        $filesystem
+            ->method('remove')
+            ->willThrowException(new IOException('permission denied'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with('import.file.delete_failed', $this->callback(static fn (array $context): bool => 7 === $context['import_id']
+                && 'import.reject_file.deleted' === $context['event']
+                && 'permission denied' === $context['error']));
+
+        $storage = new ImportFileStorage($this->projectDir, $filesystem, $logger);
+        $storage->delete('var/imports/locked.csv', 'import.reject_file.deleted', 7);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens import file cleanup introduced in #265's underlying fix by extracting a dedicated `ImportFileStorage` service. Path resolution and file deletion are now centralized; deletion uses Symfony `Filesystem::remove()` instead ofduplicated `resolvePath` logic and silent `@unlink` calls.

- Add `ImportFileStorage` with `resolve()`, `toRelative()`, and `delete()`
- Refactor `ImportRelatedDataCleanupService`, `FileChecksumCalculator`, `FileUploader`, and `ImportAllocationsMessageHandler` to use it
- Add unit and integration tests, including relative `var/imports/...` paths and reject CSV deletion
- Document deletion cleanup in `docs/Import-workflow.md`
- Forward `import.source_file.deleted` and `import.file.delete_failed` to Sentry
- Fix pre-existing Psalm `PossiblyUnusedMethod` errors on recipient resolver interfaces (unblocks `make ci`)

Closes the hardening follow-up for #265. The original bug (orphaned upload files after import deletion) was already fixed via `ImportDeletionService`. This PR improves maintainability, observability, and test realism.

## Test plan

- [x] `make ci` passes locally
- [x] `ImportFileStorageTest` - path resolution, deletion, failure logging
- [x] `ImportDeletionServiceTest` - source file (absolute + relative), reject file, DB cleanup, materialized views
- [ ] Manually: upload import -> delete via UI -> confirm file removed from `var/imports/`
- [ ] Manually: import with rejects -> delete -> confirm reject CSV removed from `var/imports/rejects/`