### PR TITLE
feat(import): allow administrators to download original import source files

### DIFF
--- a/docs/04-features/import/import-pipeline.md
+++ b/docs/04-features/import/import-pipeline.md
@@ -93,6 +93,15 @@ Reimports intentionally keep the source file; only result data from the previous
 
 File paths are resolved and removed through `ImportFileStorage` (Symfony `Filesystem::remove()`). Failed deletions are logged as `import.file.delete_failed`.
 
+## Source file download (admin)
+
+Administrators can download the original uploaded CSV from the import detail page (`/import/{id}`). The file is served through `DownloadImportSourceFileController` at `/import/{id}/source-file` — not via a public path under `var/imports/`.
+
+- Access requires `ROLE_ADMIN` and `ImportVoter::DOWNLOAD_SOURCE`
+- The download link is shown only when the voter grants access
+- Missing or deleted source files return HTTP 404
+- Downloads are recorded with audit intent `import.source_file.downloaded`
+
 ## Test locally
 
 ```bash
@@ -104,7 +113,7 @@ php bin/console app:import:requeue-all --resume
 Useful tests:
 - `tests/Import/Integration/...`
 - `tests/Import/Functional/Command/RequeueAllImportsCommandTest.php`
-- `tests/Import/Functional/Controller/NewImportControllerTest.php` (upload validation, Excel rejection)
+- `tests/Import/Functional/Controller/DownloadImportSourceFileControllerTest.php` (admin source file download)
 - `tests/Import/Unit/Service/ImportUploadGuardTest.php`
 - `tests/Import/Integration/Validator/Constraints/ImportSourceFileValidatorTest.php`
 

--- a/src/Import/Application/Exception/ImportSourceFileNotFoundException.php
+++ b/src/Import/Application/Exception/ImportSourceFileNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Exception;
+
+final class ImportSourceFileNotFoundException extends \RuntimeException
+{
+    public function __construct(int $importId)
+    {
+        parent::__construct(sprintf('No source file found for import %d', $importId));
+    }
+}

--- a/src/Import/Application/Service/ImportSourceFileDownloadService.php
+++ b/src/Import/Application/Service/ImportSourceFileDownloadService.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Application\Exception\ImportSourceFileNotFoundException;
+use App\Import\Domain\Entity\Import;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+final readonly class ImportSourceFileDownloadService
+{
+    public function __construct(
+        private ImportFileStorage $fileStorage,
+    ) {
+    }
+
+    public function createDownloadResponse(Import $import): BinaryFileResponse
+    {
+        $importId = $import->getId();
+        if (null === $importId) {
+            throw new ImportSourceFileNotFoundException(0);
+        }
+
+        $storedPath = $import->getFilePath();
+        if (null === $storedPath || '' === trim($storedPath)) {
+            throw new ImportSourceFileNotFoundException($importId);
+        }
+
+        $absolutePath = $this->fileStorage->resolve($storedPath);
+        if (!\is_file($absolutePath)) {
+            throw new ImportSourceFileNotFoundException($importId);
+        }
+
+        $filename = $this->buildDownloadFilename($import, $storedPath);
+        $mimeType = $import->getFileMimeType() ?? 'text/csv';
+
+        $response = new BinaryFileResponse($absolutePath);
+        $response->headers->set('Content-Type', $mimeType);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename);
+
+        return $response;
+    }
+
+    private function buildDownloadFilename(Import $import, string $storedPath): string
+    {
+        $extension = strtolower(trim((string) $import->getFileExtension()));
+        if ('' === $extension) {
+            $extension = strtolower(pathinfo($storedPath, PATHINFO_EXTENSION));
+        }
+
+        $name = trim((string) $import->getName());
+        if ('' !== $name) {
+            $sanitized = $this->sanitizeFilenameSegment($name);
+
+            return '' !== $extension ? $sanitized.'.'.$extension : $sanitized;
+        }
+
+        return basename(str_replace('\\', '/', $storedPath));
+    }
+
+    private function sanitizeFilenameSegment(string $value): string
+    {
+        $sanitized = preg_replace('/[^\w\-. ]+/u', '_', $value) ?? $value;
+        $sanitized = trim($sanitized, "._ \t\n\r\0\x0B");
+
+        if ('' === $sanitized) {
+            return 'import';
+        }
+
+        return $sanitized;
+    }
+}

--- a/src/Import/Infrastructure/Security/Voter/ImportVoter.php
+++ b/src/Import/Infrastructure/Security/Voter/ImportVoter.php
@@ -22,6 +22,8 @@ final class ImportVoter extends Voter
 
     public const string DELETE = 'DELETE';
 
+    public const string DOWNLOAD_SOURCE = 'DOWNLOAD_SOURCE';
+
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private readonly ImportListAccess $importListAccess,
@@ -38,7 +40,7 @@ final class ImportVoter extends Voter
     #[\Override]
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return $subject instanceof Import && \in_array($attribute, [self::VIEW, self::DELETE], true);
+        return $subject instanceof Import && \in_array($attribute, [self::VIEW, self::DELETE, self::DOWNLOAD_SOURCE], true);
     }
 
     #[\Override]
@@ -52,6 +54,18 @@ final class ImportVoter extends Voter
         $hospitalId = $subject->getHospital()?->getId();
 
         if (self::VIEW === $attribute) {
+            if (null === $hospitalId) {
+                return false;
+            }
+
+            return $this->importListAccess->canAccessImportHospital($user, $hospitalId);
+        }
+
+        if (self::DOWNLOAD_SOURCE === $attribute) {
+            if (!\in_array(UserRole::ADMIN, $user->getRoles(), true)) {
+                return false;
+            }
+
             if (null === $hospitalId) {
                 return false;
             }

--- a/src/Import/UI/Http/Controller/DownloadImportSourceFileController.php
+++ b/src/Import/UI/Http/Controller/DownloadImportSourceFileController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\UI\Http\Controller;
+
+use App\Import\Application\Exception\ImportSourceFileNotFoundException;
+use App\Import\Application\Service\ImportSourceFileDownloadService;
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Security\Voter\ImportVoter;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+final class DownloadImportSourceFileController extends AbstractController
+{
+    public function __construct(
+        private readonly ImportSourceFileDownloadService $downloadService,
+        private readonly AuditContext $auditContext,
+    ) {
+    }
+
+    #[Route('/import/{id}/source-file', name: 'app_import_source_file_download', methods: ['GET'])]
+    #[IsGranted(ImportVoter::DOWNLOAD_SOURCE, subject: 'import')]
+    public function __invoke(Import $import): BinaryFileResponse
+    {
+        $importId = $import->getId();
+        if (null === $importId) {
+            throw new NotFoundHttpException();
+        }
+
+        try {
+            $this->auditContext->beginIntent('import.source_file.downloaded', [
+                'import_id' => $importId,
+            ]);
+
+            return $this->downloadService->createDownloadResponse($import);
+        } catch (ImportSourceFileNotFoundException) {
+            throw new NotFoundHttpException();
+        }
+    }
+}

--- a/src/Import/UI/Twig/templates/show.html.twig
+++ b/src/Import/UI/Twig/templates/show.html.twig
@@ -128,6 +128,14 @@
                                     </div>
                                 </div>
                             </div>
+                            {% if is_granted(constant('App\\Import\\Infrastructure\\Security\\Voter\\ImportVoter::DOWNLOAD_SOURCE'), import) %}
+                                <div class="mt-3">
+                                    <a class="btn btn-outline-primary" href="{{ path('app_import_source_file_download', {id: import.id}) }}">
+                                        <twig:ux:icon name="tabler:download" class="w-3 h-3" />
+                                        {{ 'import.action.download_source_file'|trans({}, 'import') }}
+                                    </a>
+                                </div>
+                            {% endif %}
                         </twig:Card>
                     </div>
 

--- a/tests/Import/Functional/Controller/DownloadImportSourceFileControllerTest.php
+++ b/tests/Import/Functional/Controller/DownloadImportSourceFileControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Functional\Controller;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DownloadImportSourceFileControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testAdminCanDownloadSourceFile(): void
+    {
+        $client = self::createClient();
+        [$admin, $importId, $relativePath, $content] = $this->createImportWithSourceFile(asAdmin: true);
+
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/import/'.$importId.'/source-file');
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('attachment', (string) $client->getResponse()->headers->get('Content-Disposition'));
+        self::assertStringContainsString('Test Allocations.csv', (string) $client->getResponse()->headers->get('Content-Disposition'));
+        self::assertSame(\strlen($content), (int) $client->getResponse()->headers->get('Content-Length'));
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        self::assertSame($content, file_get_contents(Path::join((string) $projectDir, $relativePath)));
+    }
+
+    public function testHospitalOwnerWithoutAdminRoleCannotDownloadSourceFile(): void
+    {
+        $client = self::createClient();
+        [$owner, $importId] = $this->createImportWithSourceFile();
+
+        $client->loginUser($owner);
+        $client->request(Request::METHOD_GET, '/import/'.$importId.'/source-file');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminGetsNotFoundWhenSourceFileMissingOnDisk(): void
+    {
+        $client = self::createClient();
+        [$admin, $importId] = $this->createImportWithSourceFile(asAdmin: true, writeFile: false);
+
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/import/'.$importId.'/source-file');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testShowPageDisplaysDownloadLinkForAdmin(): void
+    {
+        $client = self::createClient();
+        [$admin, $importId] = $this->createImportWithSourceFile(asAdmin: true);
+
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/import/'.$importId);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href="/import/'.$importId.'/source-file"]');
+        self::assertSelectorTextContains('a[href="/import/'.$importId.'/source-file"]', 'Download original file');
+    }
+
+    public function testShowPageHidesDownloadLinkForParticipant(): void
+    {
+        $client = self::createClient();
+        [$owner, $importId] = $this->createImportWithSourceFile();
+
+        $client->loginUser($owner);
+        $client->request(Request::METHOD_GET, '/import/'.$importId);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('a[href="/import/'.$importId.'/source-file"]');
+    }
+
+    /**
+     * @return array{0: User, 1: int, 2: string, 3: string}
+     */
+    private function createImportWithSourceFile(bool $asAdmin = false, bool $writeFile = true): array
+    {
+        $owner = UserFactory::createOne([
+            'username' => 'owner-'.bin2hex(random_bytes(4)),
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $admin = $asAdmin ? UserFactory::new()->asAdmin()->create() : $owner;
+        $createdBy = UserFactory::createOne(['username' => 'creator-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne();
+
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'createdBy' => $createdBy,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $projectDir = self::getContainer()->getParameter('kernel.project_dir');
+        $relativePath = 'var/imports/functional/'.bin2hex(random_bytes(4)).'.csv';
+        $absolutePath = Path::join((string) $projectDir, $relativePath);
+        $content = "col1;col2\nvalue1;value2\n";
+
+        if ($writeFile) {
+            new Filesystem()->dumpFile($absolutePath, $content);
+        }
+
+        $import = ImportFactory::createOne([
+            'name' => 'Test Allocations',
+            'hospital' => $hospital,
+            'createdBy' => $createdBy,
+            'type' => ImportType::ALLOCATION,
+            'status' => ImportStatus::PENDING,
+            'filePath' => $relativePath,
+            'fileExtension' => 'csv',
+            'fileMimeType' => 'text/csv',
+            'fileSize' => \strlen($content),
+            'rowCount' => 1,
+            'rowsPassed' => 1,
+            'rowsRejected' => 0,
+            'runCount' => 0,
+            'runTime' => 0,
+        ]);
+
+        return [$admin, (int) $import->getId(), $relativePath, $content];
+    }
+}

--- a/tests/Import/Integration/Infrastructure/Security/ImportVoterTest.php
+++ b/tests/Import/Integration/Infrastructure/Security/ImportVoterTest.php
@@ -128,6 +128,41 @@ final class ImportVoterTest extends KernelTestCase
         );
     }
 
+    public function testDownloadSourceGrantedForAdmin(): void
+    {
+        $admin = UserFactory::new()->asAdmin()->create();
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($this->createToken($admin), $import, [ImportVoter::DOWNLOAD_SOURCE]),
+        );
+    }
+
+    public function testDownloadSourceDeniedForHospitalOwner(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($owner), $import, [ImportVoter::DOWNLOAD_SOURCE]),
+        );
+    }
+
+    public function testDownloadSourceDeniedForForeignParticipant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $import = $this->createImportForOwner($owner);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($intruder), $import, [ImportVoter::DOWNLOAD_SOURCE]),
+        );
+    }
+
     public function testDeleteDeniedForCreatorWithoutHospitalAccess(): void
     {
         $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);

--- a/tests/Import/Unit/Application/Service/ImportSourceFileDownloadServiceTest.php
+++ b/tests/Import/Unit/Application/Service/ImportSourceFileDownloadServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Import\Application\Exception\ImportSourceFileNotFoundException;
+use App\Import\Application\Service\ImportFileStorage;
+use App\Import\Application\Service\ImportSourceFileDownloadService;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Domain\Enum\ImportType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+final class ImportSourceFileDownloadServiceTest extends TestCase
+{
+    private string $projectDir;
+
+    private ImportSourceFileDownloadService $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/import-download-'.bin2hex(random_bytes(4));
+        new Filesystem()->mkdir($this->projectDir);
+        $this->service = new ImportSourceFileDownloadService(new ImportFileStorage($this->projectDir, new Filesystem(), new \Psr\Log\NullLogger()));
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        new Filesystem()->remove($this->projectDir);
+    }
+
+    public function testCreateDownloadResponseUsesImportNameAndExtension(): void
+    {
+        $relativePath = 'var/imports/test.csv';
+        $absolutePath = Path::join($this->projectDir, $relativePath);
+        new Filesystem()->dumpFile($absolutePath, "a;b;c\n");
+
+        $import = $this->createImport($relativePath, 'My Import File', 'csv', 'text/csv');
+
+        $response = $this->service->createDownloadResponse($import);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('attachment', (string) $response->headers->get('Content-Disposition'));
+        self::assertStringContainsString('My Import File.csv', (string) $response->headers->get('Content-Disposition'));
+        self::assertSame('text/csv', $response->headers->get('Content-Type'));
+        self::assertSame($absolutePath, $response->getFile()->getPathname());
+    }
+
+    public function testCreateDownloadResponseThrowsWhenFileMissingOnDisk(): void
+    {
+        $import = $this->createImport('var/imports/missing.csv', 'Missing', 'csv', 'text/csv');
+
+        $this->expectException(ImportSourceFileNotFoundException::class);
+
+        $this->service->createDownloadResponse($import);
+    }
+
+    public function testCreateDownloadResponseThrowsWhenStoredPathEmpty(): void
+    {
+        $import = $this->createImport('', 'Empty', 'csv', 'text/csv');
+
+        $this->expectException(ImportSourceFileNotFoundException::class);
+
+        $this->service->createDownloadResponse($import);
+    }
+
+    public function testCreateDownloadResponseFallsBackToStoredBasenameWhenImportNameEmpty(): void
+    {
+        $relativePath = 'var/imports/fallback-name.csv';
+        $absolutePath = Path::join($this->projectDir, $relativePath);
+        new Filesystem()->dumpFile($absolutePath, "a\n");
+
+        $import = $this->createImport($relativePath, '', 'csv', 'text/csv');
+
+        $response = $this->service->createDownloadResponse($import);
+
+        self::assertStringContainsString('fallback-name.csv', (string) $response->headers->get('Content-Disposition'));
+    }
+
+    private function createImport(string $filePath, string $name, string $extension, string $mimeType): Import
+    {
+        $import = new Import()
+            ->setName($name)
+            ->setType(ImportType::ALLOCATION)
+            ->setStatus(ImportStatus::PENDING)
+            ->setFilePath($filePath)
+            ->setFileExtension($extension)
+            ->setFileMimeType($mimeType)
+            ->setFileSize(10)
+            ->setFileChecksum('checksum')
+            ->setRunCount(0)
+            ->setRunTime(0)
+            ->setRowCount(1);
+
+        $idProperty = new \ReflectionProperty(Import::class, 'id');
+        $idProperty->setValue($import, 42);
+
+        return $import;
+    }
+}

--- a/translations/import+intl-icu.de.xlf
+++ b/translations/import+intl-icu.de.xlf
@@ -21,6 +21,10 @@
         <source>import.action.delete</source>
         <target>Import löschen</target>
       </trans-unit>
+      <trans-unit id="DeActDlSrc" resname="import.action.download_source_file">
+        <source>import.action.download_source_file</source>
+        <target>Originaldatei herunterladen</target>
+      </trans-unit>
       <trans-unit id="De5c35af0b" resname="import.action.preview_mci_cases">
         <source>import.action.preview_mci_cases</source>
         <target>MANV-Fälle ansehen</target>

--- a/translations/import+intl-icu.en.xlf
+++ b/translations/import+intl-icu.en.xlf
@@ -29,6 +29,10 @@
         <source>import.action.delete</source>
         <target>Delete import</target>
       </trans-unit>
+      <trans-unit id="impActDlSrc" resname="import.action.download_source_file">
+        <source>import.action.download_source_file</source>
+        <target>Download original file</target>
+      </trans-unit>
       <trans-unit id="impDelTit" resname="import.delete.modal.title">
         <source>import.delete.modal.title</source>
         <target>Delete import?</target>


### PR DESCRIPTION
## Summary

- Adds a protected admin-only download endpoint at `/import/{id}/source-file` for the original uploaded CSV associated with an import
- Shows a download action on the import detail page only when `ImportVoter::DOWNLOAD_SOURCE` is granted
- Streams files from `var/imports/` via `BinaryFileResponse` with attachment headers instead of exposing a public file path
- Records downloads with audit intent `import.source_file.downloaded`

Closes #293.

## Security

- Requires `ROLE_ADMIN` and `ImportVoter::DOWNLOAD_SOURCE`
- Download link is hidden for non-admin users
- Missing or deleted source files return HTTP 404 without leaking storage details

## Test plan

- [x] `make ci`
- [x] Import voter tests for admin download authorization
- [x] Unit tests for `ImportSourceFileDownloadService`
- [x] Functional tests for download success, 403, 404, and link visibility
- [x] Manual: open `/import/{id}` as admin and download the original CSV
- [x] Manual: confirm participants do not see the download action and receive 403 on direct access