### PR TITLE
fix(admin): align EasyAdmin CRUD lifecycle signatures with EA 5

### DIFF
--- a/docs/03-development/testing.md
+++ b/docs/03-development/testing.md
@@ -68,6 +68,12 @@ make lint-trans-de  # lint DE catalogue only
 - Linting: `.github/workflows/lint.yml`
 - Security scan: `.github/workflows/security.yml`
 
+## Rector and EasyAdmin CRUD lifecycle hooks
+
+EasyAdmin 5 declares `persistEntity()`, `updateEntity()`, and `deleteEntity()` with `object $entityInstance` in `AbstractCrudController`. CRUD controller overrides must use the same parameter type — not an entity-specific type (PHP forbids narrowing `object` to e.g. `Post`).
+
+After an EasyAdmin upgrade, run `composer install` so `vendor/` matches `composer.lock`. If Rector behaves unexpectedly locally, clear `var/cache/rector` and re-run `vendor/bin/rector --dry-run` (CI always runs without a persisted Rector cache).
+
 ## Common pitfalls
 
 - Tests using `#[ResetDatabase]` or `DatabaseKernelTestCase` belong under `tests/*/Integration/` (or higher layers), not `tests/*/Unit/`: the CI unit job runs ParaTest without PostgreSQL.

--- a/rector.php
+++ b/rector.php
@@ -6,20 +6,8 @@ use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 use Rector\Symfony\Set\SymfonySetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
 
 $entityPath = __DIR__.'/src/**/Domain/Entity/*';
-
-/** EasyAdmin AbstractCrudController keeps $entityInstance untyped; object breaks LSP. */
-$easyAdminCrudControllerPaths = [
-    __DIR__.'/src/Admin/UI/Http/Controller/Blog/PostCategoryCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/Blog/PostCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/Blog/PostTagCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/Media/MediaCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/Page/PageCrudController.php',
-    __DIR__.'/src/Admin/UI/Http/Controller/User/UserCrudController.php',
-];
 
 return RectorConfig::configure()
     ->withPaths([
@@ -50,7 +38,6 @@ return RectorConfig::configure()
         ControllerMethodInjectionToConstructorRector::class => [
             __DIR__.'/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php',
         ],
-        ParamTypeByParentCallTypeRector::class => $easyAdminCrudControllerPaths,
     ])
     ->withCache(__DIR__.'/var/cache/rector')
     ->withParallel();

--- a/src/Admin/UI/Http/Controller/Blog/PostCategoryCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCategoryCrudController.php
@@ -58,7 +58,7 @@ final class PostCategoryCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         /* @var PostCategory $entityInstance */
         $entityInstance->setSlug(strtolower(new AsciiSlugger()->slug((string) $entityInstance->getName())->toString()));
@@ -67,7 +67,7 @@ final class PostCategoryCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         /* @var PostCategory $entityInstance */
         $entityInstance->setSlug(strtolower(new AsciiSlugger()->slug((string) $entityInstance->getName())->toString()));

--- a/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
@@ -137,7 +137,7 @@ final class PostCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof Post) {
             return;
@@ -149,7 +149,7 @@ final class PostCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof Post) {
             return;

--- a/src/Admin/UI/Http/Controller/Blog/PostTagCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostTagCrudController.php
@@ -58,7 +58,7 @@ final class PostTagCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         /* @var PostTag $entityInstance */
         $entityInstance->setSlug(strtolower(new AsciiSlugger()->slug((string) $entityInstance->getName())->toString()));
@@ -67,7 +67,7 @@ final class PostTagCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         /* @var PostTag $entityInstance */
         $entityInstance->setSlug(strtolower(new AsciiSlugger()->slug((string) $entityInstance->getName())->toString()));

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -50,7 +50,7 @@ final class HospitalCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->auditContext->beginIntent('hospital.admin.created', ['source' => 'easyadmin']);
         try {
@@ -61,7 +61,7 @@ final class HospitalCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->auditContext->beginIntent('hospital.admin.updated', ['source' => 'easyadmin']);
         try {

--- a/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
+++ b/src/Admin/UI/Http/Controller/Import/ImportCrudController.php
@@ -117,7 +117,7 @@ final class ImportCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function deleteEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->importDeletionService->delete($entityInstance);
     }

--- a/src/Admin/UI/Http/Controller/Media/MediaCrudController.php
+++ b/src/Admin/UI/Http/Controller/Media/MediaCrudController.php
@@ -124,7 +124,7 @@ final class MediaCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->mediaTypeResolver->applyTo($entityInstance);
 
@@ -132,7 +132,7 @@ final class MediaCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $this->mediaTypeResolver->applyTo($entityInstance);
 

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -191,7 +191,7 @@ final class PageCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof Page) {
             return;
@@ -202,7 +202,7 @@ final class PageCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof Page) {
             return;

--- a/src/Admin/UI/Http/Controller/User/UserCrudController.php
+++ b/src/Admin/UI/Http/Controller/User/UserCrudController.php
@@ -134,7 +134,7 @@ final class UserCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof User) {
             return;
@@ -156,7 +156,7 @@ final class UserCrudController extends AbstractCrudController
     }
 
     #[\Override]
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         if (!$entityInstance instanceof User) {
             return;


### PR DESCRIPTION
## Summary

Resolves #292 by aligning EasyAdmin CRUD lifecycle hook overrides with EasyAdmin 5’s parent signatures.

- Add `object $entityInstance` to `persistEntity()`, `updateEntity()`, and `deleteEntity()` overrides in 8 admin CRUD controllers
- Remove the `ParamTypeByParentCallTypeRector` skip workaround from `rector.php`
- Document EA 5 signature expectations and Rector troubleshooting in `docs/03-development/testing.md`

### Background

During the EasyAdmin 4 → 5 upgrade, Rector’s `ParamTypeByParentCallTypeRector` suggested adding `object` to untyped `$entityInstance` parameters. A temporary Rector skip was added after a boot-time fatal error that likely came from a vendor mismatch during migration.

With EasyAdmin 5.1.0, `AbstractCrudController` already declares these hooks with `object $entityInstance`, so child overrides should match that signature. Entity-specific parameter types (e.g. `Post $entityInstance`) remain invalid in PHP.

## Test plan

- [x] `rm -rf var/cache/rector && vendor/bin/rector --dry-run` — no changes
- [x] `bin/console lint:container` — passes
- [x] `./vendor/bin/phpstan analyze src/Admin/UI/Http/Controller/` — no errors
- [x] CI lint workflow (Rector, PHPStan, PHP-CS-Fixer)