### PR TITLE
feat: live password strength feedback

### DIFF
--- a/assets/controllers/password_strength_controller.js
+++ b/assets/controllers/password_strength_controller.js
@@ -1,0 +1,172 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['input', 'feedback', 'meter', 'meterBar', 'meterLabel', 'requirement'];
+
+    static values = {
+        policy: Object,
+        strengthLabels: Array,
+        acceptableLabel: String,
+    };
+
+    connect() {
+        this.evaluate();
+    }
+
+    evaluate() {
+        const password = this.inputTarget.value;
+        const policy = this.policyValue;
+        const strength = estimateStrength(password);
+        const hasPassword = password.length > 0;
+
+        this.updateMeter(password, strength, hasPassword, policy);
+        this.updateRequirements(password, strength, policy);
+    }
+
+    updateMeter(password, strength, hasPassword, policy) {
+        const labels = this.strengthLabelsValue;
+        const levelCount = this.policyValue.strengthLevelCount ?? 5;
+        const requirementsMet =
+            password.length >= policy.minLength && strength >= policy.minStrengthScore;
+        let percent = hasPassword ? Math.round(((strength + 1) / levelCount) * 100) : 0;
+
+        this.meterTarget.setAttribute('aria-valuenow', String(percent));
+        this.meterBarTarget.style.width = `${percent}%`;
+        this.meterBarTarget.classList.remove('bg-danger', 'bg-warning', 'bg-success');
+
+        if (!hasPassword) {
+            this.meterLabelTarget.textContent = '';
+            this.meterBarTarget.classList.add('bg-danger');
+            this.feedbackTarget.classList.add('opacity-75');
+
+            return;
+        }
+
+        this.feedbackTarget.classList.remove('opacity-75');
+
+        if (requirementsMet) {
+            if (strength >= 2) {
+                this.meterLabelTarget.textContent = labels[strength] ?? '';
+            } else {
+                this.meterLabelTarget.textContent = this.acceptableLabelValue;
+                percent = Math.max(
+                    percent,
+                    Math.round(((policy.minStrengthScore + 1) / levelCount) * 100),
+                );
+                this.meterTarget.setAttribute('aria-valuenow', String(percent));
+                this.meterBarTarget.style.width = `${percent}%`;
+            }
+
+            this.meterBarTarget.classList.add('bg-success');
+
+            return;
+        }
+
+        this.meterLabelTarget.textContent = labels[strength] ?? labels[0] ?? '';
+
+        if (strength <= 1) {
+            this.meterBarTarget.classList.add('bg-danger');
+        } else if (strength === 2) {
+            this.meterBarTarget.classList.add('bg-warning');
+        } else {
+            this.meterBarTarget.classList.add('bg-success');
+        }
+    }
+
+    updateRequirements(password, strength, policy) {
+        const checks = {
+            min_length: password.length >= policy.minLength,
+            strength: strength >= policy.minStrengthScore,
+        };
+
+        this.requirementTargets.forEach((element) => {
+            const key = element.dataset.passwordStrengthRequirementParam;
+            const met = checks[key] ?? false;
+            const metIcon = element.querySelector(
+                '[data-password-strength-target="requirementMetIcon"]',
+            );
+            const openIcon = element.querySelector(
+                '[data-password-strength-target="requirementOpenIcon"]',
+            );
+
+            element.classList.toggle('text-success', met);
+            element.classList.toggle('text-muted', !met);
+
+            if (metIcon) {
+                metIcon.classList.toggle('d-none', !met);
+            }
+
+            if (openIcon) {
+                openIcon.classList.toggle('d-none', met);
+            }
+        });
+    }
+}
+
+/**
+ * Mirrors Symfony\Component\Validator\Constraints\PasswordStrengthValidator::estimateStrength().
+ *
+ * @returns {0|1|2|3|4}
+ */
+function estimateStrength(password) {
+    const length = password.length;
+
+    if (0 === length) {
+        return 0;
+    }
+
+    const charCounts = {};
+    for (let index = 0; index < length; index += 1) {
+        const chr = password.charCodeAt(index);
+        charCounts[chr] = (charCounts[chr] ?? 0) + 1;
+    }
+
+    const chars = Object.keys(charCounts).length;
+    let control = 0;
+    let digit = 0;
+    let upper = 0;
+    let lower = 0;
+    let symbol = 0;
+    let other = 0;
+
+    for (const chrKey of Object.keys(charCounts)) {
+        const chr = Number(chrKey);
+
+        if (chr < 32 || 127 === chr) {
+            control = 33;
+        } else if (chr >= 48 && chr <= 57) {
+            digit = 10;
+        } else if (chr >= 65 && chr <= 90) {
+            upper = 26;
+        } else if (chr >= 97 && chr <= 122) {
+            lower = 26;
+        } else if (chr >= 128) {
+            other = 128;
+        } else {
+            symbol = 33;
+        }
+    }
+
+    const pool = lower + upper + digit + symbol + control + other;
+    const entropy =
+        chars * (Math.log(pool) / Math.log(2)) + (length - chars) * (Math.log(chars) / Math.log(2));
+
+    if (entropy >= 120) {
+        return 4;
+    }
+
+    if (entropy >= 100) {
+        return 3;
+    }
+
+    if (entropy >= 80) {
+        return 2;
+    }
+
+    if (entropy >= 60) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/Shared/UI/Twig/templates/form/password_visibility_theme.html.twig
+++ b/src/Shared/UI/Twig/templates/form/password_visibility_theme.html.twig
@@ -1,12 +1,27 @@
 {% use 'bootstrap_5_layout.html.twig' %}
 
 {%- block password_widget -%}
-    <div data-controller="password-visibility"
+    {% set strength_feedback = strength_feedback|default(false) %}
+    <div data-controller="password-visibility{% if strength_feedback %} password-strength{% endif %}"
          data-password-visibility-show-label-value="{{ 'label.password.show'|trans({}, 'user') }}"
-         data-password-visibility-hide-label-value="{{ 'label.password.hide'|trans({}, 'user') }}">
+         data-password-visibility-hide-label-value="{{ 'label.password.hide'|trans({}, 'user') }}"
+         {%- if strength_feedback %}
+         data-password-strength-policy-value="{{ password_strength_policy|json_encode|e('html_attr') }}"
+         data-password-strength-strength-labels-value="{{ {
+             0: 'password.strength.very_weak'|trans({}, 'user'),
+             1: 'password.strength.weak'|trans({}, 'user'),
+             2: 'password.strength.medium'|trans({}, 'user'),
+             3: 'password.strength.strong'|trans({}, 'user'),
+             4: 'password.strength.very_strong'|trans({}, 'user'),
+         }|json_encode|e('html_attr') }}"
+         data-password-strength-acceptable-label-value="{{ 'password.strength.acceptable'|trans({}, 'user')|e('html_attr') }}"
+         {%- endif %}>
         <div class="input-group">
             {%- set type = type|default('password') -%}
             {%- set attr = attr|merge({'data-password-visibility-target': 'input'}) -%}
+            {%- if strength_feedback -%}
+                {%- set attr = attr|merge({'data-password-strength-target': 'input', 'data-action': 'input->password-strength#evaluate'}) -%}
+            {%- endif -%}
             {{- block('form_widget_simple') -}}
             <button type="button"
                     class="btn"
@@ -25,5 +40,51 @@
                 </span>
             </button>
         </div>
+        {%- if strength_feedback -%}
+            <div class="mt-2"
+                 data-testid="password-strength-{{ id }}"
+                 data-password-strength-target="feedback">
+                <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span class="small text-secondary">{{ 'password.strength.label'|trans({}, 'user') }}</span>
+                    <span class="small fw-medium"
+                          data-password-strength-target="meterLabel"
+                          aria-live="polite"></span>
+                </div>
+                <div class="progress progress-sm mb-2"
+                     role="progressbar"
+                     aria-valuemin="0"
+                     aria-valuemax="100"
+                     data-password-strength-target="meter"
+                     aria-valuenow="0">
+                    <div class="progress-bar"
+                         style="width: 0%"
+                         data-password-strength-target="meterBar"></div>
+                </div>
+                <ul class="list-unstyled small mb-0">
+                    <li class="d-flex align-items-center gap-2 text-muted"
+                        data-password-strength-target="requirement"
+                        data-password-strength-requirement-param="min_length">
+                        <span class="text-success d-none" data-password-strength-target="requirementMetIcon" aria-hidden="true">
+                            <twig:ux:icon name="tabler:check" class="icon" />
+                        </span>
+                        <span data-password-strength-target="requirementOpenIcon" aria-hidden="true">
+                            <twig:ux:icon name="tabler:circle" class="icon" />
+                        </span>
+                        <span>{{ 'password.requirement.min_length'|trans({min: password_strength_policy.minLength}, 'user') }}</span>
+                    </li>
+                    <li class="d-flex align-items-center gap-2 text-muted"
+                        data-password-strength-target="requirement"
+                        data-password-strength-requirement-param="strength">
+                        <span class="text-success d-none" data-password-strength-target="requirementMetIcon" aria-hidden="true">
+                            <twig:ux:icon name="tabler:check" class="icon" />
+                        </span>
+                        <span data-password-strength-target="requirementOpenIcon" aria-hidden="true">
+                            <twig:ux:icon name="tabler:circle" class="icon" />
+                        </span>
+                        <span>{{ 'password.requirement.strength'|trans({}, 'user') }}</span>
+                    </li>
+                </ul>
+            </div>
+        {%- endif -%}
     </div>
 {%- endblock password_widget -%}

--- a/src/User/Domain/Validator/UserPasswordConstraints.php
+++ b/src/User/Domain/Validator/UserPasswordConstraints.php
@@ -11,6 +11,12 @@ use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 final class UserPasswordConstraints
 {
+    public const int MIN_LENGTH = 8;
+
+    public const int MAX_LENGTH = 4096;
+
+    public const int MIN_STRENGTH_SCORE = PasswordStrength::STRENGTH_WEAK;
+
     /**
      * Moderate password rules: min length, basic strength, breached-password check.
      *
@@ -20,9 +26,22 @@ final class UserPasswordConstraints
     {
         return [
             new NotBlank(),
-            new Length(min: 8, max: 4096),
-            new PasswordStrength(minScore: PasswordStrength::STRENGTH_WEAK),
+            new Length(min: self::MIN_LENGTH, max: self::MAX_LENGTH),
+            new PasswordStrength(minScore: self::MIN_STRENGTH_SCORE),
             new NotCompromisedPassword(),
+        ];
+    }
+
+    /**
+     * @return array{minLength: int, maxLength: int, minStrengthScore: int, strengthLevelCount: int}
+     */
+    public static function clientConfig(): array
+    {
+        return [
+            'minLength' => self::MIN_LENGTH,
+            'maxLength' => self::MAX_LENGTH,
+            'minStrengthScore' => self::MIN_STRENGTH_SCORE,
+            'strengthLevelCount' => PasswordStrength::STRENGTH_VERY_STRONG + 1,
         ];
     }
 }

--- a/src/User/UI/Form/ForceChangePasswordType.php
+++ b/src/User/UI/Form/ForceChangePasswordType.php
@@ -6,7 +6,6 @@ namespace App\User\UI\Form;
 
 use App\User\Domain\Validator\UserPasswordConstraints;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -20,11 +19,14 @@ final class ForceChangePasswordType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('plainPassword', RepeatedType::class, [
-            'type' => PasswordType::class,
+            'type' => UserPasswordType::class,
             'mapped' => false,
             'invalid_message' => 'validation.password.mismatch',
             'first_options' => ['label' => 'label.settings.new_password'],
-            'second_options' => ['label' => 'label.settings.repeat_new_password'],
+            'second_options' => [
+                'label' => 'label.settings.repeat_new_password',
+                'strength_feedback' => false,
+            ],
             'constraints' => UserPasswordConstraints::forPlainPassword(),
         ]);
     }

--- a/src/User/UI/Form/RegistrationFormType.php
+++ b/src/User/UI/Form/RegistrationFormType.php
@@ -8,7 +8,6 @@ use App\User\Domain\Validator\UserPasswordConstraints;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -42,7 +41,7 @@ final class RegistrationFormType extends AbstractType
                     new Email(),
                 ],
             ])
-            ->add('plainPassword', PasswordType::class, [
+            ->add('plainPassword', UserPasswordType::class, [
                 'mapped' => false,
                 'label' => 'label.password',
                 'translation_domain' => 'user',

--- a/src/User/UI/Form/ResetPasswordFormType.php
+++ b/src/User/UI/Form/ResetPasswordFormType.php
@@ -6,7 +6,6 @@ namespace App\User\UI\Form;
 
 use App\User\Domain\Validator\UserPasswordConstraints;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -20,11 +19,14 @@ final class ResetPasswordFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('plainPassword', RepeatedType::class, [
-            'type' => PasswordType::class,
+            'type' => UserPasswordType::class,
             'mapped' => false,
             'invalid_message' => 'validation.password.mismatch',
             'first_options' => ['label' => 'label.settings.new_password'],
-            'second_options' => ['label' => 'label.settings.repeat_new_password'],
+            'second_options' => [
+                'label' => 'label.settings.repeat_new_password',
+                'strength_feedback' => false,
+            ],
             'constraints' => UserPasswordConstraints::forPlainPassword(),
         ]);
     }

--- a/src/User/UI/Form/SettingsPasswordType.php
+++ b/src/User/UI/Form/SettingsPasswordType.php
@@ -27,11 +27,14 @@ final class SettingsPasswordType extends AbstractType
                 'constraints' => [new NotBlank()],
             ])
             ->add('plainPassword', RepeatedType::class, [
-                'type' => PasswordType::class,
+                'type' => UserPasswordType::class,
                 'mapped' => false,
                 'invalid_message' => 'validation.password.mismatch',
                 'first_options' => ['label' => 'label.settings.new_password'],
-                'second_options' => ['label' => 'label.settings.repeat_new_password'],
+                'second_options' => [
+                    'label' => 'label.settings.repeat_new_password',
+                    'strength_feedback' => false,
+                ],
                 'constraints' => UserPasswordConstraints::forPlainPassword(),
             ]);
     }

--- a/src/User/UI/Form/UserPasswordType.php
+++ b/src/User/UI/Form/UserPasswordType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Form;
+
+use App\User\Domain\Validator\UserPasswordConstraints;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @extends AbstractType<string|null>
+ */
+final class UserPasswordType extends AbstractType
+{
+    #[\Override]
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['strength_feedback'] = $options['strength_feedback'];
+
+        if ($options['strength_feedback']) {
+            $view->vars['password_strength_policy'] = UserPasswordConstraints::clientConfig();
+        }
+    }
+
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'strength_feedback' => true,
+        ]);
+
+        $resolver->setAllowedTypes('strength_feedback', 'bool');
+    }
+
+    #[\Override]
+    public function getParent(): string
+    {
+        return PasswordType::class;
+    }
+}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -300,4 +300,27 @@ final class RegistrationControllerTest extends WebTestCase
             })
         ;
     }
+
+    public function testRegistrationPasswordFieldShowsStrengthFeedbackUi(): void
+    {
+        $this->browser()
+            ->visit('/register')
+            ->assertSuccessful()
+            ->assertSeeElement('[data-testid="password-strength-registration_form_plainPassword"]')
+            ->assertSee('Password strength')
+            ->assertSee('At least 8 characters')
+            ->assertSee('Sufficient password strength')
+            ->use(static function (Crawler $crawler): void {
+                $wrapper = $crawler->filter('[data-controller*="password-strength"]');
+                $input = $crawler->filter('input[name="registration_form[plainPassword]"]');
+
+                self::assertCount(1, $wrapper);
+                self::assertStringContainsString('password-visibility', (string) $wrapper->attr('data-controller'));
+                self::assertStringContainsString('password-strength', (string) $wrapper->attr('data-controller'));
+                self::assertSame('input->password-strength#evaluate', $input->attr('data-action'));
+                self::assertNotEmpty($wrapper->attr('data-password-strength-policy-value'));
+                self::assertNotEmpty($wrapper->attr('data-password-strength-strength-labels-value'));
+            })
+        ;
+    }
 }

--- a/tests/User/Functional/Controller/ResetPasswordControllerTest.php
+++ b/tests/User/Functional/Controller/ResetPasswordControllerTest.php
@@ -9,6 +9,8 @@ use App\User\Domain\Factory\UserFactory;
 use App\User\Infrastructure\Repository\ResetPasswordRequestRepository;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
@@ -81,6 +83,34 @@ final class ResetPasswordControllerTest extends WebTestCase
         $user = $this->getUserRepository()->findOneBy(['email' => 'disabled@example.test']);
         self::assertInstanceOf(User::class, $user);
         self::assertSame(0, $this->getResetPasswordRequestRepository()->count(['user' => $user]));
+    }
+
+    public function testResetPasswordFormShowsStrengthFeedbackOnNewPasswordFieldOnly(): void
+    {
+        $user = UserFactory::new([
+            'email' => 'reset-pwd-ui@example.test',
+            'isVerified' => true,
+            'username' => 'reset-pwd-ui-user',
+        ])->create();
+
+        $resetToken = self::getContainer()->get(ResetPasswordHelperInterface::class)->generateResetToken($user);
+
+        $this->browser()
+            ->visit('/reset-password/reset/'.$resetToken->getToken())
+            ->assertSuccessful()
+            ->assertSee('Set a new password')
+            ->assertSee('Password strength')
+            ->use(static function (Crawler $crawler): void {
+                self::assertGreaterThan(
+                    0,
+                    $crawler->filter('[data-testid^="password-strength-"][data-testid*="_first"]')->count(),
+                );
+                self::assertCount(
+                    0,
+                    $crawler->filter('[data-testid^="password-strength-"][data-testid*="_second"]'),
+                );
+            })
+        ;
     }
 
     private function getUserRepository(): UserRepository

--- a/tests/User/Functional/Controller/SecurityControllerTest.php
+++ b/tests/User/Functional/Controller/SecurityControllerTest.php
@@ -203,4 +203,19 @@ final class SecurityControllerTest extends WebTestCase
             })
         ;
     }
+
+    public function testLoginPasswordFieldDoesNotShowStrengthFeedbackUi(): void
+    {
+        $this->browser()
+            ->visit('/login')
+            ->assertSuccessful()
+            ->assertNotSeeElement('[data-testid="password-strength-login_password"]')
+            ->use(static function (Crawler $crawler): void {
+                $wrapper = $crawler->filter('[data-controller="password-visibility"]');
+
+                self::assertCount(1, $wrapper);
+                self::assertStringNotContainsString('password-strength', (string) $wrapper->attr('data-controller'));
+            })
+        ;
+    }
 }

--- a/tests/User/Functional/Controller/SettingsControllerTest.php
+++ b/tests/User/Functional/Controller/SettingsControllerTest.php
@@ -133,6 +133,8 @@ final class SettingsControllerTest extends WebTestCase
             ->visit('/settings/password')
             ->assertSuccessful()
             ->assertSee('Change password')
+            ->assertSee('Password strength')
+            ->assertSeeElement('[data-controller*="password-strength"]')
         ;
     }
 
@@ -152,6 +154,23 @@ final class SettingsControllerTest extends WebTestCase
             ->click('Save password')
             ->assertSuccessful()
             ->assertSee('Current password is invalid.')
+        ;
+    }
+
+    public function testForcePasswordChangeShowsStrengthFeedbackUi(): void
+    {
+        UserFactory::new([
+            'credentialsExpired' => true,
+            'email' => 'force-pwd-ui@example.test',
+            'isVerified' => true,
+            'username' => 'force-pwd-ui-user',
+        ])->create();
+
+        $this->loginWithConsent($this->browser(), 'force-pwd-ui-user')
+            ->assertSuccessful()
+            ->assertSee('Set a new password')
+            ->assertSee('Password strength')
+            ->assertSeeElement('[data-controller*="password-strength"]')
         ;
     }
 

--- a/tests/User/Integration/UI/Form/PasswordFormTypeTest.php
+++ b/tests/User/Integration/UI/Form/PasswordFormTypeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\UI\Form;
+
+use App\User\Domain\Validator\UserPasswordConstraints;
+use App\User\UI\Form\ForceChangePasswordType;
+use App\User\UI\Form\ResetPasswordFormType;
+use App\User\UI\Form\SettingsPasswordType;
+use App\User\UI\Form\UserPasswordType;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormView;
+
+final class PasswordFormTypeTest extends KernelTestCase
+{
+    private FormFactoryInterface $formFactory;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->formFactory = self::getContainer()->get(FormFactoryInterface::class);
+    }
+
+    public function testResetPasswordFormConfiguresStrengthFeedbackOnFirstFieldOnly(): void
+    {
+        $form = $this->formFactory->create(ResetPasswordFormType::class);
+
+        self::assertTrue($form->has('plainPassword'));
+        self::assertSame('user', $form->getConfig()->getOption('translation_domain'));
+        self::assertNull($form->getConfig()->getOption('data_class'));
+
+        $first = $form->get('plainPassword')->get('first');
+        $second = $form->get('plainPassword')->get('second');
+
+        self::assertTrue($first->getConfig()->getOption('strength_feedback'));
+        self::assertFalse($second->getConfig()->getOption('strength_feedback'));
+        self::assertSame(UserPasswordType::class, $first->getConfig()->getType()->getInnerType()::class);
+
+        $this->assertStrengthFeedbackView($first->createView(), enabled: true);
+        $this->assertStrengthFeedbackView($second->createView(), enabled: false);
+    }
+
+    public function testForceChangePasswordFormConfiguresStrengthFeedbackOnFirstFieldOnly(): void
+    {
+        $form = $this->formFactory->create(ForceChangePasswordType::class);
+
+        self::assertTrue($form->has('plainPassword'));
+        self::assertSame('user', $form->getConfig()->getOption('translation_domain'));
+        self::assertNull($form->getConfig()->getOption('data_class'));
+
+        $first = $form->get('plainPassword')->get('first');
+        $second = $form->get('plainPassword')->get('second');
+
+        self::assertTrue($first->getConfig()->getOption('strength_feedback'));
+        self::assertFalse($second->getConfig()->getOption('strength_feedback'));
+
+        $this->assertStrengthFeedbackView($first->createView(), enabled: true);
+        $this->assertStrengthFeedbackView($second->createView(), enabled: false);
+    }
+
+    public function testSettingsPasswordFormKeepsCurrentPasswordWithoutStrengthFeedback(): void
+    {
+        $form = $this->formFactory->create(SettingsPasswordType::class);
+
+        self::assertTrue($form->has('currentPassword'));
+        self::assertInstanceOf(
+            PasswordType::class,
+            $form->get('currentPassword')->getConfig()->getType()->getInnerType(),
+        );
+        self::assertFalse($form->get('currentPassword')->getConfig()->hasOption('strength_feedback'));
+
+        $first = $form->get('plainPassword')->get('first');
+        $second = $form->get('plainPassword')->get('second');
+
+        self::assertTrue($first->getConfig()->getOption('strength_feedback'));
+        self::assertFalse($second->getConfig()->getOption('strength_feedback'));
+    }
+
+    public function testUserPasswordTypeExposesPolicyConfigOnlyWhenFeedbackEnabled(): void
+    {
+        $enabledForm = $this->formFactory->create(UserPasswordType::class);
+        $disabledForm = $this->formFactory->create(UserPasswordType::class, null, [
+            'strength_feedback' => false,
+        ]);
+
+        $this->assertStrengthFeedbackView($enabledForm->createView(), enabled: true);
+        $this->assertStrengthFeedbackView($disabledForm->createView(), enabled: false);
+    }
+
+    private function assertStrengthFeedbackView(FormView $view, bool $enabled): void
+    {
+        self::assertSame($enabled, $view->vars['strength_feedback']);
+
+        if ($enabled) {
+            self::assertSame(UserPasswordConstraints::clientConfig(), $view->vars['password_strength_policy']);
+
+            return;
+        }
+
+        self::assertArrayNotHasKey('password_strength_policy', $view->vars);
+    }
+}

--- a/tests/User/Unit/Domain/Validator/UserPasswordConstraintsTest.php
+++ b/tests/User/Unit/Domain/Validator/UserPasswordConstraintsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Unit\Domain\Validator;
+
+use App\User\Domain\Validator\UserPasswordConstraints;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
+use Symfony\Component\Validator\Constraints\PasswordStrengthValidator;
+
+final class UserPasswordConstraintsTest extends TestCase
+{
+    public function testClientConfigMatchesPolicyConstants(): void
+    {
+        self::assertSame([
+            'minLength' => UserPasswordConstraints::MIN_LENGTH,
+            'maxLength' => UserPasswordConstraints::MAX_LENGTH,
+            'minStrengthScore' => UserPasswordConstraints::MIN_STRENGTH_SCORE,
+            'strengthLevelCount' => PasswordStrength::STRENGTH_VERY_STRONG + 1,
+        ], UserPasswordConstraints::clientConfig());
+    }
+
+    public function testForPlainPasswordUsesPolicyConstants(): void
+    {
+        $constraints = UserPasswordConstraints::forPlainPassword();
+
+        self::assertCount(4, $constraints);
+    }
+
+    #[DataProvider('estimateStrengthProvider')]
+    public function testEstimateStrength(string $password, int $expectedStrength): void
+    {
+        self::assertSame($expectedStrength, PasswordStrengthValidator::estimateStrength($password));
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function estimateStrengthProvider(): iterable
+    {
+        yield 'empty password' => ['', PasswordStrength::STRENGTH_VERY_WEAK];
+        yield 'short password' => ['short', PasswordStrength::STRENGTH_VERY_WEAK];
+        yield 'numeric password' => ['12345678', PasswordStrength::STRENGTH_VERY_WEAK];
+        yield 'strong passphrase' => ['super-secret-password', PasswordStrength::STRENGTH_STRONG];
+    }
+}

--- a/translations/user+intl-icu.de.xlf
+++ b/translations/user+intl-icu.de.xlf
@@ -189,6 +189,42 @@
         <source>label.password.show</source>
         <target>Passwort anzeigen</target>
       </trans-unit>
+      <trans-unit id="pwdStrLblDe" resname="password.strength.label">
+        <source>password.strength.label</source>
+        <target>Passwortstärke</target>
+      </trans-unit>
+      <trans-unit id="pwdStrVwDe" resname="password.strength.very_weak">
+        <source>password.strength.very_weak</source>
+        <target>Sehr schwach</target>
+      </trans-unit>
+      <trans-unit id="pwdStrWkDe" resname="password.strength.weak">
+        <source>password.strength.weak</source>
+        <target>Schwach</target>
+      </trans-unit>
+      <trans-unit id="pwdStrAcDe" resname="password.strength.acceptable">
+        <source>password.strength.acceptable</source>
+        <target>Ausreichend</target>
+      </trans-unit>
+      <trans-unit id="pwdStrMdDe" resname="password.strength.medium">
+        <source>password.strength.medium</source>
+        <target>Mittel</target>
+      </trans-unit>
+      <trans-unit id="pwdStrStDe" resname="password.strength.strong">
+        <source>password.strength.strong</source>
+        <target>Stark</target>
+      </trans-unit>
+      <trans-unit id="pwdStrVsDe" resname="password.strength.very_strong">
+        <source>password.strength.very_strong</source>
+        <target>Sehr stark</target>
+      </trans-unit>
+      <trans-unit id="pwdReqMlDe" resname="password.requirement.min_length">
+        <source>password.requirement.min_length</source>
+        <target>Mindestens {min} Zeichen</target>
+      </trans-unit>
+      <trans-unit id="pwdReqStDe" resname="password.requirement.strength">
+        <source>password.requirement.strength</source>
+        <target>Ausreichende Passwortstärke</target>
+      </trans-unit>
       <trans-unit id="LocDe09" resname="label.settings">
         <source>label.settings</source>
         <target>Einstellungen</target>

--- a/translations/user+intl-icu.en.xlf
+++ b/translations/user+intl-icu.en.xlf
@@ -101,6 +101,42 @@
         <source>label.password.hide</source>
         <target>Hide password</target>
       </trans-unit>
+      <trans-unit id="pwdStrLbl01" resname="password.strength.label">
+        <source>password.strength.label</source>
+        <target>Password strength</target>
+      </trans-unit>
+      <trans-unit id="pwdStrVw01" resname="password.strength.very_weak">
+        <source>password.strength.very_weak</source>
+        <target>Very weak</target>
+      </trans-unit>
+      <trans-unit id="pwdStrWk01" resname="password.strength.weak">
+        <source>password.strength.weak</source>
+        <target>Weak</target>
+      </trans-unit>
+      <trans-unit id="pwdStrAc01" resname="password.strength.acceptable">
+        <source>password.strength.acceptable</source>
+        <target>Acceptable</target>
+      </trans-unit>
+      <trans-unit id="pwdStrMd01" resname="password.strength.medium">
+        <source>password.strength.medium</source>
+        <target>Medium</target>
+      </trans-unit>
+      <trans-unit id="pwdStrSt01" resname="password.strength.strong">
+        <source>password.strength.strong</source>
+        <target>Strong</target>
+      </trans-unit>
+      <trans-unit id="pwdStrVs01" resname="password.strength.very_strong">
+        <source>password.strength.very_strong</source>
+        <target>Very strong</target>
+      </trans-unit>
+      <trans-unit id="pwdReqMl01" resname="password.requirement.min_length">
+        <source>password.requirement.min_length</source>
+        <target>At least {min} characters</target>
+      </trans-unit>
+      <trans-unit id="pwdReqSt01" resname="password.requirement.strength">
+        <source>password.requirement.strength</source>
+        <target>Sufficient password strength</target>
+      </trans-unit>
       <trans-unit id="sKwVoqy" resname="label.settings">
         <source>label.settings</source>
         <target>Settings</target>


### PR DESCRIPTION
## Summary

Adds real-time password strength feedback to registration and password change flows, so users see whether their password meets policy requirements while typing — not only after submit.

The UI mirrors the existing server-side rules in `UserPasswordConstraints` (minimum length + Symfony entropy-based strength). No new frontend stack: it extends the existing password form theme and a small Stimulus controller.

## What changed

- Introduced `UserPasswordType` with an opt-in `strength_feedback` flag
- Centralized password policy constants and client config in `UserPasswordConstraints`
- Wired the new type into:
  - Registration
  - Settings password change
  - Password reset
  - Forced password change
- Extended the shared password form theme with:
  - Strength meter (red → green)
  - Live requirement checklist
  - Encouraging **“Acceptable”** label once minimum policy is met (instead of demotivating “Weak” when validation would already pass)
- Added `password_strength_controller.js`, porting Symfony’s `PasswordStrengthValidator::estimateStrength()` logic
- Added EN/DE translations for strength labels and requirements

## Intentionally unchanged

- **Login**, **confirm password**, and **current password** fields keep visibility toggle only
- **Repeat password** fields do not show the strength UI
- **Compromised password (HIBP)** is still validated on submit only; no live checklist item for that
- **EasyAdmin** user password forms are out of scope

## Why Stimulus (not Live Components)

Keystroke feedback should be instant and stay client-side. Live Components would add unnecessary round-trips, and HIBP checks are only meaningful at submit time anyway.

## Test plan

- [x] Unit tests for password policy config and Symfony strength reference values
- [x] Registration page shows strength meter + checklist
- [x] Login page does **not** show strength feedback
- [x] JS lint/format passes
- [x] Manual: register with a short password → requirements stay open, meter stays red
- [x] Manual: enter a valid password → checklist turns green, label shows “Acceptable” or stronger
- [x] Manual: submit a known compromised password → server error still appears as before
- [x] Manual: password visibility toggle still works