### PR TITLE
bugfix: Fix filter persistence, add indications, and speed up the filter drawer

### DIFF
--- a/docs/04-features/allocation/explore-filter-reference-cache.md
+++ b/docs/04-features/allocation/explore-filter-reference-cache.md
@@ -31,8 +31,17 @@ User-specific hospital scope options stay uncached via `AllocationListHospitalSc
 | `explore_filter.specialities` | `specialities()` | `/explore/allocation` |
 | `explore_filter.assignments` | `assignments()` | `/explore/allocation` |
 | `explore_filter.occasions` | `occasions()` | `/explore/allocation` |
+| `explore_filter.indication_groups` | `indicationGroups()` | Analysis Explorer filter drawer |
 
 **Not cached:** `hospitalScopeOptions` (per-user hospital access).
+
+## Shared with Analysis Explorer
+
+The Statistics Analysis Explorer reuses the same provider via `AnalysisFilterChoiceProvider` for entity-backed filter dropdowns (departments, specialities, assignments, indications, indication groups). Enum-backed filters (urgency, gender, transport, age group, boolean) are built in memory and are not cached.
+
+| Consumer | Path |
+|----------|------|
+| Analysis Explorer filter choices | `src/Statistics/AnalysisExplorer/Application/AnalysisFilterChoiceProvider.php` |
 
 ## Arrays instead of entities
 
@@ -47,6 +56,7 @@ Cached values are plain arrays (`id`, `name`, and `code` for indications), not D
 | Allocation list | `src/Allocation/UI/Http/Controller/Allocations/ListAllocationsController.php` |
 | Hospital list | `src/Allocation/UI/Http/Controller/Hospitals/ListHospitalsController.php` |
 | Dispatch area list | `src/Allocation/UI/Http/Controller/DispatchAreas/ListDispatchAreasController.php` |
+| Analysis Explorer | `src/Statistics/AnalysisExplorer/Application/AnalysisFilterChoiceProvider.php` |
 
 ## Limits
 

--- a/docs/04-features/statistics/analysis-explorer.md
+++ b/docs/04-features/statistics/analysis-explorer.md
@@ -237,6 +237,36 @@ Legacy flat state (`scopeGroup`, `period`, `dimensionGrain`, …) is upgraded on
 
 `ExplorerConfigMapper::buildViewConfig()` / `filterToStateArray()` / `viewPreferencesToStateArray()` are convenience helpers for future URL or partial-state composition.
 
+### Analysis filters (drawer)
+
+Analysis filters narrow the allocation set **before** row/column grouping. They are stored in config state as `query.filters` (array of `{ dimensionKey, operator, value }`). This is separate from **scope/period** (see [statistics-filter-and-scope.md](statistics-filter-and-scope.md)).
+
+| Dimension key | Form field | Operator | Notes |
+|---|---|---|---|
+| `department` | `filterDepartmentId` | `equals` | Single-select dropdown |
+| `speciality` | `filterSpecialityId` | `equals` | Single-select dropdown |
+| `indication` | `filterIndicationId` | `equals` | Single-select; labels show name + code |
+| `secondary_indication` | `filterSecondaryIndicationId` | `equals` | Single-select dropdown |
+| `indication_group` | `filterIndicationGroupId` | `equals` | Virtual filter; expanded to `indication IN (...)` at query time |
+| `urgency` | `filterUrgency` | `equals` | Readable labels (emergency/inpatient/outpatient) |
+| `transport_type` | `filterTransportType` | `equals` | |
+| `gender` | `filterGender` | `equals` | |
+| `age_group` | `filterAgeGroup` | `equals` | Includes aggregate buckets |
+| `resus` / `cpr` / `ventilation` | boolean fields | `equals` | `0` / `1` |
+| `assignment` | `filterAssignmentId` | `equals` | |
+
+**Legacy saved views:** Older configs may still store `department` / `speciality` / `indication` filters with operator `in` and an array value. On load, only the first ID is applied to the dropdown.
+
+**Axis conflict:** A filter is disabled (and removed from config) when its dimension is already used as a row or column axis. `indication_group` is also disabled when `indication` is an axis (it resolves to the same column).
+
+**Hospitals data source:** All analysis filters are disabled; only allocation analyses support drawer filters.
+
+**Combined filters:** Multiple filters are combined with AND logic. Selecting both specific indications and an indication group restricts to the intersection.
+
+**Reference data cache:** Entity-backed dropdown choices (department, speciality, assignment, indication, indication group) are loaded through [`ExploreFilterOptionsProvider`](../allocation/explore-filter-reference-cache.md) (`cache.allocation.reference_data`, TTL 1 hour). After cache warmup, opening or refreshing the edit drawer does not re-query those tables. Manual invalidation: `bin/console cache:pool:clear cache.allocation.reference_data`.
+
+**Classes:** `ExplorerAnalysisFilterMapper`, `ExplorerAnalysisFilterExpander`, `ExplorerAnalysisFilterPolicy`, `AnalysisFilterChoiceProvider`, `ExplorerFilterBadgePresenter`.
+
 ## Supported capabilities (allocations)
 
 | Area | Values |

--- a/src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php
+++ b/src/Allocation/Application/Explore/ExploreFilterOptionsProvider.php
@@ -7,6 +7,7 @@ namespace App\Allocation\Application\Explore;
 use App\Allocation\Domain\Entity\Assignment;
 use App\Allocation\Domain\Entity\Department;
 use App\Allocation\Domain\Entity\DispatchArea;
+use App\Allocation\Domain\Entity\IndicationGroup;
 use App\Allocation\Domain\Entity\IndicationNormalized;
 use App\Allocation\Domain\Entity\Infection;
 use App\Allocation\Domain\Entity\Occasion;
@@ -16,6 +17,7 @@ use App\Allocation\Domain\Entity\State;
 use App\Allocation\Infrastructure\Repository\AssignmentRepository;
 use App\Allocation\Infrastructure\Repository\DepartmentRepository;
 use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
+use App\Allocation\Infrastructure\Repository\IndicationGroupRepository;
 use App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository;
 use App\Allocation\Infrastructure\Repository\InfectionRepository;
 use App\Allocation\Infrastructure\Repository\OccasionRepository;
@@ -48,12 +50,15 @@ final readonly class ExploreFilterOptionsProvider
 
     private const string CACHE_KEY_OCCASIONS = 'explore_filter.occasions';
 
+    private const string CACHE_KEY_INDICATION_GROUPS = 'explore_filter.indication_groups';
+
     public function __construct(
         #[Autowire(service: 'cache.allocation.reference_data')]
         private CacheInterface $cache,
         private StateRepository $stateRepository,
         private DispatchAreaRepository $dispatchAreaRepository,
         private IndicationNormalizedRepository $indicationNormalizedRepository,
+        private IndicationGroupRepository $indicationGroupRepository,
         private SecondaryTransportRepository $secondaryTransportRepository,
         private InfectionRepository $infectionRepository,
         private DepartmentRepository $departmentRepository,
@@ -215,6 +220,24 @@ final readonly class ExploreFilterOptionsProvider
             $item->expiresAfter(self::TTL_SECONDS);
 
             return $this->mapNamedEntities($this->occasionRepository->findBy([], ['name' => 'ASC']));
+        });
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function indicationGroups(): array
+    {
+        return $this->cache->get(self::CACHE_KEY_INDICATION_GROUPS, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL_SECONDS);
+
+            return array_map(
+                static fn (IndicationGroup $group): array => [
+                    'id' => (int) $group->getId(),
+                    'name' => (string) $group->getName(),
+                ],
+                $this->indicationGroupRepository->findBy([], ['name' => 'ASC']),
+            );
         });
     }
 

--- a/src/Statistics/AnalysisExplorer/Application/AnalysisFilterChoiceProvider.php
+++ b/src/Statistics/AnalysisExplorer/Application/AnalysisFilterChoiceProvider.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace App\Statistics\AnalysisExplorer\Application;
 
-use App\Allocation\Infrastructure\Repository\AssignmentRepository;
-use App\Allocation\Infrastructure\Repository\DepartmentRepository;
-use App\Allocation\Infrastructure\Repository\SpecialityRepository;
+use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
+use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
 use App\Statistics\Application\Mapping\AllocationStatsTransportTypeProjectionCode;
-use App\Statistics\Application\Mapping\AllocationStatsUrgencyProjectionCode;
 use App\Statistics\Application\Mapping\StatisticsAgeGroupFilter;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -17,9 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final readonly class AnalysisFilterChoiceProvider
 {
     public function __construct(
-        private DepartmentRepository $departmentRepository,
-        private SpecialityRepository $specialityRepository,
-        private AssignmentRepository $assignmentRepository,
+        private ExploreFilterOptionsProvider $referenceData,
         private DimensionRegistry $dimensionRegistry,
         private TranslatorInterface $translator,
     ) {
@@ -30,7 +26,7 @@ final readonly class AnalysisFilterChoiceProvider
      */
     public function departmentChoices(): array
     {
-        return $this->entityChoices($this->departmentRepository->findBy([], ['name' => 'ASC']));
+        return $this->choicesFromIdNameList($this->referenceData->departments());
     }
 
     /**
@@ -38,7 +34,7 @@ final readonly class AnalysisFilterChoiceProvider
      */
     public function specialityChoices(): array
     {
-        return $this->entityChoices($this->specialityRepository->findBy([], ['name' => 'ASC']));
+        return $this->choicesFromIdNameList($this->referenceData->specialities());
     }
 
     /**
@@ -46,7 +42,7 @@ final readonly class AnalysisFilterChoiceProvider
      */
     public function assignmentChoices(): array
     {
-        return $this->entityChoices($this->assignmentRepository->findBy([], ['name' => 'ASC']));
+        return $this->choicesFromIdNameList($this->referenceData->assignments());
     }
 
     /**
@@ -55,8 +51,8 @@ final readonly class AnalysisFilterChoiceProvider
     public function urgencyChoices(): array
     {
         $choices = [];
-        foreach (AllocationStatsUrgencyProjectionCode::cases() as $case) {
-            $choices[$case->value] = $this->translator->trans($case->labelTranslationKey(), [], 'statistics');
+        foreach (AllocationUrgency::cases() as $case) {
+            $choices[$case->value] = $this->translator->trans($case->label(), [], 'messages');
         }
 
         return $choices;
@@ -131,19 +127,51 @@ final readonly class AnalysisFilterChoiceProvider
     }
 
     /**
-     * @param list<object> $entities
+     * @return array<int, string>
+     */
+    public function indicationChoices(): array
+    {
+        return $this->choicesFromIndicationList($this->referenceData->indications());
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function indicationGroupChoices(): array
+    {
+        return $this->choicesFromIdNameList($this->referenceData->indicationGroups());
+    }
+
+    /**
+     * @param list<array{id: int, name: string}> $rows
      *
      * @return array<int, string>
      */
-    private function entityChoices(array $entities): array
+    private function choicesFromIdNameList(array $rows): array
     {
         $choices = [];
-        foreach ($entities as $entity) {
-            if (!method_exists($entity, 'getId') || !method_exists($entity, 'getName')) {
-                continue;
+        foreach ($rows as $row) {
+            $choices[$row['id']] = $row['name'];
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @param list<array{id: int, code: int, name: string}> $rows
+     *
+     * @return array<int, string>
+     */
+    private function choicesFromIndicationList(array $rows): array
+    {
+        $choices = [];
+        foreach ($rows as $row) {
+            $label = $row['name'];
+            if (0 !== $row['code']) {
+                $label .= ' ('.$row['code'].')';
             }
 
-            $choices[(int) $entity->getId()] = (string) $entity->getName();
+            $choices[$row['id']] = $label;
         }
 
         return $choices;

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterExpander.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterExpander.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use App\Allocation\Infrastructure\Repository\IndicationGroupRepository;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisFilter;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisFilterOperator;
+
+final readonly class ExplorerAnalysisFilterExpander
+{
+    public function __construct(
+        private IndicationGroupRepository $indicationGroupRepository,
+    ) {
+    }
+
+    /**
+     * @param list<AnalysisFilter> $filters
+     *
+     * @return list<AnalysisFilter>
+     */
+    public function expand(array $filters): array
+    {
+        $expanded = [];
+        foreach ($filters as $filter) {
+            if ('indication_group' !== $filter->dimensionKey) {
+                $expanded[] = $filter;
+
+                continue;
+            }
+
+            $groupId = $this->intValue($filter->value);
+            if (null === $groupId) {
+                continue;
+            }
+
+            $memberIds = $this->indicationGroupRepository->getIndicationIds($groupId);
+            if ([] === $memberIds) {
+                $expanded[] = new AnalysisFilter('indication', AnalysisFilterOperator::In, [-1]);
+
+                continue;
+            }
+
+            $expanded[] = new AnalysisFilter('indication', AnalysisFilterOperator::In, $memberIds);
+        }
+
+        return $expanded;
+    }
+
+    /**
+     * @param int|string|bool|list<int|string|bool> $value
+     */
+    private function intValue(int|string|bool|array $value): ?int
+    {
+        if (\is_array($value)) {
+            return null;
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 1 : 0;
+        }
+
+        if (\is_int($value)) {
+            return $value;
+        }
+
+        if ('' === $value || !ctype_digit($value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterMapper.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterMapper.php
@@ -18,12 +18,12 @@ final readonly class ExplorerAnalysisFilterMapper
     {
         $filters = [];
 
-        if ([] !== $formData->filterDepartmentIds) {
-            $filters[] = new AnalysisFilter('department', AnalysisFilterOperator::In, $formData->filterDepartmentIds);
+        if (null !== $formData->filterDepartmentId) {
+            $filters[] = new AnalysisFilter('department', AnalysisFilterOperator::Equals, $formData->filterDepartmentId);
         }
 
-        if ([] !== $formData->filterSpecialityIds) {
-            $filters[] = new AnalysisFilter('speciality', AnalysisFilterOperator::In, $formData->filterSpecialityIds);
+        if (null !== $formData->filterSpecialityId) {
+            $filters[] = new AnalysisFilter('speciality', AnalysisFilterOperator::Equals, $formData->filterSpecialityId);
         }
 
         if (null !== $formData->filterUrgency) {
@@ -58,6 +58,18 @@ final readonly class ExplorerAnalysisFilterMapper
             $filters[] = new AnalysisFilter('assignment', AnalysisFilterOperator::Equals, $formData->filterAssignmentId);
         }
 
+        if (null !== $formData->filterIndicationId) {
+            $filters[] = new AnalysisFilter('indication', AnalysisFilterOperator::Equals, $formData->filterIndicationId);
+        }
+
+        if (null !== $formData->filterSecondaryIndicationId) {
+            $filters[] = new AnalysisFilter('secondary_indication', AnalysisFilterOperator::Equals, $formData->filterSecondaryIndicationId);
+        }
+
+        if (null !== $formData->filterIndicationGroupId) {
+            $filters[] = new AnalysisFilter('indication_group', AnalysisFilterOperator::Equals, $formData->filterIndicationGroupId);
+        }
+
         return $this->sanitize($filters);
     }
 
@@ -66,8 +78,8 @@ final readonly class ExplorerAnalysisFilterMapper
      */
     public function applyToFormData(ExplorerEditFormData $formData, array $filters): ExplorerEditFormData
     {
-        $formData->filterDepartmentIds = [];
-        $formData->filterSpecialityIds = [];
+        $formData->filterDepartmentId = null;
+        $formData->filterSpecialityId = null;
         $formData->filterUrgency = null;
         $formData->filterTransportType = null;
         $formData->filterGender = null;
@@ -76,11 +88,14 @@ final readonly class ExplorerAnalysisFilterMapper
         $formData->filterCpr = null;
         $formData->filterVentilation = null;
         $formData->filterAssignmentId = null;
+        $formData->filterIndicationId = null;
+        $formData->filterSecondaryIndicationId = null;
+        $formData->filterIndicationGroupId = null;
 
         foreach ($this->sanitize($filters) as $filter) {
             match ($filter->dimensionKey) {
-                'department' => $formData->filterDepartmentIds = $this->intList($filter->value),
-                'speciality' => $formData->filterSpecialityIds = $this->intList($filter->value),
+                'department' => $formData->filterDepartmentId = $this->singleEntityId($filter->value),
+                'speciality' => $formData->filterSpecialityId = $this->singleEntityId($filter->value),
                 'urgency' => $formData->filterUrgency = $this->intValue($filter->value),
                 'transport_type' => $formData->filterTransportType = $this->intValue($filter->value),
                 'gender' => $formData->filterGender = $this->intValue($filter->value),
@@ -89,6 +104,9 @@ final readonly class ExplorerAnalysisFilterMapper
                 'cpr' => $formData->filterCpr = 1 === $this->intValue($filter->value),
                 'ventilation' => $formData->filterVentilation = 1 === $this->intValue($filter->value),
                 'assignment' => $formData->filterAssignmentId = $this->intValue($filter->value),
+                'indication' => $formData->filterIndicationId = $this->singleEntityId($filter->value),
+                'secondary_indication' => $formData->filterSecondaryIndicationId = $this->singleEntityId($filter->value),
+                'indication_group' => $formData->filterIndicationGroupId = $this->intValue($filter->value),
                 default => null,
             };
         }
@@ -159,26 +177,21 @@ final readonly class ExplorerAnalysisFilterMapper
 
     /**
      * @param int|string|bool|list<int|string|bool> $value
-     *
-     * @return list<int>
      */
-    private function intList(int|string|bool|array $value): array
+    private function singleEntityId(int|string|bool|array $value): ?int
     {
-        if (!\is_array($value)) {
-            $int = $this->intValue($value);
-
-            return null === $int ? [] : [$int];
-        }
-
-        $ids = [];
-        foreach ($value as $item) {
-            $int = $this->intValue($item);
-            if (null !== $int) {
-                $ids[] = $int;
+        if (\is_array($value)) {
+            foreach ($value as $item) {
+                $int = $this->intValue($item);
+                if (null !== $int) {
+                    return $int;
+                }
             }
+
+            return null;
         }
 
-        return $ids;
+        return $this->intValue($value);
     }
 
     /**

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterPolicy.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisFilterPolicy.php
@@ -25,7 +25,13 @@ final readonly class ExplorerAnalysisFilterPolicy
 
         return array_values(array_filter(
             $filters,
-            static fn (AnalysisFilter $filter): bool => !\in_array($filter->dimensionKey, $axisKeys, true),
+            static function (AnalysisFilter $filter) use ($axisKeys): bool {
+                if (\in_array($filter->dimensionKey, $axisKeys, true)) {
+                    return false;
+                }
+
+                return !('indication_group' === $filter->dimensionKey && \in_array('indication', $axisKeys, true));
+            },
         ));
     }
 

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisQueryFactory.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerAnalysisQueryFactory.php
@@ -16,12 +16,20 @@ final readonly class ExplorerAnalysisQueryFactory
     public function __construct(
         private StatisticsContextFactory $statisticsContextFactory,
         private StatisticsScopeResolver $statisticsScopeResolver,
+        private ExplorerAnalysisFilterExpander $analysisFilterExpander,
+        private ExplorerAnalysisFilterPolicy $analysisFilterPolicy,
     ) {
     }
 
     public function create(AnalysisViewConfig $config, ?User $user): AnalysisQuery
     {
         $context = $this->statisticsContextFactory->create($user, $config->statisticsFilter);
+        $filters = $this->analysisFilterExpander->expand($config->filters);
+        $filters = $this->analysisFilterPolicy->excludeAxisDimensions(
+            $filters,
+            $config->rowAxis,
+            $config->columnAxis,
+        );
 
         return new AnalysisQuery(
             dataSourceKey: $config->dataSourceKey,
@@ -32,7 +40,7 @@ final readonly class ExplorerAnalysisQueryFactory
             scopeCriteria: $this->statisticsScopeResolver->resolveCriteria($context),
             periodBounds: StatisticsPeriodResolver::resolve($config->statisticsFilter),
             hospitalPopulationMode: $config->hospitalPopulationMode,
-            filters: $config->filters,
+            filters: $filters,
         );
     }
 }

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerEditAxisSwapper.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerEditAxisSwapper.php
@@ -81,6 +81,19 @@ final readonly class ExplorerEditAxisSwapper
                 chartRowLimit: $formData->chartRowLimit,
                 hospitalPopulation: ExplorerHospitalPopulationMode::Compare->value,
                 additionalTableMetrics: $formData->additionalTableMetrics,
+                filterDepartmentId: $formData->filterDepartmentId,
+                filterSpecialityId: $formData->filterSpecialityId,
+                filterUrgency: $formData->filterUrgency,
+                filterTransportType: $formData->filterTransportType,
+                filterGender: $formData->filterGender,
+                filterAgeGroup: $formData->filterAgeGroup,
+                filterResus: $formData->filterResus,
+                filterCpr: $formData->filterCpr,
+                filterVentilation: $formData->filterVentilation,
+                filterAssignmentId: $formData->filterAssignmentId,
+                filterIndicationId: $formData->filterIndicationId,
+                filterSecondaryIndicationId: $formData->filterSecondaryIndicationId,
+                filterIndicationGroupId: $formData->filterIndicationGroupId,
             ));
         }
 
@@ -102,6 +115,19 @@ final readonly class ExplorerEditAxisSwapper
             chartRowLimit: $formData->chartRowLimit,
             hospitalPopulation: $formData->hospitalPopulation,
             additionalTableMetrics: $formData->additionalTableMetrics,
+            filterDepartmentId: $formData->filterDepartmentId,
+            filterSpecialityId: $formData->filterSpecialityId,
+            filterUrgency: $formData->filterUrgency,
+            filterTransportType: $formData->filterTransportType,
+            filterGender: $formData->filterGender,
+            filterAgeGroup: $formData->filterAgeGroup,
+            filterResus: $formData->filterResus,
+            filterCpr: $formData->filterCpr,
+            filterVentilation: $formData->filterVentilation,
+            filterAssignmentId: $formData->filterAssignmentId,
+            filterIndicationId: $formData->filterIndicationId,
+            filterSecondaryIndicationId: $formData->filterSecondaryIndicationId,
+            filterIndicationGroupId: $formData->filterIndicationGroupId,
         ));
     }
 

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerEditFormFilterFieldMapper.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerEditFormFilterFieldMapper.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use App\Statistics\AnalysisExplorer\UI\Form\Data\ExplorerEditFormData;
+
+final class ExplorerEditFormFilterFieldMapper
+{
+    /**
+     * @param array<string, mixed> $submitted
+     */
+    public function mergeSubmittedFilters(ExplorerEditFormData $data, array $submitted): ExplorerEditFormData
+    {
+        return new ExplorerEditFormData(
+            scopePeriod: $data->scopePeriod,
+            dataSource: $data->dataSource,
+            rowDimension: $data->rowDimension,
+            rowGrain: $data->rowGrain,
+            columnDimension: $data->columnDimension,
+            columnGrain: $data->columnGrain,
+            metric: $data->metric,
+            showPercentOfTotal: $data->showPercentOfTotal,
+            chartType: $data->chartType,
+            tableLayout: $data->tableLayout,
+            chartRowLimit: $data->chartRowLimit,
+            hospitalPopulation: $data->hospitalPopulation,
+            additionalTableMetrics: $data->additionalTableMetrics,
+            filterDepartmentId: $this->nullableIntFromSubmitted($submitted, 'filterDepartmentId', $data->filterDepartmentId),
+            filterSpecialityId: $this->nullableIntFromSubmitted($submitted, 'filterSpecialityId', $data->filterSpecialityId),
+            filterUrgency: $this->nullableIntFromSubmitted($submitted, 'filterUrgency', $data->filterUrgency),
+            filterTransportType: $this->nullableIntFromSubmitted($submitted, 'filterTransportType', $data->filterTransportType),
+            filterGender: $this->nullableIntFromSubmitted($submitted, 'filterGender', $data->filterGender),
+            filterAgeGroup: $this->nullableStringFromSubmitted($submitted, 'filterAgeGroup', $data->filterAgeGroup),
+            filterResus: $this->nullableBoolFromSubmitted($submitted, 'filterResus', $data->filterResus),
+            filterCpr: $this->nullableBoolFromSubmitted($submitted, 'filterCpr', $data->filterCpr),
+            filterVentilation: $this->nullableBoolFromSubmitted($submitted, 'filterVentilation', $data->filterVentilation),
+            filterAssignmentId: $this->nullableIntFromSubmitted($submitted, 'filterAssignmentId', $data->filterAssignmentId),
+            filterIndicationId: $this->nullableIntFromSubmitted($submitted, 'filterIndicationId', $data->filterIndicationId),
+            filterSecondaryIndicationId: $this->nullableIntFromSubmitted($submitted, 'filterSecondaryIndicationId', $data->filterSecondaryIndicationId),
+            filterIndicationGroupId: $this->nullableIntFromSubmitted($submitted, 'filterIndicationGroupId', $data->filterIndicationGroupId),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $submitted
+     */
+    private function nullableIntFromSubmitted(array $submitted, string $key, ?int $current): ?int
+    {
+        if (!\array_key_exists($key, $submitted)) {
+            return $current;
+        }
+
+        $value = $submitted[$key];
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param array<string, mixed> $submitted
+     */
+    private function nullableStringFromSubmitted(array $submitted, string $key, ?string $current): ?string
+    {
+        if (!\array_key_exists($key, $submitted)) {
+            return $current;
+        }
+
+        $value = $submitted[$key];
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $submitted
+     */
+    private function nullableBoolFromSubmitted(array $submitted, string $key, ?bool $current): ?bool
+    {
+        if (!\array_key_exists($key, $submitted)) {
+            return $current;
+        }
+
+        $value = $submitted[$key];
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        return (bool) (int) $value;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerEditFormNormalizer.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerEditFormNormalizer.php
@@ -151,6 +151,19 @@ final readonly class ExplorerEditFormNormalizer
             chartRowLimit: $chartRowLimit->value,
             hospitalPopulation: $hospitalPopulation->value,
             additionalTableMetrics: $additionalTableMetrics,
+            filterDepartmentId: $formData->filterDepartmentId,
+            filterSpecialityId: $formData->filterSpecialityId,
+            filterUrgency: $formData->filterUrgency,
+            filterTransportType: $formData->filterTransportType,
+            filterGender: $formData->filterGender,
+            filterAgeGroup: $formData->filterAgeGroup,
+            filterResus: $formData->filterResus,
+            filterCpr: $formData->filterCpr,
+            filterVentilation: $formData->filterVentilation,
+            filterAssignmentId: $formData->filterAssignmentId,
+            filterIndicationId: $formData->filterIndicationId,
+            filterSecondaryIndicationId: $formData->filterSecondaryIndicationId,
+            filterIndicationGroupId: $formData->filterIndicationGroupId,
         );
     }
 }

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerFilterBadgePresenter.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerFilterBadgePresenter.php
@@ -36,6 +36,10 @@ final readonly class ExplorerFilterBadgePresenter
 
     private function dimensionLabel(string $dimensionKey): string
     {
+        if ('indication_group' === $dimensionKey) {
+            return $this->translator->trans('label.indication_group', [], 'messages');
+        }
+
         if (!$this->dimensionRegistry->has($dimensionKey)) {
             return $dimensionKey;
         }
@@ -46,13 +50,16 @@ final readonly class ExplorerFilterBadgePresenter
     private function valueLabel(AnalysisFilter $filter): string
     {
         return match ($filter->dimensionKey) {
-            'department' => $this->entityListLabel($this->choiceProvider->departmentChoices(), $filter->value),
-            'speciality' => $this->entityListLabel($this->choiceProvider->specialityChoices(), $filter->value),
+            'department' => $this->singleChoiceLabel($this->choiceProvider->departmentChoices(), $filter->value),
+            'speciality' => $this->singleChoiceLabel($this->choiceProvider->specialityChoices(), $filter->value),
             'assignment' => $this->entityListLabel($this->choiceProvider->assignmentChoices(), $filter->value),
             'urgency' => $this->singleChoiceLabel($this->choiceProvider->urgencyChoices(), $filter->value),
             'transport_type' => $this->singleChoiceLabel($this->choiceProvider->transportTypeChoices(), $filter->value),
             'gender' => $this->singleChoiceLabel($this->choiceProvider->genderChoices(), $filter->value),
             'age_group' => $this->singleChoiceLabel($this->choiceProvider->ageGroupChoices(), $filter->value),
+            'indication' => $this->singleChoiceLabel($this->choiceProvider->indicationChoices(), $filter->value),
+            'secondary_indication' => $this->singleChoiceLabel($this->choiceProvider->indicationChoices(), $filter->value),
+            'indication_group' => $this->singleChoiceLabel($this->choiceProvider->indicationGroupChoices(), $filter->value),
             'resus', 'cpr', 'ventilation' => $this->booleanLabel($filter->value),
             default => \is_array($filter->value) ? implode(', ', array_map(strval(...), $filter->value)) : (string) $filter->value,
         };

--- a/src/Statistics/AnalysisExplorer/Domain/ExplorerAnalysisFilterCatalog.php
+++ b/src/Statistics/AnalysisExplorer/Domain/ExplorerAnalysisFilterCatalog.php
@@ -21,6 +21,9 @@ final class ExplorerAnalysisFilterCatalog
         'cpr',
         'ventilation',
         'assignment',
+        'indication',
+        'secondary_indication',
+        'indication_group',
     ];
 
     public static function isAllowed(string $dimensionKey): bool

--- a/src/Statistics/AnalysisExplorer/UI/Form/Data/ExplorerEditFormData.php
+++ b/src/Statistics/AnalysisExplorer/UI/Form/Data/ExplorerEditFormData.php
@@ -23,10 +23,8 @@ final class ExplorerEditFormData
         public string $hospitalPopulation = 'participating',
         /** @var list<string> */
         public array $additionalTableMetrics = [],
-        /** @var list<int> */
-        public array $filterDepartmentIds = [],
-        /** @var list<int> */
-        public array $filterSpecialityIds = [],
+        public ?int $filterDepartmentId = null,
+        public ?int $filterSpecialityId = null,
         public ?int $filterUrgency = null,
         public ?int $filterTransportType = null,
         public ?int $filterGender = null,
@@ -35,6 +33,9 @@ final class ExplorerEditFormData
         public ?bool $filterCpr = null,
         public ?bool $filterVentilation = null,
         public ?int $filterAssignmentId = null,
+        public ?int $filterIndicationId = null,
+        public ?int $filterSecondaryIndicationId = null,
+        public ?int $filterIndicationGroupId = null,
     ) {
     }
 }

--- a/src/Statistics/AnalysisExplorer/UI/Form/ExplorerEditFormType.php
+++ b/src/Statistics/AnalysisExplorer/UI/Form/ExplorerEditFormType.php
@@ -10,6 +10,7 @@ use App\Statistics\AnalysisExplorer\Application\DataSourceCapabilitiesRegistry;
 use App\Statistics\AnalysisExplorer\Application\ExplorerColumnGrainResolver;
 use App\Statistics\AnalysisExplorer\Application\ExplorerConfigPreviewFactory;
 use App\Statistics\AnalysisExplorer\Application\ExplorerEditChoicePresenter;
+use App\Statistics\AnalysisExplorer\Application\ExplorerEditFormFilterFieldMapper;
 use App\Statistics\AnalysisExplorer\Application\ExplorerMetricCapabilityPolicy;
 use App\Statistics\AnalysisExplorer\Application\ExplorerStatisticsFilterInputFactory;
 use App\Statistics\AnalysisExplorer\Domain\DTO\AnalysisAxisRef;
@@ -56,6 +57,7 @@ final class ExplorerEditFormType extends AbstractType
         private readonly AnalysisAxisResolver $axisResolver,
         private readonly Security $security,
         private readonly AnalysisFilterChoiceProvider $filterChoiceProvider,
+        private readonly ExplorerEditFormFilterFieldMapper $filterFieldMapper,
     ) {
     }
 
@@ -91,16 +93,19 @@ final class ExplorerEditFormType extends AbstractType
                 'expanded' => true,
                 'required' => false,
             ])
-            ->add('filterDepartmentIds', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.department', 'choices' => [], 'multiple' => true, 'required' => false]))
-            ->add('filterSpecialityIds', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.speciality', 'choices' => [], 'multiple' => true, 'required' => false]))
-            ->add('filterUrgency', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.urgency', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
-            ->add('filterTransportType', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.transport_type', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
-            ->add('filterGender', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.gender', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
-            ->add('filterAgeGroup', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.age_group', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
+            ->add('filterDepartmentId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.department', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_departments']))
+            ->add('filterSpecialityId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.speciality', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_specialities']))
+            ->add('filterUrgency', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.urgency', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_urgencies']))
+            ->add('filterTransportType', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.transport_type', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_transport_types']))
+            ->add('filterGender', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.gender', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_genders']))
+            ->add('filterAgeGroup', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.age_group', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_age_groups']))
             ->add('filterResus', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.requires_resus', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
             ->add('filterCpr', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.is_cpr', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
             ->add('filterVentilation', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.is_ventilated', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
-            ->add('filterAssignmentId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.assignment', 'choices' => [], 'required' => false, 'placeholder' => 'label.all']))
+            ->add('filterAssignmentId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.assignment', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_assignments']))
+            ->add('filterIndicationId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.indication', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_indications']))
+            ->add('filterSecondaryIndicationId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.secondary_indication', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_secondary_indications']))
+            ->add('filterIndicationGroupId', PreTranslatedChoiceType::class, $this->messagesField(['label' => 'label.indication_group', 'choices' => [], 'required' => false, 'placeholder' => 'label.all_indication_groups']))
         ;
 
         $scopePeriodField = $builder->get('scopePeriod');
@@ -164,7 +169,7 @@ final class ExplorerEditFormType extends AbstractType
      */
     private function previewFromSubmitted(array $submitted, ExplorerEditFormData $current): ExplorerEditFormData
     {
-        return new ExplorerEditFormData(
+        $base = new ExplorerEditFormData(
             scopePeriod: $current->scopePeriod,
             dataSource: \is_string($submitted['dataSource'] ?? null) ? $submitted['dataSource'] : $current->dataSource,
             rowDimension: \is_string($submitted['rowDimension'] ?? null) ? $submitted['rowDimension'] : $current->rowDimension,
@@ -189,85 +194,22 @@ final class ExplorerEditFormType extends AbstractType
                     static fn (mixed $value): bool => \is_string($value) && '' !== $value,
                 ))
                 : $current->additionalTableMetrics,
-            filterDepartmentIds: $this->intListFromSubmitted($submitted, 'filterDepartmentIds', $current->filterDepartmentIds),
-            filterSpecialityIds: $this->intListFromSubmitted($submitted, 'filterSpecialityIds', $current->filterSpecialityIds),
-            filterUrgency: $this->nullableIntFromSubmitted($submitted, 'filterUrgency', $current->filterUrgency),
-            filterTransportType: $this->nullableIntFromSubmitted($submitted, 'filterTransportType', $current->filterTransportType),
-            filterGender: $this->nullableIntFromSubmitted($submitted, 'filterGender', $current->filterGender),
-            filterAgeGroup: $this->nullableStringFromSubmitted($submitted, 'filterAgeGroup', $current->filterAgeGroup),
-            filterResus: $this->nullableBoolFromSubmitted($submitted, 'filterResus', $current->filterResus),
-            filterCpr: $this->nullableBoolFromSubmitted($submitted, 'filterCpr', $current->filterCpr),
-            filterVentilation: $this->nullableBoolFromSubmitted($submitted, 'filterVentilation', $current->filterVentilation),
-            filterAssignmentId: $this->nullableIntFromSubmitted($submitted, 'filterAssignmentId', $current->filterAssignmentId),
+            filterDepartmentId: $current->filterDepartmentId,
+            filterSpecialityId: $current->filterSpecialityId,
+            filterUrgency: $current->filterUrgency,
+            filterTransportType: $current->filterTransportType,
+            filterGender: $current->filterGender,
+            filterAgeGroup: $current->filterAgeGroup,
+            filterResus: $current->filterResus,
+            filterCpr: $current->filterCpr,
+            filterVentilation: $current->filterVentilation,
+            filterAssignmentId: $current->filterAssignmentId,
+            filterIndicationId: $current->filterIndicationId,
+            filterSecondaryIndicationId: $current->filterSecondaryIndicationId,
+            filterIndicationGroupId: $current->filterIndicationGroupId,
         );
-    }
 
-    /**
-     * @param array<string, mixed> $submitted
-     * @param list<int>            $current
-     *
-     * @return list<int>
-     */
-    private function intListFromSubmitted(array $submitted, string $key, array $current): array
-    {
-        if (!\array_key_exists($key, $submitted)) {
-            return $current;
-        }
-
-        $values = \is_array($submitted[$key]) ? $submitted[$key] : [];
-
-        return array_values(array_map(intval(...), array_filter($values, static fn (mixed $value): bool => '' !== $value && null !== $value)));
-    }
-
-    /**
-     * @param array<string, mixed> $submitted
-     */
-    private function nullableIntFromSubmitted(array $submitted, string $key, ?int $current): ?int
-    {
-        if (!\array_key_exists($key, $submitted)) {
-            return $current;
-        }
-
-        $value = $submitted[$key];
-        if (null === $value || '' === $value) {
-            return null;
-        }
-
-        return (int) $value;
-    }
-
-    /**
-     * @param array<string, mixed> $submitted
-     */
-    private function nullableStringFromSubmitted(array $submitted, string $key, ?string $current): ?string
-    {
-        if (!\array_key_exists($key, $submitted)) {
-            return $current;
-        }
-
-        $value = $submitted[$key];
-        if (!\is_string($value) || '' === $value) {
-            return null;
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param array<string, mixed> $submitted
-     */
-    private function nullableBoolFromSubmitted(array $submitted, string $key, ?bool $current): ?bool
-    {
-        if (!\array_key_exists($key, $submitted)) {
-            return $current;
-        }
-
-        $value = $submitted[$key];
-        if (null === $value || '' === $value) {
-            return null;
-        }
-
-        return (bool) (int) $value;
+        return $this->filterFieldMapper->mergeSubmittedFilters($base, $submitted);
     }
 
     /**
@@ -453,46 +395,46 @@ final class ExplorerEditFormType extends AbstractType
             $this->translator->trans('label.no', [], 'messages') => 0,
         ];
 
-        $form->add('filterDepartmentIds', PreTranslatedChoiceType::class, $this->messagesField([
+        $form->add('filterDepartmentId', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.department',
             'choices' => $this->flipChoices($this->filterChoiceProvider->departmentChoices()),
-            'multiple' => true,
             'required' => false,
+            'placeholder' => 'label.all_departments',
             'disabled' => $disabled || $isAxis('department'),
         ]));
-        $form->add('filterSpecialityIds', PreTranslatedChoiceType::class, $this->messagesField([
+        $form->add('filterSpecialityId', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.speciality',
             'choices' => $this->flipChoices($this->filterChoiceProvider->specialityChoices()),
-            'multiple' => true,
             'required' => false,
+            'placeholder' => 'label.all_specialities',
             'disabled' => $disabled || $isAxis('speciality'),
         ]));
         $form->add('filterUrgency', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.urgency',
             'choices' => $this->flipChoices($this->filterChoiceProvider->urgencyChoices()),
             'required' => false,
-            'placeholder' => 'label.all',
+            'placeholder' => 'label.all_urgencies',
             'disabled' => $disabled || $isAxis('urgency'),
         ]));
         $form->add('filterTransportType', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.transport_type',
             'choices' => $this->flipChoices($this->filterChoiceProvider->transportTypeChoices()),
             'required' => false,
-            'placeholder' => 'label.all',
+            'placeholder' => 'label.all_transport_types',
             'disabled' => $disabled || $isAxis('transport_type'),
         ]));
         $form->add('filterGender', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.gender',
             'choices' => $this->flipChoices($this->filterChoiceProvider->genderChoices()),
             'required' => false,
-            'placeholder' => 'label.all',
+            'placeholder' => 'label.all_genders',
             'disabled' => $disabled || $isAxis('gender'),
         ]));
         $form->add('filterAgeGroup', PreTranslatedChoiceType::class, $this->messagesField([
             'label' => 'label.age_group',
             'choices' => $this->flipChoices($this->filterChoiceProvider->ageGroupChoices()),
             'required' => false,
-            'placeholder' => 'label.all',
+            'placeholder' => 'label.all_age_groups',
             'disabled' => $disabled || $isAxis('age_group'),
         ]));
         $form->add('filterResus', PreTranslatedChoiceType::class, $this->messagesField([
@@ -520,8 +462,29 @@ final class ExplorerEditFormType extends AbstractType
             'label' => 'label.assignment',
             'choices' => $this->flipChoices($this->filterChoiceProvider->assignmentChoices()),
             'required' => false,
-            'placeholder' => 'label.all',
+            'placeholder' => 'label.all_assignments',
             'disabled' => $disabled || $isAxis('assignment'),
+        ]));
+        $form->add('filterIndicationId', PreTranslatedChoiceType::class, $this->messagesField([
+            'label' => 'label.indication',
+            'choices' => $this->flipChoices($this->filterChoiceProvider->indicationChoices()),
+            'required' => false,
+            'placeholder' => 'label.all_indications',
+            'disabled' => $disabled || $isAxis('indication'),
+        ]));
+        $form->add('filterSecondaryIndicationId', PreTranslatedChoiceType::class, $this->messagesField([
+            'label' => 'label.secondary_indication',
+            'choices' => $this->flipChoices($this->filterChoiceProvider->indicationChoices()),
+            'required' => false,
+            'placeholder' => 'label.all_secondary_indications',
+            'disabled' => $disabled || $isAxis('secondary_indication'),
+        ]));
+        $form->add('filterIndicationGroupId', PreTranslatedChoiceType::class, $this->messagesField([
+            'label' => 'label.indication_group',
+            'choices' => $this->flipChoices($this->filterChoiceProvider->indicationGroupChoices()),
+            'required' => false,
+            'placeholder' => 'label.all_indication_groups',
+            'disabled' => $disabled || $isAxis('indication'),
         ]));
     }
 
@@ -532,6 +495,10 @@ final class ExplorerEditFormType extends AbstractType
      */
     private function messagesField(array $options): array
     {
+        if (isset($options['help']) && \is_string($options['help'])) {
+            $options['help'] = $this->translator->trans($options['help'], [], 'statistics');
+        }
+
         return array_merge($options, [
             'translation_domain' => 'messages',
             'choice_translation_domain' => false,
@@ -737,8 +704,8 @@ final class ExplorerEditFormType extends AbstractType
             chartRowLimit: $overrides['chartRowLimit'] ?? $source->chartRowLimit,
             hospitalPopulation: $overrides['hospitalPopulation'] ?? $source->hospitalPopulation,
             additionalTableMetrics: $overrides['additionalTableMetrics'] ?? $source->additionalTableMetrics,
-            filterDepartmentIds: $source->filterDepartmentIds,
-            filterSpecialityIds: $source->filterSpecialityIds,
+            filterDepartmentId: $source->filterDepartmentId,
+            filterSpecialityId: $source->filterSpecialityId,
             filterUrgency: $source->filterUrgency,
             filterTransportType: $source->filterTransportType,
             filterGender: $source->filterGender,
@@ -747,6 +714,9 @@ final class ExplorerEditFormType extends AbstractType
             filterCpr: $source->filterCpr,
             filterVentilation: $source->filterVentilation,
             filterAssignmentId: $source->filterAssignmentId,
+            filterIndicationId: $source->filterIndicationId,
+            filterSecondaryIndicationId: $source->filterSecondaryIndicationId,
+            filterIndicationGroupId: $source->filterIndicationGroupId,
         );
     }
 }

--- a/src/Statistics/AnalysisExplorer/UI/LiveComponent/AnalysisExplorerShell.php
+++ b/src/Statistics/AnalysisExplorer/UI/LiveComponent/AnalysisExplorerShell.php
@@ -14,6 +14,7 @@ use App\Statistics\AnalysisExplorer\Application\ExplorerChartPresenter;
 use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
 use App\Statistics\AnalysisExplorer\Application\ExplorerDescriptionFactory;
 use App\Statistics\AnalysisExplorer\Application\ExplorerEditAxisSwapper;
+use App\Statistics\AnalysisExplorer\Application\ExplorerEditFormFilterFieldMapper;
 use App\Statistics\AnalysisExplorer\Application\ExplorerEditFormNormalizer;
 use App\Statistics\AnalysisExplorer\Application\ExplorerEditFormSummaryFactory;
 use App\Statistics\AnalysisExplorer\Application\ExplorerFilterBadgePresenter;
@@ -188,6 +189,7 @@ final class AnalysisExplorerShell
         private readonly AnalysisViewConfigValidator $configValidator,
         private readonly AnalysisViewConfigNormalizer $configNormalizer,
         private readonly ExplorerEditFormNormalizer $editFormNormalizer,
+        private readonly ExplorerEditFormFilterFieldMapper $editFormFilterFieldMapper,
         private readonly TranslatorInterface $translator,
         private readonly Security $security,
         private readonly LoggerInterface $logger,
@@ -792,7 +794,7 @@ final class AnalysisExplorerShell
 
         $scopePeriod = $this->resolveScopePeriodFormData($formData->scopePeriod, $submitted);
 
-        return new ExplorerEditFormData(
+        $base = new ExplorerEditFormData(
             scopePeriod: $scopePeriod,
             dataSource: \is_string($submitted['dataSource'] ?? null) ? $submitted['dataSource'] : $formData->dataSource,
             rowDimension: \is_string($submitted['rowDimension'] ?? null) ? $submitted['rowDimension'] : $formData->rowDimension,
@@ -817,7 +819,22 @@ final class AnalysisExplorerShell
                     static fn (mixed $value): bool => \is_string($value) && '' !== $value,
                 ))
                 : $formData->additionalTableMetrics,
+            filterDepartmentId: $formData->filterDepartmentId,
+            filterSpecialityId: $formData->filterSpecialityId,
+            filterUrgency: $formData->filterUrgency,
+            filterTransportType: $formData->filterTransportType,
+            filterGender: $formData->filterGender,
+            filterAgeGroup: $formData->filterAgeGroup,
+            filterResus: $formData->filterResus,
+            filterCpr: $formData->filterCpr,
+            filterVentilation: $formData->filterVentilation,
+            filterAssignmentId: $formData->filterAssignmentId,
+            filterIndicationId: $formData->filterIndicationId,
+            filterSecondaryIndicationId: $formData->filterSecondaryIndicationId,
+            filterIndicationGroupId: $formData->filterIndicationGroupId,
         );
+
+        return $this->editFormFilterFieldMapper->mergeSubmittedFilters($base, $submitted);
     }
 
     /**

--- a/src/Statistics/UI/Twig/templates/analysis_explorer/_edit_drawer.html.twig
+++ b/src/Statistics/UI/Twig/templates/analysis_explorer/_edit_drawer.html.twig
@@ -1,4 +1,5 @@
 {% set compactRow = {label: false, row_attr: {class: 'mb-0'}} %}
+{% set filterRow = {row_attr: {class: 'mb-0'}, label_attr: {class: 'form-label small mb-1'}} %}
 {% set refreshAttrs = {
     'data-action': 'change->live#action',
     'data-live-action-param': 'refreshEditForm',
@@ -128,16 +129,19 @@
                     <div class="accordion-body">
                         <p class="text-secondary small mb-3">{{ 'stats.analysis_explorer.edit.section.filters_help'|trans({}, 'statistics') }}</p>
                         <div class="row g-3">
-                            <div class="col-12">{{ form_row(form.filterDepartmentIds, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-12">{{ form_row(form.filterSpecialityIds, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-6">{{ form_row(form.filterUrgency, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-6">{{ form_row(form.filterTransportType, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-6">{{ form_row(form.filterGender, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-6">{{ form_row(form.filterAgeGroup, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-4">{{ form_row(form.filterResus, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-4">{{ form_row(form.filterCpr, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-md-4">{{ form_row(form.filterVentilation, compactRow|merge({attr: refreshAttrs})) }}</div>
-                            <div class="col-12">{{ form_row(form.filterAssignmentId, compactRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterDepartmentId, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterSpecialityId, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterIndicationId, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterSecondaryIndicationId, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterIndicationGroupId, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-6">{{ form_row(form.filterUrgency, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-6">{{ form_row(form.filterTransportType, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-6">{{ form_row(form.filterGender, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-6">{{ form_row(form.filterAgeGroup, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-4">{{ form_row(form.filterResus, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-4">{{ form_row(form.filterCpr, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-md-4">{{ form_row(form.filterVentilation, filterRow|merge({attr: refreshAttrs})) }}</div>
+                            <div class="col-12">{{ form_row(form.filterAssignmentId, filterRow|merge({attr: refreshAttrs})) }}</div>
                         </div>
                     </div>
                 {{ editAccordion.panel_end() }}

--- a/tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php
+++ b/tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php
@@ -8,6 +8,7 @@ use App\Allocation\Application\Explore\ExploreFilterOptionsProvider;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\IndicationGroupFactory;
 use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
 use App\Allocation\Infrastructure\Factory\InfectionFactory;
 use App\Allocation\Infrastructure\Factory\OccasionFactory;
@@ -90,5 +91,21 @@ final class ExploreFilterOptionsProviderTest extends KernelTestCase
             'name' => 'STEMI',
         ], $options['indications'][0]);
         self::assertSame(['Alpha Assignment', 'Zebra Assignment'], array_column($options['assignments'], 'name'));
+    }
+
+    public function testSecondCallUsesCachedIndicationGroups(): void
+    {
+        self::bootKernel();
+        IndicationGroupFactory::createOne(['name' => 'Cardiac group']);
+
+        $provider = self::getContainer()->get(ExploreFilterOptionsProvider::class);
+        self::assertInstanceOf(ExploreFilterOptionsProvider::class, $provider);
+
+        $first = $provider->indicationGroups();
+        IndicationGroupFactory::createOne(['name' => 'Neurology group']);
+        $second = $provider->indicationGroups();
+
+        self::assertSame([['id' => $first[0]['id'], 'name' => 'Cardiac group']], $first);
+        self::assertSame($first, $second);
     }
 }

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellTest.php
@@ -368,6 +368,48 @@ final class AnalysisExplorerShellTest extends WebTestCase
         self::assertFalse($testComponent->component()->isEditOpen);
     }
 
+    public function testApplyEditPersistsAnalysisFiltersInAppliedState(): void
+    {
+        $testComponent = $this->createShellComponent();
+        $testComponent->call('openEdit');
+        $formName = $this->formName($testComponent->render());
+
+        $testComponent
+            ->submitForm($this->formPayload($formName, [
+                'filterUrgency' => '1',
+                'filterAgeGroup' => 'under_18',
+            ]))
+            ->call('applyEdit');
+
+        $filters = $testComponent->component()->appliedConfigState['query']['filters'] ?? [];
+        self::assertCount(2, $filters);
+        self::assertSame('urgency', $filters[0]['dimensionKey']);
+        self::assertSame(1, $filters[0]['value']);
+        self::assertSame('age_group', $filters[1]['dimensionKey']);
+        self::assertSame('under_18', $filters[1]['value']);
+    }
+
+    public function testRefreshEditFormPreservesSubmittedFilters(): void
+    {
+        $testComponent = $this->createShellComponent();
+        $testComponent->call('openEdit');
+        $formName = $this->formName($testComponent->render());
+
+        $testComponent
+            ->submitForm($this->formPayload($formName, [
+                'filterUrgency' => '2',
+                'rowDimension' => 'gender',
+                'rowGrain' => 'total',
+            ]))
+            ->call('refreshEditForm')
+            ->call('applyEdit');
+
+        $filters = $testComponent->component()->appliedConfigState['query']['filters'] ?? [];
+        self::assertCount(1, $filters);
+        self::assertSame('urgency', $filters[0]['dimensionKey']);
+        self::assertSame(2, $filters[0]['value']);
+    }
+
     public function testFormChangeWithoutApplyDoesNotUpdateAppliedConfig(): void
     {
         $testComponent = $this->createShellComponent();

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisFilterChoiceProviderIntegrationTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisFilterChoiceProviderIntegrationTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Statistics\Integration\AnalysisExplorer;
 
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\IndicationGroupFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Statistics\AnalysisExplorer\Application\AnalysisFilterChoiceProvider;
 use App\Statistics\Application\Mapping\StatisticsAgeGroupFilter;
@@ -57,6 +59,8 @@ final class AnalysisFilterChoiceProviderIntegrationTest extends KernelTestCase
         self::assertNotEmpty($transportChoices);
         self::assertNotEmpty($genderChoices);
         self::assertContainsOnly('string', $urgencyChoices);
+        self::assertNotContains('U1', $urgencyChoices);
+        self::assertContains('Emergency Care', $urgencyChoices);
     }
 
     public function testAgeGroupChoicesIncludeAggregatesAndDecadeBuckets(): void
@@ -76,5 +80,42 @@ final class AnalysisFilterChoiceProviderIntegrationTest extends KernelTestCase
         self::assertArrayHasKey('', $choices);
         self::assertArrayHasKey(1, $choices);
         self::assertArrayHasKey(0, $choices);
+    }
+
+    public function testIndicationChoicesUseNameAndCodeLabel(): void
+    {
+        UserFactory::createOne();
+        $indication = IndicationNormalizedFactory::createOne([
+            'name' => 'STEMI',
+            'code' => 42,
+        ]);
+        $indicationId = $indication->getId();
+        self::assertNotNull($indicationId);
+
+        self::assertSame('STEMI (42)', $this->provider->indicationChoices()[$indicationId]);
+    }
+
+    public function testIndicationGroupChoicesReturnSeededLabels(): void
+    {
+        UserFactory::createOne();
+        $group = IndicationGroupFactory::createOne(['name' => 'Cardiac group']);
+        $groupId = $group->getId();
+        self::assertNotNull($groupId);
+
+        self::assertSame('Cardiac group', $this->provider->indicationGroupChoices()[$groupId]);
+    }
+
+    public function testSecondEntityChoiceCallUsesCachedReferenceData(): void
+    {
+        UserFactory::createOne();
+        DepartmentFactory::createOne(['name' => 'Cached Department']);
+
+        $first = $this->provider->departmentChoices();
+        DepartmentFactory::createOne(['name' => 'New Department']);
+        $second = $this->provider->departmentChoices();
+
+        self::assertSame($first, $second);
+        self::assertCount(1, $second);
+        self::assertSame('Cached Department', $second[array_key_first($second)]);
     }
 }

--- a/tests/Statistics/Integration/AnalysisExplorer/ExplorerAnalysisQueryFactoryTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/ExplorerAnalysisQueryFactoryTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Integration\AnalysisExplorer;
 
+use App\Allocation\Domain\Entity\IndicationGroup;
+use App\Allocation\Infrastructure\Factory\IndicationGroupFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
 use App\Statistics\AnalysisExplorer\Application\ExplorerAnalysisQueryFactory;
 use App\Statistics\AnalysisExplorer\Domain\AnalysisViewConfig;
 use App\Statistics\AnalysisExplorer\Domain\DTO\AnalysisAxisRef;
@@ -17,10 +20,19 @@ use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\Application\StatisticsPeriod;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisFilter;
+use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisFilterOperator;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
 
+#[ResetDatabase]
 final class ExplorerAnalysisQueryFactoryTest extends KernelTestCase
 {
+    use Factories;
+
     public function testCreateResolvesRollingPeriodForAllFilter(): void
     {
         self::bootKernel();
@@ -48,5 +60,51 @@ final class ExplorerAnalysisQueryFactoryTest extends KernelTestCase
 
         self::assertSame(StatisticsPeriod::overviewPeriodStart()->format('Y-m-d'), $query->periodBounds->from?->format('Y-m-d'));
         self::assertSame(AnalysisDimensionKey::Time, $query->rowAxis->dimensionKey);
+    }
+
+    public function testCreateExpandsIndicationGroupFilterForQueryExecution(): void
+    {
+        self::bootKernel();
+        $factory = self::getContainer()->get(ExplorerAnalysisQueryFactory::class);
+        \assert($factory instanceof ExplorerAnalysisQueryFactory);
+
+        UserFactory::createOne();
+        $indication = IndicationNormalizedFactory::createOne(['name' => 'Chest pain', 'code' => 101]);
+        $group = IndicationGroupFactory::createOne(['name' => 'Cardiac group']);
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $groupEntity = $entityManager->find(IndicationGroup::class, $group->getId());
+        self::assertNotNull($groupEntity);
+        $groupEntity->addIndication($indication);
+        $entityManager->flush();
+        $groupId = $group->getId();
+        $indicationId = $indication->getId();
+        self::assertNotNull($groupId);
+        self::assertNotNull($indicationId);
+
+        $query = $factory->create(
+            new AnalysisViewConfig(
+                dataSourceKey: AnalysisDataSourceKey::Allocations,
+                metricKeys: [AnalysisMetricKey::AllocationCount],
+                visualMetricKey: AnalysisMetricKey::AllocationCount,
+                rowAxis: AnalysisAxisRef::time(AnalysisDimensionGrain::Month),
+                columnAxis: null,
+                statisticsFilter: new StatisticsFilter(
+                    scope: StatisticsFilterScope::Public,
+                    hospitalId: null,
+                    cohortType: null,
+                    period: StatisticsFilterPeriod::All,
+                ),
+                presentation: new PresentationConfig(chartType: ChartPresentationType::Bar),
+                title: 'Filtered allocations',
+                filters: [
+                    new AnalysisFilter('indication_group', AnalysisFilterOperator::Equals, $groupId),
+                ],
+            ),
+            null,
+        );
+
+        self::assertCount(1, $query->filters);
+        self::assertSame('indication', $query->filters[0]->dimensionKey);
+        self::assertSame([$indicationId], $query->filters[0]->value);
     }
 }

--- a/tests/Statistics/Integration/AnalysisExplorer/ExplorerEditFormTypeTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/ExplorerEditFormTypeTest.php
@@ -54,7 +54,7 @@ final class ExplorerEditFormTypeTest extends KernelTestCase
             'locale' => 'en',
         ]);
 
-        self::assertTrue($form->get('filterDepartmentIds')->getConfig()->getOption('disabled'));
+        self::assertTrue($form->get('filterDepartmentId')->getConfig()->getOption('disabled'));
         self::assertTrue($form->get('filterUrgency')->getConfig()->getOption('disabled'));
     }
 
@@ -69,6 +69,19 @@ final class ExplorerEditFormTypeTest extends KernelTestCase
 
         self::assertTrue($form->get('filterUrgency')->getConfig()->getOption('disabled'));
         self::assertFalse($form->get('filterGender')->getConfig()->getOption('disabled'));
+    }
+
+    public function testPreSetDataDisablesIndicationGroupFilterWhenIndicationIsRowAxis(): void
+    {
+        $form = $this->formFactory->create(ExplorerEditFormType::class, $this->defaultFormData(
+            rowDimension: 'indication',
+            rowGrain: 'total',
+        ), [
+            'locale' => 'en',
+        ]);
+
+        self::assertTrue($form->get('filterIndicationId')->getConfig()->getOption('disabled'));
+        self::assertTrue($form->get('filterIndicationGroupId')->getConfig()->getOption('disabled'));
     }
 
     private function defaultFormData(

--- a/tests/Statistics/Integration/AnalysisExplorer/ExplorerFilterBadgePresenterIntegrationTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/ExplorerFilterBadgePresenterIntegrationTest.php
@@ -55,8 +55,8 @@ final class ExplorerFilterBadgePresenterIntegrationTest extends KernelTestCase
         self::assertNotNull($assignmentId);
 
         $badges = $this->presenter->present($this->viewConfig([
-            new AnalysisFilter('department', AnalysisFilterOperator::In, [$departmentId]),
-            new AnalysisFilter('speciality', AnalysisFilterOperator::In, [$specialityId]),
+            new AnalysisFilter('department', AnalysisFilterOperator::Equals, $departmentId),
+            new AnalysisFilter('speciality', AnalysisFilterOperator::Equals, $specialityId),
             new AnalysisFilter('assignment', AnalysisFilterOperator::Equals, $assignmentId),
             new AnalysisFilter('urgency', AnalysisFilterOperator::Equals, 1),
             new AnalysisFilter('gender', AnalysisFilterOperator::Equals, 2),
@@ -77,7 +77,7 @@ final class ExplorerFilterBadgePresenterIntegrationTest extends KernelTestCase
     {
         $badges = $this->presenter->present($this->viewConfig([
             new AnalysisFilter('custom_metric', AnalysisFilterOperator::Equals, ['a', 'b']),
-            new AnalysisFilter('department', AnalysisFilterOperator::In, [99]),
+            new AnalysisFilter('department', AnalysisFilterOperator::Equals, 99),
         ]));
 
         self::assertSame('custom_metric', $badges[0]['label']);

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerAnalysisFilterMapperTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerAnalysisFilterMapperTest.php
@@ -22,8 +22,8 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
     public function testFromFormDataMapsAllSupportedFilters(): void
     {
         $filters = $this->mapper->fromFormData(new ExplorerEditFormData(
-            filterDepartmentIds: [10, 20],
-            filterSpecialityIds: [3],
+            filterDepartmentId: 10,
+            filterSpecialityId: 3,
             filterUrgency: 1,
             filterTransportType: 2,
             filterGender: 1,
@@ -32,18 +32,25 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
             filterCpr: false,
             filterVentilation: true,
             filterAssignmentId: 7,
+            filterIndicationId: 11,
+            filterSecondaryIndicationId: 21,
+            filterIndicationGroupId: 4,
         ));
 
-        self::assertCount(10, $filters);
+        self::assertCount(13, $filters);
         self::assertSame('department', $filters[0]->dimensionKey);
-        self::assertSame(AnalysisFilterOperator::In, $filters[0]->operator);
-        self::assertSame([10, 20], $filters[0]->value);
+        self::assertSame(AnalysisFilterOperator::Equals, $filters[0]->operator);
+        self::assertSame(10, $filters[0]->value);
         self::assertSame('urgency', $filters[2]->dimensionKey);
         self::assertSame(1, $filters[2]->value);
         self::assertSame('resus', $filters[6]->dimensionKey);
         self::assertSame(1, $filters[6]->value);
         self::assertSame('cpr', $filters[7]->dimensionKey);
         self::assertSame(0, $filters[7]->value);
+        self::assertSame('indication', $filters[10]->dimensionKey);
+        self::assertSame(11, $filters[10]->value);
+        self::assertSame('indication_group', $filters[12]->dimensionKey);
+        self::assertSame(4, $filters[12]->value);
     }
 
     public function testFromFormDataIgnoresEmptyValues(): void
@@ -54,7 +61,7 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
     public function testApplyToFormDataRoundTripsFilters(): void
     {
         $original = new ExplorerEditFormData(
-            filterDepartmentIds: [5],
+            filterDepartmentId: 5,
             filterUrgency: 2,
             filterAgeGroup: 'over_80',
             filterResus: false,
@@ -63,7 +70,7 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
         $filters = $this->mapper->fromFormData($original);
         $restored = $this->mapper->applyToFormData(new ExplorerEditFormData(), $filters);
 
-        self::assertSame([5], $restored->filterDepartmentIds);
+        self::assertSame(5, $restored->filterDepartmentId);
         self::assertSame(2, $restored->filterUrgency);
         self::assertSame('over_80', $restored->filterAgeGroup);
         self::assertFalse($restored->filterResus);
@@ -74,7 +81,7 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
     {
         $filters = [
             new AnalysisFilter('gender', AnalysisFilterOperator::Equals, 2),
-            new AnalysisFilter('department', AnalysisFilterOperator::In, [1, 2]),
+            new AnalysisFilter('department', AnalysisFilterOperator::Equals, 1),
         ];
 
         $state = $this->mapper->toStateArray($filters);
@@ -83,7 +90,7 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
         self::assertCount(2, $restored);
         self::assertSame('gender', $restored[0]->dimensionKey);
         self::assertSame(2, $restored[0]->value);
-        self::assertSame([1, 2], $restored[1]->value);
+        self::assertSame(1, $restored[1]->value);
     }
 
     public function testFromStateArraySkipsInvalidRowsAndUnknownDimensions(): void
@@ -112,7 +119,7 @@ final class ExplorerAnalysisFilterMapperTest extends TestCase
             new AnalysisFilter('unknown_axis', AnalysisFilterOperator::Equals, 1),
         ]);
 
-        self::assertSame([10, 20], $restored->filterDepartmentIds);
+        self::assertSame(10, $restored->filterDepartmentId);
         self::assertSame(3, $restored->filterUrgency);
         self::assertSame('30_39', $restored->filterAgeGroup);
         self::assertTrue($restored->filterVentilation);

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditFormFilterFieldMapperTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditFormFilterFieldMapperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerEditFormFilterFieldMapper;
+use App\Statistics\AnalysisExplorer\UI\Form\Data\ExplorerEditFormData;
+use PHPUnit\Framework\TestCase;
+
+final class ExplorerEditFormFilterFieldMapperTest extends TestCase
+{
+    private ExplorerEditFormFilterFieldMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ExplorerEditFormFilterFieldMapper();
+    }
+
+    public function testMergeSubmittedFiltersCoercesScalarValues(): void
+    {
+        $merged = $this->mapper->mergeSubmittedFilters(new ExplorerEditFormData(), [
+            'filterDepartmentId' => '10',
+            'filterUrgency' => '2',
+            'filterAgeGroup' => 'under_18',
+            'filterResus' => '1',
+            'filterIndicationId' => '5',
+            'filterIndicationGroupId' => '3',
+        ]);
+
+        self::assertSame(10, $merged->filterDepartmentId);
+        self::assertSame(2, $merged->filterUrgency);
+        self::assertSame('under_18', $merged->filterAgeGroup);
+        self::assertTrue($merged->filterResus);
+        self::assertSame(5, $merged->filterIndicationId);
+        self::assertSame(3, $merged->filterIndicationGroupId);
+    }
+
+    public function testMergeSubmittedFiltersKeepsCurrentWhenKeyMissing(): void
+    {
+        $current = new ExplorerEditFormData(filterUrgency: 1, filterIndicationId: 7);
+
+        $merged = $this->mapper->mergeSubmittedFilters($current, []);
+
+        self::assertSame(7, $merged->filterIndicationId);
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditFormNormalizerTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditFormNormalizerTest.php
@@ -161,6 +161,24 @@ final class ExplorerEditFormNormalizerTest extends KernelTestCase
         self::assertSame('total', $normalized->columnGrain);
     }
 
+    public function testNormalizePreservesFilterFields(): void
+    {
+        $normalized = $this->normalizer->normalize(new ExplorerEditFormData(
+            scopePeriod: new StatisticsScopePeriodFormData('public', null, 'all'),
+            rowDimension: 'time',
+            rowGrain: 'month',
+            metric: 'allocation_count',
+            chartType: 'bar',
+            filterUrgency: 2,
+            filterIndicationId: 15,
+            filterIndicationGroupId: 3,
+        ));
+
+        self::assertSame(2, $normalized->filterUrgency);
+        self::assertSame(15, $normalized->filterIndicationId);
+        self::assertSame(3, $normalized->filterIndicationGroupId);
+    }
+
     private function formData(
         string $rowDimension,
         ?string $rowGrain,

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -329,6 +329,22 @@
         <source>label.all_urgencies</source>
         <target>Alle Dringlichkeiten</target>
       </trans-unit>
+      <trans-unit id="lblAllGendersDe" resname="label.all_genders">
+        <source>label.all_genders</source>
+        <target>Alle Geschlechter</target>
+      </trans-unit>
+      <trans-unit id="lblAllAgeGroupsDe" resname="label.all_age_groups">
+        <source>label.all_age_groups</source>
+        <target>Alle Altersgruppen</target>
+      </trans-unit>
+      <trans-unit id="lblAllSecIndDe" resname="label.all_secondary_indications">
+        <source>label.all_secondary_indications</source>
+        <target>Alle Sekundärindikationen</target>
+      </trans-unit>
+      <trans-unit id="lblAllIndGrpDe" resname="label.all_indication_groups">
+        <source>label.all_indication_groups</source>
+        <target>Alle Indikationsgruppen</target>
+      </trans-unit>
       <trans-unit id="lblAllocationDe" resname="label.allocation">
         <source>label.allocation</source>
         <target>Zuweisung</target>
@@ -684,6 +700,14 @@
       <trans-unit id="De3c1a2121" resname="label.indication">
         <source>label.indication</source>
         <target>Indikation</target>
+      </trans-unit>
+      <trans-unit id="LblSecIndDe" resname="label.secondary_indication">
+        <source>label.secondary_indication</source>
+        <target>Sekundärindikation</target>
+      </trans-unit>
+      <trans-unit id="LblIndGrpDe" resname="label.indication_group">
+        <source>label.indication_group</source>
+        <target>Indikationsgruppe</target>
       </trans-unit>
       <trans-unit id="De68ef184a" resname="label.indication.code">
         <source>label.indication.code</source>

--- a/translations/messages+intl-icu.en.xlf
+++ b/translations/messages+intl-icu.en.xlf
@@ -277,6 +277,22 @@
         <source>label.all_urgencies</source>
         <target>All urgencies</target>
       </trans-unit>
+      <trans-unit id="lblAllGendersEn" resname="label.all_genders">
+        <source>label.all_genders</source>
+        <target>All genders</target>
+      </trans-unit>
+      <trans-unit id="lblAllAgeGroupsEn" resname="label.all_age_groups">
+        <source>label.all_age_groups</source>
+        <target>All age groups</target>
+      </trans-unit>
+      <trans-unit id="lblAllSecIndEn" resname="label.all_secondary_indications">
+        <source>label.all_secondary_indications</source>
+        <target>All secondary indications</target>
+      </trans-unit>
+      <trans-unit id="lblAllIndGrpEn" resname="label.all_indication_groups">
+        <source>label.all_indication_groups</source>
+        <target>All indication groups</target>
+      </trans-unit>
       <trans-unit id="allocAllDept" resname="label.all_departments">
         <source>label.all_departments</source>
         <target>All departments</target>
@@ -524,6 +540,14 @@
       <trans-unit id="UcOVbOd" resname="label.indication">
         <source>label.indication</source>
         <target>Indication</target>
+      </trans-unit>
+      <trans-unit id="LblSecInd" resname="label.secondary_indication">
+        <source>label.secondary_indication</source>
+        <target>Secondary indication</target>
+      </trans-unit>
+      <trans-unit id="LblIndGrp" resname="label.indication_group">
+        <source>label.indication_group</source>
+        <target>Indication group</target>
       </trans-unit>
       <trans-unit id="vBKlakB" resname="label.indication.code">
         <source>label.indication.code</source>


### PR DESCRIPTION
## Summary

- **Fix filter persistence** — Analysis filters were lost on Apply because the Live Component round-trip did not carry `filter*` fields through `syncFormDataFromForm`, the normalizer, and the axis swapper. A dedicated `ExplorerEditFormFilterFieldMapper` now merges submitted filter values reliably.
- **Extend allocation filters** — Adds primary/secondary indication and indication-group filters. Virtual `indication_group` filters are expanded to member indications at query time; badges show readable labels.
- **Cache entity filter choices** — Reuses `ExploreFilterOptionsProvider` (`cache.allocation.reference_data`, TTL 1h) for department, speciality, assignment, indication, and indication-group dropdowns. Urgency labels now come from `AllocationUrgency` instead of raw projection codes.
- **Improve filter drawer UX** — Replaces hidden labels + duplicate help text with compact field labels and contextual placeholders (e.g. “All urgencies”). Entity filters are single-select dropdowns instead of multi-select.
- **Docs** — Updates `analysis-explorer.md` and `explore-filter-reference-cache.md` for the new filter behaviour and shared cache.

## Test plan

- [x] Open Analysis Explorer edit drawer → set department, urgency, and indication filters → Apply → filters remain active and badges show correct labels
- [x] Refresh/reopen drawer after Apply → filter dropdowns still show selected values
- [x] Select an indication group → results narrow to group members; badge shows group name
- [x] Use indication as row/column axis → related filters are disabled as expected
- [x] After cache warmup, reopen drawer → no noticeable delay loading reference-data dropdowns
- [x] `php bin/phpunit tests/Statistics/Unit/AnalysisExplorer/ tests/Statistics/Integration/AnalysisExplorer/ tests/Allocation/Integration/Application/Explore/ExploreFilterOptionsProviderTest.php`