### PR TITLE
Testing/improve login smoke tests

### DIFF
--- a/tests/Onboarding/Functional/OnboardingHappyPathTest.php
+++ b/tests/Onboarding/Functional/OnboardingHappyPathTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Onboarding\Functional;
+
+use App\Admin\Application\Service\GrantParticipantUrlGenerator;
+use App\Tests\Support\Browser\CookieConsentTestHelper;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
+use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class OnboardingHappyPathTest extends WebTestCase
+{
+    use CookieConsentTestHelper;
+    use Factories;
+    use HasBrowser;
+
+    public function testRegisteredParticipantSeesFirstOnboardingStepAfterLogin(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('onboarding-%s', $suffix);
+        $email = sprintf('onboarding-%s@example.test', $suffix);
+        $password = 'super-secret-password';
+
+        $admin = UserFactory::new()
+            ->asNotificationRecipient()
+            ->create([
+                'username' => sprintf('onboarding-admin-%s', $suffix),
+            ]);
+
+        $this->browser()
+            ->visit('/register')
+            ->fillField('registration_form[username]', $username)
+            ->fillField('registration_form[email]', $email)
+            ->fillField('registration_form[plainPassword]', $password)
+            ->checkField('registration_form[acceptTerms]')
+            ->click('Register')
+            ->assertSuccessful()
+            ->assertSeeIn('h2', 'Check your email')
+        ;
+
+        $user = UserFactory::repository()->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+        self::assertFalse($user->isVerified());
+
+        /** @var VerifyEmailHelperInterface $verifyEmailHelper */
+        $verifyEmailHelper = self::getContainer()->get(VerifyEmailHelperInterface::class);
+        $verificationUrl = $verifyEmailHelper->generateSignature(
+            'app_verify_email',
+            (string) $user->getId(),
+            (string) $user->getEmail(),
+            ['id' => (string) $user->getId()],
+        )->getSignedUrl();
+
+        $this->browser()
+            ->visit($verificationUrl)
+            ->assertSuccessful()
+            ->assertSeeIn('h2', 'Login')
+            ->assertSee('Your email address has been confirmed. You can sign in now.')
+        ;
+
+        \Zenstruck\Foundry\Persistence\refresh($user);
+        self::assertTrue($user->isVerified());
+
+        /** @var GrantParticipantUrlGenerator $grantParticipantUrlGenerator */
+        $grantParticipantUrlGenerator = self::getContainer()->get(GrantParticipantUrlGenerator::class);
+        $grantParticipantUrl = $grantParticipantUrlGenerator->generate((int) $user->getId());
+
+        $this->browser()
+            ->actingAs($admin)
+            ->visit($grantParticipantUrl)
+            ->assertSuccessful()
+            ->visit('/logout')
+        ;
+
+        \Zenstruck\Foundry\Persistence\refresh($user);
+        self::assertContains(UserRole::PARTICIPANT, $user->getRoles());
+
+        $this->loginWithConsent($this->browser(), $username, $password)
+            ->assertSeeElement('[data-testid="dashboard-onboarding-card"]')
+            ->assertSeeElement('[data-testid="onboarding-step-request_clinic_access"]')
+        ;
+    }
+}

--- a/tests/User/Functional/Controller/SecurityControllerTest.php
+++ b/tests/User/Functional/Controller/SecurityControllerTest.php
@@ -94,6 +94,48 @@ final class SecurityControllerTest extends WebTestCase
         ;
     }
 
+    public function testWrongPasswordShowsInvalidCredentialsError(): void
+    {
+        UserFactory::new(['username' => 'login-user'])->create();
+
+        $this->acceptEssentialCookies($this->browser())
+            ->visit('/login')
+            ->fillField('Username', 'login-user')
+            ->fillField('Password', 'wrong-password')
+            ->click('Sign in')
+            ->assertSuccessful()
+            ->assertSeeIn('.alert.alert-danger', 'Invalid credentials.')
+            ->assertSee('Login')
+            ->use(static function (Crawler $crawler): void {
+                self::assertSame('login-user', $crawler->filter('input[name="login[username]"]')->attr('value'));
+            })
+        ;
+    }
+
+    public function testGuestCannotAccessProtectedRouteWithoutLogin(): void
+    {
+        $this->acceptEssentialCookies($this->browser())
+            ->visit('/settings')
+            ->assertSeeIn('h2', 'Login')
+            ->assertNotSeeElement('#user_name')
+        ;
+    }
+
+    public function testLoginRedirectsToOriginallyRequestedProtectedRoute(): void
+    {
+        UserFactory::new(['username' => 'redirect-user'])->create();
+
+        $this->acceptEssentialCookies($this->browser())
+            ->visit('/settings')
+            ->assertSeeIn('h2', 'Login')
+            ->fillField('Username', 'redirect-user')
+            ->fillField('Password', 'password')
+            ->click('Sign in')
+            ->assertSuccessful()
+            ->assertSee('Account Settings')
+        ;
+    }
+
     public function testLoginIsRateLimitedAfterMaxAttempts(): void
     {
         UserFactory::new(['username' => 'throttle-user'])->create();


### PR DESCRIPTION
## Summary

Closes #271.

This PR adds explicit functional smoke coverage for the login flow before beta. Registration, password reset, and password confirmation were already tested; login itself was only covered indirectly.

Changes extend the existing `SecurityControllerTest` (the login endpoint lives in `SecurityController`, not a separate `LoginController`) and add an optional end-to-end onboarding happy-path test.

### Login smoke tests (`SecurityControllerTest`)

- **Wrong password** — valid user submits an incorrect password and sees `Invalid credentials.`; username is preserved in the form
- **Protected route guard** — guest visiting `/settings` is redirected to login and is not authenticated
- **Target-path redirect** — guest requests `/settings`, signs in successfully, and lands on the Account Settings page

Existing coverage (consent requirement, logout, disabled/unverified users, rate limiting, session invalidation) is left unchanged.

### Onboarding happy path (`OnboardingHappyPathTest`)

End-to-end flow using the browser and Foundry fixtures:

1. Register a new user
2. Verify email
3. Grant `ROLE_PARTICIPANT` via signed admin URL
4. Log in through the real login form
5. Assert the first onboarding step is visible on the dashboard

## Test plan

- [x] `make test PATH_ARG=tests/User/Functional/Controller/SecurityControllerTest.php`
- [x] `make test PATH_ARG=tests/Onboarding/Functional/OnboardingHappyPathTest.php`
- [x] `make ci`