### PR TITLE
bugfix: Monthly reminder uses the same reporting period as the month users are asked to upload

### DIFF
--- a/docs/03-development/development-workflow.md
+++ b/docs/03-development/development-workflow.md
@@ -84,7 +84,14 @@ php bin/console messenger:stats
 
 The scheduler triggers `SendMonthlySubmissionRemindersMessage` **daily at 08:00 Europe/Berlin**. Actual email dispatch happens only on the **first working day** of each month.
 
-Dispatch history is stored in `monthly_reminder_dispatch`.
+The reminder distinguishes two periods:
+
+- **Upload month** — the calendar month before the send date (the data users are asked to upload).
+- **Insights month** — one month before the upload month (the last complete reporting period used for KPIs and personalized statistics).
+
+Example: a reminder sent on 1 July requests a June upload but shows statistics for May.
+
+Dispatch history is stored in `monthly_reminder_dispatch` (keyed by upload month).
 
 **Local preview:**
 

--- a/src/Engagement/Application/MonthlyReminderPeriodResolver.php
+++ b/src/Engagement/Application/MonthlyReminderPeriodResolver.php
@@ -9,6 +9,9 @@ final readonly class MonthlyReminderPeriodResolver
     private const string TIMEZONE = 'Europe/Berlin';
 
     /**
+     * reporting* = last complete reporting month used for insights and KPIs.
+     * upload* = month users are asked to upload (one month ahead of reporting).
+     *
      * @return array{
      *     referenceDate: \DateTimeImmutable,
      *     reportingYear: int,
@@ -28,7 +31,8 @@ final readonly class MonthlyReminderPeriodResolver
         $reference = ($referenceDate ?? new \DateTimeImmutable('now', $tz))->setTimezone($tz);
 
         $currentMonthStart = $reference->modify('first day of this month 00:00:00');
-        $reportingMonthStart = $currentMonthStart->modify('-1 month');
+        $uploadMonthStart = $currentMonthStart->modify('-1 month');
+        $reportingMonthStart = $uploadMonthStart->modify('-1 month');
         $reportingYear = (int) $reportingMonthStart->format('Y');
         $reportingMonth = (int) $reportingMonthStart->format('n');
         $reportingMonthEnd = $reportingMonthStart->modify('+1 month');
@@ -49,8 +53,8 @@ final readonly class MonthlyReminderPeriodResolver
             'reportingMonth' => $reportingMonth,
             'reportingMonthStart' => $reportingMonthStart,
             'reportingMonthEnd' => $reportingMonthEnd,
-            'uploadYear' => (int) $currentMonthStart->format('Y'),
-            'uploadMonth' => (int) $currentMonthStart->format('n'),
+            'uploadYear' => (int) $uploadMonthStart->format('Y'),
+            'uploadMonth' => (int) $uploadMonthStart->format('n'),
             'chartStart' => $chartStart,
             'chartMonthKeys' => $chartMonthKeys,
             'chartLabels' => $chartLabels,

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -72,13 +72,13 @@ final readonly class MonthlyReminderSender
         }
 
         $period = $this->periodResolver->resolve($referenceDate);
-        $reportingPeriod = sprintf('%04d-%02d', $period['reportingYear'], $period['reportingMonth']);
+        $dispatchPeriod = sprintf('%04d-%02d', $period['uploadYear'], $period['uploadMonth']);
 
         if (
             MonthlyReminderTrigger::Scheduler === $trigger
             && $this->dispatchRepository->existsForHospitalPeriodAndTrigger(
                 (int) $hospital->getId(),
-                $reportingPeriod,
+                $dispatchPeriod,
                 $trigger->value,
             )
         ) {
@@ -102,7 +102,7 @@ final readonly class MonthlyReminderSender
             if (MonthlyReminderTrigger::Scheduler === $trigger) {
                 $this->dispatchRepository->save(new MonthlyReminderDispatch(
                     $hospital,
-                    $reportingPeriod,
+                    $dispatchPeriod,
                     $trigger->value,
                     new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
                 ));

--- a/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php
@@ -39,7 +39,7 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
 
     public function testBuildUsesFallbackContentWhenHospitalHasLittleData(): void
     {
-        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $referenceDate = new \DateTimeImmutable('2026-07-01', new \DateTimeZone('Europe/Berlin'));
         $hospital = $this->seedHospital();
 
         $content = $this->builder->build($hospital, $referenceDate, 'en');
@@ -55,7 +55,7 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
 
     public function testBuildPersonalizedContentWhenReportingMonthHasEnoughAllocations(): void
     {
-        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $referenceDate = new \DateTimeImmutable('2026-07-01', new \DateTimeZone('Europe/Berlin'));
         $seed = $this->seedHospitalGraph();
         $hospital = $seed['hospital'];
         $import = ImportFactory::createOne([
@@ -82,13 +82,13 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
 
         $this->insertHospitalKpi(
             (int) $hospital->getId(),
-            '2026-04-01',
+            '2026-03-01',
             100,
             15,
         );
         $this->insertHospitalKpi(
             (int) $hospital->getId(),
-            '2026-05-01',
+            '2026-04-01',
             100,
             5,
         );
@@ -105,7 +105,7 @@ final class MonthlyReminderContentBuilderTest extends DatabaseKernelTestCase
 
     public function testBuildUsesGermanPeriodLabelsForGermanLocale(): void
     {
-        $referenceDate = new \DateTimeImmutable('2026-06-17', new \DateTimeZone('Europe/Berlin'));
+        $referenceDate = new \DateTimeImmutable('2026-07-01', new \DateTimeZone('Europe/Berlin'));
         $hospital = $this->seedHospital();
 
         $content = $this->builder->build($hospital, $referenceDate, 'de');

--- a/tests/Engagement/Unit/Application/MonthlyReminderPeriodResolverTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderPeriodResolverTest.php
@@ -9,17 +9,28 @@ use PHPUnit\Framework\TestCase;
 
 final class MonthlyReminderPeriodResolverTest extends TestCase
 {
-    public function testResolveUsesPreviousMonthAsReportingPeriod(): void
+    public function testResolveUsesLastCompleteMonthForInsightsAndPreviousMonthForUpload(): void
     {
         $resolver = new MonthlyReminderPeriodResolver();
         $result = $resolver->resolve(new \DateTimeImmutable('2026-01-15 10:00:00', new \DateTimeZone('Europe/Berlin')));
 
         self::assertSame(2025, $result['reportingYear']);
-        self::assertSame(12, $result['reportingMonth']);
-        self::assertSame(2026, $result['uploadYear']);
-        self::assertSame(1, $result['uploadMonth']);
+        self::assertSame(11, $result['reportingMonth']);
+        self::assertSame(2025, $result['uploadYear']);
+        self::assertSame(12, $result['uploadMonth']);
         self::assertCount(12, $result['chartMonthKeys']);
         self::assertSame('2026-01', $result['chartMonthKeys'][11]);
         self::assertSame('2025-02', $result['chartMonthKeys'][0]);
+    }
+
+    public function testResolveOnFirstOfMonthSeparatesUploadAndInsightsByOneMonth(): void
+    {
+        $resolver = new MonthlyReminderPeriodResolver();
+        $result = $resolver->resolve(new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin')));
+
+        self::assertSame(2026, $result['reportingYear']);
+        self::assertSame(5, $result['reportingMonth']);
+        self::assertSame(2026, $result['uploadYear']);
+        self::assertSame(6, $result['uploadMonth']);
     }
 }


### PR DESCRIPTION
## Summary

The monthly submission reminder was using the same reporting period for personalized insights as the month users are asked to upload. On the first working day of a new month, that upload month typically has incomplete or missing data, which led to inaccurate or empty statistics in reminder emails. Fixes #303.

This PR separates the two periods:

- **Upload month** — the previous calendar month (the data users are asked to upload)
- **Insights month** — one month before that (the last complete reporting period used for KPIs, benchmarks, and personalized insights)

Example: a reminder sent on **1 July** now requests a **June** upload but shows statistics for **May**.

Changes:

- Shift insights period calculation back by one month in `MonthlyReminderPeriodResolver`
- Key scheduler dispatch deduplication by upload month (not insights month), so duplicate-send protection still aligns with the upload cycle
- Update tests and document the two-period model in the development workflow

## Test plan

- [x] `php bin/phpunit tests/Engagement/Unit/Application/MonthlyReminderPeriodResolverTest.php`
- [x] `php bin/phpunit tests/Engagement/Integration/Application/MonthlyReminderContentBuilderTest.php`
- [x] `php bin/phpunit tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php`
- [x] `php bin/phpunit tests/Engagement/Integration/Application/SendMonthlySubmissionRemindersMessageHandlerTest.php`
- [x] `php bin/console app:reminder:preview --hospital-id=ID --date=2026-07-01` -> verify KPIs/heading show **May 2026** and CTA shows **Upload data for June 2026**