### PR TITLE
chore(deps): raise PHP minimum to 8.4.3 for Dependabot resolution (#267)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.4.1",
+        "php": ">=8.4.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "azuyalabs/yasumi": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcd111fa2fc358f049d53eccc350c61f",
+    "content-hash": "28be1dad92600b5de7f0d802122e02bb",
     "packages": [
         {
             "name": "azuyalabs/yasumi",
@@ -17818,7 +17818,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4.1",
+        "php": ">=8.4.3",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },


### PR DESCRIPTION
## Summary

- Raise `require.php` from `>=8.4.1` to `>=8.4.3` so Dependabot's simulated platform satisfies `vimeo/psalm` (`~8.4.3`).
- Refresh `composer.lock` platform metadata.

Follow-up to #273. Dependabot still created no Composer PRs because Psalm blocked resolution of the full lockfile graph, even for unrelated packages.

Fixes #267

## Test plan

- [x] `composer validate --strict`
- [ ] After merge: confirm Dependabot opens grouped Symfony patch PRs