### PR TITLE
bugfix: Fix monthly reminder SMTP rate limiting and add delivery tracking (#302)`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ MAILER_DSN=null://null
 APP_URL=http://127.0.0.1:8000
 MAILER_FROM=no-reply@localhost
 MAILER_REPLY_TO=
+# Optional: MAILER_BULK_DELAY_MS=3000
 ###< app/mail ###
 
 ###> symfony/lock ###

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ compile: ## Execute some tasks before deployment
 	@$(CONSOLE) cache:warmup
 
 consume: ## Consume messages from symfony messenger
-	@$(CONSOLE) messenger:consume async_priority_high async_priority_low scheduler_default -vv
+	@$(CONSOLE) messenger:consume async_priority_high async_priority_low async_mail scheduler_default -vv
 
 ## —— Backups 💾 ———————————————————————————————————————————————————————————————
 backup-db: ## PostgreSQL dump to var/backups (uses Docker database service when running)

--- a/config/packages/mail.yaml
+++ b/config/packages/mail.yaml
@@ -1,0 +1,7 @@
+parameters:
+    app.default.mailer_bulk_delay_ms: 3000
+    app.mailer_bulk_delay_ms: '%env(int:default:app.default.mailer_bulk_delay_ms:MAILER_BULK_DELAY_MS)%'
+
+when@test:
+    parameters:
+        app.mailer_bulk_delay_ms: 0

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -18,6 +18,16 @@ framework:
                 retry_strategy:
                     max_retries: 3
                     multiplier: 2
+            async_mail:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    queue_name: mail
+                rate_limiter: transactional_mail
+                retry_strategy:
+                    max_retries: 5
+                    delay: 10000
+                    multiplier: 2
+                    max_delay: 300000
             failed: 'doctrine://default?queue_name=failed'
             sync: 'sync://'
 
@@ -29,7 +39,7 @@ framework:
                     - 'App\Shared\Infrastructure\Audit\Messenger\AuditMessengerMiddleware'
 
         routing:
-            Symfony\Component\Mailer\Messenger\SendEmailMessage: async_priority_low
+            Symfony\Component\Mailer\Messenger\SendEmailMessage: async_mail
             Symfony\Component\Notifier\Message\ChatMessage: async_priority_low
             Symfony\Component\Notifier\Message\SmsMessage: async_priority_low
 
@@ -57,3 +67,4 @@ when@test:
                 App\Kpi\Application\Message\GenerateDailyKpisMessage: sync
                 App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage: sync
                 App\Allocation\Application\Message\BackfillAllocationsForIndicationRawMessage: sync
+                Symfony\Component\Mailer\Messenger\SendEmailMessage: sync

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -20,6 +20,10 @@ framework:
             policy: fixed_window
             limit: 3
             interval: '1 hour'
+        transactional_mail:
+            policy: sliding_window
+            limit: 1
+            interval: '3 seconds'
 
 when@test:
     framework:
@@ -39,4 +43,8 @@ when@test:
             feedback_submit_anonymous_email:
                 policy: fixed_window
                 limit: 10000
+                interval: '1 second'
+            transactional_mail:
+                policy: sliding_window
+                limit: 1000
                 interval: '1 second'

--- a/docs/02-architecture/decisions/003-doctrine-messenger-transport.md
+++ b/docs/02-architecture/decisions/003-doctrine-messenger-transport.md
@@ -8,7 +8,7 @@ Production runs on Uberspace without dedicated Redis or RabbitMQ infrastructure.
 
 ## Decision
 
-Use Doctrine transport (`doctrine://default`) backed by the PostgreSQL `messenger_messages` table. A single systemd user service consumes `async_priority_high`, `async_priority_low`, and `scheduler_default`.
+Use Doctrine transport (`doctrine://default`) backed by the PostgreSQL `messenger_messages` table. A single systemd user service consumes `async_priority_high`, `async_priority_low`, `async_mail`, and `scheduler_default`.
 
 ## Consequences
 

--- a/docs/02-architecture/messenger-and-scheduler.md
+++ b/docs/02-architecture/messenger-and-scheduler.md
@@ -11,7 +11,8 @@ Configured in `config/packages/messenger.yaml`:
 | Transport | Purpose |
 |-----------|---------|
 | `async_priority_high` | Import processing |
-| `async_priority_low` | Statistics rebuild, KPI aggregation, mail |
+| `async_priority_low` | Statistics rebuild, KPI aggregation |
+| `async_mail` | Transactional and bulk mail (rate-limited) |
 | `scheduler_default` | Symfony Scheduler messages |
 | `failed` | Failed message store |
 
@@ -24,7 +25,7 @@ Default DSN: `doctrine://default?auto_setup=0` (PostgreSQL `messenger_messages` 
 | `ImportAllocationsMessage` | `async_priority_high` |
 | `RebuildAllocationStatsProjection` | `async_priority_low` |
 | `GenerateDailyKpisMessage` | `async_priority_low` |
-| `SendEmailMessage` (prod) | `async_priority_low` |
+| `SendEmailMessage` (prod) | `async_mail` |
 
 In `dev`, mail is synchronous. In `test`, most messages use `sync`.
 
@@ -47,7 +48,7 @@ Details: [../04-features/kpi/kpi-aggregation.md](../04-features/kpi/kpi-aggregat
 make consume
 ```
 
-This runs `messenger:consume async_priority_high async_priority_low scheduler_default` with verbose output.
+This runs `messenger:consume async_priority_high async_priority_low async_mail scheduler_default` with verbose output.
 
 ## Production
 

--- a/docs/02-architecture/overview.md
+++ b/docs/02-architecture/overview.md
@@ -16,7 +16,7 @@ See [bounded-contexts.md](bounded-contexts.md) for context responsibilities and 
 
 - **Bundles / stack:** Symfony 8.1, Doctrine ORM/Migrations, Messenger, EasyAdmin, UX components, Sentry
 - **Persistence:** PostgreSQL
-- **Async:** Messenger with `async_priority_high`, `async_priority_low`, `failed`, `scheduler_default`
+- **Async:** Messenger with `async_priority_high`, `async_priority_low`, `async_mail`, `failed`, `scheduler_default`
 - **Admin:** CRUD controllers under `src/Admin/UI/Http/Controller`
 
 ## Key entry points

--- a/docs/05-operations/messenger-workers.md
+++ b/docs/05-operations/messenger-workers.md
@@ -1,8 +1,8 @@
 # Messenger workers
 
-Async messages use three transports (`async_priority_high`, `async_priority_low`, `scheduler_default`) configured in [`config/packages/messenger.yaml`](../../config/packages/messenger.yaml).
+Async messages use four transports (`async_priority_high`, `async_priority_low`, `async_mail`, `scheduler_default`) configured in [`config/packages/messenger.yaml`](../../config/packages/messenger.yaml).
 
-In production, email and domain jobs are routed to the async queues; scheduled KPI aggregation uses `scheduler_default`. Without a running worker, messages stay in the database.
+In production, email uses the dedicated `async_mail` transport with rate limiting and slower retries; other domain jobs use the priority queues. Scheduled KPI aggregation uses `scheduler_default`. Without a running worker, messages stay in the database.
 
 Related: [deployment.md](deployment.md), [transactional-mail.md](transactional-mail.md), [../02-architecture/messenger-and-scheduler.md](../02-architecture/messenger-and-scheduler.md)
 
@@ -20,7 +20,7 @@ Replace:
 
 ```ini
 [Unit]
-Description=Symfony Messenger worker (high + low + scheduler)
+Description=Symfony Messenger worker (high + low + mail + scheduler)
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
@@ -30,7 +30,7 @@ WorkingDirectory=/home/YOUR_USERNAME/www/current
 Environment=APP_ENV=prod
 Environment=APP_DEBUG=0
 
-ExecStart=/usr/bin/php -d memory_limit=-1 bin/console messenger:consume async_priority_high async_priority_low scheduler_default --env=prod --memory-limit=256M --time-limit=3600 -q
+ExecStart=/usr/bin/php -d memory_limit=-1 bin/console messenger:consume async_priority_high async_priority_low async_mail scheduler_default --env=prod --memory-limit=256M --time-limit=3600 -q
 
 Restart=always
 RestartSec=5
@@ -64,7 +64,7 @@ Before relying on systemd, run the consumer manually from the deploy path:
 
 ```bash
 cd ~/html/current
-php bin/console messenger:consume async_priority_high async_priority_low scheduler_default -vv --time-limit=30
+php bin/console messenger:consume async_priority_high async_priority_low async_mail scheduler_default -vv --time-limit=30
 ```
 
 Trigger an async action in the app (for example an import or statistics rebuild) and confirm messages are processed.

--- a/docs/05-operations/transactional-mail.md
+++ b/docs/05-operations/transactional-mail.md
@@ -72,7 +72,7 @@ If no matching user exists, feedback is still stored but no email is sent. Check
 
 ## Async delivery in production
 
-In `prod`, Symfony Mailer dispatches `SendEmailMessage` to the **`async_priority_low`** queue. In `dev`, mail is sent synchronously.
+In `prod`, Symfony Mailer dispatches `SendEmailMessage` to the **`async_mail`** queue (rate-limited, with exponential backoff). In `dev`, mail is sent synchronously.
 
 Requirements:
 
@@ -95,7 +95,7 @@ Configure SPF, DKIM, and DMARC for the domain used in `MAILER_FROM`.
 
 | Symptom | Likely cause |
 |---------|----------------|
-| No verification / reset / feedback mail | `MAILER_DSN` missing or worker not consuming `async_priority_low` |
+| No verification / reset / feedback mail | `MAILER_DSN` missing or worker not consuming `async_mail` |
 | Reset link or mail images use `http://localhost` | `APP_URL` unset or wrong; restart worker after change |
 | Feedback saved but no admin email | No user with Admin + Receives Feedback |
 | Mail in spam | SPF/DKIM/DMARC or `MAILER_FROM` not aligned with SMTP provider |

--- a/docs/06-reference/configuration.md
+++ b/docs/06-reference/configuration.md
@@ -22,6 +22,7 @@
 | `MAILER_DSN` | Mail transport | required in production |
 | `MAILER_FROM` | Sender address | transactional mail |
 | `MAILER_REPLY_TO` | Reply-to address | optional |
+| `MAILER_BULK_DELAY_MS` | Delay between bulk reminder emails | default `3000` |
 | `APP_URL` | Public base URL | required in prod for correct links |
 | `APP_TITLE` | Application display title | overrides `app.title` in `app.yaml` |
 | `SENTRY_DSN` | Sentry DSN | empty = disabled |
@@ -60,6 +61,7 @@ Transports (see `config/packages/messenger.yaml`):
 
 - `async_priority_high`
 - `async_priority_low`
+- `async_mail`
 - `scheduler_default`
 - `failed`
 - `sync`
@@ -68,7 +70,7 @@ Routing examples:
 
 - Import dispatch → `async_priority_high`
 - Statistics rebuild → `async_priority_low`
-- Mail / notifier → async in prod, partly sync in dev
+- Mail / notifier → `async_mail` in prod, sync in dev/test
 
 Details: [../02-architecture/messenger-and-scheduler.md](../02-architecture/messenger-and-scheduler.md)
 

--- a/migrations/Version20260708110251.php
+++ b/migrations/Version20260708110251.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260708110251 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add delivery tracking columns to monthly_reminder_dispatch.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE monthly_reminder_dispatch ADD status VARCHAR(16) DEFAULT 'queued' NOT NULL");
+        $this->addSql("ALTER TABLE monthly_reminder_dispatch ADD recipient_email VARCHAR(255) DEFAULT '' NOT NULL");
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch ADD failure_reason TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch ADD delivered_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql("UPDATE monthly_reminder_dispatch SET status = 'sent' WHERE status = 'queued'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch DROP delivered_at');
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch DROP failure_reason');
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch DROP recipient_email');
+        $this->addSql('ALTER TABLE monthly_reminder_dispatch DROP status');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Engagement/MonthlyReminderDispatchCrudController.php
+++ b/src/Admin/UI/Http/Controller/Engagement/MonthlyReminderDispatchCrudController.php
@@ -6,6 +6,7 @@ namespace App\Admin\UI\Http\Controller\Engagement;
 
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -15,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\ChoiceFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
@@ -64,7 +66,12 @@ final class MonthlyReminderDispatchCrudController extends AbstractCrudController
                 'Admin' => MonthlyReminderTrigger::Admin->value,
                 'CLI' => MonthlyReminderTrigger::Cli->value,
             ]))
-            ->add(DateTimeFilter::new('sentAt', 'Sent at'));
+            ->add(ChoiceFilter::new('status', 'Status')->setChoices([
+                'Queued' => MonthlyReminderDispatchStatus::Queued->value,
+                'Sent' => MonthlyReminderDispatchStatus::Sent->value,
+                'Failed' => MonthlyReminderDispatchStatus::Failed->value,
+            ]))
+            ->add(DateTimeFilter::new('sentAt', 'Queued at'));
     }
 
     #[\Override]
@@ -85,7 +92,24 @@ final class MonthlyReminderDispatchCrudController extends AbstractCrudController
                 MonthlyReminderTrigger::Admin->value => 'warning',
                 MonthlyReminderTrigger::Cli->value => 'secondary',
             ]);
-        yield DateTimeField::new('sentAt', 'Sent at')
+        yield ChoiceField::new('status', 'Status')
+            ->setChoices([
+                'Queued' => MonthlyReminderDispatchStatus::Queued->value,
+                'Sent' => MonthlyReminderDispatchStatus::Sent->value,
+                'Failed' => MonthlyReminderDispatchStatus::Failed->value,
+            ])
+            ->renderAsBadges([
+                MonthlyReminderDispatchStatus::Queued->value => 'info',
+                MonthlyReminderDispatchStatus::Sent->value => 'success',
+                MonthlyReminderDispatchStatus::Failed->value => 'danger',
+            ]);
+        yield TextField::new('recipientEmail', 'Recipient');
+        yield DateTimeField::new('sentAt', 'Queued at')
             ->setFormat('dd.MM.yyyy HH:mm');
+        yield DateTimeField::new('deliveredAt', 'Delivered at')
+            ->setFormat('dd.MM.yyyy HH:mm');
+        yield TextareaField::new('failureReason', 'Failure reason')
+            ->onlyOnDetail()
+            ->renderAsHtml(false);
     }
 }

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -29,6 +29,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -114,8 +115,10 @@ final class HospitalCrudController extends AbstractCrudController
     }
 
     #[AdminRoute(path: '/{entityId}/send-monthly-reminder', name: 'send_monthly_reminder')]
-    public function sendMonthlyReminder(Hospital $hospital, MonthlyReminderSender $monthlyReminderSender): RedirectResponse
-    {
+    public function sendMonthlyReminder(
+        #[MapEntity(id: 'entityId')] Hospital $hospital,
+        MonthlyReminderSender $monthlyReminderSender,
+    ): RedirectResponse {
         $errors = $monthlyReminderSender->sendForHospital($hospital, MonthlyReminderTrigger::Admin);
         if ([] === $errors) {
             $this->addFlash('success', new TranslatableMessage('flash.admin.hospital.reminder.sent', domain: 'admin'));

--- a/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
+++ b/src/Admin/UI/Http/Controller/Hospital/HospitalCrudController.php
@@ -89,12 +89,20 @@ final class HospitalCrudController extends AbstractCrudController
     #[\Override]
     public function configureActions(Actions $actions): Actions
     {
-        $sendReminder = Action::new('sendMonthlyReminder', 'admin.hospital.action.send_reminder', 'fas fa-envelope')
+        $sendReminder = Action::new(
+            'sendMonthlyReminder',
+            new TranslatableMessage('admin.hospital.action.send_reminder', domain: 'admin'),
+            'fas fa-envelope',
+        )
             ->linkToCrudAction('sendMonthlyReminder')
             ->displayIf(static fn (Hospital $hospital): bool => $hospital->isParticipating() && $hospital->getOwner() instanceof \App\User\Domain\Entity\User)
             ->askConfirmation(new TranslatableMessage('admin.hospital.action.send_reminder.confirm', domain: 'admin'));
 
-        $reminderHistory = Action::new('reminderHistory', 'admin.hospital.action.reminder_history', 'fas fa-clock-rotate-left')
+        $reminderHistory = Action::new(
+            'reminderHistory',
+            new TranslatableMessage('admin.hospital.action.reminder_history', domain: 'admin'),
+            'fas fa-clock-rotate-left',
+        )
             ->linkToUrl(fn (Hospital $hospital): string => $this->adminUrlGenerator
                 ->unsetAll()
                 ->setController(MonthlyReminderDispatchCrudController::class)

--- a/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
+++ b/src/Engagement/Application/MessageHandler/SendMonthlySubmissionRemindersMessageHandler.php
@@ -50,15 +50,18 @@ final readonly class SendMonthlySubmissionRemindersMessageHandler
             $hospitals = $this->hospitalRepository->findParticipatingWithOwner();
             $sent = 0;
             $skipped = 0;
+            $bulkIndex = 0;
 
             foreach ($hospitals as $hospital) {
                 $errors = $this->reminderSender->sendForHospital(
                     $hospital,
                     MonthlyReminderTrigger::Scheduler,
                     $referenceDate,
+                    $bulkIndex,
                 );
                 if ([] === $errors) {
                     ++$sent;
+                    ++$bulkIndex;
                 } else {
                     ++$skipped;
                     $this->logger->info('Monthly submission reminder skipped for hospital.', [

--- a/src/Engagement/Application/MonthlyReminderMailer.php
+++ b/src/Engagement/Application/MonthlyReminderMailer.php
@@ -8,22 +8,36 @@ use App\Engagement\Application\Dto\MonthlyReminderContent;
 use App\Shared\Infrastructure\Mail\MailConfig;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Mime\Address;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class MonthlyReminderMailer
 {
+    public const string DISPATCH_ID_HEADER = 'X-COIS-Monthly-Reminder-Dispatch-Id';
+
     public function __construct(
         private MailerInterface $mailer,
+        private MessageBusInterface $messageBus,
         private MailConfig $mailConfig,
         private TranslatorInterface $translator,
         private LoggerInterface $logger,
+        #[Autowire('%app.mailer_bulk_delay_ms%')]
+        private int $bulkDelayMs,
     ) {
     }
 
-    public function send(string $recipientEmail, MonthlyReminderContent $content, string $locale): void
-    {
+    public function send(
+        string $recipientEmail,
+        MonthlyReminderContent $content,
+        string $locale,
+        int $bulkIndex = 0,
+        ?int $dispatchId = null,
+    ): void {
         $email = new TemplatedEmail()
             ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
             ->to($recipientEmail)
@@ -43,11 +57,23 @@ final readonly class MonthlyReminderMailer
             $email->replyTo($replyTo);
         }
 
-        $this->mailer->send($email);
+        if (null !== $dispatchId) {
+            $email->getHeaders()->addTextHeader(self::DISPATCH_ID_HEADER, (string) $dispatchId);
+        }
+
+        $delayMs = $bulkIndex * $this->bulkDelayMs;
+        if ($delayMs > 0) {
+            $this->messageBus->dispatch(new SendEmailMessage($email), [new DelayStamp($delayMs)]);
+        } else {
+            $this->mailer->send($email);
+        }
 
         $this->logger->info('Monthly submission reminder sent.', [
             'recipient' => $recipientEmail,
             'hospital' => $content->hospitalName,
+            'bulk_index' => $bulkIndex,
+            'delay_ms' => $delayMs,
+            'dispatch_id' => $dispatchId,
         ]);
     }
 }

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -7,6 +7,7 @@ namespace App\Engagement\Application;
 use App\Allocation\Domain\Entity\Hospital;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
@@ -35,6 +36,7 @@ final readonly class MonthlyReminderSender
         Hospital $hospital,
         MonthlyReminderTrigger $trigger,
         ?\DateTimeImmutable $referenceDate = null,
+        int $bulkIndex = 0,
     ): array {
         if (!$hospital->isParticipating()) {
             return ['monthly_reminder.error.not_participating'];
@@ -76,7 +78,7 @@ final readonly class MonthlyReminderSender
 
         if (
             MonthlyReminderTrigger::Scheduler === $trigger
-            && $this->dispatchRepository->existsForHospitalPeriodAndTrigger(
+            && $this->dispatchRepository->hasActiveDispatchForHospitalPeriodAndTrigger(
                 (int) $hospital->getId(),
                 $dispatchPeriod,
                 $trigger->value,
@@ -89,24 +91,50 @@ final readonly class MonthlyReminderSender
         $content = $this->contentBuilder->build($hospital, $referenceDate, $ownerLocale);
         $reportingMonth = $content->reportingPeriodLabel;
 
+        $queuedAt = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin'));
+        $existingDispatch = $this->dispatchRepository->findForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            $dispatchPeriod,
+            $trigger->value,
+        );
+
+        if ($existingDispatch instanceof MonthlyReminderDispatch) {
+            $existingDispatch->prepareForSend($email, $queuedAt);
+            $dispatch = $existingDispatch;
+        } else {
+            $dispatch = new MonthlyReminderDispatch(
+                $hospital,
+                $dispatchPeriod,
+                $trigger->value,
+                $queuedAt,
+                MonthlyReminderDispatchStatus::Queued,
+                $email,
+            );
+        }
+
+        $this->dispatchRepository->save($dispatch);
+
         $this->auditContext->beginIntent('hospital.reminder_sent', [
             'hospital_id' => $hospital->getId(),
             'owner_id' => $owner->getId(),
             'reporting_period' => $reportingMonth,
             'trigger' => $trigger->value,
             'owner_locale' => $ownerLocale,
+            'dispatch_id' => $dispatch->getId(),
         ]);
         try {
-            $this->mailer->send($email, $content, $ownerLocale);
+            $this->mailer->send(
+                $email,
+                $content,
+                $ownerLocale,
+                $bulkIndex,
+                $dispatch->getId(),
+            );
+        } catch (\Throwable $exception) {
+            $dispatch->markFailed($exception->getMessage());
+            $this->dispatchRepository->save($dispatch);
 
-            if (MonthlyReminderTrigger::Scheduler === $trigger) {
-                $this->dispatchRepository->save(new MonthlyReminderDispatch(
-                    $hospital,
-                    $dispatchPeriod,
-                    $trigger->value,
-                    new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
-                ));
-            }
+            throw $exception;
         } finally {
             $this->auditContext->endIntent();
         }

--- a/src/Engagement/Domain/Entity/MonthlyReminderDispatch.php
+++ b/src/Engagement/Domain/Entity/MonthlyReminderDispatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Engagement\Domain\Entity;
 
 use App\Allocation\Domain\Entity\Hospital;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -29,6 +30,14 @@ class MonthlyReminderDispatch
         private string $trigger,
         #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
         private \DateTimeImmutable $sentAt,
+        #[ORM\Column(enumType: MonthlyReminderDispatchStatus::class, options: ['default' => 'queued'])]
+        private MonthlyReminderDispatchStatus $status = MonthlyReminderDispatchStatus::Queued,
+        #[ORM\Column(length: 255)]
+        private string $recipientEmail = '',
+        #[ORM\Column(type: Types::TEXT, nullable: true)]
+        private ?string $failureReason = null,
+        #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+        private ?\DateTimeImmutable $deliveredAt = null,
     ) {
     }
 
@@ -55,5 +64,47 @@ class MonthlyReminderDispatch
     public function getSentAt(): \DateTimeImmutable
     {
         return $this->sentAt;
+    }
+
+    public function getStatus(): MonthlyReminderDispatchStatus
+    {
+        return $this->status;
+    }
+
+    public function getRecipientEmail(): string
+    {
+        return $this->recipientEmail;
+    }
+
+    public function getFailureReason(): ?string
+    {
+        return $this->failureReason;
+    }
+
+    public function getDeliveredAt(): ?\DateTimeImmutable
+    {
+        return $this->deliveredAt;
+    }
+
+    public function markSent(\DateTimeImmutable $deliveredAt): void
+    {
+        $this->status = MonthlyReminderDispatchStatus::Sent;
+        $this->deliveredAt = $deliveredAt;
+        $this->failureReason = null;
+    }
+
+    public function markFailed(string $failureReason): void
+    {
+        $this->status = MonthlyReminderDispatchStatus::Failed;
+        $this->failureReason = $failureReason;
+    }
+
+    public function prepareForSend(string $recipientEmail, \DateTimeImmutable $queuedAt): void
+    {
+        $this->recipientEmail = $recipientEmail;
+        $this->sentAt = $queuedAt;
+        $this->status = MonthlyReminderDispatchStatus::Queued;
+        $this->failureReason = null;
+        $this->deliveredAt = null;
     }
 }

--- a/src/Engagement/Domain/Enum/MonthlyReminderDispatchStatus.php
+++ b/src/Engagement/Domain/Enum/MonthlyReminderDispatchStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Domain\Enum;
+
+enum MonthlyReminderDispatchStatus: string
+{
+    case Queued = 'queued';
+    case Sent = 'sent';
+    case Failed = 'failed';
+}

--- a/src/Engagement/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriber.php
+++ b/src/Engagement/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriber.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Engagement\Infrastructure\EventSubscriber;
+
+use App\Engagement\Application\MonthlyReminderMailer;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
+
+final readonly class MonthlyReminderDeliverySubscriber
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    public function __construct(
+        private MonthlyReminderDispatchRepository $dispatchRepository,
+    ) {
+    }
+
+    #[AsEventListener(event: SentMessageEvent::class)]
+    public function onSent(SentMessageEvent $event): void
+    {
+        $dispatchId = $this->extractDispatchId($event->getMessage()->getOriginalMessage());
+        if (null === $dispatchId) {
+            return;
+        }
+
+        $dispatch = $this->dispatchRepository->find($dispatchId);
+        if (null === $dispatch) {
+            return;
+        }
+
+        $dispatch->markSent(new \DateTimeImmutable('now', new \DateTimeZone(self::TIMEZONE)));
+        $this->dispatchRepository->save($dispatch);
+    }
+
+    #[AsEventListener(event: WorkerMessageFailedEvent::class)]
+    public function onMessengerFailed(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        if (!$message instanceof SendEmailMessage) {
+            return;
+        }
+
+        $dispatchId = $this->extractDispatchId($message->getMessage());
+        if (null === $dispatchId) {
+            return;
+        }
+
+        $dispatch = $this->dispatchRepository->find($dispatchId);
+        if (null === $dispatch) {
+            return;
+        }
+
+        $dispatch->markFailed($event->getThrowable()->getMessage());
+        $this->dispatchRepository->save($dispatch);
+    }
+
+    private function extractDispatchId(RawMessage $message): ?int
+    {
+        if (!$message instanceof Message) {
+            return null;
+        }
+
+        $header = $message->getHeaders()->get(MonthlyReminderMailer::DISPATCH_ID_HEADER);
+        if (!$header instanceof \Symfony\Component\Mime\Header\HeaderInterface) {
+            return null;
+        }
+
+        $value = trim($header->getBodyAsString());
+
+        return '' !== $value && ctype_digit($value) ? (int) $value : null;
+    }
+}

--- a/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
+++ b/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Engagement\Infrastructure\Repository;
 
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -23,7 +24,37 @@ final class MonthlyReminderDispatchRepository extends ServiceEntityRepository
         string $reportingPeriod,
         string $trigger,
     ): bool {
-        return null !== $this->findOneBy([
+        return $this->hasActiveDispatchForHospitalPeriodAndTrigger($hospitalId, $reportingPeriod, $trigger);
+    }
+
+    public function hasActiveDispatchForHospitalPeriodAndTrigger(
+        int $hospitalId,
+        string $reportingPeriod,
+        string $trigger,
+    ): bool {
+        return null !== $this->createQueryBuilder('dispatch')
+            ->andWhere('dispatch.hospital = :hospitalId')
+            ->andWhere('dispatch.reportingPeriod = :reportingPeriod')
+            ->andWhere('dispatch.trigger = :trigger')
+            ->andWhere('dispatch.status IN (:statuses)')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('reportingPeriod', $reportingPeriod)
+            ->setParameter('trigger', $trigger)
+            ->setParameter('statuses', [
+                MonthlyReminderDispatchStatus::Queued,
+                MonthlyReminderDispatchStatus::Sent,
+            ])
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findForHospitalPeriodAndTrigger(
+        int $hospitalId,
+        string $reportingPeriod,
+        string $trigger,
+    ): ?MonthlyReminderDispatch {
+        return $this->findOneBy([
             'hospital' => $hospitalId,
             'reportingPeriod' => $reportingPeriod,
             'trigger' => $trigger,

--- a/tests/Admin/Functional/Controller/MonthlyReminderDispatchCrudControllerTest.php
+++ b/tests/Admin/Functional/Controller/MonthlyReminderDispatchCrudControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Admin\Functional\Controller;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,10 @@ final class MonthlyReminderDispatchCrudControllerTest extends WebTestCase
             $hospital,
             '2026-06',
             MonthlyReminderTrigger::Scheduler->value,
+            new \DateTimeImmutable(),
+            MonthlyReminderDispatchStatus::Sent,
+            'owner@example.test',
+            null,
             new \DateTimeImmutable(),
         ));
         $entityManager->flush();

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -17,6 +17,9 @@ use App\User\Domain\Factory\UserFactory;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\RawMessage;
 
 final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
 {
@@ -211,6 +214,66 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
         self::assertSame(MonthlyReminderTrigger::Admin->value, $dispatch->getTrigger());
         self::assertSame(MonthlyReminderDispatchStatus::Sent, $dispatch->getStatus());
         self::assertNotNull($dispatch->getDeliveredAt());
+    }
+
+    public function testSchedulerRetryReusesFailedDispatchRecord(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+        $dispatchRepository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
+
+        $dispatch = $dispatchRepository->findForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        );
+        self::assertNotNull($dispatch);
+        $dispatchId = (int) $dispatch->getId();
+
+        $dispatch->markFailed('SMTP rate limit');
+        $dispatchRepository->save($dispatch);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
+
+        $retried = $dispatchRepository->find($dispatchId);
+        self::assertNotNull($retried);
+        self::assertSame(MonthlyReminderDispatchStatus::Sent, $retried->getStatus());
+        self::assertNull($retried->getFailureReason());
+    }
+
+    public function testMarksDispatchFailedWhenMailerThrows(): void
+    {
+        self::ensureKernelShutdown();
+        self::bootKernel();
+
+        $hospital = $this->createHospital(optedOut: false);
+        $dispatchRepository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+
+        self::getContainer()->set(MailerInterface::class, new class implements MailerInterface {
+            public function send(RawMessage $message, ?Envelope $envelope = null): void
+            {
+                throw new \RuntimeException('SMTP unavailable');
+            }
+        });
+
+        $sender = self::getContainer()->get(MonthlyReminderSender::class);
+
+        try {
+            $sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler);
+            self::fail('Expected mailer exception.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('SMTP unavailable', $exception->getMessage());
+        }
+
+        $dispatch = $dispatchRepository->findForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        );
+        self::assertNotNull($dispatch);
+        self::assertSame(MonthlyReminderDispatchStatus::Failed, $dispatch->getStatus());
+        self::assertSame('SMTP unavailable', $dispatch->getFailureReason());
     }
 
     public function testSendUsesOwnerGermanLocale(): void

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -10,6 +10,7 @@ use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Engagement\Application\Dto\MonthlyReminderTrigger;
 use App\Engagement\Application\MonthlyReminderSender;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
 use App\Tests\Support\Foundry\DatabaseKernelTestCase;
 use App\User\Domain\Factory\UserFactory;
@@ -159,6 +160,8 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
         self::assertNotNull($dispatch);
         self::assertSame('2026-06', $dispatch->getReportingPeriod());
         self::assertSame(MonthlyReminderTrigger::Scheduler->value, $dispatch->getTrigger());
+        self::assertSame(MonthlyReminderDispatchStatus::Sent, $dispatch->getStatus());
+        self::assertNotNull($dispatch->getDeliveredAt());
     }
 
     public function testSchedulerTriggerReturnsErrorWhenAlreadySentForPeriod(): void
@@ -179,6 +182,35 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
 
         self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Scheduler));
         self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
+
+        $dispatchRepository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+        self::assertTrue($dispatchRepository->existsForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+        ));
+        self::assertTrue($dispatchRepository->existsForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Admin->value,
+        ));
+    }
+
+    public function testAdminSendPersistsDispatchLogWithDeliveryStatus(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+
+        self::assertSame([], $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin));
+
+        $dispatch = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->findForHospitalPeriodAndTrigger(
+            (int) $hospital->getId(),
+            '2026-06',
+            MonthlyReminderTrigger::Admin->value,
+        );
+        self::assertNotNull($dispatch);
+        self::assertSame(MonthlyReminderTrigger::Admin->value, $dispatch->getTrigger());
+        self::assertSame(MonthlyReminderDispatchStatus::Sent, $dispatch->getStatus());
+        self::assertNotNull($dispatch->getDeliveredAt());
     }
 
     public function testSendUsesOwnerGermanLocale(): void

--- a/tests/Engagement/Integration/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriberTest.php
+++ b/tests/Engagement/Integration/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriberTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Integration\Infrastructure\EventSubscriber;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Application\MonthlyReminderMailer;
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
+use App\Engagement\Infrastructure\EventSubscriber\MonthlyReminderDeliverySubscriber;
+use App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\Envelope as MailerEnvelope;
+use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Mime\Address;
+
+final class MonthlyReminderDeliverySubscriberTest extends DatabaseKernelTestCase
+{
+    public function testOnSentMarksDispatchAsDelivered(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $email = new TemplatedEmail()
+            ->from('no-reply@example.test')
+            ->to('owner@example.test')
+            ->subject('Reminder')
+            ->text('Reminder body');
+        $email->getHeaders()->addTextHeader(
+            MonthlyReminderMailer::DISPATCH_ID_HEADER,
+            (string) $dispatch->getId(),
+        );
+
+        $subscriber->onSent(new SentMessageEvent(new SentMessage(
+            $email,
+            new MailerEnvelope(
+                new Address('no-reply@example.test'),
+                [new Address('owner@example.test')],
+            ),
+        )));
+
+        $updated = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($updated);
+        self::assertSame(MonthlyReminderDispatchStatus::Sent, $updated->getStatus());
+        self::assertNotNull($updated->getDeliveredAt());
+    }
+
+    public function testOnMessengerFailedMarksDispatchWhenRetriesAreExhausted(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $email = new TemplatedEmail()
+            ->from('no-reply@example.test')
+            ->to('owner@example.test')
+            ->subject('Reminder')
+            ->text('Reminder body');
+        $email->getHeaders()->addTextHeader(
+            MonthlyReminderMailer::DISPATCH_ID_HEADER,
+            (string) $dispatch->getId(),
+        );
+        $message = new SendEmailMessage($email);
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope($message),
+            'async_mail',
+            new HandlerFailedException(new Envelope($message), [
+                new UnrecoverableMessageHandlingException('SMTP rate limit'),
+            ]),
+        );
+
+        $subscriber->onMessengerFailed($event);
+
+        $updated = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($updated);
+        self::assertSame(MonthlyReminderDispatchStatus::Failed, $updated->getStatus());
+        self::assertStringContainsString('SMTP rate limit', (string) $updated->getFailureReason());
+    }
+
+    private function createDispatch(): MonthlyReminderDispatch
+    {
+        $owner = UserFactory::createOne([
+            'email' => sprintf('delivery-%s@example.test', bin2hex(random_bytes(4))),
+            'isVerified' => true,
+        ]);
+        $state = StateFactory::createOne();
+        $dispatchArea = DispatchAreaFactory::createOne(['state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+        ]);
+
+        $dispatch = new MonthlyReminderDispatch(
+            $hospital,
+            '2026-06',
+            MonthlyReminderTrigger::Scheduler->value,
+            new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
+            MonthlyReminderDispatchStatus::Queued,
+            (string) $owner->getEmail(),
+        );
+
+        $repository = self::getContainer()->get(MonthlyReminderDispatchRepository::class);
+        $repository->save($dispatch);
+
+        return $dispatch;
+    }
+}

--- a/tests/Engagement/Integration/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriberTest.php
+++ b/tests/Engagement/Integration/Infrastructure/EventSubscriber/MonthlyReminderDeliverySubscriberTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\RawMessage;
 
 final class MonthlyReminderDeliverySubscriberTest extends DatabaseKernelTestCase
 {
@@ -91,6 +92,141 @@ final class MonthlyReminderDeliverySubscriberTest extends DatabaseKernelTestCase
         self::assertNotNull($updated);
         self::assertSame(MonthlyReminderDispatchStatus::Failed, $updated->getStatus());
         self::assertStringContainsString('SMTP rate limit', (string) $updated->getFailureReason());
+    }
+
+    public function testOnSentIgnoresMessagesWithoutDispatchHeader(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $subscriber->onSent($this->sentMessageEvent($this->email()));
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    public function testOnSentIgnoresUnknownDispatchId(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $email = $this->email();
+        $email->getHeaders()->addTextHeader(MonthlyReminderMailer::DISPATCH_ID_HEADER, '999999');
+
+        $subscriber->onSent($this->sentMessageEvent($email));
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    public function testOnMessengerFailedIgnoresRetryableFailures(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $email = $this->email();
+        $email->getHeaders()->addTextHeader(
+            MonthlyReminderMailer::DISPATCH_ID_HEADER,
+            (string) $dispatch->getId(),
+        );
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new SendEmailMessage($email)),
+            'async_mail',
+            new \RuntimeException('temporary'),
+        );
+        $event->setForRetry();
+
+        $subscriber->onMessengerFailed($event);
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    public function testOnMessengerFailedIgnoresNonEmailMessages(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $subscriber->onMessengerFailed(new WorkerMessageFailedEvent(
+            new Envelope(new \stdClass()),
+            'async_mail',
+            new \RuntimeException('failed'),
+        ));
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    public function testOnMessengerFailedIgnoresInvalidDispatchHeader(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $email = $this->email();
+        $email->getHeaders()->addTextHeader(MonthlyReminderMailer::DISPATCH_ID_HEADER, 'not-numeric');
+
+        $subscriber->onMessengerFailed(new WorkerMessageFailedEvent(
+            new Envelope(new SendEmailMessage($email)),
+            'async_mail',
+            new \RuntimeException('failed'),
+        ));
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    public function testOnMessengerFailedIgnoresRawMessagesWithoutHeaders(): void
+    {
+        self::bootKernel();
+
+        $dispatch = $this->createDispatch();
+        $subscriber = self::getContainer()->get(MonthlyReminderDeliverySubscriber::class);
+
+        $subscriber->onMessengerFailed(new WorkerMessageFailedEvent(
+            new Envelope(new SendEmailMessage(new RawMessage('body'))),
+            'async_mail',
+            new \RuntimeException('failed'),
+        ));
+
+        $unchanged = self::getContainer()->get(MonthlyReminderDispatchRepository::class)->find($dispatch->getId());
+        self::assertNotNull($unchanged);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $unchanged->getStatus());
+    }
+
+    private function email(): TemplatedEmail
+    {
+        return new TemplatedEmail()
+            ->from('no-reply@example.test')
+            ->to('owner@example.test')
+            ->subject('Reminder')
+            ->text('Reminder body');
+    }
+
+    private function sentMessageEvent(TemplatedEmail $email): SentMessageEvent
+    {
+        return new SentMessageEvent(new SentMessage(
+            $email,
+            new MailerEnvelope(
+                new Address('no-reply@example.test'),
+                [new Address('owner@example.test')],
+            ),
+        ));
     }
 
     private function createDispatch(): MonthlyReminderDispatch

--- a/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
@@ -11,6 +11,10 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class MonthlyReminderMailerTest extends TestCase
@@ -51,11 +55,15 @@ final class MonthlyReminderMailerTest extends TestCase
                 return true;
             }));
 
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('info');
 
         new MonthlyReminderMailer(
             $mailer,
+            $messageBus,
             new MailConfig(
                 fromEmail: 'no-reply@example.test',
                 fromName: 'IVENA Stats',
@@ -64,6 +72,7 @@ final class MonthlyReminderMailerTest extends TestCase
             ),
             $translator,
             $logger,
+            bulkDelayMs: 0,
         )->send('owner@example.test', $content, 'de');
 
         self::assertSame('de', $capturedLocale);
@@ -88,6 +97,7 @@ final class MonthlyReminderMailerTest extends TestCase
 
         new MonthlyReminderMailer(
             $mailer,
+            $this->createMock(MessageBusInterface::class),
             new MailConfig(
                 fromEmail: 'no-reply@example.test',
                 fromName: 'IVENA Stats',
@@ -96,7 +106,78 @@ final class MonthlyReminderMailerTest extends TestCase
             ),
             $translator,
             $this->createMock(LoggerInterface::class),
+            bulkDelayMs: 0,
         )->send('owner@example.test', $this->content(), 'en');
+    }
+
+    public function testBulkIndexDispatchesDelayedSendEmailMessage(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('subject');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                self::callback(static fn (SendEmailMessage $message): bool => $message->getMessage() instanceof TemplatedEmail),
+                self::callback(function (array $stamps): bool {
+                    self::assertCount(1, $stamps);
+                    self::assertInstanceOf(DelayStamp::class, $stamps[0]);
+                    self::assertSame(6000, $stamps[0]->getDelay());
+
+                    return true;
+                }),
+            )
+            ->willReturn(new Envelope(new SendEmailMessage(new TemplatedEmail())));
+
+        new MonthlyReminderMailer(
+            $mailer,
+            $messageBus,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'IVENA Stats',
+                appName: 'IVENA Stats',
+                replyTo: '',
+            ),
+            $translator,
+            $this->createMock(LoggerInterface::class),
+            bulkDelayMs: 3000,
+        )->send('owner@example.test', $this->content(), 'en', bulkIndex: 2);
+    }
+
+    public function testDispatchIdHeaderIsAddedWhenProvided(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('subject');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(
+                    '42',
+                    $email->getHeaders()->get(MonthlyReminderMailer::DISPATCH_ID_HEADER)?->getBodyAsString(),
+                );
+
+                return true;
+            }));
+
+        new MonthlyReminderMailer(
+            $mailer,
+            $this->createMock(MessageBusInterface::class),
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'IVENA Stats',
+                appName: 'IVENA Stats',
+                replyTo: '',
+            ),
+            $translator,
+            $this->createMock(LoggerInterface::class),
+            bulkDelayMs: 0,
+        )->send('owner@example.test', $this->content(), 'en', dispatchId: 42);
     }
 
     private function content(): MonthlyReminderContent

--- a/tests/Engagement/Unit/Domain/Entity/MonthlyReminderDispatchTest.php
+++ b/tests/Engagement/Unit/Domain/Entity/MonthlyReminderDispatchTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Engagement\Unit\Domain\Entity;
+
+use App\Allocation\Domain\Entity\Hospital;
+use App\Engagement\Application\Dto\MonthlyReminderTrigger;
+use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
+use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
+use PHPUnit\Framework\TestCase;
+
+final class MonthlyReminderDispatchTest extends TestCase
+{
+    public function testLifecycleMethodsUpdateDeliveryFields(): void
+    {
+        $queuedAt = new \DateTimeImmutable('2026-07-01 08:00:00', new \DateTimeZone('Europe/Berlin'));
+        $deliveredAt = new \DateTimeImmutable('2026-07-01 08:01:00', new \DateTimeZone('Europe/Berlin'));
+        $hospital = $this->createMock(Hospital::class);
+
+        $dispatch = new MonthlyReminderDispatch(
+            $hospital,
+            '2026-06',
+            MonthlyReminderTrigger::Admin->value,
+            $queuedAt,
+            MonthlyReminderDispatchStatus::Queued,
+            'owner@example.test',
+        );
+
+        self::assertSame($hospital, $dispatch->getHospital());
+        self::assertSame('2026-06', $dispatch->getReportingPeriod());
+        self::assertSame(MonthlyReminderTrigger::Admin->value, $dispatch->getTrigger());
+        self::assertSame($queuedAt, $dispatch->getSentAt());
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $dispatch->getStatus());
+        self::assertSame('owner@example.test', $dispatch->getRecipientEmail());
+        self::assertNull($dispatch->getFailureReason());
+        self::assertNull($dispatch->getDeliveredAt());
+
+        $dispatch->markFailed('SMTP rate limit');
+        self::assertSame(MonthlyReminderDispatchStatus::Failed, $dispatch->getStatus());
+        self::assertSame('SMTP rate limit', $dispatch->getFailureReason());
+
+        $dispatch->prepareForSend('owner@example.test', $queuedAt);
+        self::assertSame(MonthlyReminderDispatchStatus::Queued, $dispatch->getStatus());
+        self::assertNull($dispatch->getFailureReason());
+        self::assertNull($dispatch->getDeliveredAt());
+
+        $dispatch->markSent($deliveredAt);
+        self::assertSame(MonthlyReminderDispatchStatus::Sent, $dispatch->getStatus());
+        self::assertSame($deliveredAt, $dispatch->getDeliveredAt());
+        self::assertNull($dispatch->getFailureReason());
+    }
+}


### PR DESCRIPTION
## Summary

- Route outbound mail through a dedicated `async_mail` Messenger transport with rate limiting (1 message / 3s) and exponential retry backoff to prevent SMTP `451 4.7.1` failures during bulk sends
- Stagger scheduler reminder dispatches using cumulative `DelayStamp` values (configurable via `MAILER_BULK_DELAY_MS`, default 3s)
- Add delivery tracking for monthly reminder dispatches (`queued` / `sent` / `failed`), including recipient, failure reason, and delivery timestamp
- Log dispatches for all triggers (scheduler, admin, CLI) and expose status in the admin overview
- Fix the admin “Send monthly reminder” action (`MapEntity` + correct translation domain)

Closes #302

## Changes

### Mail infrastructure
- New `async_mail` transport with `transactional_mail` rate limiter and slower retries (`10s → 20s → 40s …`, capped at 5 min)
- `SendEmailMessage` routed to `async_mail` in production; remains synchronous in `dev`/`test`
- Worker docs, Makefile, and `.env.example` updated for the new transport

### Bulk sending
- Batch handler passes a `bulkIndex` to space out queued reminder emails
- `MonthlyReminderMailer` dispatches delayed `SendEmailMessage` jobs when `bulkIndex > 0`

### Delivery observability
- Migration adds `status`, `recipient_email`, `failure_reason`, and `delivered_at` to `monthly_reminder_dispatch`
- `MonthlyReminderDeliverySubscriber` marks dispatches as `sent` or `failed` via mail/Messenger events
- Admin CRUD shows status badges, recipient, failure reason, and filters by status/trigger

### Admin fixes
- Resolve `Hospital` from EasyAdmin’s `entityId` route parameter via `#[MapEntity]`
- Use `admin` translation domain for reminder action labels

## Deployment notes

1. Run migrations: `php bin/console doctrine:migrations:migrate`
2. Add `async_mail` to the Messenger worker consume command
3. Restart the worker after deploy
4. Optional: set `MAILER_BULK_DELAY_MS` in server `.env.local`

## Test plan

- [x] `./bin/run-tests --no-coverage tests/Engagement/`
- [x] Send a reminder from the admin hospital detail page → entry appears with trigger `admin` and status `sent`
- [x] Verify `messenger:stats` shows messages on the `mail` queue in prod-like setup
- [x] Confirm action labels render in German (`Monatliche Erinnerung senden`, `Erinnerungsverlauf`)