### PR TITLE
feat(explore): Cache explore filter reference data to reduce per-request database load

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -14,12 +14,15 @@ framework:
         # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
         #app: cache.adapter.apcu
 
-        # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            cache.allocation.reference_data:
+                adapter: cache.app
 
 when@test:
     framework:
         cache:
             # "TEST_TOKEN" is typically set by ParaTest
             directory: '%kernel.cache_dir%/pools/%env(default::TEST_TOKEN)%'
+            pools:
+                cache.allocation.reference_data:
+                    adapter: cache.adapter.array

--- a/config/services/foundry_test.yaml
+++ b/config/services/foundry_test.yaml
@@ -8,3 +8,4 @@ when@test:
             arguments:
                 $decorated: '@.inner'
                 $materializedViewsInstaller: '@App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller'
+                $cacheClearer: '@cache.global_clearer'

--- a/docs/04-features/allocation/README.md
+++ b/docs/04-features/allocation/README.md
@@ -5,4 +5,5 @@
 | Document | Description |
 |----------|-------------|
 | [explore-allocation-list.md](explore-allocation-list.md) | Allocation list route and filters |
+| [explore-filter-reference-cache.md](explore-filter-reference-cache.md) | Cached reference data for Explore filter dropdowns |
 | [indication-normalization.md](indication-normalization.md) | Raw indication review and backfill |

--- a/docs/04-features/allocation/explore-allocation-list.md
+++ b/docs/04-features/allocation/explore-allocation-list.md
@@ -27,6 +27,7 @@ Legacy URLs with `hospitalScope=my_hospitals` and optional `hospital={id}` remai
 
 | Area | Path |
 |---|---|
+| Filter reference cache | `src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php` (see [explore-filter-reference-cache.md](explore-filter-reference-cache.md)) |
 | Scope resolution | `src/Allocation/Application/Allocations/AllocationListHospitalScopeResolver.php` |
 | Filter criteria | `src/Allocation/Application/Allocations/AllocationListFilterCriteriaFactory.php` |
 | SQL filter | `src/Allocation/Application/Export/AllocationListFilterApplicator.php` |

--- a/docs/04-features/allocation/explore-filter-reference-cache.md
+++ b/docs/04-features/allocation/explore-filter-reference-cache.md
@@ -1,0 +1,67 @@
+# Explore filter reference cache
+
+**Audience:** Developers working on Explore list pages and allocation performance.
+
+Explore list routes render filter dropdowns from slowly changing reference data (states, dispatch areas, indications, and more). Before caching, each page view reloaded that data from the database — up to nine extra queries on `/explore/allocation` alone.
+
+## Motivation
+
+Issue [#268](https://github.com/nplhse/collaborative-ivena-statistics/issues/268): with real data volumes and multiple concurrent beta participants, redundant `findAll()` / `findBy()` calls on every request create unnecessary database load.
+
+## Architecture
+
+`ExploreFilterOptionsProvider` serves reference data through the Symfony cache pool `cache.allocation.reference_data` (filesystem via `cache.app`). TTL is one hour — acceptable for closed beta without explicit invalidation.
+
+```text
+Controller → ExploreFilterOptionsProvider → cache pool → (miss) repository
+```
+
+User-specific hospital scope options stay uncached via `AllocationListHospitalScopeOptionsProvider`.
+
+## Cached data
+
+| Cache key | Getter | Routes |
+|-----------|--------|--------|
+| `explore_filter.states` | `states()` | `/explore/allocation`, `/explore/hospital`, `/explore/dispatch_area` |
+| `explore_filter.dispatch_areas` | `dispatchAreas()` | `/explore/allocation`, `/explore/hospital` |
+| `explore_filter.indications` | `indications()` | `/explore/allocation` |
+| `explore_filter.secondary_transports` | `secondaryTransports()` | `/explore/allocation` |
+| `explore_filter.infections` | `infections()` | `/explore/allocation` |
+| `explore_filter.departments` | `departments()` | `/explore/allocation` |
+| `explore_filter.specialities` | `specialities()` | `/explore/allocation` |
+| `explore_filter.assignments` | `assignments()` | `/explore/allocation` |
+| `explore_filter.occasions` | `occasions()` | `/explore/allocation` |
+
+**Not cached:** `hospitalScopeOptions` (per-user hospital access).
+
+## Arrays instead of entities
+
+Cached values are plain arrays (`id`, `name`, and `code` for indications), not Doctrine entities. Entities such as `State` carry lazy collections and user proxies that do not serialize reliably into the filesystem cache. Twig accepts both objects and arrays (`state.id`, `indication.code`).
+
+## Code locations
+
+| Area | Path |
+|------|------|
+| Provider | `src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php` |
+| Cache pool | `config/packages/cache.yaml` (`cache.allocation.reference_data`) |
+| Allocation list | `src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php` |
+| Hospital list | `src/Allocation/UI/Http/Controller/Hospitals/ListHospitalsController.php` |
+| Dispatch area list | `src/Allocation/UI/Http/Controller/DispatchAreas/ListDispatchAreasController.php` |
+
+## Limits
+
+- No Redis or multi-instance cache coordination
+- No event-based invalidation on admin changes — TTL is sufficient for beta
+- Manual clear if needed: `bin/console cache:pool:clear cache.allocation.reference_data`
+
+## Test environment
+
+- Pool uses `cache.adapter.array` under `when@test` for isolation
+- `MaterializedViewAwareOrmResetter` clears the pool on each Foundry database reset so stale reference IDs do not leak between tests
+
+## Tests
+
+| Test | Path |
+|------|------|
+| Integration (cache hit) | `tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php` |
+| Functional (query count) | `tests/Allocation/Functional/Controller/Allocations/ExploreAllocationListQueryCountTest.php` |

--- a/src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php
+++ b/src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Explore;
+
+use App\Allocation\Domain\Entity\Assignment;
+use App\Allocation\Domain\Entity\Department;
+use App\Allocation\Domain\Entity\DispatchArea;
+use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Allocation\Domain\Entity\Infection;
+use App\Allocation\Domain\Entity\Occasion;
+use App\Allocation\Domain\Entity\SecondaryTransport;
+use App\Allocation\Domain\Entity\Speciality;
+use App\Allocation\Domain\Entity\State;
+use App\Allocation\Infrastructure\Repository\AssignmentRepository;
+use App\Allocation\Infrastructure\Repository\DepartmentRepository;
+use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
+use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
+use App\Allocation\Infrastructure\Repository\InfectionRepository;
+use App\Allocation\Infrastructure\Repository\OccasionRepository;
+use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
+use App\Allocation\Infrastructure\Repository\SpecialityRepository;
+use App\Allocation\Infrastructure\Repository\StateRepository;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final readonly class ExploreFilterOptionsProvider
+{
+    private const int TTL_SECONDS = 3600;
+
+    private const string CACHE_KEY_STATES = 'explore_filter.states';
+
+    private const string CACHE_KEY_DISPATCH_AREAS = 'explore_filter.dispatch_areas';
+
+    private const string CACHE_KEY_INDICATIONS = 'explore_filter.indications';
+
+    private const string CACHE_KEY_SECONDARY_TRANSPORTS = 'explore_filter.secondary_transports';
+
+    private const string CACHE_KEY_INFECTIONS = 'explore_filter.infections';
+
+    private const string CACHE_KEY_DEPARTMENTS = 'explore_filter.departments';
+
+    private const string CACHE_KEY_SPECIALITIES = 'explore_filter.specialities';
+
+    private const string CACHE_KEY_ASSIGNMENTS = 'explore_filter.assignments';
+
+    private const string CACHE_KEY_OCCASIONS = 'explore_filter.occasions';
+
+    public function __construct(
+        #[Autowire(service: 'cache.allocation.reference_data')]
+        private CacheInterface $cache,
+        private StateRepository $stateRepository,
+        private DispatchAreaRepository $dispatchAreaRepository,
+        private IndicationNormalizedRepository $indicationNormalizedRepository,
+        private SecondaryTransportRepository $secondaryTransportRepository,
+        private InfectionRepository $infectionRepository,
+        private DepartmentRepository $departmentRepository,
+        private SpecialityRepository $specialityRepository,
+        private AssignmentRepository $assignmentRepository,
+        private OccasionRepository $occasionRepository,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     states: list<array{id: int, name: string}>,
+     *     dispatchAreas: list<array{id: int, name: string}>,
+     *     indications: list<array{id: int, code: int, name: string}>,
+     *     secondaryTransports: list<array{id: int, name: string}>,
+     *     infections: list<array{id: int, name: string}>,
+     *     departments: list<array{id: int, name: string}>,
+     *     specialities: list<array{id: int, name: string}>,
+     *     assignments: list<array{id: int, name: string}>,
+     *     occasions: list<array{id: int, name: string}>,
+     * }
+     */
+    public function allocationListOptions(): array
+    {
+        return [
+            'states' => $this->states(),
+            'dispatchAreas' => $this->dispatchAreas(),
+            'indications' => $this->indications(),
+            'secondaryTransports' => $this->secondaryTransports(),
+            'infections' => $this->infections(),
+            'departments' => $this->departments(),
+            'specialities' => $this->specialities(),
+            'assignments' => $this->assignments(),
+            'occasions' => $this->occasions(),
+        ];
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function states(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_STATES, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return array_map(
+                static fn (State $state): array => [
+                    'id' => (int) $state->getId(),
+                    'name' => (string) $state->getName(),
+                ],
+                $this->stateRepository->findAll(),
+            );
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function dispatchAreas(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_DISPATCH_AREAS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return array_map(
+                static fn (DispatchArea $dispatchArea): array => [
+                    'id' => (int) $dispatchArea->getId(),
+                    'name' => (string) $dispatchArea->getName(),
+                ],
+                $this->dispatchAreaRepository->findAll(),
+            );
+        });
+    }
+
+    /**
+     * @return list<array{id: int, code: int, name: string}>
+     */
+    public function indications(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_INDICATIONS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return array_map(
+                static fn (IndicationNormalized $indication): array => [
+                    'id' => (int) $indication->getId(),
+                    'code' => (int) $indication->getCode(),
+                    'name' => (string) $indication->getName(),
+                ],
+                $this->indicationNormalizedRepository->findAll(),
+            );
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function secondaryTransports(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_SECONDARY_TRANSPORTS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->secondaryTransportRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function infections(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_INFECTIONS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->infectionRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function departments(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_DEPARTMENTS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->departmentRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function specialities(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_SPECIALITIES, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->specialityRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function assignments(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_ASSIGNMENTS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->assignmentRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function occasions(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_OCCASIONS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return $this->mapNamedEntities($this->occasionRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @template T of Assignment|Department|Infection|Occasion|SecondaryTransport|Speciality
+     *
+     * @param list<T> $entities
+     *
+     * @return list<array{id: int, name: string}>
+     */
+    private function mapNamedEntities(array $entities): array
+    {
+        return array_map(
+            static fn (Assignment|Department|Infection|Occasion|SecondaryTransport|Speciality $entity): array => [
+                'id' => (int) $entity->getId(),
+                'name' => (string) $entity->getName(),
+            ],
+            $entities,
+        );
+    }
+}

--- a/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
+++ b/src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php
@@ -5,21 +5,13 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\Allocations;
 
 use App\Allocation\Application\Allocations\AllocationListHospitalScopeOptionsProvider;
+use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
 use App\Allocation\Domain\Enum\AllocationTransportType;
 use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Domain\Enum\HospitalLocation;
 use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\Infrastructure\Query\ListAllocationsQuery;
-use App\Allocation\Infrastructure\Repository\AssignmentRepository;
-use App\Allocation\Infrastructure\Repository\DepartmentRepository;
-use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
-use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
-use App\Allocation\Infrastructure\Repository\InfectionRepository;
-use App\Allocation\Infrastructure\Repository\OccasionRepository;
-use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
-use App\Allocation\Infrastructure\Repository\SpecialityRepository;
-use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO;
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -32,16 +24,8 @@ final class ListAllocationsController extends AbstractController
 {
     public function __construct(
         private readonly ListAllocationsQuery $allocationsQuery,
-        private readonly DispatchAreaRepository $dispatchAreaRepository,
-        private readonly StateRepository $stateRepository,
-        private readonly IndicationNormalizedRepository $normalizedRepository,
-        private readonly SecondaryTransportRepository $secondaryTransportRepository,
-        private readonly InfectionRepository $infectionRepository,
-        private readonly DepartmentRepository $departmentRepository,
-        private readonly SpecialityRepository $specialityRepository,
+        private readonly ExploreFilterOptionsProvider $filterOptionsProvider,
         private readonly AllocationListHospitalScopeOptionsProvider $hospitalScopeOptionsProvider,
-        private readonly AssignmentRepository $assignmentRepository,
-        private readonly OccasionRepository $occasionRepository,
     ) {
     }
 
@@ -67,15 +51,7 @@ final class ListAllocationsController extends AbstractController
             'locations' => HospitalLocation::cases(),
             'sizes' => HospitalSize::cases(),
             'urgencies' => AllocationUrgency::cases(),
-            'states' => $this->stateRepository->findAll(),
-            'dispatchAreas' => $this->dispatchAreaRepository->findAll(),
-            'indications' => $this->normalizedRepository->findAll(),
-            'secondaryTransports' => $this->secondaryTransportRepository->findBy([], ['name' => 'ASC']),
-            'infections' => $this->infectionRepository->findBy([], ['name' => 'ASC']),
-            'departments' => $this->departmentRepository->findBy([], ['name' => 'ASC']),
-            'specialities' => $this->specialityRepository->findBy([], ['name' => 'ASC']),
-            'assignments' => $this->assignmentRepository->findBy([], ['name' => 'ASC']),
-            'occasions' => $this->occasionRepository->findBy([], ['name' => 'ASC']),
+            ...$this->filterOptionsProvider->allocationListOptions(),
             'transportTypes' => AllocationTransportType::cases(),
             'hospitalScopeOptions' => $hospitalScopeOptions,
         ]);

--- a/src/Allocation/UI/Http/Controller/DispatchAreas/ListDispatchAreasController.php
+++ b/src/Allocation/UI/Http/Controller/DispatchAreas/ListDispatchAreasController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Allocation\UI\Http\Controller\DispatchAreas;
 
+use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
-use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Allocation\UI\Http\DTO\AreaListQueryParametersDTO;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,7 +17,7 @@ final class ListDispatchAreasController extends AbstractController
 {
     public function __construct(
         private readonly DispatchAreaRepository $dispatchAreaRepository,
-        private readonly StateRepository $stateRepository,
+        private readonly ExploreFilterOptionsProvider $filterOptionsProvider,
     ) {
     }
 
@@ -34,7 +34,7 @@ final class ListDispatchAreasController extends AbstractController
             'orderBy' => $query->orderBy,
             'filters' => $query,
             'activeFilterCount' => $this->countActiveFilters($query),
-            'states' => $this->stateRepository->findAll(),
+            'states' => $this->filterOptionsProvider->states(),
         ]);
     }
 

--- a/src/Allocation/UI/Http/Controller/Hospitals/ListHospitalsController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/ListHospitalsController.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Allocation\UI\Http\Controller\Hospitals;
 
+use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
 use App\Allocation\Domain\Enum\HospitalLocation;
 use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
-use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
-use App\Allocation\Infrastructure\Repository\StateRepository;
 use App\Allocation\UI\Http\DTO\HospitalQueryParametersDTO;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,8 +20,7 @@ final class ListHospitalsController extends AbstractController
 {
     public function __construct(
         private readonly HospitalRepository $hospitalRepository,
-        private readonly DispatchAreaRepository $dispatchAreaRepository,
-        private readonly StateRepository $stateRepository,
+        private readonly ExploreFilterOptionsProvider $filterOptionsProvider,
     ) {
     }
 
@@ -42,8 +40,8 @@ final class ListHospitalsController extends AbstractController
             'tiers' => HospitalTier::cases(),
             'locations' => HospitalLocation::cases(),
             'sizes' => HospitalSize::cases(),
-            'states' => $this->stateRepository->findAll(),
-            'dispatchAreas' => $this->dispatchAreaRepository->findAll(),
+            'states' => $this->filterOptionsProvider->states(),
+            'dispatchAreas' => $this->filterOptionsProvider->dispatchAreas(),
         ]);
     }
 

--- a/tests/Allocation/Functional/Controller/Allocations/ExploreAllocationListQueryCountTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ExploreAllocationListQueryCountTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Functional\Controller\Allocations;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Baseline without cache: each /explore/allocation request loads nine reference lists from the DB.
+ * After cache warmup on the first request, the second request should skip those redundant queries.
+ */
+#[ResetDatabase]
+final class ExploreAllocationListQueryCountTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+
+    private const int MIN_SAVED_REFERENCE_QUERIES = 5;
+
+    public function testSecondRequestUsesFewerReferenceQueries(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedDependencies();
+
+        AllocationFactory::createOne();
+
+        $client->enableProfiler();
+        $client->request(Request::METHOD_GET, '/explore/allocation?limit=10');
+        self::assertResponseIsSuccessful();
+        $firstCount = $this->doctrineQueryCount($client->getProfile());
+
+        $client->enableProfiler();
+        $client->request(Request::METHOD_GET, '/explore/allocation?limit=10');
+        self::assertResponseIsSuccessful();
+        $secondCount = $this->doctrineQueryCount($client->getProfile());
+
+        self::assertGreaterThanOrEqual(
+            self::MIN_SAVED_REFERENCE_QUERIES,
+            $firstCount - $secondCount,
+            sprintf(
+                'Expected at least %d fewer DB queries on cached /explore/allocation request (first: %d, second: %d).',
+                self::MIN_SAVED_REFERENCE_QUERIES,
+                $firstCount,
+                $secondCount,
+            ),
+        );
+    }
+
+    private function doctrineQueryCount(?\Symfony\Component\HttpKernel\Profiler\Profile $profile): int
+    {
+        self::assertNotNull($profile);
+
+        $collector = $profile->getCollector('db');
+        self::assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        return $collector->getQueryCount();
+    }
+
+    private function seedDependencies(): void
+    {
+        StateFactory::createOne(['name' => 'Hessen']);
+        DispatchAreaFactory::createOne(['name' => 'Dispatch Area']);
+        HospitalFactory::createOne(['name' => 'Test Hospital']);
+        ImportFactory::createOne(['name' => 'Test Import']);
+        SpecialityFactory::createOne(['name' => 'Innere Medizin']);
+        DepartmentFactory::createOne(['name' => 'Kardiologie']);
+        AssignmentFactory::createOne(['name' => 'Test Assignment']);
+        OccasionFactory::createOne(['name' => 'Test Occasion']);
+        SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
+        InfectionFactory::createOne(['name' => 'Test Infection']);
+        IndicationRawFactory::createOne(['name' => 'Test Indication']);
+        IndicationNormalizedFactory::createOne(['name' => 'Test Indication']);
+    }
+}

--- a/tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php
+++ b/tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Application\Explore;
+
+use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ExploreFilterOptionsProviderTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testSecondCallUsesCachedStates(): void
+    {
+        self::bootKernel();
+        StateFactory::createOne(['name' => 'Hessen']);
+
+        $provider = self::getContainer()->get(ExploreFilterOptionsProvider::class);
+        self::assertInstanceOf(ExploreFilterOptionsProvider::class, $provider);
+
+        $first = $provider->states();
+        StateFactory::createOne(['name' => 'Bayern']);
+        $second = $provider->states();
+
+        self::assertSame([['id' => $first[0]['id'], 'name' => 'Hessen']], $first);
+        self::assertSame($first, $second);
+    }
+
+    public function testAllocationListOptionsReturnsMappedReferenceArrays(): void
+    {
+        self::bootKernel();
+
+        $state = StateFactory::createOne(['name' => 'Hessen']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'North']);
+        $indication = IndicationNormalizedFactory::createOne([
+            'name' => 'STEMI',
+            'code' => 42,
+        ]);
+        $assignment = AssignmentFactory::createOne(['name' => 'Zebra Assignment']);
+        AssignmentFactory::createOne(['name' => 'Alpha Assignment']);
+        DepartmentFactory::createOne(['name' => 'Cardiology']);
+        SpecialityFactory::createOne(['name' => 'Internal Medicine']);
+        OccasionFactory::createOne(['name' => 'Emergency']);
+        SecondaryTransportFactory::createOne(['name' => 'Capacity']);
+        InfectionFactory::createOne(['name' => 'MRSA']);
+
+        $provider = self::getContainer()->get(ExploreFilterOptionsProvider::class);
+        self::assertInstanceOf(ExploreFilterOptionsProvider::class, $provider);
+
+        $options = $provider->allocationListOptions();
+
+        self::assertSame(
+            [
+                'states',
+                'dispatchAreas',
+                'indications',
+                'secondaryTransports',
+                'infections',
+                'departments',
+                'specialities',
+                'assignments',
+                'occasions',
+            ],
+            array_keys($options),
+        );
+        self::assertSame([
+            'id' => (int) $state->getId(),
+            'name' => 'Hessen',
+        ], $options['states'][0]);
+        self::assertSame([
+            'id' => (int) $dispatchArea->getId(),
+            'name' => 'North',
+        ], $options['dispatchAreas'][0]);
+        self::assertSame([
+            'id' => (int) $indication->getId(),
+            'code' => 42,
+            'name' => 'STEMI',
+        ], $options['indications'][0]);
+        self::assertSame(['Alpha Assignment', 'Zebra Assignment'], array_column($options['assignments'], 'name'));
+    }
+}

--- a/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
+++ b/tests/Support/Foundry/MaterializedViewAwareOrmResetter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Support\Foundry;
 
 use App\Statistics\Infrastructure\Query\Overview\OverviewMaterializedViewsInstaller;
+use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\ORM\ResetDatabase\OrmResetter;
 
@@ -25,6 +26,7 @@ final readonly class MaterializedViewAwareOrmResetter implements OrmResetter
     public function __construct(
         private OrmResetter $decorated,
         private OverviewMaterializedViewsInstaller $materializedViewsInstaller,
+        private Psr6CacheClearer $cacheClearer,
     ) {
     }
 
@@ -33,6 +35,7 @@ final readonly class MaterializedViewAwareOrmResetter implements OrmResetter
         $this->materializedViewsInstaller->resetInstallationState();
         $this->decorated->resetBeforeFirstTest($kernel);
         $this->materializedViewsInstaller->ensureInstalled();
+        $this->clearExploreFilterReferenceCache();
     }
 
     public function resetBeforeEachTest(KernelInterface $kernel): void
@@ -40,5 +43,11 @@ final readonly class MaterializedViewAwareOrmResetter implements OrmResetter
         $this->materializedViewsInstaller->resetInstallationState();
         $this->decorated->resetBeforeEachTest($kernel);
         $this->materializedViewsInstaller->ensureInstalled();
+        $this->clearExploreFilterReferenceCache();
+    }
+
+    private function clearExploreFilterReferenceCache(): void
+    {
+        $this->cacheClearer->clearPool('cache.allocation.reference_data');
     }
 }


### PR DESCRIPTION
## Summary

Explore list pages (`/explore/allocation`, `/explore/hospital`, `/explore/dispatch_area`) previously loaded filter dropdown reference data from the database on every request — up to nine extra queries on the allocation list alone.

This PR introduces a shared `ExploreFilterOptionsProvider` backed by a dedicated Symfony cache pool (`cache.allocation.reference_data`, 1h TTL). Reference data is cached as plain arrays (`id`, `name`, and `code` for indications) instead of Doctrine entities to avoid serialization issues with lazy associations.

Closes #268.

## Changes

- Add `ExploreFilterOptionsProvider` with separate cache keys per reference list
- Configure `cache.allocation.reference_data` (filesystem in prod, array adapter in test)
- Refactor three explore list controllers to use the provider instead of direct repository `findAll()` / `findBy()` calls
- User-specific hospital scope options remain uncached
- Add integration tests (cache hit + mapped option shape) and a functional query-count regression test
- Clear the reference cache pool on Foundry database resets for test isolation
- Document the approach in `docs/04-features/allocation/explore-filter-reference-cache.md`

## Out of scope (by design)

- No Redis / multi-instance cache
- No event-based invalidation — TTL is sufficient for closed beta
- Manual clear if needed: `bin/console cache:pool:clear cache.allocation.reference_data`

## Test plan

- [x] `make ci`
- [x] Integration tests for provider caching and option mapping
- [x] Functional test: second `/explore/allocation` request saves ≥5 DB queries
- [x] Existing allocation/hospital explore list functional tests pass