### PR TITLE
feat(admin): operational control center dashboard and extended entity coverage (#261)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ MAILER_DSN=null://null
 
 ###> app/branding ###
 # APP_TITLE=My statistics portal
+# APP_ADMIN_STORAGE_LIMIT_BYTES=10737418240
 ###< app/branding ###
 
 ###> app/mail ###

--- a/assets/styles/admin-kpi.css
+++ b/assets/styles/admin-kpi.css
@@ -17,3 +17,47 @@
 .ea-dashboard-kpi .ea-kpi-chart-target {
     min-height: 280px;
 }
+
+.ea-ops-health-banner {
+    border-color: var(--bs-border-color, #dee2e6) !important;
+}
+
+.ea-ops-health-badge {
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.ea-dashboard-ops .ea-kpi-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.ea-ops-card-trend {
+    font-size: 0.8125rem;
+}
+
+.ea-admin-primary-badge-btn {
+    gap: 0.625rem;
+    padding: 0.5rem 1rem;
+}
+
+.ea-admin-primary-badge-btn__badge {
+    background-color: #fff;
+    color: var(--bs-primary, #0d6efd);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.35em 0.65em;
+}
+
+.ea-admin-action-btn {
+    padding: 0.5rem 1rem;
+}
+
+.ea-failed-messages-toolbar {
+    gap: 0.75rem;
+}
+
+.ea-failed-messages-row-actions {
+    gap: 0.5rem;
+}

--- a/config/reference.php
+++ b/config/reference.php
@@ -127,7 +127,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: InstanceofType,
+ *     _instanceof?: array<class-string, InstanceofType>,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,8 @@ parameters:
     env(SENTRY_DSN): ''
     env(SENTRY_TRACES_SAMPLE_RATE): '0'
     env(SENTRY_ENABLE_LOGS): 'true'
+    env(APP_ADMIN_STORAGE_LIMIT_BYTES): '0'
+    app.admin.storage_limit_bytes: '%env(int:APP_ADMIN_STORAGE_LIMIT_BYTES)%'
 
 services:
     _defaults:

--- a/docs/05-operations/admin-entity-coverage.md
+++ b/docs/05-operations/admin-entity-coverage.md
@@ -1,0 +1,49 @@
+# Admin entity coverage
+
+Matrix of domain entities exposed in the EasyAdmin backend (`/admin`). Use this checklist when adding entities or fields.
+
+Legend: **Full** = create/edit/delete; **Read** = index/detail only; **—** = not exposed (by design or pending).
+
+## Core entities
+
+| Entity | CRUD controller | Mode | Notes |
+|--------|-----------------|------|-------|
+| User | `UserCrudController` | Full | locale, reminder preference, owned hospitals |
+| Hospital | `HospitalCrudController` | Full | coordinates, access grants on detail |
+| HospitalAccessGrant | `HospitalAccessGrantCrudController` | Full | permission mask UI |
+| Allocation | `AllocationCrudController` | Full | secondary transport/indications, notes |
+| Import | `ImportCrudController` | Full | file metadata on detail |
+| ImportReject | `ImportRejectCrudController` | Read | |
+| ImportBatchRun | `ImportBatchRunCrudController` | Read | |
+| ImportBatchRunItem | `ImportBatchRunItemCrudController` | Read | |
+| MonthlyReminderDispatch | `MonthlyReminderDispatchCrudController` | Read | scheduler sends only |
+| SavedExplorerView | `SavedExplorerViewCrudController` | Read | |
+| UserOnboardingStep | `UserOnboardingStepCrudController` | Read | |
+
+## Reference data (full CRUD)
+
+Allocation, Assignment, Department, DispatchArea, IndicationNormalized, IndicationGroup, IndicationRaw (read-only forms), Infection, MciCase, Occasion, SecondaryTransport, Speciality, State.
+
+## Content (full CRUD)
+
+Post, PostCategory, PostTag, PostComment (read-only create), Page, Media.
+
+## System (read-only)
+
+AuditEntry, CookieConsent, Feedback (no manual create).
+
+## Intentionally not in admin
+
+| Entity | Reason |
+|--------|--------|
+| Address | Embeddable on Hospital |
+| KpiDaily | Aggregated via dashboard service |
+| ResetPasswordRequest | Security tokens |
+| SavedExplorerViewFavorite | Low operational value |
+
+## Operational views (non-CRUD)
+
+| View | Controller | Purpose |
+|------|------------|---------|
+| Dashboard ops panel | `DashboardController` | Messenger, health, storage |
+| Failed messages | `DashboardController` (`operations_failed_messages`) | Inspect `messenger_messages` failed queue |

--- a/psalm.xml
+++ b/psalm.xml
@@ -60,6 +60,7 @@
                 <directory name="src/Statistics/" />
                 <directory name="src/Kpi/" />
                 <directory name="src/Engagement/" />
+                <directory name="src/Admin/Application/Service/" />
             </errorLevel>
         </PossiblyUnusedMethod>
         <PossiblyUnusedProperty>

--- a/src/Admin/Application/DTO/HealthCheckItemDto.php
+++ b/src/Admin/Application/DTO/HealthCheckItemDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class HealthCheckItemDto
+{
+    public function __construct(
+        public string $key,
+        public string $labelKey,
+        public string $value,
+        public string $severity,
+        public string $icon,
+    ) {
+    }
+}

--- a/src/Admin/Application/DTO/HealthStatusDto.php
+++ b/src/Admin/Application/DTO/HealthStatusDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+use App\Shared\Application\Health\HealthCheckStatus;
+
+final readonly class HealthStatusDto
+{
+    /**
+     * @param array<string, string>    $checks
+     * @param list<HealthCheckItemDto> $items
+     */
+    public function __construct(
+        public HealthCheckStatus $status,
+        public string $appVersion,
+        public array $checks,
+        public array $items,
+    ) {
+    }
+}

--- a/src/Admin/Application/DTO/MessengerQueueStatDto.php
+++ b/src/Admin/Application/DTO/MessengerQueueStatDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class MessengerQueueStatDto
+{
+    public function __construct(
+        public string $queueName,
+        public int $pendingCount,
+        public ?\DateTimeImmutable $oldestCreatedAt,
+    ) {
+    }
+}

--- a/src/Admin/Application/DTO/MessengerStatsDto.php
+++ b/src/Admin/Application/DTO/MessengerStatsDto.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class MessengerStatsDto
+{
+    /**
+     * @param list<MessengerQueueStatDto> $queues
+     */
+    public function __construct(
+        public array $queues,
+        public int $failedCount,
+    ) {
+    }
+
+    public function pendingCountFor(string $queueName): int
+    {
+        foreach ($this->queues as $queue) {
+            if ($queue->queueName === $queueName) {
+                return $queue->pendingCount;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Admin/Application/DTO/OpsCardDto.php
+++ b/src/Admin/Application/DTO/OpsCardDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class OpsCardDto
+{
+    public function __construct(
+        public string $labelKey,
+        public string $value,
+        public string $icon,
+        public ?string $detailUrl = null,
+        public string $style = 'primary',
+        public ?int $trendBytes = null,
+    ) {
+    }
+}

--- a/src/Admin/Application/DTO/StorageMetricsDto.php
+++ b/src/Admin/Application/DTO/StorageMetricsDto.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class StorageMetricsDto
+{
+    /**
+     * @param list<StorageSegmentDto> $segments
+     */
+    public function __construct(
+        public int $databaseBytes,
+        public int $importBytes,
+        public int $mediaBytes,
+        public int $applicationCodeBytes,
+        public int $importBytesLast30Days,
+        public int $mediaBytesLast30Days,
+        public ?int $limitBytes,
+        public array $segments,
+    ) {
+    }
+
+    public function filesBytes(): int
+    {
+        return $this->importBytes + $this->mediaBytes;
+    }
+
+    public function filesBytesLast30Days(): int
+    {
+        return $this->importBytesLast30Days + $this->mediaBytesLast30Days;
+    }
+
+    public function totalBytes(): int
+    {
+        return $this->databaseBytes + $this->importBytes + $this->mediaBytes + $this->applicationCodeBytes;
+    }
+
+    public function usagePercent(): ?float
+    {
+        if (null === $this->limitBytes || $this->limitBytes <= 0) {
+            return null;
+        }
+
+        return round((float) $this->totalBytes() / (float) $this->limitBytes * 100.0, 1);
+    }
+
+    public function barBaseBytes(): int
+    {
+        if (null !== $this->limitBytes && $this->limitBytes > 0) {
+            return $this->limitBytes;
+        }
+
+        return max(1, $this->totalBytes());
+    }
+}

--- a/src/Admin/Application/DTO/StorageSegmentDto.php
+++ b/src/Admin/Application/DTO/StorageSegmentDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\DTO;
+
+final readonly class StorageSegmentDto
+{
+    public function __construct(
+        public string $key,
+        public string $labelKey,
+        public int $bytes,
+        public string $color,
+        public string $icon,
+    ) {
+    }
+}

--- a/src/Admin/Application/Service/ApplicationCodeSizeCalculator.php
+++ b/src/Admin/Application/Service/ApplicationCodeSizeCalculator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final readonly class ApplicationCodeSizeCalculator
+{
+    private const string CACHE_KEY = 'admin.storage.application_bytes';
+
+    private const int CACHE_TTL_SECONDS = 900;
+
+    /** @var list<string> */
+    private const array EXCLUDED_DIR_NAMES = [
+        'cache',
+        'log',
+        'test',
+        'node_modules',
+        '.git',
+    ];
+
+    public function __construct(
+        private CacheInterface $cache,
+        #[Autowire('%kernel.project_dir%')]
+        private string $projectDir,
+    ) {
+    }
+
+    public function getBytes(): int
+    {
+        return $this->cache->get(self::CACHE_KEY, function (ItemInterface $item): int {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return $this->calculateBytes();
+        });
+    }
+
+    private function calculateBytes(): int
+    {
+        $total = 0;
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(
+                $this->projectDir,
+                \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS,
+            ),
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || !$file->isFile()) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            if ($this->isExcludedPath($path)) {
+                continue;
+            }
+
+            $total += $file->getSize();
+        }
+
+        return $total;
+    }
+
+    private function isExcludedPath(string $path): bool
+    {
+        $relative = str_replace($this->projectDir.'/', '', $path);
+        $parts = explode('/', $relative);
+
+        return array_any($parts, fn ($part): bool => \in_array($part, self::EXCLUDED_DIR_NAMES, true));
+    }
+}

--- a/src/Admin/Application/Service/HospitalPermissionLabelFormatter.php
+++ b/src/Admin/Application/Service/HospitalPermissionLabelFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+
+final class HospitalPermissionLabelFormatter
+{
+    public static function formatMask(int $mask): string
+    {
+        if (0 === $mask) {
+            return '—';
+        }
+
+        $labels = [];
+        foreach (HospitalPermission::assignableCases() as $permission) {
+            if (HospitalPermissionMask::has($mask, $permission)) {
+                $labels[] = $permission->name;
+            }
+        }
+
+        return [] === $labels ? '—' : implode(', ', $labels);
+    }
+}

--- a/src/Admin/Application/Service/OperationalDashboardService.php
+++ b/src/Admin/Application/Service/OperationalDashboardService.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use App\Admin\Application\DTO\HealthCheckItemDto;
+use App\Admin\Application\DTO\HealthStatusDto;
+use App\Admin\Application\DTO\MessengerStatsDto;
+use App\Admin\Application\DTO\OpsCardDto;
+use App\Admin\Application\DTO\StorageMetricsDto;
+use App\Admin\Infrastructure\Repository\MessengerStatsRepository;
+use App\Shared\Application\Health\HealthCheckService;
+use App\Shared\Infrastructure\Audit\Repository\AuditEntryRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+
+final readonly class OperationalDashboardService
+{
+    public function __construct(
+        private MessengerStatsRepository $messengerStatsRepository,
+        private StorageMetricsService $storageMetricsService,
+        private HealthCheckService $healthCheckService,
+        private AuditEntryRepository $auditEntryRepository,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+    ) {
+    }
+
+    public function getMessengerStats(): MessengerStatsDto
+    {
+        return $this->messengerStatsRepository->getStats();
+    }
+
+    public function getHealthStatus(): HealthStatusDto
+    {
+        $report = $this->healthCheckService->check();
+
+        return new HealthStatusDto(
+            status: $report->status,
+            appVersion: $report->version,
+            checks: $report->checks,
+            items: $this->mapHealthCheckItems($report->checks),
+        );
+    }
+
+    public function getStorageMetrics(): StorageMetricsDto
+    {
+        return $this->storageMetricsService->getMetrics();
+    }
+
+    /**
+     * @return list<OpsCardDto>
+     */
+    public function getOpsCards(): array
+    {
+        $messenger = $this->getMessengerStats();
+        $storage = $this->getStorageMetrics();
+
+        return [
+            new OpsCardDto(
+                labelKey: 'ops.card.failed_messages',
+                value: (string) $messenger->failedCount,
+                icon: 'fas fa-triangle-exclamation',
+                detailUrl: $this->generateFailedMessagesUrl(),
+                style: $messenger->failedCount > 0 ? 'danger' : 'success',
+            ),
+            new OpsCardDto(
+                labelKey: 'ops.card.queue_high',
+                value: (string) $messenger->pendingCountFor('high'),
+                icon: 'fas fa-bolt',
+                style: $messenger->pendingCountFor('high') > 0 ? 'warning' : 'primary',
+            ),
+            new OpsCardDto(
+                labelKey: 'ops.card.queue_low',
+                value: (string) $messenger->pendingCountFor('low'),
+                icon: 'fas fa-hourglass-half',
+                style: $messenger->pendingCountFor('low') > 0 ? 'info' : 'primary',
+            ),
+            new OpsCardDto(
+                labelKey: 'ops.card.storage_total',
+                value: $this->formatBytes($storage->totalBytes()),
+                icon: 'fas fa-hard-drive',
+                trendBytes: $storage->filesBytesLast30Days(),
+            ),
+            new OpsCardDto(
+                labelKey: 'ops.card.database_size',
+                value: $this->formatBytes($storage->databaseBytes),
+                icon: 'fas fa-database',
+                trendBytes: 0,
+            ),
+            new OpsCardDto(
+                labelKey: 'ops.card.imports_media',
+                value: $this->formatBytes($storage->filesBytes()),
+                icon: 'fa fa-database',
+                trendBytes: $storage->filesBytesLast30Days(),
+            ),
+        ];
+    }
+
+    /**
+     * @return list<array{occurredAt: \DateTimeImmutable, intent: string, action: string, origin: string}>
+     */
+    public function getRecentNotificationEvents(int $limit = 10): array
+    {
+        return $this->auditEntryRepository->findRecentByIntents([
+            'hospital.reminder_sent',
+            'user.registration',
+            'import.failed',
+        ], $limit);
+    }
+
+    /**
+     * @param array<string, string> $checks
+     *
+     * @return list<HealthCheckItemDto>
+     */
+    private function mapHealthCheckItems(array $checks): array
+    {
+        $items = [];
+
+        foreach ($checks as $key => $value) {
+            $items[] = match ($key) {
+                'database' => new HealthCheckItemDto(
+                    key: $key,
+                    labelKey: 'ops.health.check.database',
+                    value: $value,
+                    severity: 'ok' === $value ? 'success' : 'danger',
+                    icon: 'fas fa-database',
+                ),
+                'messenger_failed' => new HealthCheckItemDto(
+                    key: $key,
+                    labelKey: 'ops.health.check.messenger_failed',
+                    value: $value,
+                    severity: 'ok' === $value ? 'success' : ('skipped' === $value ? 'warning' : 'warning'),
+                    icon: 'ok' === $value ? 'fas fa-envelope-circle-check' : 'fas fa-triangle-exclamation',
+                ),
+                default => new HealthCheckItemDto(
+                    key: $key,
+                    labelKey: 'ops.health.check.'.$key,
+                    value: $value,
+                    severity: 'success',
+                    icon: 'fas fa-circle-check',
+                ),
+            };
+        }
+
+        return $items;
+    }
+
+    private function generateFailedMessagesUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->setRoute('app_admin_dashboard_operations_failed_messages')
+            ->generateUrl();
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        if ($bytes < 1024 * 1024) {
+            return sprintf('%.1f KB', $bytes / 1024);
+        }
+
+        if ($bytes < 1024 * 1024 * 1024) {
+            return sprintf('%.1f MB', $bytes / (1024 * 1024));
+        }
+
+        return sprintf('%.2f GB', $bytes / (1024 * 1024 * 1024));
+    }
+}

--- a/src/Admin/Application/Service/StorageMetricsService.php
+++ b/src/Admin/Application/Service/StorageMetricsService.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Application\Service;
+
+use App\Admin\Application\DTO\StorageMetricsDto;
+use App\Admin\Application\DTO\StorageSegmentDto;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class StorageMetricsService
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    public function __construct(
+        private Connection $connection,
+        private ApplicationCodeSizeCalculator $applicationCodeSizeCalculator,
+        #[Autowire('%app.admin.storage_limit_bytes%')]
+        private int $storageLimitBytes,
+    ) {
+    }
+
+    public function getMetrics(): StorageMetricsDto
+    {
+        $importBytes = (int) $this->connection->fetchOne(
+            'SELECT COALESCE(SUM(file_size), 0) FROM import WHERE file_size IS NOT NULL',
+        );
+        $mediaBytes = (int) $this->connection->fetchOne(
+            'SELECT COALESCE(SUM(size), 0) FROM media WHERE size IS NOT NULL',
+        );
+        $databaseBytes = $this->fetchDatabaseSizeBytes();
+        $applicationCodeBytes = $this->applicationCodeSizeCalculator->getBytes();
+
+        $since = new \DateTimeImmutable('-30 days', new \DateTimeZone(self::TIMEZONE))
+            ->setTime(0, 0)
+            ->format('Y-m-d H:i:s');
+
+        $importBytesLast30Days = (int) $this->connection->fetchOne(
+            'SELECT COALESCE(SUM(file_size), 0) FROM import WHERE file_size IS NOT NULL AND created_at >= :since',
+            ['since' => $since],
+        );
+        $mediaBytesLast30Days = (int) $this->connection->fetchOne(
+            'SELECT COALESCE(SUM(size), 0) FROM media WHERE size IS NOT NULL AND created_at >= :since',
+            ['since' => $since],
+        );
+
+        $limitBytes = $this->storageLimitBytes > 0 ? $this->storageLimitBytes : null;
+
+        $segments = [
+            new StorageSegmentDto('database', 'ops.storage.database', $databaseBytes, '#0d6efd', 'fas fa-database'),
+            new StorageSegmentDto('imports', 'ops.storage.imports', $importBytes, '#198754', 'fa fa-database'),
+            new StorageSegmentDto('media', 'ops.storage.media', $mediaBytes, '#fd7e14', 'fas fa-photo-film'),
+            new StorageSegmentDto('application_code', 'ops.storage.application_code', $applicationCodeBytes, '#6c757d', 'fas fa-code'),
+        ];
+
+        return new StorageMetricsDto(
+            databaseBytes: $databaseBytes,
+            importBytes: $importBytes,
+            mediaBytes: $mediaBytes,
+            applicationCodeBytes: $applicationCodeBytes,
+            importBytesLast30Days: $importBytesLast30Days,
+            mediaBytesLast30Days: $mediaBytesLast30Days,
+            limitBytes: $limitBytes,
+            segments: $segments,
+        );
+    }
+
+    private function fetchDatabaseSizeBytes(): int
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return (int) $this->connection->fetchOne('SELECT pg_database_size(current_database())');
+        }
+
+        if ($platform instanceof MySQLPlatform) {
+            $database = $this->connection->getDatabase();
+            if (null === $database) {
+                return 0;
+            }
+
+            return (int) $this->connection->fetchOne(
+                'SELECT SUM(data_length + index_length)
+                 FROM information_schema.tables
+                 WHERE table_schema = :schema',
+                ['schema' => $database],
+                ['schema' => ParameterType::STRING],
+            );
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            $pageCount = (int) $this->connection->fetchOne('PRAGMA page_count');
+            $pageSize = (int) $this->connection->fetchOne('PRAGMA page_size');
+
+            return $pageCount * $pageSize;
+        }
+
+        return 0;
+    }
+}

--- a/src/Admin/Infrastructure/Repository/MessengerStatsRepository.php
+++ b/src/Admin/Infrastructure/Repository/MessengerStatsRepository.php
@@ -34,7 +34,7 @@ final readonly class MessengerStatsRepository
         foreach ($rows as $row) {
             $queueName = $row['queue_name'];
             $pendingCount = (int) $row['pending_count'];
-            $oldest = isset($row['oldest_created_at']) && \is_string($row['oldest_created_at'])
+            $oldest = isset($row['oldest_created_at'])
                 ? new \DateTimeImmutable($row['oldest_created_at'])
                 : null;
 

--- a/src/Admin/Infrastructure/Repository/MessengerStatsRepository.php
+++ b/src/Admin/Infrastructure/Repository/MessengerStatsRepository.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Infrastructure\Repository;
+
+use App\Admin\Application\DTO\MessengerQueueStatDto;
+use App\Admin\Application\DTO\MessengerStatsDto;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+
+final readonly class MessengerStatsRepository
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function getStats(): MessengerStatsDto
+    {
+        /** @var list<array{queue_name: string, pending_count: int|string, oldest_created_at: ?string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT queue_name, COUNT(*) AS pending_count, MIN(created_at) AS oldest_created_at
+             FROM messenger_messages
+             WHERE delivered_at IS NULL
+             GROUP BY queue_name
+             ORDER BY queue_name ASC',
+        );
+
+        $queues = [];
+        $failedCount = 0;
+
+        foreach ($rows as $row) {
+            $queueName = $row['queue_name'];
+            $pendingCount = (int) $row['pending_count'];
+            $oldest = isset($row['oldest_created_at']) && \is_string($row['oldest_created_at'])
+                ? new \DateTimeImmutable($row['oldest_created_at'])
+                : null;
+
+            $queues[] = new MessengerQueueStatDto($queueName, $pendingCount, $oldest);
+
+            if ('failed' === $queueName) {
+                $failedCount = $pendingCount;
+            }
+        }
+
+        return new MessengerStatsDto($queues, $failedCount);
+    }
+
+    /**
+     * @return list<array{id: int, queue_name: string, created_at: string, message_class: string, error_preview: string}>
+     */
+    public function findFailedMessages(int $limit = 50, int $offset = 0): array
+    {
+        /** @var list<array{id: int|string, queue_name: string, created_at: string, body: string, headers: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, queue_name, created_at, body, headers
+             FROM messenger_messages
+             WHERE queue_name = :queue
+             ORDER BY created_at DESC
+             LIMIT :limit OFFSET :offset',
+            ['queue' => 'failed', 'limit' => $limit, 'offset' => $offset],
+            ['limit' => ParameterType::INTEGER, 'offset' => ParameterType::INTEGER],
+        );
+
+        $messages = [];
+        foreach ($rows as $row) {
+            $headers = json_decode($row['headers'], true);
+            $messageClass = '';
+            if (\is_array($headers) && isset($headers['type']) && \is_string($headers['type'])) {
+                $messageClass = $headers['type'];
+            }
+
+            $messages[] = [
+                'id' => (int) $row['id'],
+                'queue_name' => $row['queue_name'],
+                'created_at' => $row['created_at'],
+                'message_class' => $messageClass,
+                'error_preview' => $this->buildErrorPreview($row['body']),
+            ];
+        }
+
+        return $messages;
+    }
+
+    public function countFailedMessages(): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM messenger_messages WHERE queue_name = :queue',
+            ['queue' => 'failed'],
+        );
+    }
+
+    /**
+     * @return array{id: int, queue_name: string, created_at: string, body: string, headers: string, message_class: string}|null
+     */
+    public function findFailedMessageById(int $id): ?array
+    {
+        /** @var array{id: int|string, queue_name: string, created_at: string, body: string, headers: string}|false $row */
+        $row = $this->connection->fetchAssociative(
+            'SELECT id, queue_name, created_at, body, headers
+             FROM messenger_messages
+             WHERE id = :id AND queue_name = :queue',
+            ['id' => $id, 'queue' => 'failed'],
+        );
+
+        if (false === $row) {
+            return null;
+        }
+
+        $headers = json_decode($row['headers'], true);
+        $messageClass = '';
+        if (\is_array($headers) && isset($headers['type']) && \is_string($headers['type'])) {
+            $messageClass = $headers['type'];
+        }
+
+        return [
+            'id' => (int) $row['id'],
+            'queue_name' => $row['queue_name'],
+            'created_at' => $row['created_at'],
+            'body' => $row['body'],
+            'headers' => $row['headers'],
+            'message_class' => $messageClass,
+        ];
+    }
+
+    public function deleteFailedMessageById(int $id): bool
+    {
+        return $this->connection->executeStatement(
+            'DELETE FROM messenger_messages WHERE id = :id AND queue_name = :queue',
+            ['id' => $id, 'queue' => 'failed'],
+        ) > 0;
+    }
+
+    /**
+     * @param list<int> $ids
+     */
+    public function deleteFailedMessagesByIds(array $ids): int
+    {
+        if ([] === $ids) {
+            return 0;
+        }
+
+        /** @psalm-suppress InvalidArgument Doctrine DBAL array parameter types */
+        return $this->connection->executeStatement(
+            'DELETE FROM messenger_messages WHERE queue_name = :queue AND id IN (:ids)',
+            ['queue' => 'failed', 'ids' => $ids],
+            ['ids' => ArrayParameterType::INTEGER],
+        );
+    }
+
+    public function deleteAllFailedMessages(): int
+    {
+        return $this->connection->executeStatement(
+            'DELETE FROM messenger_messages WHERE queue_name = :queue',
+            ['queue' => 'failed'],
+        );
+    }
+
+    private function buildErrorPreview(string $body): string
+    {
+        $preview = trim(preg_replace('/\s+/', ' ', $body) ?? $body);
+        if (strlen($preview) > 160) {
+            return substr($preview, 0, 157).'...';
+        }
+
+        return $preview;
+    }
+}

--- a/src/Admin/UI/Form/DataTransformer/HospitalPermissionsMaskTransformer.php
+++ b/src/Admin/UI/Form/DataTransformer/HospitalPermissionsMaskTransformer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Form\DataTransformer;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @implements DataTransformerInterface<int|null, list<HospitalPermission>>
+ */
+final class HospitalPermissionsMaskTransformer implements DataTransformerInterface
+{
+    /**
+     * @return list<HospitalPermission>
+     */
+    #[\Override]
+    public function transform(mixed $value): array
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        if (!\is_int($value)) {
+            throw new TransformationFailedException('Expected an integer permission mask.');
+        }
+
+        $permissions = [];
+        foreach (HospitalPermission::assignableCases() as $permission) {
+            if (HospitalPermissionMask::has($value, $permission)) {
+                $permissions[] = $permission;
+            }
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * @param list<HospitalPermission>|mixed $value
+     */
+    #[\Override]
+    public function reverseTransform(mixed $value): int
+    {
+        if (!\is_array($value)) {
+            return 0;
+        }
+
+        $permissions = array_values(array_filter(
+            $value,
+            static fn (mixed $permission): bool => $permission instanceof HospitalPermission,
+        ));
+
+        return HospitalPermissionMask::fromPermissions($permissions);
+    }
+}

--- a/src/Admin/UI/Form/HospitalPermissionsFieldType.php
+++ b/src/Admin/UI/Form/HospitalPermissionsFieldType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Form;
+
+use App\Admin\UI\Form\DataTransformer\HospitalPermissionsMaskTransformer;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<int>
+ */
+final class HospitalPermissionsFieldType extends AbstractType
+{
+    public function __construct(
+        private readonly HospitalPermissionsMaskTransformer $transformer,
+    ) {
+    }
+
+    #[\Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addModelTransformer($this->transformer);
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'class' => HospitalPermission::class,
+            'multiple' => true,
+            'choices' => HospitalPermission::assignableCases(),
+            'choice_label' => static fn (HospitalPermission $permission): string => $permission->name,
+        ]);
+    }
+
+    #[\Override]
+    public function getParent(): string
+    {
+        return EnumType::class;
+    }
+}

--- a/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
+++ b/src/Admin/UI/Http/Controller/Allocation/AllocationCrudController.php
@@ -18,6 +18,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
@@ -123,6 +125,16 @@ final class AllocationCrudController extends AbstractCrudController
         yield AssociationField::new('indicationNormalized', 'Indication Normalized')
             ->hideOnIndex();
         yield AssociationField::new('assessment', 'Assessment')
+            ->hideOnIndex();
+        yield AssociationField::new('secondaryTransport', 'Secondary transport')
+            ->hideOnIndex();
+        yield AssociationField::new('secondaryIndicationRaw', 'Secondary indication raw')
+            ->hideOnIndex();
+        yield AssociationField::new('secondaryIndicationNormalized', 'Secondary indication normalized')
+            ->hideOnIndex();
+        yield TextField::new('caseIdHash', 'Case ID hash')
+            ->hideOnIndex();
+        yield TextareaField::new('notes', 'Notes')
             ->hideOnIndex();
     }
 }

--- a/src/Admin/UI/Http/Controller/Audit/AuditLogCrudController.php
+++ b/src/Admin/UI/Http/Controller/Audit/AuditLogCrudController.php
@@ -70,10 +70,20 @@ final class AuditLogCrudController extends AbstractCrudController
             ->addAction(Action::new('auditLast30d', 'Last 30 days', 'fas fa-calendar')
                 ->linkToUrl(fn (): string => $this->indexUrlSince(new \DateTimeImmutable('-30 days'))));
 
+        $notificationGroup = ActionGroup::new('audit_notifications', 'Notifications', 'fas fa-envelope')
+            ->createAsGlobalActionGroup()
+            ->addAction(Action::new('auditReminderSent', 'Monthly reminders', 'fas fa-bell')
+                ->linkToUrl(fn (): string => $this->indexUrlWithMetadataIntent('hospital.reminder_sent')))
+            ->addAction(Action::new('auditUserRegistration', 'User registrations', 'fas fa-user-plus')
+                ->linkToUrl(fn (): string => $this->indexUrlWithMetadataIntent('user.registration')))
+            ->addAction(Action::new('auditImportFailed', 'Import failures', 'fas fa-triangle-exclamation')
+                ->linkToUrl(fn (): string => $this->indexUrlWithMetadataIntent('import.failed')));
+
         return $actions
             ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
             ->add(Crud::PAGE_INDEX, $timeRangeGroup)
+            ->add(Crud::PAGE_INDEX, $notificationGroup)
             ->add(Crud::PAGE_DETAIL, Action::new('auditSameRequest', 'All in this request', 'fas fa-stream')
                 ->linkToUrl(fn (AuditEntry $entry): string => $this->indexUrlWithFilters([
                     'requestId' => [
@@ -112,6 +122,7 @@ final class AuditLogCrudController extends AbstractCrudController
             ]))
             ->add(TextFilter::new('requestId', 'Request ID'))
             ->add(TextFilter::new('entityClass', 'Entity class (substring)'))
+            ->add(TextFilter::new('metadata', 'Metadata (substring)'))
             ->add(EntityFilter::new('actor', 'Actor'));
     }
 
@@ -341,6 +352,16 @@ final class AuditLogCrudController extends AbstractCrudController
             'occurredAt' => [
                 'comparison' => ComparisonType::GTE,
                 'value' => $from->format('Y-m-d H:i:s'),
+            ],
+        ]);
+    }
+
+    private function indexUrlWithMetadataIntent(string $intent): string
+    {
+        return $this->indexUrlWithFilters([
+            'metadata' => [
+                'comparison' => ComparisonType::CONTAINS,
+                'value' => $intent,
             ],
         ]);
     }

--- a/src/Admin/UI/Http/Controller/DashboardController.php
+++ b/src/Admin/UI/Http/Controller/DashboardController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Http\Controller;
 
+use App\Admin\Application\Service\OperationalDashboardService;
+use App\Admin\Infrastructure\Repository\MessengerStatsRepository;
 use App\Admin\UI\Http\Controller\Allocation\AllocationCrudController;
 use App\Admin\UI\Http\Controller\Assignment\AssignmentCrudController;
 use App\Admin\UI\Http\Controller\Audit\AuditLogCrudController;
@@ -14,8 +16,12 @@ use App\Admin\UI\Http\Controller\Blog\PostTagCrudController;
 use App\Admin\UI\Http\Controller\Consent\CookieConsentCrudController;
 use App\Admin\UI\Http\Controller\Department\DepartmentCrudController;
 use App\Admin\UI\Http\Controller\DispatchArea\DispatchAreaCrudController;
+use App\Admin\UI\Http\Controller\Engagement\MonthlyReminderDispatchCrudController;
 use App\Admin\UI\Http\Controller\Feedback\FeedbackCrudController;
+use App\Admin\UI\Http\Controller\Hospital\HospitalAccessGrantCrudController;
 use App\Admin\UI\Http\Controller\Hospital\HospitalCrudController;
+use App\Admin\UI\Http\Controller\Import\ImportBatchRunCrudController;
+use App\Admin\UI\Http\Controller\Import\ImportBatchRunItemCrudController;
 use App\Admin\UI\Http\Controller\Import\ImportCrudController;
 use App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController;
 use App\Admin\UI\Http\Controller\IndicationGroup\IndicationGroupCrudController;
@@ -25,21 +31,27 @@ use App\Admin\UI\Http\Controller\Infection\InfectionCrudController;
 use App\Admin\UI\Http\Controller\MciCase\MciCaseCrudController;
 use App\Admin\UI\Http\Controller\Media\MediaCrudController;
 use App\Admin\UI\Http\Controller\Occasion\OccasionCrudController;
+use App\Admin\UI\Http\Controller\Onboarding\UserOnboardingStepCrudController;
 use App\Admin\UI\Http\Controller\Page\PageCrudController;
 use App\Admin\UI\Http\Controller\SecondaryTransport\SecondaryTransportCrudController;
 use App\Admin\UI\Http\Controller\Speciality\SpecialityCrudController;
 use App\Admin\UI\Http\Controller\State\StateCrudController;
+use App\Admin\UI\Http\Controller\Statistics\SavedExplorerViewCrudController;
 use App\Admin\UI\Http\Controller\User\UserCrudController;
 use App\Feedback\Infrastructure\Repository\FeedbackRepository;
 use App\Kpi\Application\Service\KpiDashboardService;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -51,6 +63,8 @@ final class DashboardController extends AbstractDashboardController
         private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
         private readonly FeedbackRepository $feedbackRepository,
         private readonly KpiDashboardService $kpiDashboardService,
+        private readonly OperationalDashboardService $operationalDashboardService,
+        private readonly MessengerStatsRepository $messengerStatsRepository,
     ) {
     }
 
@@ -60,7 +74,10 @@ final class DashboardController extends AbstractDashboardController
         return $this->render('@Admin/dashboard/index.html.twig', [
             'kpi_cards' => $this->kpiDashboardService->getCards(),
             'kpi_chart' => $this->kpiDashboardService->getChart(),
-            'failed_imports' => $this->kpiDashboardService->getRecentFailedImports(),
+            'failed_imports' => $this->kpiDashboardService->getFailedImportsDashboard(),
+            'ops_cards' => $this->operationalDashboardService->getOpsCards(),
+            'ops_health' => $this->operationalDashboardService->getHealthStatus(),
+            'recent_notifications' => $this->operationalDashboardService->getRecentNotificationEvents(),
             'dashboard_sections' => $this->buildDashboardSections(),
         ]);
     }
@@ -70,6 +87,98 @@ final class DashboardController extends AbstractDashboardController
     {
         return Assets::new()
             ->addAssetMapperEntry(Asset::new('admin-kpi'));
+    }
+
+    #[AdminRoute(path: '/operations/failed-messages', name: 'operations_failed_messages')]
+    public function failedMessagesIndex(): Response
+    {
+        return $this->render('@Admin/operations/failed_messages_index.html.twig', [
+            'messages' => $this->messengerStatsRepository->findFailedMessages(),
+            'total_count' => $this->messengerStatsRepository->countFailedMessages(),
+        ]);
+    }
+
+    #[AdminRoute(path: '/operations/failed-messages/delete-selected', name: 'operations_failed_messages_delete_selected', options: ['methods' => ['POST']])]
+    public function deleteSelectedFailedMessages(Request $request): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('failed_messages_delete_batch', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        /** @var list<int|string> $rawIds */
+        $rawIds = $request->request->all('ids');
+        $ids = array_values(array_filter(array_map(
+            static fn (mixed $value): ?int => is_numeric($value) ? (int) $value : null,
+            $rawIds,
+        )));
+
+        if ([] === $ids) {
+            $this->addFlash('warning', new TranslatableMessage('ops.failed_messages.flash.none_selected', domain: 'admin'));
+
+            return $this->redirectToFailedMessagesIndex();
+        }
+
+        $deleted = $this->messengerStatsRepository->deleteFailedMessagesByIds($ids);
+        $this->addFlash('success', new TranslatableMessage('ops.failed_messages.flash.deleted_many', ['%count%' => $deleted], 'admin'));
+
+        return $this->redirectToFailedMessagesIndex();
+    }
+
+    #[AdminRoute(path: '/operations/failed-messages/delete-all', name: 'operations_failed_messages_delete_all', options: ['methods' => ['POST']])]
+    public function deleteAllFailedMessages(Request $request): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('failed_messages_delete_all', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        $deleted = $this->messengerStatsRepository->deleteAllFailedMessages();
+        $this->addFlash('success', new TranslatableMessage('ops.failed_messages.flash.deleted_all', ['%count%' => $deleted], 'admin'));
+
+        return $this->redirectToFailedMessagesIndex();
+    }
+
+    #[AdminRoute(path: '/operations/failed-messages/{id}', name: 'operations_failed_messages_detail', options: ['requirements' => ['id' => '\d+']])]
+    public function failedMessagesDetail(int $id): Response
+    {
+        $message = $this->messengerStatsRepository->findFailedMessageById($id);
+        if (null === $message) {
+            throw new NotFoundHttpException('Failed message not found.');
+        }
+
+        return $this->render('@Admin/operations/failed_messages_detail.html.twig', [
+            'message' => $message,
+            'back_url' => $this->adminUrlGenerator
+                ->setRoute('app_admin_dashboard_operations_failed_messages')
+                ->generateUrl(),
+            'delete_url' => $this->adminUrlGenerator
+                ->setRoute('app_admin_dashboard_operations_failed_messages_delete', ['id' => $id])
+                ->generateUrl(),
+        ]);
+    }
+
+    #[AdminRoute(path: '/operations/failed-messages/{id}/delete', name: 'operations_failed_messages_delete', options: ['methods' => ['POST'], 'requirements' => ['id' => '\d+']])]
+    public function deleteFailedMessage(int $id, Request $request): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('failed_message_delete_'.$id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+
+        if (!$this->messengerStatsRepository->deleteFailedMessageById($id)) {
+            throw new NotFoundHttpException('Failed message not found.');
+        }
+
+        $this->addFlash('success', new TranslatableMessage('ops.failed_messages.flash.deleted_one', domain: 'admin'));
+
+        return $this->redirectToFailedMessagesIndex();
+    }
+
+    private function redirectToFailedMessagesIndex(): RedirectResponse
+    {
+        return $this->redirect(
+            $this->adminUrlGenerator
+                ->setRoute('app_admin_dashboard_operations_failed_messages')
+                ->generateUrl(),
+        );
     }
 
     /**
@@ -94,13 +203,19 @@ final class DashboardController extends AbstractDashboardController
                     ];
                 }
 
+                if (isset($tile['route'])) {
+                    $url = $this->adminUrlGenerator->setRoute($tile['route'])->generateUrl();
+                } elseif (isset($tile['controller'])) {
+                    $url = $this->adminUrlGenerator->setController($tile['controller'])->generateUrl();
+                } else {
+                    throw new \LogicException('Dashboard tile must define either route or controller.');
+                }
+
                 $tiles[] = [
                     'label' => $tile['label'],
                     'description' => $tile['description'] ?? null,
                     'icon' => $tile['icon'],
-                    'url' => $this->adminUrlGenerator
-                        ->setController($tile['controller'])
-                        ->generateUrl(),
+                    'url' => $url,
                     'badge' => $badge,
                 ];
             }
@@ -115,7 +230,7 @@ final class DashboardController extends AbstractDashboardController
     }
 
     /**
-     * @return list<array{title: string, tiles: list<array{label: string, description?: string, icon: string, controller: class-string, badge_key?: string}>}>
+     * @return list<array{title: string, tiles: list<array{label: string, description?: string, icon: string, controller?: class-string, route?: string, badge_key?: string}>}>
      */
     private function dashboardSections(): array
     {
@@ -124,17 +239,23 @@ final class DashboardController extends AbstractDashboardController
                 'title' => 'Management',
                 'tiles' => [
                     [
-                        'label' => 'Users',
-                        'description' => 'Manage user accounts and permissions',
-                        'icon' => 'fas fa-users',
-                        'controller' => UserCrudController::class,
-                    ],
-                    [
                         'label' => 'Feedback',
                         'description' => 'Review and respond to user feedback',
                         'icon' => 'fas fa-comment-dots',
                         'controller' => FeedbackCrudController::class,
                         'badge_key' => 'feedback',
+                    ],
+                    [
+                        'label' => 'Onboarding steps',
+                        'description' => 'Review user onboarding progress',
+                        'icon' => 'fas fa-shoe-prints',
+                        'controller' => UserOnboardingStepCrudController::class,
+                    ],
+                    [
+                        'label' => 'Users',
+                        'description' => 'Manage user accounts and permissions',
+                        'icon' => 'fas fa-users',
+                        'controller' => UserCrudController::class,
                     ],
                 ],
             ],
@@ -199,6 +320,18 @@ final class DashboardController extends AbstractDashboardController
                         'icon' => 'fas fa-cookie-bite',
                         'controller' => CookieConsentCrudController::class,
                     ],
+                    [
+                        'label' => 'Failed messages',
+                        'description' => 'Inspect messenger failed queue',
+                        'icon' => 'fas fa-triangle-exclamation',
+                        'route' => 'app_admin_dashboard_operations_failed_messages',
+                    ],
+                    [
+                        'label' => 'Monthly reminders',
+                        'description' => 'Scheduler reminder dispatch history',
+                        'icon' => 'fas fa-envelope',
+                        'controller' => MonthlyReminderDispatchCrudController::class,
+                    ],
                 ],
             ],
         ];
@@ -217,7 +350,11 @@ final class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
         yield MenuItem::linkToRoute('Back to frontend', 'fas fa-backward-fast', 'app_default');
         yield MenuItem::section('Management');
-        yield MenuItem::linkTo(UserCrudController::class, 'Users', 'fas fa-users');
+        yield MenuItem::subMenu('Users', 'fas fa-users')->setSubItems([
+            MenuItem::linkTo(UserCrudController::class, new TranslatableMessage('menu.users.accounts', domain: 'admin'), 'fas fa-user'),
+            MenuItem::linkTo(HospitalAccessGrantCrudController::class, 'Hospital Access', 'fas fa-key'),
+            MenuItem::linkTo(UserOnboardingStepCrudController::class, 'Onboarding steps', 'fas fa-shoe-prints'),
+        ]);
 
         $openFeedbackCount = $this->feedbackRepository->countOpen();
         yield MenuItem::linkTo(FeedbackCrudController::class, 'Feedback', 'fas fa-comment-dots')
@@ -240,8 +377,15 @@ final class DashboardController extends AbstractDashboardController
             MenuItem::linkTo(SpecialityCrudController::class, 'Specialities', 'fas fa-list'),
             MenuItem::linkTo(StateCrudController::class, 'States', 'fas fa-list'),
         ]);
-        yield MenuItem::linkTo(ImportRejectCrudController::class, 'Import Rejects', 'fas fa-triangle-exclamation');
-        yield MenuItem::linkTo(ImportCrudController::class, 'Imports', 'fa fa-database');
+        yield MenuItem::subMenu('Imports', 'fa fa-database')->setSubItems([
+            MenuItem::linkTo(ImportCrudController::class, 'Imports', 'fa fa-database'),
+            MenuItem::linkTo(ImportRejectCrudController::class, 'Import Rejects', 'fas fa-triangle-exclamation'),
+            MenuItem::subMenu('Batch Activities', 'fas fa-layer-group')->setSubItems([
+                MenuItem::linkTo(ImportBatchRunCrudController::class, 'Import batch runs', 'fas fa-layer-group'),
+                MenuItem::linkTo(ImportBatchRunItemCrudController::class, 'Import batch items', 'fas fa-list-check'),
+            ]),
+        ]);
+        yield MenuItem::linkTo(SavedExplorerViewCrudController::class, 'Explorer views', 'fas fa-chart-bar');
 
         yield MenuItem::section('Content');
         yield MenuItem::subMenu('Blog', 'fas fa-book')->setSubItems([
@@ -256,5 +400,7 @@ final class DashboardController extends AbstractDashboardController
         yield MenuItem::section('System');
         yield MenuItem::linkTo(AuditLogCrudController::class, 'Audit log', 'fas fa-clipboard-list');
         yield MenuItem::linkTo(CookieConsentCrudController::class, 'Cookie consents', 'fas fa-cookie-bite');
+        yield MenuItem::linkToRoute('Failed messages', 'fas fa-triangle-exclamation', 'app_admin_dashboard_operations_failed_messages');
+        yield MenuItem::linkTo(MonthlyReminderDispatchCrudController::class, 'Monthly reminders', 'fas fa-envelope');
     }
 }

--- a/src/Admin/UI/Http/Controller/Engagement/MonthlyReminderDispatchCrudController.php
+++ b/src/Admin/UI/Http/Controller/Engagement/MonthlyReminderDispatchCrudController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\Engagement;
+
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\ChoiceFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Translation\TranslatableMessage;
+
+/**
+ * @extends AbstractCrudController<MonthlyReminderDispatch>
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class MonthlyReminderDispatchCrudController extends AbstractCrudController
+{
+    #[\Override]
+    public static function getEntityFqcn(): string
+    {
+        return MonthlyReminderDispatch::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Monthly reminder dispatch')
+            ->setEntityLabelInPlural('Monthly reminder dispatches')
+            ->setPageTitle(Crud::PAGE_INDEX, new TranslatableMessage('ops.reminder_dispatch.title', domain: 'admin'))
+            ->setHelp(Crud::PAGE_INDEX, new TranslatableMessage('ops.reminder_dispatch.help', domain: 'admin'))
+            ->setSearchFields(['reportingPeriod', 'trigger', 'hospital.name'])
+            ->setDefaultSort(['sentAt' => 'DESC']);
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
+            ->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add(EntityFilter::new('hospital', 'Hospital'))
+            ->add(ChoiceFilter::new('trigger', 'Trigger')->setChoices([
+                'Scheduler' => MonthlyReminderTrigger::Scheduler->value,
+                'Admin' => MonthlyReminderTrigger::Admin->value,
+                'CLI' => MonthlyReminderTrigger::Cli->value,
+            ]))
+            ->add(DateTimeFilter::new('sentAt', 'Sent at'));
+    }
+
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')
+            ->onlyOnDetail();
+        yield AssociationField::new('hospital', 'Hospital');
+        yield TextField::new('reportingPeriod', 'Reporting period');
+        yield ChoiceField::new('trigger', 'Trigger')
+            ->setChoices([
+                'Scheduler' => MonthlyReminderTrigger::Scheduler->value,
+                'Admin' => MonthlyReminderTrigger::Admin->value,
+                'CLI' => MonthlyReminderTrigger::Cli->value,
+            ])
+            ->renderAsBadges([
+                MonthlyReminderTrigger::Scheduler->value => 'primary',
+                MonthlyReminderTrigger::Admin->value => 'warning',
+                MonthlyReminderTrigger::Cli->value => 'secondary',
+            ]);
+        yield DateTimeField::new('sentAt', 'Sent at')
+            ->setFormat('dd.MM.yyyy HH:mm');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalAccessGrantCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalAccessGrantCrudController.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\Hospital;
+
+use App\Admin\Application\Service\HospitalPermissionLabelFormatter;
+use App\Admin\UI\Form\HospitalPermissionsFieldType;
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @extends AbstractCrudController<HospitalAccessGrant>
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class HospitalAccessGrantCrudController extends AbstractCrudController
+{
+    public function __construct(
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[\Override]
+    public static function getEntityFqcn(): string
+    {
+        return HospitalAccessGrant::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Hospital access grant')
+            ->setEntityLabelInPlural('Hospital access grants')
+            ->setSearchFields(['id', 'hospital.name', 'user.username', 'user.email'])
+            ->setDefaultSort(['createdAt' => 'DESC']);
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->add(Crud::PAGE_INDEX, Action::DETAIL)
+            ->add(Crud::PAGE_EDIT, Action::INDEX);
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add(EntityFilter::new('hospital', 'Hospital'))
+            ->add(EntityFilter::new('user', 'User'));
+    }
+
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')
+            ->onlyOnDetail();
+        yield AssociationField::new('hospital', 'Hospital');
+        yield AssociationField::new('user', 'User');
+        yield Field::new('permissions', 'Permissions')
+            ->setFormType(HospitalPermissionsFieldType::class)
+            ->hideOnIndex()
+            ->formatValue(static fn (mixed $value, HospitalAccessGrant $grant): string => HospitalPermissionLabelFormatter::formatMask($grant->getPermissions()));
+        yield TextField::new('permissionsSummary', 'Permissions')
+            ->onlyOnIndex()
+            ->setValue('')
+            ->formatValue(static fn (mixed $_, HospitalAccessGrant $grant): string => HospitalPermissionLabelFormatter::formatMask($grant->getPermissions()));
+        yield DateTimeField::new('createdAt', 'Created')
+            ->hideOnForm();
+        yield DateTimeField::new('updatedAt', 'Updated')
+            ->hideOnForm();
+        yield AssociationField::new('createdBy', 'Created by')
+            ->onlyOnDetail();
+        yield AssociationField::new('updatedBy', 'Updated by')
+            ->onlyOnDetail();
+    }
+
+    #[\Override]
+    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    {
+        $this->auditContext->beginIntent('hospital_access_grant.admin.created', ['source' => 'easyadmin']);
+        try {
+            parent::persistEntity($entityManager, $entityInstance);
+        } finally {
+            $this->auditContext->endIntent();
+        }
+    }
+
+    #[\Override]
+    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    {
+        $this->auditContext->beginIntent('hospital_access_grant.admin.updated', ['source' => 'easyadmin']);
+        try {
+            parent::updateEntity($entityManager, $entityInstance);
+        } finally {
+            $this->auditContext->endIntent();
+        }
+    }
+}

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalAccessGrantCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalAccessGrantCrudController.php
@@ -91,7 +91,7 @@ final class HospitalAccessGrantCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->auditContext->beginIntent('hospital_access_grant.admin.created', ['source' => 'easyadmin']);
         try {
@@ -102,7 +102,7 @@ final class HospitalAccessGrantCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->auditContext->beginIntent('hospital_access_grant.admin.updated', ['source' => 'easyadmin']);
         try {

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Http\Controller\Hospital;
 
+use App\Admin\UI\Http\Controller\Engagement\MonthlyReminderDispatchCrudController;
 use App\Allocation\Domain\Entity\Hospital;
 use App\Allocation\Domain\Enum\HospitalLocation;
 use App\Allocation\Domain\Enum\HospitalSize;
@@ -16,6 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
@@ -23,7 +25,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -89,10 +93,24 @@ final class HospitalCrudController extends AbstractCrudController
             ->displayIf(static fn (Hospital $hospital): bool => $hospital->isParticipating() && $hospital->getOwner() instanceof \App\User\Domain\Entity\User)
             ->askConfirmation(new TranslatableMessage('admin.hospital.action.send_reminder.confirm', domain: 'admin'));
 
+        $reminderHistory = Action::new('reminderHistory', 'admin.hospital.action.reminder_history', 'fas fa-clock-rotate-left')
+            ->linkToUrl(fn (Hospital $hospital): string => $this->adminUrlGenerator
+                ->unsetAll()
+                ->setController(MonthlyReminderDispatchCrudController::class)
+                ->setAction(Action::INDEX)
+                ->set(EA::FILTERS, [
+                    'hospital' => [
+                        'comparison' => ComparisonType::EQ,
+                        'value' => $hospital->getId(),
+                    ],
+                ])
+                ->generateUrl());
+
         return $actions
             ->add(Crud::PAGE_INDEX, Action::DETAIL)
             ->add(Crud::PAGE_EDIT, Action::INDEX)
-            ->add(Crud::PAGE_DETAIL, $sendReminder);
+            ->add(Crud::PAGE_DETAIL, $sendReminder)
+            ->add(Crud::PAGE_DETAIL, $reminderHistory);
     }
 
     #[AdminRoute(path: '/{entityId}/send-monthly-reminder', name: 'send_monthly_reminder')]
@@ -158,7 +176,13 @@ final class HospitalCrudController extends AbstractCrudController
             ->hideOnIndex();
         yield IntegerField::new('beds', 'Beds')
             ->hideOnIndex();
+        yield NumberField::new('latitude', 'Latitude')
+            ->hideOnIndex();
+        yield NumberField::new('longitude', 'Longitude')
+            ->hideOnIndex();
         yield BooleanField::new('isParticipating', 'Participating');
+        yield AssociationField::new('accessGrants', 'Access grants')
+            ->onlyOnDetail();
 
         yield DateTimeField::new('createdAt', 'Created')
             ->setFormat('dd.MM.yyyy HH:mm')

--- a/src/Admin/UI/Http/Controller/Import/ImportBatchRunCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportBatchRunCrudController.php
@@ -61,10 +61,14 @@ final class ImportBatchRunCrudController extends AbstractCrudController
         yield TextField::new('optionsPreview', 'Options')
             ->onlyOnDetail()
             ->setValue('')
-            ->formatValue(static fn (mixed $_, ImportBatchRun $run): string => json_encode(
-                $run->getOptions(),
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
-            ) ?: '');
+            ->formatValue(static function (mixed $_, ImportBatchRun $run): string {
+                $encoded = json_encode(
+                    $run->getOptions(),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
+                );
+
+                return \is_string($encoded) ? $encoded : '';
+            });
         yield AssociationField::new('items', 'Items')
             ->onlyOnDetail();
     }

--- a/src/Admin/UI/Http/Controller/Import/ImportBatchRunCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportBatchRunCrudController.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\Import;
+
+use App\Import\Domain\Entity\ImportBatchRun;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @extends AbstractCrudController<ImportBatchRun>
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class ImportBatchRunCrudController extends AbstractCrudController
+{
+    #[\Override]
+    public static function getEntityFqcn(): string
+    {
+        return ImportBatchRun::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Import batch run')
+            ->setEntityLabelInPlural('Import batch runs')
+            ->setDefaultSort(['startedAt' => 'DESC']);
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
+            ->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')
+            ->onlyOnDetail();
+        yield ChoiceField::new('status', 'Status')
+            ->renderAsBadges();
+        yield DateTimeField::new('startedAt', 'Started')
+            ->setFormat('dd.MM.yyyy HH:mm');
+        yield DateTimeField::new('finishedAt', 'Finished')
+            ->setFormat('dd.MM.yyyy HH:mm');
+        yield DateTimeField::new('createdAt', 'Created')
+            ->onlyOnDetail();
+        yield TextField::new('optionsPreview', 'Options')
+            ->onlyOnDetail()
+            ->setValue('')
+            ->formatValue(static fn (mixed $_, ImportBatchRun $run): string => json_encode(
+                $run->getOptions(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
+            ) ?: '');
+        yield AssociationField::new('items', 'Items')
+            ->onlyOnDetail();
+    }
+}

--- a/src/Admin/UI/Http/Controller/Import/ImportBatchRunItemCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportBatchRunItemCrudController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\Import;
+
+use App\Import\Domain\Entity\ImportBatchRunItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @extends AbstractCrudController<ImportBatchRunItem>
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class ImportBatchRunItemCrudController extends AbstractCrudController
+{
+    #[\Override]
+    public static function getEntityFqcn(): string
+    {
+        return ImportBatchRunItem::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Import batch run item')
+            ->setEntityLabelInPlural('Import batch run items')
+            ->setSearchFields(['importName'])
+            ->setDefaultSort(['id' => 'DESC']);
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
+            ->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')
+            ->onlyOnDetail();
+        yield AssociationField::new('run', 'Batch run');
+        yield IntegerField::new('importId', 'Import ID');
+        yield TextField::new('importName', 'Import name');
+        yield ChoiceField::new('status', 'Status')
+            ->renderAsBadges();
+        yield IntegerField::new('attemptCount', 'Attempts')
+            ->onlyOnDetail();
+        yield DateTimeField::new('startedAt', 'Started')
+            ->onlyOnDetail();
+        yield DateTimeField::new('finishedAt', 'Finished')
+            ->onlyOnDetail();
+        yield TextareaField::new('errorMessage', 'Error')
+            ->onlyOnDetail();
+    }
+}

--- a/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
@@ -114,6 +114,17 @@ final class ImportCrudController extends AbstractCrudController
             ->onlyOnDetail();
         yield TextField::new('rejectFilePath', 'Reject file')
             ->onlyOnDetail();
+        yield TextField::new('fileExtension', 'File extension')
+            ->onlyOnDetail();
+        yield TextField::new('fileMimeType', 'MIME type')
+            ->onlyOnDetail();
+        yield IntegerField::new('fileSize', 'File size (bytes)')
+            ->onlyOnDetail();
+        yield TextField::new('fileChecksum', 'Checksum')
+            ->onlyOnDetail();
+        yield DateTimeField::new('updatedAt', 'Updated')
+            ->setFormat('dd.MM.yy HH:mm')
+            ->onlyOnDetail();
     }
 
     #[\Override]

--- a/src/Admin/UI/Http/Controller/Media/MediaCrudController.php
+++ b/src/Admin/UI/Http/Controller/Media/MediaCrudController.php
@@ -86,6 +86,8 @@ final class MediaCrudController extends AbstractCrudController
         yield TextField::new('filename', 'label.filename')->onlyOnDetail();
         yield TextField::new('mimeType', 'label.mime_type')->onlyOnDetail();
         yield IntegerField::new('size', 'label.file_size')->onlyOnDetail();
+        yield IntegerField::new('width', 'label.width')->onlyOnDetail();
+        yield IntegerField::new('height', 'label.height')->onlyOnDetail();
         yield ChoiceField::new('type', new TranslatableMessage('label.media_type', domain: 'content'))
             ->setChoices($this->mediaTypeChoices())
             ->renderAsBadges()

--- a/src/Admin/UI/Http/Controller/Onboarding/UserOnboardingStepCrudController.php
+++ b/src/Admin/UI/Http/Controller/Onboarding/UserOnboardingStepCrudController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Http\Controller\Onboarding;
+
+use App\Onboarding\Domain\Entity\UserOnboardingStep;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @extends AbstractCrudController<UserOnboardingStep>
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class UserOnboardingStepCrudController extends AbstractCrudController
+{
+    #[\Override]
+    public static function getEntityFqcn(): string
+    {
+        return UserOnboardingStep::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('User onboarding step')
+            ->setEntityLabelInPlural('User onboarding steps')
+            ->setSearchFields(['user.username', 'user.email'])
+            ->setDefaultSort(['completedAt' => 'DESC']);
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
+            ->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add(EntityFilter::new('user', 'User'));
+    }
+
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')
+            ->onlyOnDetail();
+        yield AssociationField::new('user', 'User');
+        yield ChoiceField::new('stepKey', 'Step')
+            ->renderAsBadges();
+        yield DateTimeField::new('completedAt', 'Completed at')
+            ->setFormat('dd.MM.yyyy HH:mm');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Statistics/SavedExplorerViewCrudController.php
+++ b/src/Admin/UI/Http/Controller/Statistics/SavedExplorerViewCrudController.php
@@ -2,48 +2,49 @@
 
 declare(strict_types=1);
 
-namespace App\Admin\UI\Http\Controller\IndicationNormalized;
+namespace App\Admin\UI\Http\Controller\Statistics;
 
-use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Statistics\Domain\Entity\SavedExplorerView;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
- * @extends AbstractCrudController<IndicationNormalized>
+ * @extends AbstractCrudController<SavedExplorerView>
  */
 #[IsGranted('ROLE_ADMIN')]
-final class IndicationNormalizedCrudController extends AbstractCrudController
+final class SavedExplorerViewCrudController extends AbstractCrudController
 {
     #[\Override]
     public static function getEntityFqcn(): string
     {
-        return IndicationNormalized::class;
+        return SavedExplorerView::class;
     }
 
     #[\Override]
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
-            ->setEntityLabelInSingular('Indication Normalized')
-            ->setEntityLabelInPlural('Indication Normalized')
-            ->setSearchFields(['id', 'name', 'code'])
-            ->setDefaultSort(['name' => 'ASC']);
+            ->setEntityLabelInSingular('Saved explorer view')
+            ->setEntityLabelInPlural('Saved explorer views')
+            ->setSearchFields(['slug', 'title', 'category'])
+            ->setDefaultSort(['updatedAt' => 'DESC']);
     }
 
     #[\Override]
     public function configureActions(Actions $actions): Actions
     {
         return $actions
-            ->add(Crud::PAGE_INDEX, Action::DETAIL)
-            ->add(Crud::PAGE_EDIT, Action::INDEX);
+            ->disable(Action::NEW, Action::EDIT, Action::DELETE, Action::BATCH_DELETE)
+            ->add(Crud::PAGE_INDEX, Action::DETAIL);
     }
 
     #[\Override]
@@ -51,18 +52,22 @@ final class IndicationNormalizedCrudController extends AbstractCrudController
     {
         yield IdField::new('id')
             ->onlyOnDetail();
-        yield IntegerField::new('code', 'Code');
-        yield TextField::new('name', 'Name');
-        yield TextField::new('note', 'Note')
+        yield TextField::new('slug', 'Slug');
+        yield TextField::new('title', 'Title');
+        yield TextField::new('category', 'Category');
+        yield BooleanField::new('isSystem', 'System view');
+        yield TextareaField::new('description', 'Description')
             ->onlyOnDetail();
-        yield AssociationField::new('children', 'Children')
-            ->onlyOnDetail();
-        yield AssociationField::new('groups', 'Groups');
+        yield TextField::new('configJsonPreview', 'Config JSON')
+            ->onlyOnDetail()
+            ->setValue('')
+            ->formatValue(static fn (mixed $_, SavedExplorerView $view): string => json_encode(
+                $view->getConfigJson(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
+            ) ?: '');
         yield DateTimeField::new('createdAt', 'Created')
-            ->setFormat('dd.MM.yyyy HH:mm')
             ->hideOnForm();
         yield DateTimeField::new('updatedAt', 'Updated')
-            ->setFormat('dd.MM.yyyy HH:mm')
             ->hideOnForm();
         yield AssociationField::new('createdBy', 'Created by')
             ->onlyOnDetail();

--- a/src/Admin/UI/Http/Controller/Statistics/SavedExplorerViewCrudController.php
+++ b/src/Admin/UI/Http/Controller/Statistics/SavedExplorerViewCrudController.php
@@ -61,10 +61,14 @@ final class SavedExplorerViewCrudController extends AbstractCrudController
         yield TextField::new('configJsonPreview', 'Config JSON')
             ->onlyOnDetail()
             ->setValue('')
-            ->formatValue(static fn (mixed $_, SavedExplorerView $view): string => json_encode(
-                $view->getConfigJson(),
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
-            ) ?: '');
+            ->formatValue(static function (mixed $_, SavedExplorerView $view): string {
+                $encoded = json_encode(
+                    $view->getConfigJson(),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE,
+                );
+
+                return \is_string($encoded) ? $encoded : '';
+            });
         yield DateTimeField::new('createdAt', 'Created')
             ->hideOnForm();
         yield DateTimeField::new('updatedAt', 'Updated')

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Http\Controller\User;
 
+use App\Shared\Application\Locale\SupportedLocales;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
@@ -12,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
@@ -97,6 +99,16 @@ final class UserCrudController extends AbstractCrudController
         yield BooleanField::new('credentialsExpired');
         yield BooleanField::new('isEnabled')
             ->renderAsSwitch();
+        yield ChoiceField::new('locale', 'Locale')
+            ->setChoices([
+                'English' => SupportedLocales::DEFAULT,
+                'German' => SupportedLocales::GERMAN,
+            ])
+            ->setRequired(false);
+        yield BooleanField::new('receivesMonthlySubmissionReminder', 'Monthly submission reminder')
+            ->renderAsSwitch();
+        yield AssociationField::new('hospitals', 'Owned hospitals')
+            ->hideOnForm();
         yield ChoiceField::new('roles')
             ->setChoices([
                 'Admin' => UserRole::ADMIN,

--- a/src/Admin/UI/Twig/AdminTwigExtension.php
+++ b/src/Admin/UI/Twig/AdminTwigExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\UI\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class AdminTwigExtension extends AbstractExtension
+{
+    #[\Override]
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('format_bytes', $this->formatBytes(...)),
+        ];
+    }
+
+    public function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        if ($bytes < 1024 * 1024) {
+            return sprintf('%.1f KB', $bytes / 1024);
+        }
+
+        if ($bytes < 1024 * 1024 * 1024) {
+            return sprintf('%.1f MB', $bytes / (1024 * 1024));
+        }
+
+        return sprintf('%.2f GB', $bytes / (1024 * 1024 * 1024));
+    }
+}

--- a/src/Admin/UI/Twig/templates/dashboard/_failed_imports_table.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/_failed_imports_table.html.twig
@@ -1,5 +1,14 @@
 <div class="ea-dashboard-kpi mb-4">
-    <h3 class="h5 text-muted text-uppercase mb-3">{{ 'kpi.failed_imports.title'|trans({}, 'admin') }}</h3>
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+        <div>
+            <h3 class="h5 text-muted text-uppercase mb-1">{{ 'kpi.failed_imports.title'|trans({}, 'admin') }}</h3>
+            <p class="text-muted small mb-0">{{ 'kpi.failed_imports.subtitle_30d'|trans({}, 'admin') }}</p>
+        </div>
+        <a href="{{ failed_imports.allFailedImportsUrl }}" class="btn btn-primary ea-admin-primary-badge-btn d-inline-flex align-items-center">
+            {{ 'kpi.failed_imports.view_all'|trans({}, 'admin') }}
+            <span class="badge ea-admin-primary-badge-btn__badge">{{ failed_imports.totalFailedCount }}</span>
+        </a>
+    </div>
     <div class="card">
         <div class="table-responsive">
             <table class="table table-striped table-hover mb-0 align-middle">
@@ -15,12 +24,12 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% if failed_imports is empty %}
+                    {% if failed_imports.rows is empty %}
                         <tr>
                             <td colspan="7" class="text-muted text-center py-4">{{ 'kpi.failed_imports.empty'|trans({}, 'admin') }}</td>
                         </tr>
                     {% else %}
-                        {% for row in failed_imports %}
+                        {% for row in failed_imports.rows %}
                             <tr>
                                 <td class="text-nowrap">{{ row.createdAt|date('d.m.Y H:i') }}</td>
                                 <td>{{ row.hospitalName }}</td>

--- a/src/Admin/UI/Twig/templates/dashboard/_kpi_cards.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/_kpi_cards.html.twig
@@ -1,5 +1,4 @@
 <div class="ea-dashboard-kpi mb-4">
-    <h3 class="h5 text-muted text-uppercase mb-3">{{ 'kpi.section.title'|trans({}, 'admin') }}</h3>
     <div class="row">
         {% for card in kpi_cards.cards %}
             <div class="col-12 col-sm-6 col-xl-3 mb-3 ea-kpi-card">

--- a/src/Admin/UI/Twig/templates/dashboard/_ops_cards.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/_ops_cards.html.twig
@@ -1,0 +1,37 @@
+<div class="ea-dashboard-ops mb-4">
+    <h3 class="h5 text-muted text-uppercase mb-3">{{ 'ops.section.title'|trans({}, 'admin') }}</h3>
+    <div class="row">
+        {% for card in ops_cards %}
+            <div class="col-12 col-sm-6 col-xl-4 mb-3">
+                {% if card.detailUrl %}
+                    <a href="{{ card.detailUrl }}" class="text-decoration-none text-body d-block h-100">
+                {% endif %}
+                <div class="card h-100 border-{{ card.style }}">
+                    <div class="card-body d-flex flex-column">
+                        <div class="d-flex align-items-start justify-content-between mb-2">
+                            <div class="d-flex align-items-center gap-2">
+                                <i class="{{ card.icon }} fa-lg text-secondary" aria-hidden="true"></i>
+                                <span class="text-muted small mb-0">{{ card.labelKey|trans({}, 'admin') }}</span>
+                            </div>
+                        </div>
+                        <p class="ea-kpi-value mb-1">{{ card.value }}</p>
+                        {% if card.trendBytes is not null %}
+                            {% set trendUp = card.trendBytes > 0 %}
+                            <p class="ea-ops-card-trend mb-0 small {{ trendUp ? 'text-success' : 'text-muted' }}">
+                                <i class="fas {{ trendUp ? 'fa-arrow-trend-up' : 'fa-minus' }} me-1" aria-hidden="true"></i>
+                                {% if trendUp %}
+                                    {{ 'ops.card.trend_up'|trans({'%size%': card.trendBytes|format_bytes}, 'admin') }}
+                                {% else %}
+                                    {{ 'ops.card.trend_flat'|trans({}, 'admin') }}
+                                {% endif %}
+                            </p>
+                        {% endif %}
+                    </div>
+                </div>
+                {% if card.detailUrl %}
+                    </a>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+</div>

--- a/src/Admin/UI/Twig/templates/dashboard/_ops_health.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/_ops_health.html.twig
@@ -1,0 +1,26 @@
+<div class="ea-dashboard-kpi mb-3">
+    <div class="card ea-ops-health-banner border-2">
+        <div class="card-body">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
+                <div class="d-flex align-items-center gap-3">
+                    {% set statusIcon = ops_health.status.value == 'healthy' ? 'fas fa-circle-check' : (ops_health.status.value == 'degraded' ? 'fas fa-circle-exclamation' : 'fas fa-circle-xmark') %}
+                    {% set statusClass = ops_health.status.value == 'healthy' ? 'success' : (ops_health.status.value == 'degraded' ? 'warning' : 'danger') %}
+                    <i class="{{ statusIcon }} fa-2x text-{{ statusClass }}" aria-hidden="true"></i>
+                    <div>
+                        <div class="h4 mb-0">{{ ('ops.health.status.' ~ ops_health.status.value)|trans({}, 'admin') }}</div>
+                        <div class="text-muted small">{{ 'ops.health.version'|trans({'%version%': ops_health.appVersion}, 'admin') }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                {% for item in ops_health.items %}
+                    <span class="badge rounded-pill ea-ops-health-badge bg-{{ item.severity }} text-white d-inline-flex align-items-center gap-2 px-3 py-2">
+                        <i class="{{ item.icon }}" aria-hidden="true"></i>
+                        <span class="fw-semibold">{{ item.labelKey|trans({}, 'admin') }}:</span>
+                        <span>{{ item.value }}</span>
+                    </span>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Admin/UI/Twig/templates/dashboard/_ops_notifications.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/_ops_notifications.html.twig
@@ -1,0 +1,33 @@
+<div class="ea-dashboard-ops-notifications mb-4">
+    <h3 class="h5 text-muted text-uppercase mb-3">{{ 'ops.notifications.title'|trans({}, 'admin') }}</h3>
+    <div class="card">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th scope="col">{{ 'ops.notifications.time'|trans({}, 'admin') }}</th>
+                        <th scope="col">{{ 'ops.notifications.intent'|trans({}, 'admin') }}</th>
+                        <th scope="col">{{ 'ops.notifications.action'|trans({}, 'admin') }}</th>
+                        <th scope="col">{{ 'ops.notifications.origin'|trans({}, 'admin') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% if recent_notifications is empty %}
+                        <tr>
+                            <td colspan="4" class="text-muted text-center py-4">{{ 'ops.notifications.empty'|trans({}, 'admin') }}</td>
+                        </tr>
+                    {% else %}
+                        {% for event in recent_notifications %}
+                            <tr>
+                                <td class="text-nowrap">{{ event.occurredAt|date('d.m.Y H:i') }}</td>
+                                <td><code>{{ event.intent }}</code></td>
+                                <td>{{ event.action }}</td>
+                                <td>{{ event.origin }}</td>
+                            </tr>
+                        {% endfor %}
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Admin/UI/Twig/templates/dashboard/index.html.twig
+++ b/src/Admin/UI/Twig/templates/dashboard/index.html.twig
@@ -8,6 +8,11 @@
 {% block content_title %}{{ 'title.dashboard'|trans({}, 'admin') }}{% endblock %}
 
 {% block main %}
+    {{ include('@Admin/dashboard/_ops_health.html.twig') }}
+    {{ include('@Admin/dashboard/_ops_cards.html.twig') }}
+    {{ include('@Admin/dashboard/_ops_notifications.html.twig') }}
+
+    <h3 class="h5 text-muted text-uppercase mb-3">{{ 'kpi.section.title'|trans({}, 'admin') }}</h3>
     {{ include('@Admin/dashboard/_kpi_cards.html.twig') }}
     {{ include('@Admin/dashboard/_kpi_chart.html.twig') }}
     {{ include('@Admin/dashboard/_failed_imports_table.html.twig') }}

--- a/src/Admin/UI/Twig/templates/import_rejects/list.html.twig
+++ b/src/Admin/UI/Twig/templates/import_rejects/list.html.twig
@@ -93,7 +93,7 @@
             <tr>
                 <th class="col-2">
                     <a class="text-muted" href="{{ path(pagination_route, {
-                        ...app.request.query.all(),
+                        ... app.request.query.all(),
                         sortBy: 'createdAt',
                         orderBy: sortBy == 'createdAt' and orderBy == 'asc' ? 'desc' : 'asc',
                     }) }}">
@@ -104,7 +104,7 @@
 
                 <th class="col-3">
                     <a class="text-muted" href="{{ path(pagination_route, {
-                        ...app.request.query.all(),
+                        ... app.request.query.all(),
                         sortBy: 'hospital',
                         orderBy: sortBy == 'hospital' and orderBy == 'asc' ? 'desc' : 'asc',
                     }) }}">
@@ -115,7 +115,7 @@
 
                 <th class="col-3">
                     <a class="text-muted" href="{{ path(pagination_route, {
-                        ...app.request.query.all(),
+                        ... app.request.query.all(),
                         sortBy: 'importId',
                         orderBy: sortBy == 'importId' and orderBy == 'asc' ? 'desc' : 'asc',
                     }) }}">
@@ -126,7 +126,7 @@
 
                 <th class="col-1">
                     <a class="text-muted" href="{{ path(pagination_route, {
-                        ...app.request.query.all(),
+                        ... app.request.query.all(),
                         sortBy: 'lineNumber',
                         orderBy: sortBy == 'lineNumber' and orderBy == 'asc' ? 'desc' : 'asc',
                     }) }}">

--- a/src/Admin/UI/Twig/templates/operations/failed_messages_detail.html.twig
+++ b/src/Admin/UI/Twig/templates/operations/failed_messages_detail.html.twig
@@ -1,0 +1,38 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block configured_stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/admin-kpi.css') }}">
+{% endblock %}
+
+{% block content_title %}{{ 'ops.failed_messages.detail_title'|trans({'%id%': message.id}, 'admin') }}{% endblock %}
+
+{% block main %}
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+        <a href="{{ back_url }}" class="btn btn-outline-secondary ea-admin-action-btn">&larr; {{ 'ops.failed_messages.back'|trans({}, 'admin') }}</a>
+        <form method="post"
+              action="{{ delete_url }}"
+              class="m-0"
+              onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin')|e('js') }}');">
+            <input type="hidden" name="_token" value="{{ csrf_token('failed_message_delete_' ~ message.id) }}">
+            <button type="submit" class="btn btn-outline-secondary ea-admin-action-btn">
+                {{ 'ops.failed_messages.delete'|trans({}, 'admin') }}
+            </button>
+        </form>
+    </div>
+
+    <dl class="row">
+        <dt class="col-sm-2">{{ 'ops.failed_messages.created'|trans({}, 'admin') }}</dt>
+        <dd class="col-sm-10">{{ message.created_at|date('d.m.Y H:i:s') }}</dd>
+        <dt class="col-sm-2">{{ 'ops.failed_messages.class'|trans({}, 'admin') }}</dt>
+        <dd class="col-sm-10"><code>{{ message.message_class ?: '—' }}</code></dd>
+    </dl>
+
+    <h3 class="h5 mt-4">{{ 'ops.failed_messages.headers'|trans({}, 'admin') }}</h3>
+    <pre class="rounded border bg-white p-3 overflow-auto small" style="max-height: 16rem;">{{ message.headers }}</pre>
+
+    <h3 class="h5 mt-4">{{ 'ops.failed_messages.body'|trans({}, 'admin') }}</h3>
+    <pre class="rounded border bg-white p-3 overflow-auto small" style="max-height: 28rem;">{{ message.body }}</pre>
+
+    <p class="text-muted small mt-3">{{ 'ops.failed_messages.cli_hint'|trans({}, 'admin') }}</p>
+{% endblock %}

--- a/src/Admin/UI/Twig/templates/operations/failed_messages_index.html.twig
+++ b/src/Admin/UI/Twig/templates/operations/failed_messages_index.html.twig
@@ -1,0 +1,124 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block configured_stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/admin-kpi.css') }}">
+{% endblock %}
+
+{% block content_title %}{{ 'ops.failed_messages.title'|trans({}, 'admin') }}{% endblock %}
+
+{% block main %}
+    <p class="text-muted mb-3">{{ 'ops.failed_messages.help'|trans({}, 'admin') }}</p>
+
+    {% if messages is not empty %}
+        <div class="d-flex flex-wrap align-items-center ea-failed-messages-toolbar mb-3">
+            <form method="post"
+                  action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete_all') }}"
+                  class="m-0"
+                  onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_all'|trans({}, 'admin')|e('js') }}');">
+                <input type="hidden" name="_token" value="{{ csrf_token('failed_messages_delete_all') }}">
+                <button type="submit" class="btn btn-primary ea-admin-primary-badge-btn d-inline-flex align-items-center">
+                    {{ 'ops.failed_messages.delete_all'|trans({}, 'admin') }}
+                    <span class="badge ea-admin-primary-badge-btn__badge">{{ total_count }}</span>
+                </button>
+            </form>
+
+            <form method="post"
+                  action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete_selected') }}"
+                  id="failed-messages-batch-form"
+                  class="m-0"
+                  onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_selected'|trans({}, 'admin')|e('js') }}');">
+                <input type="hidden" name="_token" value="{{ csrf_token('failed_messages_delete_batch') }}">
+                <button type="submit" class="btn btn-outline-primary ea-admin-action-btn">
+                    {{ 'ops.failed_messages.delete_selected'|trans({}, 'admin') }}
+                </button>
+            </form>
+        </div>
+
+        <div class="card">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover mb-0 align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col" style="width: 2.5rem;">
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       id="failed-messages-select-all"
+                                       aria-label="{{ 'ops.failed_messages.select_all'|trans({}, 'admin') }}">
+                            </th>
+                            <th scope="col">ID</th>
+                            <th scope="col">{{ 'ops.failed_messages.created'|trans({}, 'admin') }}</th>
+                            <th scope="col">{{ 'ops.failed_messages.class'|trans({}, 'admin') }}</th>
+                            <th scope="col">{{ 'ops.failed_messages.preview'|trans({}, 'admin') }}</th>
+                            <th scope="col"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for message in messages %}
+                            <tr>
+                                <td>
+                                    <input type="checkbox"
+                                           class="form-check-input failed-message-select"
+                                           name="ids[]"
+                                           value="{{ message.id }}"
+                                           form="failed-messages-batch-form"
+                                           aria-label="{{ 'ops.failed_messages.select_item'|trans({'%id%': message.id}, 'admin') }}">
+                                </td>
+                                <td>{{ message.id }}</td>
+                                <td class="text-nowrap">{{ message.created_at|date('d.m.Y H:i:s') }}</td>
+                                <td class="small"><code>{{ message.message_class ?: '—' }}</code></td>
+                                <td class="small text-muted">{{ message.error_preview }}</td>
+                                <td class="text-end text-nowrap">
+                                    <div class="d-inline-flex align-items-center ea-failed-messages-row-actions">
+                                        <a href="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_detail', {id: message.id}) }}" class="btn btn-sm btn-outline-primary">
+                                            {{ 'ops.failed_messages.view'|trans({}, 'admin') }}
+                                        </a>
+                                        <form method="post"
+                                              action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete', {id: message.id}) }}"
+                                              class="m-0"
+                                              onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin')|e('js') }}');">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('failed_message_delete_' ~ message.id) }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-secondary">
+                                                {{ 'ops.failed_messages.delete'|trans({}, 'admin') }}
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <script>
+            document.getElementById('failed-messages-select-all')?.addEventListener('change', (event) => {
+                const checked = event.target.checked;
+                document.querySelectorAll('.failed-message-select').forEach((checkbox) => {
+                    checkbox.checked = checked;
+                });
+            });
+        </script>
+    {% else %}
+        <div class="card">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover mb-0 align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">ID</th>
+                            <th scope="col">{{ 'ops.failed_messages.created'|trans({}, 'admin') }}</th>
+                            <th scope="col">{{ 'ops.failed_messages.class'|trans({}, 'admin') }}</th>
+                            <th scope="col">{{ 'ops.failed_messages.preview'|trans({}, 'admin') }}</th>
+                            <th scope="col"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td colspan="5" class="text-muted text-center py-4">{{ 'ops.failed_messages.empty'|trans({}, 'admin') }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/src/Allocation/UI/Twig/templates/allocations/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/list.html.twig
@@ -84,7 +84,7 @@
                 <tr>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_allocation_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             cursor: null,
                             sortBy: 'arrivalAt',
                             orderBy: sortBy == 'arrivalAt' and orderBy == 'asc' ? 'desc' : 'asc',
@@ -94,7 +94,7 @@
                     </th>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_explore_allocation_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             cursor: null,
                             sortBy: 'age',
                             orderBy: sortBy == 'age' and orderBy == 'asc' ? 'desc' : 'asc',

--- a/src/Allocation/UI/Twig/templates/assignments/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/assignments/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-8">
                             <a class="text-muted" href="{{ path('app_explore_assignment_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -115,7 +115,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/departments/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/departments/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-8">
                             <a class="text-muted" href="{{ path('app_explore_department_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_department_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/dispatch_areas/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/dispatch_areas/list.html.twig
@@ -167,7 +167,7 @@
                     <tr>
                         <th class="col-4">
                             <a class="text-muted" href="{{ path('app_explore_dispatch_area_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -176,7 +176,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_dispatch_area_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'state',
                                 orderBy: sortBy == 'state' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -185,7 +185,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_dispatch_area_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/hospitals/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/list.html.twig
@@ -167,7 +167,7 @@
                     <th></th>
                     <th class="col-3">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'name',
                             orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -176,7 +176,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'dispatchArea',
                             orderBy: sortBy == 'dispatchArea' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -185,7 +185,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'state',
                             orderBy: sortBy == 'state' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -194,7 +194,7 @@
                     </th>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'location',
                             orderBy: sortBy == 'location' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -203,7 +203,7 @@
                     </th>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'tier',
                             orderBy: sortBy == 'tier' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -212,7 +212,7 @@
                     </th>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'size',
                             orderBy: sortBy == 'size' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -221,7 +221,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_hospital_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'lastChange',
                             orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">

--- a/src/Allocation/UI/Twig/templates/indications/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/indications/list.html.twig
@@ -104,7 +104,7 @@
                 <tr>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_explore_indication_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'code',
                             orderBy: sortBy == 'code' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -114,7 +114,7 @@
                     {% if active_type == 'raw' %}
                         <th class="col-3">
                             <a class="text-muted" href="{{ path('app_explore_indication_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -132,7 +132,7 @@
                     {% else %}
                         <th class="col-7">
                             <a class="text-muted" href="{{ path('app_explore_indication_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -142,7 +142,7 @@
                     {% endif %}
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_indication_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'lastChange',
                             orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">

--- a/src/Allocation/UI/Twig/templates/infections/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/infections/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-8">
                             <a class="text-muted" href="{{ path('app_explore_infection_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_infection_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/mci_cases/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/mci_cases/list.html.twig
@@ -65,7 +65,7 @@
                 <tr>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_explore_mci_case_list', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'createdAt',
                             orderBy: sortBy == 'createdAt' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">

--- a/src/Allocation/UI/Twig/templates/occasions/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/occasions/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-8">
                             <a class="text-muted" href="{{ path('app_explore_occasion_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_occasion_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/secondary_transports/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/secondary_transports/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-8">
                             <a class="text-muted" href="{{ path('app_explore_secondary_transport_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_secondary_transport_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Allocation/UI/Twig/templates/specialities/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/specialities/list.html.twig
@@ -97,7 +97,7 @@
                     <tr>
                         <th class="col-6">
                             <a class="text-muted" href="{{ path('app_explore_speciality_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'name',
                                 orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">
@@ -106,7 +106,7 @@
                         </th>
                         <th class="col-2">
                             <a class="text-muted" href="{{ path('app_explore_speciality_list', {
-                                ...app.request.query.all(),
+                                ... app.request.query.all(),
                                 sortBy: 'lastChange',
                                 orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                             }) }}">

--- a/src/Import/Infrastructure/Repository/ImportRepository.php
+++ b/src/Import/Infrastructure/Repository/ImportRepository.php
@@ -284,24 +284,39 @@ SQL;
     /**
      * @return list<Import>
      */
-    public function findRecentFailedImports(int $limit = 10): array
+    public function findRecentFailedImports(int $limit = 10, ?\DateTimeImmutable $since = null): array
     {
         if ($limit <= 0) {
             return [];
         }
 
-        /** @var list<Import> $imports */
-        $imports = $this->createQueryBuilder('i')
+        $qb = $this->createQueryBuilder('i')
             ->addSelect('h')
             ->join('i.hospital', 'h')
             ->where('i.status = :failed')
             ->setParameter('failed', ImportStatus::FAILED)
             ->orderBy('i.createdAt', 'DESC')
-            ->setMaxResults($limit)
-            ->getQuery()
-            ->getResult();
+            ->setMaxResults($limit);
+
+        if ($since instanceof \DateTimeImmutable) {
+            $qb->andWhere('i.createdAt >= :since')
+                ->setParameter('since', $since, Types::DATETIME_IMMUTABLE);
+        }
+
+        /** @var list<Import> $imports */
+        $imports = $qb->getQuery()->getResult();
 
         return $imports;
+    }
+
+    public function countFailedImports(): int
+    {
+        return (int) $this->createQueryBuilder('i')
+            ->select('COUNT(i.id)')
+            ->where('i.status = :failed')
+            ->setParameter('failed', ImportStatus::FAILED)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function hasImportsCreatedByUserSince(User $user, \DateTimeImmutable $since): bool

--- a/src/Import/UI/Twig/templates/index.html.twig
+++ b/src/Import/UI/Twig/templates/index.html.twig
@@ -151,7 +151,7 @@
                 <tr>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'type',
                             orderBy: sortBy == 'type' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -160,7 +160,7 @@
                     </th>
                     <th class="col-3">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'name',
                             orderBy: sortBy == 'name' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -169,7 +169,7 @@
                     </th>
                     <th class="col-1">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'status',
                             orderBy: sortBy == 'status' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -178,7 +178,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'hospital',
                             orderBy: sortBy == 'hospital' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -187,7 +187,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'createdAt',
                             orderBy: sortBy == 'createdAt' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">
@@ -196,7 +196,7 @@
                     </th>
                     <th class="col-2">
                         <a class="text-muted" href="{{ path('app_import_index', {
-                            ...app.request.query.all(),
+                            ... app.request.query.all(),
                             sortBy: 'lastChange',
                             orderBy: sortBy == 'lastChange' and orderBy == 'asc' ? 'desc' : 'asc',
                         }) }}">

--- a/src/Kpi/Application/DTO/FailedImportsDashboardDto.php
+++ b/src/Kpi/Application/DTO/FailedImportsDashboardDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Kpi\Application\DTO;
+
+final readonly class FailedImportsDashboardDto
+{
+    /**
+     * @param list<FailedImportRowDto> $rows
+     */
+    public function __construct(
+        public array $rows,
+        public int $totalFailedCount,
+        public string $allFailedImportsUrl,
+    ) {
+    }
+}

--- a/src/Kpi/Application/Service/KpiDashboardService.php
+++ b/src/Kpi/Application/Service/KpiDashboardService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Kpi\Application\Service;
 
 use App\Admin\UI\Http\Controller\Allocation\AllocationCrudController;
+use App\Admin\UI\Http\Controller\DashboardController;
 use App\Admin\UI\Http\Controller\Hospital\HospitalCrudController;
 use App\Admin\UI\Http\Controller\Import\ImportCrudController;
 use App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController;
@@ -12,10 +13,14 @@ use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Infrastructure\Repository\ImportRepository;
 use App\Kpi\Application\DTO\FailedImportRowDto;
+use App\Kpi\Application\DTO\FailedImportsDashboardDto;
 use App\Kpi\Application\DTO\KpiCardDto;
 use App\Kpi\Application\DTO\KpiCardsDto;
 use App\Kpi\Application\DTO\KpiChartSeriesDto;
 use App\Kpi\Infrastructure\Repository\KpiDailyRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -97,12 +102,27 @@ final readonly class KpiDashboardService
         return new KpiChartSeriesDto($labels, $recordsPerDay, $rejectionRatePerDay);
     }
 
+    public function getFailedImportsDashboard(int $limit = 10): FailedImportsDashboardDto
+    {
+        $since = new \DateTimeImmutable('-30 days', new \DateTimeZone(self::TIMEZONE))
+            ->setTime(0, 0);
+
+        return new FailedImportsDashboardDto(
+            rows: $this->buildFailedImportRows(
+                $this->importRepository->findRecentFailedImports($limit, $since),
+            ),
+            totalFailedCount: $this->importRepository->countFailedImports(),
+            allFailedImportsUrl: $this->generateFailedImportsIndexUrl(),
+        );
+    }
+
     /**
+     * @param list<Import> $imports
+     *
      * @return list<FailedImportRowDto>
      */
-    public function getRecentFailedImports(int $limit = 10): array
+    private function buildFailedImportRows(array $imports): array
     {
-        $imports = $this->importRepository->findRecentFailedImports($limit);
         $rows = [];
 
         foreach ($imports as $import) {
@@ -124,6 +144,22 @@ final readonly class KpiDashboardService
         }
 
         return $rows;
+    }
+
+    private function generateFailedImportsIndexUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->unsetAll()
+            ->setDashboard(DashboardController::class)
+            ->setController(ImportCrudController::class)
+            ->setAction(Action::INDEX)
+            ->set(EA::FILTERS, [
+                'status' => [
+                    'comparison' => ComparisonType::EQ,
+                    'value' => ImportStatus::FAILED->value,
+                ],
+            ])
+            ->generateUrl();
     }
 
     /**

--- a/src/Shared/Infrastructure/Audit/Repository/AuditEntryRepository.php
+++ b/src/Shared/Infrastructure/Audit/Repository/AuditEntryRepository.php
@@ -21,4 +21,48 @@ final class AuditEntryRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, AuditEntry::class);
     }
+
+    /**
+     * @param list<string> $intents
+     *
+     * @return list<array{occurredAt: \DateTimeImmutable, intent: string, action: string, origin: string}>
+     */
+    public function findRecentByIntents(array $intents, int $limit = 10): array
+    {
+        if ([] === $intents) {
+            return [];
+        }
+
+        /** @var list<AuditEntry> $entries */
+        $entries = $this->createQueryBuilder('a')
+            ->orderBy('a.occurredAt', 'DESC')
+            ->setMaxResults(200)
+            ->getQuery()
+            ->getResult();
+
+        $results = [];
+        foreach ($entries as $entry) {
+            $metadata = $entry->getMetadata();
+            if (!\is_array($metadata) || !isset($metadata['intent']) || !\is_string($metadata['intent'])) {
+                continue;
+            }
+
+            if (!\in_array($metadata['intent'], $intents, true)) {
+                continue;
+            }
+
+            $results[] = [
+                'occurredAt' => $entry->getOccurredAt(),
+                'intent' => $metadata['intent'],
+                'action' => $entry->getAction(),
+                'origin' => $entry->getOrigin(),
+            ];
+
+            if (\count($results) >= $limit) {
+                break;
+            }
+        }
+
+        return $results;
+    }
 }

--- a/tests/Admin/Functional/Controller/DashboardOperationsTest.php
+++ b/tests/Admin/Functional/Controller/DashboardOperationsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DashboardOperationsTest extends WebTestCase
+{
+    use Factories;
+
+    public function testDashboardShowsOperationsPanel(): void
+    {
+        $client = self::createClient();
+
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'ops-admin-'.bin2hex(random_bytes(4)),
+            ]);
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseIsSuccessful();
+        $text = $crawler->text();
+        self::assertStringContainsString('Operations', $text);
+        self::assertStringContainsString('Failed messages', $text);
+        self::assertStringContainsString('Total storage', $text);
+        self::assertStringContainsString('Database', $text);
+        self::assertStringContainsString('Imports / media', $text);
+        self::assertStringContainsString('Recent notifications', $text);
+        self::assertStringContainsString('Healthy', $text);
+        self::assertStringNotContainsString('Reminders this month', $text);
+        self::assertStringNotContainsString('Storage usage', $text);
+
+        $healthPosition = strpos($text, 'Healthy');
+        $kpiPosition = strpos($text, 'Key metrics (last 30 days)');
+        self::assertNotFalse($healthPosition);
+        self::assertNotFalse($kpiPosition);
+        self::assertLessThan($kpiPosition, $healthPosition);
+
+        self::assertCount(1, $crawler->filter('[data-controller="admin-kpi-chart"]'));
+        self::assertCount(0, $crawler->filter('[data-controller="admin-ops-chart"]'));
+        self::assertGreaterThan(0, $crawler->filter('.ea-ops-card-trend')->count());
+    }
+
+    public function testFailedImportsDashboardShows30DayFilterAndViewAllLink(): void
+    {
+        $client = self::createClient();
+
+        $admin = UserFactory::new()->asAdmin()->create();
+        $owner = UserFactory::createOne();
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => StateFactory::createOne(),
+            'dispatchArea' => DispatchAreaFactory::createOne(),
+        ]);
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::FAILED,
+            'name' => 'Recent failed import',
+            'createdAt' => new \DateTimeImmutable('-5 days'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::FAILED,
+            'name' => 'Old failed import',
+            'createdAt' => new \DateTimeImmutable('-40 days'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::COMPLETED,
+            'name' => 'Successful import',
+            'createdAt' => new \DateTimeImmutable('-2 days'),
+        ]);
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Last 30 days', $crawler->text());
+        self::assertStringContainsString('All failed imports', $crawler->text());
+        self::assertStringContainsString('Recent failed import', $crawler->text());
+        self::assertStringNotContainsString('Old failed import', $crawler->text());
+
+        $badge = $this->findFailedImportsBadge($crawler);
+        self::assertNotNull($badge);
+        self::assertSame('2', trim($badge->text()));
+    }
+
+    private function findFailedImportsBadge(Crawler $crawler): ?Crawler
+    {
+        $link = $crawler->filter('a')->reduce(
+            static fn (Crawler $node): bool => str_contains($node->text(), 'All failed imports'),
+        );
+
+        if (0 === $link->count()) {
+            return null;
+        }
+
+        $badge = $link->filter('.ea-admin-primary-badge-btn__badge');
+        if (0 === $badge->count()) {
+            return null;
+        }
+
+        return $badge;
+    }
+}

--- a/tests/Admin/Functional/Controller/FailedMessengerControllerTest.php
+++ b/tests/Admin/Functional/Controller/FailedMessengerControllerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class FailedMessengerControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testAdminCanInspectFailedMessages(): void
+    {
+        $client = self::createClient();
+
+        $admin = UserFactory::new()->asAdmin()->create([
+            'username' => 'failed-msg-admin-'.bin2hex(random_bytes(4)),
+        ]);
+
+        $messageId = $this->insertFailedMessage('test-body-content');
+
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('ImportAllocationsMessage', $client->getResponse()->getContent());
+
+        $client->request(Request::METHOD_GET, '/admin/operations/failed-messages/'.$messageId);
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('test-body-content', $client->getResponse()->getContent());
+    }
+
+    public function testAdminCanDeleteSingleFailedMessage(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create();
+        $messageId = $this->insertFailedMessage('delete-me');
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        $client->request(Request::METHOD_POST, '/admin/operations/failed-messages/'.$messageId.'/delete', [
+            '_token' => $this->extractCsrfToken($crawler, 'failed-messages/'.$messageId.'/delete'),
+        ]);
+
+        self::assertResponseRedirects('/admin/operations/failed-messages');
+        $client->followRedirect();
+        self::assertStringContainsString('Failed message deleted.', $client->getResponse()->getContent());
+        self::assertSame(0, $this->countFailedMessages());
+    }
+
+    public function testAdminCanDeleteSelectedFailedMessages(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create();
+        $firstId = $this->insertFailedMessage('first');
+        $secondId = $this->insertFailedMessage('second');
+        $thirdId = $this->insertFailedMessage('third');
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        $client->request(Request::METHOD_POST, '/admin/operations/failed-messages/delete-selected', [
+            '_token' => $this->extractCsrfToken($crawler, 'delete-selected'),
+            'ids' => [$firstId, $thirdId],
+        ]);
+
+        self::assertResponseRedirects('/admin/operations/failed-messages');
+        self::assertSame(1, $this->countFailedMessages());
+        self::assertNotFalse($this->findFailedMessageById($secondId));
+        self::assertFalse($this->findFailedMessageById($firstId));
+        self::assertFalse($this->findFailedMessageById($thirdId));
+    }
+
+    public function testAdminCanDeleteAllFailedMessages(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create();
+        $this->insertFailedMessage('one');
+        $this->insertFailedMessage('two');
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        $client->request(Request::METHOD_POST, '/admin/operations/failed-messages/delete-all', [
+            '_token' => $this->extractCsrfToken($crawler, 'delete-all'),
+        ]);
+
+        self::assertResponseRedirects('/admin/operations/failed-messages');
+        self::assertSame(0, $this->countFailedMessages());
+    }
+
+    public function testDeleteSelectedWithoutSelectionShowsWarning(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create();
+        $this->insertFailedMessage('keep-me');
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        $client->request(Request::METHOD_POST, '/admin/operations/failed-messages/delete-selected', [
+            '_token' => $this->extractCsrfToken($crawler, 'delete-selected'),
+            'ids' => [],
+        ]);
+
+        self::assertResponseRedirects('/admin/operations/failed-messages');
+        $client->followRedirect();
+        self::assertStringContainsString('Select at least one failed message to delete.', $client->getResponse()->getContent());
+        self::assertSame(1, $this->countFailedMessages());
+    }
+
+    public function testNonAdminIsForbidden(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne();
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    private function insertFailedMessage(string $body): int
+    {
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->insert('messenger_messages', [
+            'body' => $body,
+            'headers' => json_encode(['type' => \App\Import\Application\Message\ImportAllocationsMessage::class], JSON_THROW_ON_ERROR),
+            'queue_name' => 'failed',
+            'created_at' => new \DateTimeImmutable()->format('Y-m-d H:i:s'),
+            'available_at' => new \DateTimeImmutable()->format('Y-m-d H:i:s'),
+            'delivered_at' => null,
+        ]);
+
+        return (int) $connection->lastInsertId();
+    }
+
+    private function countFailedMessages(): int
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        return (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM messenger_messages WHERE queue_name = :queue',
+            ['queue' => 'failed'],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|false
+     */
+    private function findFailedMessageById(int $id): array|false
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        return $connection->fetchAssociative(
+            'SELECT id FROM messenger_messages WHERE id = :id AND queue_name = :queue',
+            ['id' => $id, 'queue' => 'failed'],
+        );
+    }
+
+    private function extractCsrfToken(Crawler $crawler, string $actionContains): string
+    {
+        $token = $crawler->filter(sprintf('form[action*="%s"] input[name="_token"]', $actionContains))->first();
+        if (0 === $token->count()) {
+            self::fail(sprintf('CSRF token for action containing "%s" not found.', $actionContains));
+        }
+
+        return (string) $token->attr('value');
+    }
+}

--- a/tests/Admin/Functional/Controller/HospitalAccessGrantCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/HospitalAccessGrantCrudControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class HospitalAccessGrantCrudControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testAdminCanCreateHospitalAccessGrant(): void
+    {
+        $client = self::createClient();
+
+        $admin = UserFactory::new()->asAdmin()->create([
+            'username' => 'grant-admin-'.bin2hex(random_bytes(4)),
+        ]);
+        $user = UserFactory::createOne([
+            'username' => 'grant-user-'.bin2hex(random_bytes(4)),
+        ]);
+        $hospital = HospitalFactory::createOne();
+
+        $client->loginUser($admin);
+        $crawler = $client->request(Request::METHOD_GET, '/admin/hospital-access-grant/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Create')->form();
+        $this->selectChoice($form, 'HospitalAccessGrant[hospital]', (string) $hospital->getId());
+        $this->selectChoice($form, 'HospitalAccessGrant[user]', (string) $user->getId());
+        $this->selectChoice($form, 'HospitalAccessGrant[permissions]', [
+            (string) HospitalPermission::View->value,
+            (string) HospitalPermission::Statistics->value,
+        ]);
+        $client->submit($form);
+        $client->followRedirect();
+        self::assertResponseIsSuccessful();
+
+        $grant = self::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(\App\Allocation\Domain\Entity\HospitalAccessGrant::class)
+            ->findOneBy(['hospital' => $hospital, 'user' => $user]);
+
+        self::assertNotNull($grant);
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::Statistics));
+    }
+
+    /**
+     * @param list<string>|string $value
+     */
+    private function selectChoice(Form $form, string $name, array|string $value): void
+    {
+        $field = $form->get($name);
+        self::assertInstanceOf(ChoiceFormField::class, $field);
+        $field->select($value);
+    }
+}

--- a/tests/Admin/Functional/Controller/MonthlyReminderDispatchCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/MonthlyReminderDispatchCrudControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class MonthlyReminderDispatchCrudControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testAdminCanViewReadOnlyReminderDispatchList(): void
+    {
+        $client = self::createClient();
+
+        $admin = UserFactory::new()->asAdmin()->create([
+            'username' => 'reminder-admin-'.bin2hex(random_bytes(4)),
+        ]);
+        $hospital = HospitalFactory::createOne();
+
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        $entityManager->persist(new MonthlyReminderDispatch(
+            $hospital,
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+            new \DateTimeImmutable(),
+        ));
+        $entityManager->flush();
+
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/admin/monthly-reminder-dispatch');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('2026-06', $client->getResponse()->getContent());
+    }
+
+    public function testCreateActionIsDisabled(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create();
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/admin/monthly-reminder-dispatch/new');
+        self::assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Admin/Functional/Controller/UserCrudLocaleTest.php
+++ b/tests/Admin/Functional/Controller/UserCrudLocaleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Functional\Controller;
+
+use App\Shared\Application\Locale\SupportedLocales;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class UserCrudLocaleTest extends WebTestCase
+{
+    use Factories;
+
+    public function testAdminCanEditLocaleAndReminderPreference(): void
+    {
+        $client = self::createClient();
+
+        $target = UserFactory::createOne([
+            'username' => 'locale-user-'.bin2hex(random_bytes(4)),
+            'locale' => SupportedLocales::DEFAULT,
+            'receivesMonthlySubmissionReminder' => true,
+        ]);
+        $admin = UserFactory::new()
+            ->asAdmin()
+            ->create([
+                'username' => 'locale-admin-'.bin2hex(random_bytes(4)),
+            ]);
+
+        $client->loginUser($admin);
+
+        $crawler = $client->request(Request::METHOD_GET, '/admin/user/'.$target->getId().'/edit');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Save changes')->form();
+        $this->selectChoice($form, 'User[locale]', SupportedLocales::GERMAN);
+        $this->setCheckboxValue($form, 'User[receivesMonthlySubmissionReminder]', false);
+        $client->submit($form);
+        $client->followRedirect();
+        self::assertResponseIsSuccessful();
+
+        \Zenstruck\Foundry\Persistence\refresh($target);
+        self::assertSame(SupportedLocales::GERMAN, $target->getLocale());
+        self::assertFalse($target->receivesMonthlySubmissionReminder());
+    }
+
+    private function setCheckboxValue(Form $form, string $name, bool $checked): void
+    {
+        $field = $form->get($name);
+        self::assertInstanceOf(ChoiceFormField::class, $field);
+
+        if ($checked) {
+            $field->tick();
+        } else {
+            $field->untick();
+        }
+    }
+
+    private function selectChoice(Form $form, string $name, string $value): void
+    {
+        $field = $form->get($name);
+        self::assertInstanceOf(ChoiceFormField::class, $field);
+        $field->select($value);
+    }
+}

--- a/tests/Admin/Unit/Application/DTO/StorageMetricsDtoTest.php
+++ b/tests/Admin/Unit/Application/DTO/StorageMetricsDtoTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Unit\Application\DTO;
+
+use App\Admin\Application\DTO\StorageMetricsDto;
+use App\Admin\Application\DTO\StorageSegmentDto;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StorageMetricsDtoTest extends TestCase
+{
+    public function testTotalBytesIncludesApplicationCode(): void
+    {
+        $dto = $this->createDto(applicationCodeBytes: 500, limitBytes: null);
+
+        self::assertSame(1400, $dto->totalBytes());
+    }
+
+    public function testUsagePercentReturnsNullWithoutLimit(): void
+    {
+        $dto = $this->createDto(limitBytes: null);
+
+        self::assertNull($dto->usagePercent());
+    }
+
+    #[DataProvider('usagePercentProvider')]
+    public function testUsagePercentWithLimit(int $limit, float $expected): void
+    {
+        $dto = $this->createDto(limitBytes: $limit);
+
+        self::assertSame($expected, $dto->usagePercent());
+    }
+
+    /**
+     * @return iterable<string, array{int, float}>
+     */
+    public static function usagePercentProvider(): iterable
+    {
+        yield 'half used' => [1800, 50.0];
+        yield 'full limit' => [900, 100.0];
+    }
+
+    public function testBarBaseBytesUsesLimitWhenConfigured(): void
+    {
+        $dto = $this->createDto(limitBytes: 5000);
+
+        self::assertSame(5000, $dto->barBaseBytes());
+    }
+
+    public function testBarBaseBytesFallsBackToTotalWhenNoLimit(): void
+    {
+        $dto = $this->createDto(limitBytes: null);
+
+        self::assertSame(900, $dto->barBaseBytes());
+    }
+
+    public function testFilesBytesAndGrowthHelpers(): void
+    {
+        $dto = $this->createDto();
+
+        self::assertSame(500, $dto->filesBytes());
+        self::assertSame(75, $dto->filesBytesLast30Days());
+    }
+
+    private function createDto(int $applicationCodeBytes = 0, ?int $limitBytes = 2000): StorageMetricsDto
+    {
+        return new StorageMetricsDto(
+            databaseBytes: 400,
+            importBytes: 300,
+            mediaBytes: 200,
+            applicationCodeBytes: $applicationCodeBytes,
+            importBytesLast30Days: 50,
+            mediaBytesLast30Days: 25,
+            limitBytes: $limitBytes,
+            segments: [
+                new StorageSegmentDto('database', 'ops.storage.database', 400, '#000', 'fas fa-database'),
+                new StorageSegmentDto('imports', 'ops.storage.imports', 300, '#000', 'fa fa-database'),
+                new StorageSegmentDto('media', 'ops.storage.media', 200, '#000', 'fas fa-photo-film'),
+                new StorageSegmentDto('application_code', 'ops.storage.application_code', $applicationCodeBytes, '#000', 'fas fa-code'),
+            ],
+        );
+    }
+}

--- a/tests/Admin/Unit/Application/Service/ApplicationCodeSizeCalculatorTest.php
+++ b/tests/Admin/Unit/Application/Service/ApplicationCodeSizeCalculatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Unit\Application\Service;
+
+use App\Admin\Application\Service\ApplicationCodeSizeCalculator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class ApplicationCodeSizeCalculatorTest extends TestCase
+{
+    public function testCalculatesBytesExcludingVolatileDirectories(): void
+    {
+        $projectDir = sys_get_temp_dir().'/app-code-size-'.bin2hex(random_bytes(4));
+        mkdir($projectDir.'/src', 0777, true);
+        mkdir($projectDir.'/vendor/pkg', 0777, true);
+        mkdir($projectDir.'/var/cache', 0777, true);
+        mkdir($projectDir.'/node_modules/pkg', 0777, true);
+
+        file_put_contents($projectDir.'/src/App.php', '<?php echo 1;');
+        file_put_contents($projectDir.'/vendor/pkg/lib.php', str_repeat('a', 100));
+        file_put_contents($projectDir.'/var/cache/warm.php', str_repeat('b', 500));
+        file_put_contents($projectDir.'/node_modules/pkg/index.js', str_repeat('c', 200));
+
+        try {
+            $calculator = new ApplicationCodeSizeCalculator(
+                new ArrayAdapter(),
+                $projectDir,
+            );
+
+            self::assertSame(
+                strlen('<?php echo 1;') + 100,
+                $calculator->getBytes(),
+            );
+        } finally {
+            $this->removeDirectory($projectDir);
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+        if (false === $items) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ('.' === $item || '..' === $item) {
+                continue;
+            }
+
+            $path = $directory.'/'.$item;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Import/Integration/Repository/ImportRepositoryFailedQueryTest.php
+++ b/tests/Import/Integration/Repository/ImportRepositoryFailedQueryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+
+final class ImportRepositoryFailedQueryTest extends DatabaseKernelTestCase
+{
+    private ImportRepository $repository;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = self::getContainer()->get(ImportRepository::class);
+    }
+
+    public function testFindRecentFailedImportsRespectsSinceFilter(): void
+    {
+        $hospital = HospitalFactory::createOne();
+
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::FAILED,
+            'createdAt' => new \DateTimeImmutable('-5 days'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::FAILED,
+            'createdAt' => new \DateTimeImmutable('-40 days'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('-2 days'),
+        ]);
+
+        $since = new \DateTimeImmutable('-30 days')->setTime(0, 0);
+        $recent = $this->repository->findRecentFailedImports(10, $since);
+
+        self::assertCount(1, $recent);
+        self::assertSame(ImportStatus::FAILED, $recent[0]->getStatus());
+        self::assertSame(2, $this->repository->countFailedImports());
+    }
+}

--- a/tests/Shared/Integration/Audit/AuditEntryRepositoryTest.php
+++ b/tests/Shared/Integration/Audit/AuditEntryRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Integration\Audit;
+
+use App\Allocation\Domain\Entity\State;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
+use App\Shared\Infrastructure\Audit\Repository\AuditEntryRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AuditEntryRepositoryTest extends DatabaseKernelTestCase
+{
+    private AuditEntryRepository $repository;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = self::getContainer()->get(AuditEntryRepository::class);
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testFindRecentByIntentsReturnsEmptyForNoIntents(): void
+    {
+        self::assertSame([], $this->repository->findRecentByIntents([]));
+    }
+
+    public function testFindRecentByIntentsFiltersByIntentAndRespectsLimit(): void
+    {
+        $this->persistAuditEntry(
+            occurredAt: new \DateTimeImmutable('2025-06-05 12:00:00'),
+            intent: 'other.intent',
+            action: 'create',
+            origin: 'cli',
+        );
+        $this->persistAuditEntry(
+            occurredAt: new \DateTimeImmutable('2025-06-04 12:00:00'),
+            intent: null,
+            action: 'create',
+            origin: 'cli',
+        );
+        $this->persistAuditEntry(
+            occurredAt: new \DateTimeImmutable('2025-06-03 12:00:00'),
+            intent: 'import.failed',
+            action: 'update',
+            origin: 'messenger',
+        );
+        $this->persistAuditEntry(
+            occurredAt: new \DateTimeImmutable('2025-06-02 12:00:00'),
+            intent: 'user.registration',
+            action: 'create',
+            origin: 'http',
+        );
+        $this->persistAuditEntry(
+            occurredAt: new \DateTimeImmutable('2025-06-01 12:00:00'),
+            intent: 'hospital.reminder_sent',
+            action: 'create',
+            origin: 'cli',
+        );
+
+        $results = $this->repository->findRecentByIntents([
+            'import.failed',
+            'user.registration',
+            'hospital.reminder_sent',
+        ], 2);
+
+        self::assertCount(2, $results);
+        self::assertSame('import.failed', $results[0]['intent']);
+        self::assertSame('update', $results[0]['action']);
+        self::assertSame('messenger', $results[0]['origin']);
+        self::assertSame('user.registration', $results[1]['intent']);
+        self::assertSame('create', $results[1]['action']);
+        self::assertSame('http', $results[1]['origin']);
+    }
+
+    private function persistAuditEntry(
+        \DateTimeImmutable $occurredAt,
+        ?string $intent,
+        string $action,
+        string $origin,
+    ): void {
+        $metadata = null;
+        if (null !== $intent) {
+            $metadata = ['intent' => $intent];
+        }
+
+        $entry = new AuditEntry(
+            $occurredAt,
+            'audit-repo-test-'.bin2hex(random_bytes(4)),
+            null,
+            $origin,
+            $action,
+            State::class,
+            '1',
+            [],
+            $metadata,
+        );
+
+        $this->entityManager->persist($entry);
+        $this->entityManager->flush();
+    }
+}

--- a/translations/admin+intl-icu.de.xlf
+++ b/translations/admin+intl-icu.de.xlf
@@ -491,7 +491,7 @@
       </trans-unit>
       <trans-unit id="opsHlth01de" resname="ops.health.status.healthy">
         <source>ops.health.status.healthy</source>
-        <target>Gesund</target>
+        <target>Fehlerfrei</target>
       </trans-unit>
       <trans-unit id="opsHlth02de" resname="ops.health.status.degraded">
         <source>ops.health.status.degraded</source>

--- a/translations/admin+intl-icu.de.xlf
+++ b/translations/admin+intl-icu.de.xlf
@@ -137,6 +137,10 @@
         <source>title.dashboard</source>
         <target>Admin-Dashboard</target>
       </trans-unit>
+      <trans-unit id="menuUsr01de" resname="menu.users.accounts">
+        <source>menu.users.accounts</source>
+        <target>Benutzerkonten</target>
+      </trans-unit>
       <trans-unit id="DpRvyMB" resname="title.import_reject.list">
         <source>title.import_reject.list</source>
         <target>Zurückgewiesene Importe</target>
@@ -309,6 +313,14 @@
         <source>kpi.failed_imports.empty</source>
         <target>Keine fehlgeschlagenen Importe gefunden.</target>
       </trans-unit>
+      <trans-unit id="kpi017a" resname="kpi.failed_imports.view_all">
+        <source>kpi.failed_imports.view_all</source>
+        <target>Alle fehlgeschlagenen Importe</target>
+      </trans-unit>
+      <trans-unit id="kpi017b" resname="kpi.failed_imports.subtitle_30d">
+        <source>kpi.failed_imports.subtitle_30d</source>
+        <target>Letzte 30 Tage</target>
+      </trans-unit>
       <trans-unit id="kpi018" resname="kpi.failure_reason.no_rows">
         <source>kpi.failure_reason.no_rows</source>
         <target>Keine verarbeitbaren Zeilen</target>
@@ -432,6 +444,246 @@
       <trans-unit id="FlsAdmPtOkDe" resname="flash.admin.user.grant_participant.success">
         <source>flash.admin.user.grant_participant.success</source>
         <target>Teilnehmer-Rolle wurde zugewiesen.</target>
+      </trans-unit>
+      <trans-unit id="admMr04" resname="admin.hospital.action.reminder_history">
+        <source>admin.hospital.action.reminder_history</source>
+        <target>Erinnerungsverlauf</target>
+      </trans-unit>
+      <trans-unit id="opsSec01de" resname="ops.section.title">
+        <source>ops.section.title</source>
+        <target>Betrieb</target>
+      </trans-unit>
+      <trans-unit id="opsCard01de" resname="ops.card.failed_messages">
+        <source>ops.card.failed_messages</source>
+        <target>Fehlgeschlagene Nachrichten</target>
+      </trans-unit>
+      <trans-unit id="opsCard02de" resname="ops.card.queue_high">
+        <source>ops.card.queue_high</source>
+        <target>High-Priority-Warteschlange</target>
+      </trans-unit>
+      <trans-unit id="opsCard03de" resname="ops.card.queue_low">
+        <source>ops.card.queue_low</source>
+        <target>Low-Priority-Warteschlange</target>
+      </trans-unit>
+      <trans-unit id="opsCard04de" resname="ops.card.database_size">
+        <source>ops.card.database_size</source>
+        <target>Datenbankgröße</target>
+      </trans-unit>
+      <trans-unit id="opsCard05de" resname="ops.card.storage_total">
+        <source>ops.card.storage_total</source>
+        <target>Gesamtspeicher</target>
+      </trans-unit>
+      <trans-unit id="opsCard06de" resname="ops.card.reminders_this_month">
+        <source>ops.card.reminders_this_month</source>
+        <target>Erinnerungen diesen Monat</target>
+      </trans-unit>
+      <trans-unit id="opsCard07de" resname="ops.card.imports_media">
+        <source>ops.card.imports_media</source>
+        <target>Importe / Medien</target>
+      </trans-unit>
+      <trans-unit id="opsCard08de" resname="ops.card.trend_up">
+        <source>ops.card.trend_up</source>
+        <target>+{size} in 30 Tagen</target>
+      </trans-unit>
+      <trans-unit id="opsCard09de" resname="ops.card.trend_flat">
+        <source>ops.card.trend_flat</source>
+        <target>Keine Änderung (30 Tage)</target>
+      </trans-unit>
+      <trans-unit id="opsHlth01de" resname="ops.health.status.healthy">
+        <source>ops.health.status.healthy</source>
+        <target>Gesund</target>
+      </trans-unit>
+      <trans-unit id="opsHlth02de" resname="ops.health.status.degraded">
+        <source>ops.health.status.degraded</source>
+        <target>Eingeschränkt</target>
+      </trans-unit>
+      <trans-unit id="opsHlth03de" resname="ops.health.status.unhealthy">
+        <source>ops.health.status.unhealthy</source>
+        <target>Ungesund</target>
+      </trans-unit>
+      <trans-unit id="opsHlth04de" resname="ops.health.version">
+        <source>ops.health.version</source>
+        <target>Version {version}</target>
+      </trans-unit>
+      <trans-unit id="opsHlth05de" resname="ops.health.check.database">
+        <source>ops.health.check.database</source>
+        <target>Datenbank</target>
+      </trans-unit>
+      <trans-unit id="opsHlth06de" resname="ops.health.check.messenger_failed">
+        <source>ops.health.check.messenger_failed</source>
+        <target>Messenger fehlgeschlagen</target>
+      </trans-unit>
+      <trans-unit id="opsStor01de" resname="ops.storage.title">
+        <source>ops.storage.title</source>
+        <target>Speichernutzung</target>
+      </trans-unit>
+      <trans-unit id="opsStor02de" resname="ops.storage.database">
+        <source>ops.storage.database</source>
+        <target>Datenbank</target>
+      </trans-unit>
+      <trans-unit id="opsStor03de" resname="ops.storage.imports">
+        <source>ops.storage.imports</source>
+        <target>CSV-Importe</target>
+      </trans-unit>
+      <trans-unit id="opsStor04de" resname="ops.storage.media">
+        <source>ops.storage.media</source>
+        <target>Medien-Uploads</target>
+      </trans-unit>
+      <trans-unit id="opsStor05de" resname="ops.storage.growth_30d">
+        <source>ops.storage.growth_30d</source>
+        <target>Wachstum (letzte 30 Tage)</target>
+      </trans-unit>
+      <trans-unit id="opsStor06de" resname="ops.storage.growth_imports">
+        <source>ops.storage.growth_imports</source>
+        <target>Importe: {size}</target>
+      </trans-unit>
+      <trans-unit id="opsStor07de" resname="ops.storage.growth_media">
+        <source>ops.storage.growth_media</source>
+        <target>Medien: {size}</target>
+      </trans-unit>
+      <trans-unit id="opsStor08de" resname="ops.storage.application_code">
+        <source>ops.storage.application_code</source>
+        <target>Quellcode</target>
+      </trans-unit>
+      <trans-unit id="opsStor09de" resname="ops.storage.of_limit">
+        <source>ops.storage.of_limit</source>
+        <target>von {limit}</target>
+      </trans-unit>
+      <trans-unit id="opsStor10de" resname="ops.storage.used">
+        <source>ops.storage.used</source>
+        <target>{size} belegt</target>
+      </trans-unit>
+      <trans-unit id="opsStor11de" resname="ops.storage.total_used">
+        <source>ops.storage.total_used</source>
+        <target>{size} gesamt</target>
+      </trans-unit>
+      <trans-unit id="opsNot01de" resname="ops.notifications.title">
+        <source>ops.notifications.title</source>
+        <target>Aktuelle Benachrichtigungen</target>
+      </trans-unit>
+      <trans-unit id="opsNot02de" resname="ops.notifications.time">
+        <source>ops.notifications.time</source>
+        <target>Zeit</target>
+      </trans-unit>
+      <trans-unit id="opsNot03de" resname="ops.notifications.intent">
+        <source>ops.notifications.intent</source>
+        <target>Intent</target>
+      </trans-unit>
+      <trans-unit id="opsNot04de" resname="ops.notifications.action">
+        <source>ops.notifications.action</source>
+        <target>Aktion</target>
+      </trans-unit>
+      <trans-unit id="opsNot05de" resname="ops.notifications.origin">
+        <source>ops.notifications.origin</source>
+        <target>Herkunft</target>
+      </trans-unit>
+      <trans-unit id="opsNot06de" resname="ops.notifications.empty">
+        <source>ops.notifications.empty</source>
+        <target>Keine aktuellen Benachrichtigungsereignisse.</target>
+      </trans-unit>
+      <trans-unit id="opsFm01de" resname="ops.failed_messages.title">
+        <source>ops.failed_messages.title</source>
+        <target>Fehlgeschlagene Messenger-Nachrichten</target>
+      </trans-unit>
+      <trans-unit id="opsFm02de" resname="ops.failed_messages.help">
+        <source>ops.failed_messages.help</source>
+        <target>Fehlgeschlagene Nachrichten einsehen und aus der Failed-Queue entfernen. Für erneutes Zustellen die CLI verwenden.</target>
+      </trans-unit>
+      <trans-unit id="opsFm03de" resname="ops.failed_messages.created">
+        <source>ops.failed_messages.created</source>
+        <target>Erstellt</target>
+      </trans-unit>
+      <trans-unit id="opsFm04de" resname="ops.failed_messages.class">
+        <source>ops.failed_messages.class</source>
+        <target>Nachrichtenklasse</target>
+      </trans-unit>
+      <trans-unit id="opsFm05de" resname="ops.failed_messages.preview">
+        <source>ops.failed_messages.preview</source>
+        <target>Vorschau</target>
+      </trans-unit>
+      <trans-unit id="opsFm06de" resname="ops.failed_messages.empty">
+        <source>ops.failed_messages.empty</source>
+        <target>Keine fehlgeschlagenen Nachrichten.</target>
+      </trans-unit>
+      <trans-unit id="opsFm07de" resname="ops.failed_messages.view">
+        <source>ops.failed_messages.view</source>
+        <target>Ansehen</target>
+      </trans-unit>
+      <trans-unit id="opsFm08de" resname="ops.failed_messages.detail_title">
+        <source>ops.failed_messages.detail_title</source>
+        <target>Fehlgeschlagene Nachricht #{id}</target>
+      </trans-unit>
+      <trans-unit id="opsFm09de" resname="ops.failed_messages.back">
+        <source>ops.failed_messages.back</source>
+        <target>Zurück zur Liste</target>
+      </trans-unit>
+      <trans-unit id="opsFm10de" resname="ops.failed_messages.headers">
+        <source>ops.failed_messages.headers</source>
+        <target>Headers</target>
+      </trans-unit>
+      <trans-unit id="opsFm11de" resname="ops.failed_messages.body">
+        <source>ops.failed_messages.body</source>
+        <target>Body</target>
+      </trans-unit>
+      <trans-unit id="opsFm12de" resname="ops.failed_messages.cli_hint">
+        <source>ops.failed_messages.cli_hint</source>
+        <target>Nach Behebung des Problems bin/console messenger:failed:retry verwenden, um eine Nachricht erneut zuzustellen.</target>
+      </trans-unit>
+      <trans-unit id="opsFm13de" resname="ops.failed_messages.delete">
+        <source>ops.failed_messages.delete</source>
+        <target>Löschen</target>
+      </trans-unit>
+      <trans-unit id="opsFm14de" resname="ops.failed_messages.delete_selected">
+        <source>ops.failed_messages.delete_selected</source>
+        <target>Auswahl löschen</target>
+      </trans-unit>
+      <trans-unit id="opsFm15de" resname="ops.failed_messages.delete_all">
+        <source>ops.failed_messages.delete_all</source>
+        <target>Alle löschen</target>
+      </trans-unit>
+      <trans-unit id="opsFm16de" resname="ops.failed_messages.select_all">
+        <source>ops.failed_messages.select_all</source>
+        <target>Alle auswählen</target>
+      </trans-unit>
+      <trans-unit id="opsFm17de" resname="ops.failed_messages.select_item">
+        <source>ops.failed_messages.select_item</source>
+        <target>Nachricht #{id} auswählen</target>
+      </trans-unit>
+      <trans-unit id="opsFm18de" resname="ops.failed_messages.confirm_delete_one">
+        <source>ops.failed_messages.confirm_delete_one</source>
+        <target>Diese fehlgeschlagene Nachricht endgültig löschen?</target>
+      </trans-unit>
+      <trans-unit id="opsFm19de" resname="ops.failed_messages.confirm_delete_selected">
+        <source>ops.failed_messages.confirm_delete_selected</source>
+        <target>Die ausgewählten fehlgeschlagenen Nachrichten endgültig löschen?</target>
+      </trans-unit>
+      <trans-unit id="opsFm20de" resname="ops.failed_messages.confirm_delete_all">
+        <source>ops.failed_messages.confirm_delete_all</source>
+        <target>Alle fehlgeschlagenen Nachrichten endgültig löschen?</target>
+      </trans-unit>
+      <trans-unit id="opsFm21de" resname="ops.failed_messages.flash.deleted_one">
+        <source>ops.failed_messages.flash.deleted_one</source>
+        <target>Fehlgeschlagene Nachricht gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="opsFm22de" resname="ops.failed_messages.flash.deleted_many">
+        <source>ops.failed_messages.flash.deleted_many</source>
+        <target>{count, plural, =0 {Keine fehlgeschlagenen Nachrichten gelöscht.} =1 {Eine fehlgeschlagene Nachricht gelöscht.} other {# fehlgeschlagene Nachrichten gelöscht.}}</target>
+      </trans-unit>
+      <trans-unit id="opsFm23de" resname="ops.failed_messages.flash.deleted_all">
+        <source>ops.failed_messages.flash.deleted_all</source>
+        <target>{count, plural, =0 {Keine fehlgeschlagenen Nachrichten gelöscht.} =1 {Eine fehlgeschlagene Nachricht gelöscht.} other {# fehlgeschlagene Nachrichten gelöscht.}}</target>
+      </trans-unit>
+      <trans-unit id="opsFm24de" resname="ops.failed_messages.flash.none_selected">
+        <source>ops.failed_messages.flash.none_selected</source>
+        <target>Bitte mindestens eine fehlgeschlagene Nachricht zum Löschen auswählen.</target>
+      </trans-unit>
+      <trans-unit id="opsRd01de" resname="ops.reminder_dispatch.title">
+        <source>ops.reminder_dispatch.title</source>
+        <target>Monatliche Erinnerungsversände</target>
+      </trans-unit>
+      <trans-unit id="opsRd02de" resname="ops.reminder_dispatch.help">
+        <source>ops.reminder_dispatch.help</source>
+        <target>Nur Scheduler-Versände werden hier erfasst. Admin- und CLI-Versände stehen im Audit-Log.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/admin+intl-icu.en.xlf
+++ b/translations/admin+intl-icu.en.xlf
@@ -137,6 +137,10 @@
         <source>title.dashboard</source>
         <target>Admin Dashboard</target>
       </trans-unit>
+      <trans-unit id="menuUsr01" resname="menu.users.accounts">
+        <source>menu.users.accounts</source>
+        <target>Accounts</target>
+      </trans-unit>
       <trans-unit id="DpRvyMB" resname="title.import_reject.list">
         <source>title.import_reject.list</source>
         <target>List rejected Imports</target>
@@ -309,6 +313,14 @@
         <source>kpi.failed_imports.empty</source>
         <target>No failed imports found.</target>
       </trans-unit>
+      <trans-unit id="kpi017a" resname="kpi.failed_imports.view_all">
+        <source>kpi.failed_imports.view_all</source>
+        <target>All failed imports</target>
+      </trans-unit>
+      <trans-unit id="kpi017b" resname="kpi.failed_imports.subtitle_30d">
+        <source>kpi.failed_imports.subtitle_30d</source>
+        <target>Last 30 days</target>
+      </trans-unit>
       <trans-unit id="kpi018" resname="kpi.failure_reason.no_rows">
         <source>kpi.failure_reason.no_rows</source>
         <target>No processable rows</target>
@@ -432,6 +444,246 @@
       <trans-unit id="adminIndGrp01" resname="admin.indication_group.action.view_statistics">
         <source>admin.indication_group.action.view_statistics</source>
         <target>Open in statistics</target>
+      </trans-unit>
+      <trans-unit id="admMr04" resname="admin.hospital.action.reminder_history">
+        <source>admin.hospital.action.reminder_history</source>
+        <target>Reminder history</target>
+      </trans-unit>
+      <trans-unit id="opsSec01" resname="ops.section.title">
+        <source>ops.section.title</source>
+        <target>Operations</target>
+      </trans-unit>
+      <trans-unit id="opsCard01" resname="ops.card.failed_messages">
+        <source>ops.card.failed_messages</source>
+        <target>Failed messages</target>
+      </trans-unit>
+      <trans-unit id="opsCard02" resname="ops.card.queue_high">
+        <source>ops.card.queue_high</source>
+        <target>High-priority queue</target>
+      </trans-unit>
+      <trans-unit id="opsCard03" resname="ops.card.queue_low">
+        <source>ops.card.queue_low</source>
+        <target>Low-priority queue</target>
+      </trans-unit>
+      <trans-unit id="opsCard04" resname="ops.card.database_size">
+        <source>ops.card.database_size</source>
+        <target>Database size</target>
+      </trans-unit>
+      <trans-unit id="opsCard05" resname="ops.card.storage_total">
+        <source>ops.card.storage_total</source>
+        <target>Total storage</target>
+      </trans-unit>
+      <trans-unit id="opsCard06" resname="ops.card.reminders_this_month">
+        <source>ops.card.reminders_this_month</source>
+        <target>Reminders this month</target>
+      </trans-unit>
+      <trans-unit id="opsCard07" resname="ops.card.imports_media">
+        <source>ops.card.imports_media</source>
+        <target>Imports / media</target>
+      </trans-unit>
+      <trans-unit id="opsCard08" resname="ops.card.trend_up">
+        <source>ops.card.trend_up</source>
+        <target>+{size} in 30 days</target>
+      </trans-unit>
+      <trans-unit id="opsCard09" resname="ops.card.trend_flat">
+        <source>ops.card.trend_flat</source>
+        <target>No change (30 days)</target>
+      </trans-unit>
+      <trans-unit id="opsHlth01" resname="ops.health.status.healthy">
+        <source>ops.health.status.healthy</source>
+        <target>Healthy</target>
+      </trans-unit>
+      <trans-unit id="opsHlth02" resname="ops.health.status.degraded">
+        <source>ops.health.status.degraded</source>
+        <target>Degraded</target>
+      </trans-unit>
+      <trans-unit id="opsHlth03" resname="ops.health.status.unhealthy">
+        <source>ops.health.status.unhealthy</source>
+        <target>Unhealthy</target>
+      </trans-unit>
+      <trans-unit id="opsHlth04" resname="ops.health.version">
+        <source>ops.health.version</source>
+        <target>Version {version}</target>
+      </trans-unit>
+      <trans-unit id="opsHlth05" resname="ops.health.check.database">
+        <source>ops.health.check.database</source>
+        <target>Database</target>
+      </trans-unit>
+      <trans-unit id="opsHlth06" resname="ops.health.check.messenger_failed">
+        <source>ops.health.check.messenger_failed</source>
+        <target>Messenger failed</target>
+      </trans-unit>
+      <trans-unit id="opsStor01" resname="ops.storage.title">
+        <source>ops.storage.title</source>
+        <target>Storage usage</target>
+      </trans-unit>
+      <trans-unit id="opsStor02" resname="ops.storage.database">
+        <source>ops.storage.database</source>
+        <target>Database</target>
+      </trans-unit>
+      <trans-unit id="opsStor03" resname="ops.storage.imports">
+        <source>ops.storage.imports</source>
+        <target>CSV imports</target>
+      </trans-unit>
+      <trans-unit id="opsStor04" resname="ops.storage.media">
+        <source>ops.storage.media</source>
+        <target>Media uploads</target>
+      </trans-unit>
+      <trans-unit id="opsStor05" resname="ops.storage.growth_30d">
+        <source>ops.storage.growth_30d</source>
+        <target>Growth (last 30 days)</target>
+      </trans-unit>
+      <trans-unit id="opsStor06" resname="ops.storage.growth_imports">
+        <source>ops.storage.growth_imports</source>
+        <target>Imports: {size}</target>
+      </trans-unit>
+      <trans-unit id="opsStor07" resname="ops.storage.growth_media">
+        <source>ops.storage.growth_media</source>
+        <target>Media: {size}</target>
+      </trans-unit>
+      <trans-unit id="opsStor08" resname="ops.storage.application_code">
+        <source>ops.storage.application_code</source>
+        <target>Application code</target>
+      </trans-unit>
+      <trans-unit id="opsStor09" resname="ops.storage.of_limit">
+        <source>ops.storage.of_limit</source>
+        <target>of {limit}</target>
+      </trans-unit>
+      <trans-unit id="opsStor10" resname="ops.storage.used">
+        <source>ops.storage.used</source>
+        <target>{size} used</target>
+      </trans-unit>
+      <trans-unit id="opsStor11" resname="ops.storage.total_used">
+        <source>ops.storage.total_used</source>
+        <target>{size} total</target>
+      </trans-unit>
+      <trans-unit id="opsNot01" resname="ops.notifications.title">
+        <source>ops.notifications.title</source>
+        <target>Recent notifications</target>
+      </trans-unit>
+      <trans-unit id="opsNot02" resname="ops.notifications.time">
+        <source>ops.notifications.time</source>
+        <target>Time</target>
+      </trans-unit>
+      <trans-unit id="opsNot03" resname="ops.notifications.intent">
+        <source>ops.notifications.intent</source>
+        <target>Intent</target>
+      </trans-unit>
+      <trans-unit id="opsNot04" resname="ops.notifications.action">
+        <source>ops.notifications.action</source>
+        <target>Action</target>
+      </trans-unit>
+      <trans-unit id="opsNot05" resname="ops.notifications.origin">
+        <source>ops.notifications.origin</source>
+        <target>Origin</target>
+      </trans-unit>
+      <trans-unit id="opsNot06" resname="ops.notifications.empty">
+        <source>ops.notifications.empty</source>
+        <target>No recent notification events.</target>
+      </trans-unit>
+      <trans-unit id="opsFm01" resname="ops.failed_messages.title">
+        <source>ops.failed_messages.title</source>
+        <target>Failed messenger messages</target>
+      </trans-unit>
+      <trans-unit id="opsFm02" resname="ops.failed_messages.help">
+        <source>ops.failed_messages.help</source>
+        <target>Inspect and remove messages from the failed queue. Use the CLI to retry failed messages.</target>
+      </trans-unit>
+      <trans-unit id="opsFm03" resname="ops.failed_messages.created">
+        <source>ops.failed_messages.created</source>
+        <target>Created</target>
+      </trans-unit>
+      <trans-unit id="opsFm04" resname="ops.failed_messages.class">
+        <source>ops.failed_messages.class</source>
+        <target>Message class</target>
+      </trans-unit>
+      <trans-unit id="opsFm05" resname="ops.failed_messages.preview">
+        <source>ops.failed_messages.preview</source>
+        <target>Preview</target>
+      </trans-unit>
+      <trans-unit id="opsFm06" resname="ops.failed_messages.empty">
+        <source>ops.failed_messages.empty</source>
+        <target>No failed messages.</target>
+      </trans-unit>
+      <trans-unit id="opsFm07" resname="ops.failed_messages.view">
+        <source>ops.failed_messages.view</source>
+        <target>View</target>
+      </trans-unit>
+      <trans-unit id="opsFm08" resname="ops.failed_messages.detail_title">
+        <source>ops.failed_messages.detail_title</source>
+        <target>Failed message #{id}</target>
+      </trans-unit>
+      <trans-unit id="opsFm09" resname="ops.failed_messages.back">
+        <source>ops.failed_messages.back</source>
+        <target>Back to list</target>
+      </trans-unit>
+      <trans-unit id="opsFm10" resname="ops.failed_messages.headers">
+        <source>ops.failed_messages.headers</source>
+        <target>Headers</target>
+      </trans-unit>
+      <trans-unit id="opsFm11" resname="ops.failed_messages.body">
+        <source>ops.failed_messages.body</source>
+        <target>Body</target>
+      </trans-unit>
+      <trans-unit id="opsFm12" resname="ops.failed_messages.cli_hint">
+        <source>ops.failed_messages.cli_hint</source>
+        <target>Use bin/console messenger:failed:retry to re-dispatch a message after fixing the underlying issue.</target>
+      </trans-unit>
+      <trans-unit id="opsFm13" resname="ops.failed_messages.delete">
+        <source>ops.failed_messages.delete</source>
+        <target>Delete</target>
+      </trans-unit>
+      <trans-unit id="opsFm14" resname="ops.failed_messages.delete_selected">
+        <source>ops.failed_messages.delete_selected</source>
+        <target>Delete selected</target>
+      </trans-unit>
+      <trans-unit id="opsFm15" resname="ops.failed_messages.delete_all">
+        <source>ops.failed_messages.delete_all</source>
+        <target>Delete all</target>
+      </trans-unit>
+      <trans-unit id="opsFm16" resname="ops.failed_messages.select_all">
+        <source>ops.failed_messages.select_all</source>
+        <target>Select all</target>
+      </trans-unit>
+      <trans-unit id="opsFm17" resname="ops.failed_messages.select_item">
+        <source>ops.failed_messages.select_item</source>
+        <target>Select message #{id}</target>
+      </trans-unit>
+      <trans-unit id="opsFm18" resname="ops.failed_messages.confirm_delete_one">
+        <source>ops.failed_messages.confirm_delete_one</source>
+        <target>Delete this failed message permanently?</target>
+      </trans-unit>
+      <trans-unit id="opsFm19" resname="ops.failed_messages.confirm_delete_selected">
+        <source>ops.failed_messages.confirm_delete_selected</source>
+        <target>Delete the selected failed messages permanently?</target>
+      </trans-unit>
+      <trans-unit id="opsFm20" resname="ops.failed_messages.confirm_delete_all">
+        <source>ops.failed_messages.confirm_delete_all</source>
+        <target>Delete all failed messages permanently?</target>
+      </trans-unit>
+      <trans-unit id="opsFm21" resname="ops.failed_messages.flash.deleted_one">
+        <source>ops.failed_messages.flash.deleted_one</source>
+        <target>Failed message deleted.</target>
+      </trans-unit>
+      <trans-unit id="opsFm22" resname="ops.failed_messages.flash.deleted_many">
+        <source>ops.failed_messages.flash.deleted_many</source>
+        <target>{count, plural, =0 {No failed messages deleted.} =1 {One failed message deleted.} other {# failed messages deleted.}}</target>
+      </trans-unit>
+      <trans-unit id="opsFm23" resname="ops.failed_messages.flash.deleted_all">
+        <source>ops.failed_messages.flash.deleted_all</source>
+        <target>{count, plural, =0 {No failed messages deleted.} =1 {One failed message deleted.} other {# failed messages deleted.}}</target>
+      </trans-unit>
+      <trans-unit id="opsFm24" resname="ops.failed_messages.flash.none_selected">
+        <source>ops.failed_messages.flash.none_selected</source>
+        <target>Select at least one failed message to delete.</target>
+      </trans-unit>
+      <trans-unit id="opsRd01" resname="ops.reminder_dispatch.title">
+        <source>ops.reminder_dispatch.title</source>
+        <target>Monthly reminder dispatches</target>
+      </trans-unit>
+      <trans-unit id="opsRd02" resname="ops.reminder_dispatch.help">
+        <source>ops.reminder_dispatch.help</source>
+        <target>Only scheduler-triggered sends are recorded here. Admin and CLI sends appear in the audit log.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary

This PR turns the admin dashboard into an **operational control center** and closes several gaps in EasyAdmin entity coverage.

### Operational dashboard
- Adds a health banner at the top (database + failed messenger queue checks, app version)
- Introduces ops cards for messenger queues and storage (total, database, imports/media) with 30-day trends
- Reorders the dashboard: health → ops → notifications → KPIs → chart → failed imports → navigation tiles
- Limits the failed-imports widget to the **last 30 days**, with a link to the full filtered import list and a badge showing the total failed count
- Adds storage metrics via `StorageMetricsService` (including optional `APP_ADMIN_STORAGE_LIMIT_BYTES` and cached application code size)
- Removes the duplicate KPI chart caused by a second Stimulus bootstrap

### Failed messenger messages
- Adds index and detail views for the failed queue
- Supports deleting individual, selected, or all failed messages (CSRF-protected POST actions)

### Admin navigation & CRUD coverage
- Restructures the sidebar: **Users** (accounts, hospital access, onboarding), **Data → Imports** (imports, rejects, batch runs/items), **System** (audit log, cookie consents, failed messages, monthly reminders)
- Adds CRUD/read-only screens for hospital access grants, import batch runs/items, onboarding steps, monthly reminder dispatches, and saved explorer views
- Improves hospital permission editing with a dedicated form field and label formatter
- Aligns pagination across admin list templates

### i18n & polish
- Adds EN/DE admin translations for all new UI
- Uses **“Fehlerfrei”** instead of “Gesund” for the healthy system status in German

Closes #261

## Test plan

- [x] Open `/admin` as an admin user and verify dashboard order: health banner → ops cards → notifications → KPI section → chart → failed imports → nav tiles
- [x] Confirm healthy status shows correctly (EN: “Healthy”, DE: “Fehlerfrei”)
- [x] Verify storage ops cards show total/database/imports-media values and 30-day trends
- [x] Create failed imports (recent + older than 30 days) and confirm only recent ones appear on the dashboard; “All failed imports” link opens the filtered list with the correct badge count
- [x] Open **System → Failed messages**, inspect a message, delete one / a selection / all, and confirm CSRF protection on POST actions
- [x] Check new sidebar entries: hospital access grants, batch runs/items, onboarding steps, monthly reminders, saved explorer views
- [x] Run `make ci` locally (PHPUnit, PHPStan, Psalm, Rector, Twig CS)