### PR TITLE
bugfix: Localize predefined Analysis Library system views

### DIFF
--- a/docs/04-features/statistics/analysis-explorer.md
+++ b/docs/04-features/statistics/analysis-explorer.md
@@ -47,7 +47,13 @@ Favorites are stored in `saved_explorer_view_favorite` as a per-user relation to
 
 ### Library sections
 
-The analysis library page lists **Overview** (38 system views with category filters), **Favorites**, and **My views** for signed-in users.
+The analysis library page lists **Overview** (44 system views with category filters), **Favorites**, and **My views** for signed-in users.
+
+### System view labels (i18n)
+
+System views store **translation keys** (not display text) in `title`, `description`, and `config_json.title`, for example `stats.analysis_explorer.system_view.allocations-over-time.title`. At display time, [`SavedExplorerViewLabelResolver`](../../../src/Statistics/AnalysisExplorer/Application/SavedExplorerViewLabelResolver.php) resolves them via the `statistics` translation domain according to the active locale. User-created views keep plain-text titles and descriptions.
+
+Copy for system views lives in `translations/statistics+intl-icu.{en,de}.xlf`. The sync command updates analysis configuration only; wording changes are made in the XLF files.
 
 Library standards, dashboard alignment, and phased refactor backlog: [analysis-explorer-library-standards.md](analysis-explorer-library-standards.md).
 

--- a/src/Statistics/AnalysisExplorer/Application/ExplorerSystemViewSeeder.php
+++ b/src/Statistics/AnalysisExplorer/Application/ExplorerSystemViewSeeder.php
@@ -32,24 +32,30 @@ final readonly class ExplorerSystemViewSeeder
         $skipped = 0;
 
         foreach ($this->definitions() as $definition) {
+            $slug = $definition['slug'];
+            $titleKey = self::titleKey($slug);
+            $descriptionKey = self::descriptionKey($slug);
+            $preferences = $definition['preferences'];
+            $preferences['title'] = $titleKey;
+
             $configJson = $this->configMapper->toStateArray(
                 $this->configMapper->buildViewConfig(
                     $this->defaultFilterState(),
-                    $definition['preferences'],
+                    $preferences,
                     null,
                 ),
             );
-            $configJson['title'] = $definition['title'];
+            $configJson['title'] = $titleKey;
             $category = $definition['category'];
 
-            $existing = $this->repository->findBySlug($definition['slug']);
+            $existing = $this->repository->findBySlug($slug);
             if (!$existing instanceof SavedExplorerView) {
                 $view = new SavedExplorerView(
-                    slug: $definition['slug'],
-                    title: $definition['title'],
+                    slug: $slug,
+                    title: $titleKey,
                     category: $category,
                     configJson: $configJson,
-                    description: $definition['description'],
+                    description: $descriptionKey,
                     isSystem: true,
                 );
                 $view->setCreatedBy($admin);
@@ -64,10 +70,10 @@ final readonly class ExplorerSystemViewSeeder
             }
 
             $existing->update(
-                title: $definition['title'],
+                title: $titleKey,
                 category: $category,
                 configJson: $configJson,
-                description: $definition['description'],
+                description: $descriptionKey,
             );
             if (!$existing->getCreatedBy() instanceof User) {
                 $existing->setCreatedBy($admin);
@@ -83,8 +89,6 @@ final readonly class ExplorerSystemViewSeeder
     /**
      * @return list<array{
      *     slug: string,
-     *     title: string,
-     *     description: string,
      *     category: string,
      *     preferences: array<string, mixed>
      * }>
@@ -100,8 +104,6 @@ final readonly class ExplorerSystemViewSeeder
     /**
      * @return list<array{
      *     slug: string,
-     *     title: string,
-     *     description: string,
      *     category: string,
      *     preferences: array<string, mixed>
      * }>
@@ -111,188 +113,141 @@ final readonly class ExplorerSystemViewSeeder
         return [
             [
                 'slug' => 'allocations-over-time',
-                'title' => 'Allocations over time',
-                'description' => 'Monthly allocation counts over the selected period.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'time',
                     'grain' => 'month',
                     'chartType' => 'line',
-                    'title' => 'Allocations over time',
                 ],
             ],
             [
                 'slug' => 'allocations-by-year',
-                'title' => 'Allocations by year',
-                'description' => 'Yearly allocation totals as a line chart.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'time',
                     'grain' => 'year',
                     'chartType' => 'line',
-                    'title' => 'Allocations by year',
                 ],
             ],
             [
                 'slug' => 'gender-distribution',
-                'title' => 'Gender distribution',
-                'description' => 'Allocation counts grouped by patient gender.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'gender',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Gender distribution',
                 ],
             ],
             [
                 'slug' => 'gender-over-time',
-                'title' => 'Gender over time',
-                'description' => 'Monthly allocation counts split by gender.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'gender',
                     'grain' => 'month',
                     'chartType' => 'grouped_bar',
-                    'title' => 'Gender over time',
                 ],
             ],
             [
                 'slug' => 'urgency-distribution',
-                'title' => 'Urgency distribution',
-                'description' => 'Allocation counts grouped by urgency level.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'urgency',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Urgency distribution',
                 ],
             ],
             [
                 'slug' => 'urgency-over-time',
-                'title' => 'Urgency over time',
-                'description' => 'Yearly allocation counts stacked by urgency.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'urgency',
                     'grain' => 'year',
                     'chartType' => 'stacked_bar',
-                    'title' => 'Urgency over time',
                 ],
             ],
             [
                 'slug' => 'age-group-distribution',
-                'title' => 'Age group distribution',
-                'description' => 'Allocation counts grouped by patient age group.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'age_group',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Age group distribution',
                 ],
             ],
             [
                 'slug' => 'allocations-by-weekday',
-                'title' => 'Allocations by weekday',
-                'description' => 'Allocation counts distributed across weekdays.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'weekday',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Allocations by weekday',
                 ],
             ],
             [
                 'slug' => 'allocations-by-department',
-                'title' => 'Allocations by department',
-                'description' => 'Which departments handle the most allocations.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'department',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Allocations by department',
                 ],
             ],
             [
                 'slug' => 'transport-type-distribution',
-                'title' => 'Transport type distribution',
-                'description' => 'Ground versus air transport allocation counts.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'transport_type',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Transport type distribution',
                 ],
             ],
             [
                 'slug' => 'day-time-bucket-distribution',
-                'title' => 'Day-time distribution',
-                'description' => 'Allocation counts by time-of-day bucket.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'day_time_bucket',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Day-time distribution',
                 ],
             ],
             [
                 'slug' => 'shift-bucket-distribution',
-                'title' => 'Shift distribution',
-                'description' => 'Allocation counts by shift bucket.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'shift_bucket',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Shift distribution',
                 ],
             ],
             [
                 'slug' => 'with-physician-distribution',
-                'title' => 'Physician accompaniment',
-                'description' => 'Allocations with versus without physician accompaniment.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'with_physician',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Physician accompaniment',
                 ],
             ],
             [
                 'slug' => 'secondary-indication-distribution',
-                'title' => 'Secondary indication distribution',
-                'description' => 'Allocation counts grouped by secondary indication.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'secondary_indication',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Secondary indication distribution',
                 ],
             ],
             [
                 'slug' => 'transport-time-bucket-distribution',
-                'title' => 'Transport time bucket distribution',
-                'description' => 'Allocation counts grouped by transport duration bucket in minutes.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'transport_time_bucket',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Transport time bucket distribution',
                 ],
             ],
             [
                 'slug' => 'transport-time-distribution-by-urgency',
-                'title' => 'Transport time distribution by urgency',
-                'description' => 'Distribution of transport times in minutes per urgency level as a box plot.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'urgency',
@@ -300,49 +255,37 @@ final readonly class ExplorerSystemViewSeeder
                     'metrics' => ['transport_time_distribution'],
                     'visualMetric' => 'transport_time_distribution',
                     'chartType' => 'box_plot',
-                    'title' => 'Transport time distribution by urgency',
                 ],
             ],
             [
                 'slug' => 'allocations-weekday-by-day-time-heatmap',
-                'title' => 'Allocations by weekday and day-time',
-                'description' => 'Allocation counts as a heatmap of weekday versus time-of-day bucket.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'rows' => ['dimension' => 'weekday', 'grain' => 'total'],
                     'columns' => ['dimension' => 'day_time_bucket', 'grain' => 'total'],
                     'chartType' => 'heatmap',
-                    'title' => 'Allocations by weekday and day-time',
                 ],
             ],
             [
                 'slug' => 'allocations-weekday-by-shift-heatmap',
-                'title' => 'Allocations by weekday and shift',
-                'description' => 'Allocation counts as a heatmap of weekday versus shift bucket.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'rows' => ['dimension' => 'weekday', 'grain' => 'total'],
                     'columns' => ['dimension' => 'shift_bucket', 'grain' => 'total'],
                     'chartType' => 'heatmap',
-                    'title' => 'Allocations by weekday and shift',
                 ],
             ],
             [
                 'slug' => 'allocations-by-hour',
-                'title' => 'Allocations by hour',
-                'description' => 'Allocation counts distributed across hours of the day (0–23).',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'hour',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Allocations by hour',
                 ],
             ],
             [
                 'slug' => 'overview-clinical-resources',
-                'title' => 'Clinical resources overview',
-                'description' => 'Resuscitation room and cath lab rates compared for the selected period.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'clinical_resources',
@@ -350,13 +293,10 @@ final readonly class ExplorerSystemViewSeeder
                     'metrics' => ['prevalence_rate'],
                     'visualMetric' => 'prevalence_rate',
                     'chartType' => 'bar',
-                    'title' => 'Clinical resources overview',
                 ],
             ],
             [
                 'slug' => 'overview-clinical-features',
-                'title' => 'Clinical features overview',
-                'description' => 'Clinical feature rates compared for the selected period.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'clinical_features',
@@ -364,13 +304,10 @@ final readonly class ExplorerSystemViewSeeder
                     'metrics' => ['prevalence_rate'],
                     'visualMetric' => 'prevalence_rate',
                     'chartType' => 'bar',
-                    'title' => 'Clinical features overview',
                 ],
             ],
             [
                 'slug' => 'clinical-resources-by-gender',
-                'title' => 'Clinical resources by gender',
-                'description' => 'Resuscitation room and cath lab rates grouped by gender.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'rows' => ['dimension' => 'clinical_resources', 'grain' => 'total'],
@@ -378,13 +315,10 @@ final readonly class ExplorerSystemViewSeeder
                     'metrics' => ['prevalence_rate'],
                     'visualMetric' => 'prevalence_rate',
                     'chartType' => 'grouped_bar',
-                    'title' => 'Clinical resources by gender',
                 ],
             ],
             [
                 'slug' => 'clinical-features-by-urgency',
-                'title' => 'Clinical features by urgency',
-                'description' => 'Clinical feature rates grouped by urgency level.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'rows' => ['dimension' => 'clinical_features', 'grain' => 'total'],
@@ -392,105 +326,80 @@ final readonly class ExplorerSystemViewSeeder
                     'metrics' => ['prevalence_rate'],
                     'visualMetric' => 'prevalence_rate',
                     'chartType' => 'grouped_bar',
-                    'title' => 'Clinical features by urgency',
                 ],
             ],
             [
                 'slug' => 'resus-distribution',
-                'title' => 'Resuscitation room required',
-                'description' => 'Allocation counts grouped by whether a resuscitation room was requested at registration.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'resus',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Resuscitation room required',
                 ],
             ],
             [
                 'slug' => 'cathlab-distribution',
-                'title' => 'Cath lab required',
-                'description' => 'Allocation counts grouped by whether a cath lab was requested at registration.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'cathlab',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Cath lab required',
                 ],
             ],
             [
                 'slug' => 'cpr-distribution',
-                'title' => 'CPR cases',
-                'description' => 'Allocation counts grouped by CPR case flag.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'cpr',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'CPR cases',
                 ],
             ],
             [
                 'slug' => 'ventilation-distribution',
-                'title' => 'Ventilation cases',
-                'description' => 'Allocation counts grouped by ventilation case flag.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'ventilation',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Ventilation cases',
                 ],
             ],
             [
                 'slug' => 'shock-distribution',
-                'title' => 'Shock cases',
-                'description' => 'Allocation counts grouped by shock case flag.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'shock',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Shock cases',
                 ],
             ],
             [
                 'slug' => 'allocations-by-speciality',
-                'title' => 'Allocations by speciality',
-                'description' => 'Which medical specialities handle the most allocations.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'speciality',
                     'grain' => 'total',
                     'chartType' => 'bar',
                     'chartRowLimit' => '10',
-                    'title' => 'Allocations by speciality',
                 ],
             ],
             [
                 'slug' => 'allocations-by-occasion',
-                'title' => 'Allocations by occasion',
-                'description' => 'Allocation counts grouped by occasion.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'occasion',
                     'grain' => 'total',
                     'chartType' => 'bar',
                     'chartRowLimit' => '10',
-                    'title' => 'Allocations by occasion',
                 ],
             ],
             [
                 'slug' => 'allocations-by-infection',
-                'title' => 'Allocations by infection',
-                'description' => 'Allocation counts grouped by infection flag.',
                 'category' => self::CATEGORY_ALLOCATIONS,
                 'preferences' => [
                     'dimension' => 'infection',
                     'grain' => 'total',
                     'chartType' => 'bar',
-                    'title' => 'Allocations by infection',
                 ],
             ],
         ];
@@ -499,8 +408,6 @@ final readonly class ExplorerSystemViewSeeder
     /**
      * @return list<array{
      *     slug: string,
-     *     title: string,
-     *     description: string,
      *     category: string,
      *     preferences: array<string, mixed>
      * }>
@@ -517,161 +424,122 @@ final readonly class ExplorerSystemViewSeeder
         return [
             [
                 'slug' => 'hospitals-by-cohort',
-                'title' => 'Hospitals by master cohort',
-                'description' => 'Participating hospital counts grouped by master cohort.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_master_cohort',
                     'metric' => 'hospital_count',
-                    'title' => 'Hospitals by master cohort',
                 ]),
             ],
             [
                 'slug' => 'hospitals-by-tier',
-                'title' => 'Hospitals by tier',
-                'description' => 'Participating hospital counts grouped by care tier.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metric' => 'hospital_count',
-                    'title' => 'Hospitals by tier',
                 ]),
             ],
             [
                 'slug' => 'hospitals-by-tier-compare',
-                'title' => 'Hospitals by tier (participation compare)',
-                'description' => 'Hospital counts by tier split into participating and non-participating.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metric' => 'hospital_count',
                     'hospitalPopulation' => 'compare',
                     'chartType' => 'grouped_bar',
-                    'title' => 'Hospitals by tier (participation compare)',
                 ]),
             ],
             [
                 'slug' => 'hospitals-by-size',
-                'title' => 'Hospitals by size',
-                'description' => 'Participating hospital counts and average beds grouped by size class.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_size',
                     'metrics' => ['hospital_count', 'avg_beds'],
                     'visualMetric' => 'hospital_count',
-                    'title' => 'Hospitals by size',
                 ]),
             ],
             [
                 'slug' => 'hospital-tier-by-location',
-                'title' => 'Hospital tier by location',
-                'description' => 'Participating hospital counts in a tier-by-location matrix.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'rows' => ['dimension' => 'hospital_tier', 'grain' => 'total'],
                     'columns' => ['dimension' => 'hospital_location', 'grain' => 'total'],
                     'metric' => 'hospital_count',
                     'chartType' => 'grouped_bar',
-                    'title' => 'Hospital tier by location',
                 ]),
             ],
             [
                 'slug' => 'allocations-per-hospital-tier',
-                'title' => 'Allocations per hospital tier',
-                'description' => 'How many allocations participating hospitals handle per care tier.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metrics' => ['total_allocations', 'avg_allocations_per_hospital'],
                     'visualMetric' => 'total_allocations',
-                    'title' => 'Allocations per hospital tier',
                 ]),
             ],
             [
                 'slug' => 'beds-distribution-by-tier',
-                'title' => 'Beds distribution by tier',
-                'description' => 'Distribution of hospital bed counts per care tier as a box plot.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metrics' => ['beds_distribution'],
                     'visualMetric' => 'beds_distribution',
                     'chartType' => 'box_plot',
-                    'title' => 'Beds distribution by tier',
                 ]),
             ],
             [
                 'slug' => 'allocations-distribution-by-tier',
-                'title' => 'Allocations distribution by tier',
-                'description' => 'Distribution of allocations per hospital by care tier as a box plot.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metrics' => ['allocations_per_hospital_distribution'],
                     'visualMetric' => 'allocations_per_hospital_distribution',
                     'chartType' => 'box_plot',
-                    'title' => 'Allocations distribution by tier',
                 ]),
             ],
             [
                 'slug' => 'transport-time-distribution-by-tier',
-                'title' => 'Transport time distribution by tier',
-                'description' => 'Distribution of median transport times per hospital by care tier as a box plot.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_tier',
                     'metrics' => ['transport_time_per_hospital_distribution'],
                     'visualMetric' => 'transport_time_per_hospital_distribution',
                     'chartType' => 'box_plot',
-                    'title' => 'Transport time distribution by tier',
                 ]),
             ],
             [
                 'slug' => 'hospitals-by-location',
-                'title' => 'Hospitals by location',
-                'description' => 'Participating hospital counts grouped by location type.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_location',
                     'metric' => 'hospital_count',
-                    'title' => 'Hospitals by location',
                 ]),
             ],
             [
                 'slug' => 'beds-distribution-by-location',
-                'title' => 'Beds distribution by location',
-                'description' => 'Distribution of hospital bed counts per location type as a box plot.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_location',
                     'metrics' => ['beds_distribution'],
                     'visualMetric' => 'beds_distribution',
                     'chartType' => 'box_plot',
-                    'title' => 'Beds distribution by location',
                 ]),
             ],
             [
                 'slug' => 'allocations-per-hospital-size',
-                'title' => 'Allocations per hospital size',
-                'description' => 'How many allocations participating hospitals handle per size class.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_size',
                     'metrics' => ['total_allocations', 'avg_allocations_per_hospital'],
                     'visualMetric' => 'total_allocations',
-                    'title' => 'Allocations per hospital size',
                 ]),
             ],
             [
                 'slug' => 'allocations-per-hospital-location',
-                'title' => 'Allocations per hospital location',
-                'description' => 'How many allocations participating hospitals handle per location type.',
                 'category' => self::CATEGORY_HOSPITALS,
                 'preferences' => array_merge($hospitalBase, [
                     'dimension' => 'hospital_location',
                     'metrics' => ['total_allocations', 'avg_allocations_per_hospital'],
                     'visualMetric' => 'total_allocations',
-                    'title' => 'Allocations per hospital location',
                 ]),
             ],
         ];
@@ -699,16 +567,28 @@ final readonly class ExplorerSystemViewSeeder
     }
 
     /**
-     * @param array{slug: string, title: string, description: string, category: string, preferences: array<string, mixed>} $definition
-     * @param array<string, mixed>                                                                                         $configJson
+     * @param array{slug: string, category: string, preferences: array<string, mixed>} $definition
+     * @param array<string, mixed>                                                     $configJson
      */
     private function isUpToDate(SavedExplorerView $existing, array $definition, array $configJson, User $admin): bool
     {
-        return $existing->getTitle() === $definition['title']
-            && $existing->getDescription() === $definition['description']
+        $slug = $definition['slug'];
+
+        return $existing->getTitle() === self::titleKey($slug)
+            && $existing->getDescription() === self::descriptionKey($slug)
             && $definition['category'] === $existing->getCategory()
             && $existing->isSystem()
             && $existing->getConfigJson() === $configJson
             && $existing->wasCreatedBy($admin);
+    }
+
+    public static function titleKey(string $slug): string
+    {
+        return 'stats.analysis_explorer.system_view.'.$slug.'.title';
+    }
+
+    public static function descriptionKey(string $slug): string
+    {
+        return 'stats.analysis_explorer.system_view.'.$slug.'.description';
     }
 }

--- a/src/Statistics/AnalysisExplorer/Application/SavedExplorerViewLabelResolver.php
+++ b/src/Statistics/AnalysisExplorer/Application/SavedExplorerViewLabelResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\AnalysisExplorer\Application;
+
+use App\Statistics\Domain\Entity\SavedExplorerView;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class SavedExplorerViewLabelResolver
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function title(SavedExplorerView $view): string
+    {
+        return $this->resolve($view, $view->getTitle());
+    }
+
+    public function description(SavedExplorerView $view): ?string
+    {
+        $raw = $view->getDescription();
+
+        return null === $raw ? null : $this->resolve($view, $raw);
+    }
+
+    private function resolve(SavedExplorerView $view, string $value): string
+    {
+        if (!$view->isSystem()) {
+            return $value;
+        }
+
+        return $this->translator->trans($value, [], 'statistics');
+    }
+}

--- a/src/Statistics/AnalysisExplorer/Application/SavedExplorerViewLoader.php
+++ b/src/Statistics/AnalysisExplorer/Application/SavedExplorerViewLoader.php
@@ -18,6 +18,7 @@ final readonly class SavedExplorerViewLoader
         private SavedExplorerViewRepository $repository,
         private ExplorerConfigMapper $configMapper,
         private DefaultAnalysisViewFactoryRegistry $defaultAnalysisViewFactory,
+        private SavedExplorerViewLabelResolver $labelResolver,
     ) {
     }
 
@@ -69,9 +70,13 @@ final readonly class SavedExplorerViewLoader
             $state = $configJson;
             $this->applyFilterOverlay($state, $filter);
             $config = $this->configMapper->viewConfigFromState($state, $user);
+            $state = $this->configMapper->toStateArray($config);
+            if ($savedView->isSystem()) {
+                $state['title'] = $this->labelResolver->title($savedView);
+            }
 
             return new SavedExplorerViewLoadResult(
-                state: $this->configMapper->toStateArray($config),
+                state: $state,
                 view: $savedView,
             );
         } catch (\Throwable) {

--- a/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerController.php
+++ b/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerController.php
@@ -7,6 +7,7 @@ namespace App\Statistics\AnalysisExplorer\UI\Http\Controller;
 use App\Statistics\AnalysisExplorer\Application\DefaultAnalysisViewFactoryRegistry;
 use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewFavoriteService;
+use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewLabelResolver;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewLoader;
 use App\Statistics\AnalysisExplorer\Domain\Enum\AnalysisDataSourceKey;
 use App\Statistics\AnalysisExplorer\Domain\Enum\ExplorerChartRowLimit;
@@ -42,6 +43,7 @@ final class AnalysisExplorerController extends AbstractController
         private readonly ExplorerConfigMapper $explorerConfigMapper,
         private readonly SavedExplorerViewLoader $savedExplorerViewLoader,
         private readonly SavedExplorerViewFavoriteService $favoriteService,
+        private readonly SavedExplorerViewLabelResolver $labelResolver,
         private readonly UrlGeneratorInterface $router,
         private readonly TranslatorInterface $translator,
     ) {
@@ -125,8 +127,8 @@ final class AnalysisExplorerController extends AbstractController
             && $this->favoriteService->isFavorite($user, $view);
 
         return [
-            'savedViewTitle' => $view?->getTitle(),
-            'savedViewDescription' => $view?->getDescription(),
+            'savedViewTitle' => $view instanceof SavedExplorerView ? $this->labelResolver->title($view) : null,
+            'savedViewDescription' => $view instanceof SavedExplorerView ? $this->labelResolver->description($view) : null,
             'savedViewId' => $savedViewId,
             'isSystemView' => $isSystemView,
             'canSave' => $canSave,

--- a/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerLibraryPageViewModelFactory.php
+++ b/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerLibraryPageViewModelFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Statistics\AnalysisExplorer\UI\Http\Controller;
 
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewFavoriteService;
+use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewLabelResolver;
 use App\Statistics\AnalysisExplorer\UI\Http\Navigation\ExplorerLibraryQueryKeys;
 use App\Statistics\Domain\Entity\SavedExplorerView;
 use App\Statistics\Infrastructure\Repository\SavedExplorerViewRepository;
@@ -25,6 +26,7 @@ final readonly class AnalysisExplorerLibraryPageViewModelFactory
     public function __construct(
         private SavedExplorerViewRepository $repository,
         private SavedExplorerViewFavoriteService $favoriteService,
+        private SavedExplorerViewLabelResolver $labelResolver,
         private UrlGeneratorInterface $router,
         private TranslatorInterface $translator,
     ) {
@@ -139,7 +141,9 @@ final readonly class AnalysisExplorerLibraryPageViewModelFactory
         }
 
         $needle = mb_strtolower($searchQuery);
-        $haystack = mb_strtolower(trim($view->getTitle()."\n".($view->getDescription() ?? '')));
+        $haystack = mb_strtolower(trim(
+            $this->labelResolver->title($view)."\n".($this->labelResolver->description($view) ?? ''),
+        ));
 
         return str_contains($haystack, $needle);
     }
@@ -308,8 +312,8 @@ final readonly class AnalysisExplorerLibraryPageViewModelFactory
 
         return [
             'id' => $viewId,
-            'title' => $view->getTitle(),
-            'description' => $view->getDescription() ?? '',
+            'title' => $this->labelResolver->title($view),
+            'description' => $this->labelResolver->description($view) ?? '',
             'dimension' => $this->dimensionLabel($dimension),
             'grain' => $this->grainLabel($grain),
             'chartType' => $this->chartTypeLabel((string) ($presentation['chartType'] ?? '')),

--- a/tests/Statistics/Functional/Controller/AnalysisExplorerControllerTest.php
+++ b/tests/Statistics/Functional/Controller/AnalysisExplorerControllerTest.php
@@ -218,6 +218,25 @@ final class AnalysisExplorerControllerTest extends WebTestCase
         yield 'urgency over time' => ['urgency-over-time', 'Urgency over time', '"stacked_bar"'];
     }
 
+    public function testSystemViewTitleIsLocalizedInGerman(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $this->seedExplorerSystemViews();
+        $this->seedProjectionWithAllocation();
+        $client->followRedirects(true);
+
+        $client->request(
+            Request::METHOD_GET,
+            '/locale/switch/de?_target_path=/statistics/analysis/explorer/allocations-over-time?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains(
+            '[data-testid="stats-analysis-explorer-title"]',
+            'Allokationen im Zeitverlauf',
+        );
+    }
+
     public function testTransportTimeBucketDistributionViewOpensInExplorer(): void
     {
         $client = $this->createClientAsRoleUser();

--- a/tests/Statistics/Functional/Controller/AnalysisExplorerLibraryControllerTest.php
+++ b/tests/Statistics/Functional/Controller/AnalysisExplorerLibraryControllerTest.php
@@ -95,4 +95,25 @@ final class AnalysisExplorerLibraryControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-analysis-explorer-view-card-'.$genderView->getId().'"]');
         $this->assertSelectorNotExists('[data-testid="stats-analysis-explorer-view-card-'.$overTime->getId().'"]');
     }
+
+    public function testSystemViewTitleIsLocalizedInGerman(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedExplorerSystemViews();
+
+        $view = self::getContainer()->get(SavedExplorerViewRepository::class)->findBySlug('allocations-over-time');
+        self::assertNotNull($view?->getId());
+
+        $client->followRedirects(true);
+        $client->request(
+            Request::METHOD_GET,
+            '/locale/switch/de?_target_path=/statistics/analysis/library?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains(
+            '[data-testid="stats-analysis-explorer-view-card-'.$view->getId().'"]',
+            'Allokationen im Zeitverlauf',
+        );
+    }
 }

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerLibraryPageViewModelFactoryTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerLibraryPageViewModelFactoryTest.php
@@ -65,6 +65,7 @@ final class AnalysisExplorerLibraryPageViewModelFactoryTest extends KernelTestCa
         self::assertSame('Time period', $card['dimension']);
         self::assertSame('Month', $card['grain']);
         self::assertSame('Line chart', $card['chartType']);
+        self::assertSame('Allocations over time', $card['title']);
         self::assertTrue($card['isSystem']);
         self::assertSame('allocations', $card['categoryKey']);
         self::assertSame('Allocations', $card['categoryLabel']);

--- a/tests/Statistics/Integration/AnalysisExplorer/SavedExplorerViewFavoriteServiceTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/SavedExplorerViewFavoriteServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Integration\AnalysisExplorer;
 
+use App\Statistics\AnalysisExplorer\Application\ExplorerSystemViewSeeder;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewFavoriteService;
 use App\Statistics\Domain\Entity\SavedExplorerView;
 use App\Statistics\Infrastructure\Repository\SavedExplorerViewRepository;
@@ -57,7 +58,7 @@ final class SavedExplorerViewFavoriteServiceTest extends KernelTestCase
         $this->service->toggle($user, $second);
 
         $titles = array_map(static fn (SavedExplorerView $view): string => $view->getTitle(), $this->service->listViewsForUser($user));
-        self::assertContains('Allocations over time', $titles);
-        self::assertContains('Urgency over time', $titles);
+        self::assertContains(ExplorerSystemViewSeeder::titleKey('allocations-over-time'), $titles);
+        self::assertContains(ExplorerSystemViewSeeder::titleKey('urgency-over-time'), $titles);
     }
 }

--- a/tests/Statistics/Integration/AnalysisExplorer/SavedExplorerViewLoaderTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/SavedExplorerViewLoaderTest.php
@@ -126,6 +126,14 @@ final class SavedExplorerViewLoaderTest extends KernelTestCase
         self::assertSame(2024, $result->state['query']['period']['year'] ?? null);
     }
 
+    public function testSystemViewStateTitleIsLocalized(): void
+    {
+        $result = $this->loader->load('allocations-over-time', $this->publicFilter(), null);
+
+        self::assertFalse($result->notFound);
+        self::assertSame('Allocations over time', $result->state['title'] ?? null);
+    }
+
     public function testForeignUserViewIsNotFoundForOtherUsers(): void
     {
         $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerSystemViewSeederTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerSystemViewSeederTest.php
@@ -50,9 +50,11 @@ final class ExplorerSystemViewSeederTest extends KernelTestCase
         ];
 
         foreach ($seeder->definitions() as $definition) {
-            $config = $mapper->buildViewConfig($filterState, $definition['preferences'], null);
+            $preferences = $definition['preferences'];
+            $preferences['title'] = ExplorerSystemViewSeeder::titleKey($definition['slug']);
+            $config = $mapper->buildViewConfig($filterState, $preferences, null);
 
-            self::assertSame($definition['title'], $config->title, $definition['slug']);
+            self::assertSame(ExplorerSystemViewSeeder::titleKey($definition['slug']), $config->title, $definition['slug']);
             self::assertNotEmpty($config->metricKeys, $definition['slug']);
 
             if ('box_plot' === ($definition['preferences']['chartType'] ?? null)) {

--- a/tests/Statistics/Unit/AnalysisExplorer/SavedExplorerViewLabelResolverTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/SavedExplorerViewLabelResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewLabelResolver;
+use App\Statistics\Domain\Entity\SavedExplorerView;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class SavedExplorerViewLabelResolverTest extends TestCase
+{
+    public function testResolvesSystemViewTitleViaTranslator(): void
+    {
+        $view = new SavedExplorerView(
+            slug: 'allocations-over-time',
+            title: 'stats.analysis_explorer.system_view.allocations-over-time.title',
+            category: 'Allocations',
+            configJson: ['schemaVersion' => 3],
+            description: 'stats.analysis_explorer.system_view.allocations-over-time.description',
+            isSystem: true,
+        );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::once())
+            ->method('trans')
+            ->with('stats.analysis_explorer.system_view.allocations-over-time.title', [], 'statistics')
+            ->willReturn('Allocations over time');
+
+        $resolver = new SavedExplorerViewLabelResolver($translator);
+
+        self::assertSame('Allocations over time', $resolver->title($view));
+    }
+
+    public function testReturnsPlainTextForUserView(): void
+    {
+        $view = new SavedExplorerView(
+            slug: null,
+            title: 'My custom analysis',
+            category: 'My views',
+            configJson: ['schemaVersion' => 3],
+            description: 'User description',
+            isSystem: false,
+        );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects(self::never())->method('trans');
+
+        $resolver = new SavedExplorerViewLabelResolver($translator);
+
+        self::assertSame('My custom analysis', $resolver->title($view));
+        self::assertSame('User description', $resolver->description($view));
+    }
+
+    public function testDescriptionReturnsNullWhenUnset(): void
+    {
+        $view = new SavedExplorerView(
+            slug: null,
+            title: 'Untitled',
+            category: 'My views',
+            configJson: ['schemaVersion' => 3],
+            isSystem: false,
+        );
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $resolver = new SavedExplorerViewLabelResolver($translator);
+
+        self::assertNull($resolver->description($view));
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/SystemViewTranslationCoverageTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/SystemViewTranslationCoverageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerSystemViewSeeder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class SystemViewTranslationCoverageTest extends KernelTestCase
+{
+    public function testAllSystemViewTranslationKeysExistInEnglishAndGerman(): void
+    {
+        self::bootKernel();
+
+        $seeder = self::getContainer()->get(ExplorerSystemViewSeeder::class);
+        self::assertInstanceOf(ExplorerSystemViewSeeder::class, $seeder);
+
+        $translator = self::getContainer()->get('translator');
+        self::assertInstanceOf(TranslatorInterface::class, $translator);
+
+        foreach ($seeder->definitions() as $definition) {
+            $slug = $definition['slug'];
+            $titleKey = ExplorerSystemViewSeeder::titleKey($slug);
+            $descriptionKey = ExplorerSystemViewSeeder::descriptionKey($slug);
+
+            foreach (['en', 'de'] as $locale) {
+                $title = $translator->trans($titleKey, [], 'statistics', $locale);
+                self::assertNotSame($titleKey, $title, sprintf('Missing %s title translation for %s', $locale, $slug));
+
+                $description = $translator->trans($descriptionKey, [], 'statistics', $locale);
+                self::assertNotSame($descriptionKey, $description, sprintf('Missing %s description translation for %s', $locale, $slug));
+            }
+        }
+    }
+}

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -4625,6 +4625,358 @@
         <source>stats.reports.top_specialities.label</source>
         <target>Top-Fachrichtungen</target>
       </trans-unit>
+      <trans-unit id="statsSvc3ed06c6" resname="stats.analysis_explorer.system_view.allocations-over-time.title">
+        <source>stats.analysis_explorer.system_view.allocations-over-time.title</source>
+        <target>Allokationen im Zeitverlauf</target>
+      </trans-unit>
+      <trans-unit id="statsSv56914bf1" resname="stats.analysis_explorer.system_view.allocations-over-time.description">
+        <source>stats.analysis_explorer.system_view.allocations-over-time.description</source>
+        <target>Monatliche Allokationszahlen im gewählten Zeitraum.</target>
+      </trans-unit>
+      <trans-unit id="statsSv143a1766" resname="stats.analysis_explorer.system_view.allocations-by-year.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-year.title</source>
+        <target>Allokationen nach Jahr</target>
+      </trans-unit>
+      <trans-unit id="statsSvc2901c41" resname="stats.analysis_explorer.system_view.allocations-by-year.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-year.description</source>
+        <target>Jährliche Allokationssummen als Liniendiagramm.</target>
+      </trans-unit>
+      <trans-unit id="statsSva7de68ae" resname="stats.analysis_explorer.system_view.gender-distribution.title">
+        <source>stats.analysis_explorer.system_view.gender-distribution.title</source>
+        <target>Geschlechterverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSva78386f9" resname="stats.analysis_explorer.system_view.gender-distribution.description">
+        <source>stats.analysis_explorer.system_view.gender-distribution.description</source>
+        <target>Allokationszahlen nach Patientengeschlecht.</target>
+      </trans-unit>
+      <trans-unit id="statsSvad6e9fb0" resname="stats.analysis_explorer.system_view.gender-over-time.title">
+        <source>stats.analysis_explorer.system_view.gender-over-time.title</source>
+        <target>Geschlecht im Zeitverlauf</target>
+      </trans-unit>
+      <trans-unit id="statsSv816a93f0" resname="stats.analysis_explorer.system_view.gender-over-time.description">
+        <source>stats.analysis_explorer.system_view.gender-over-time.description</source>
+        <target>Monatliche Allokationszahlen aufgeteilt nach Geschlecht.</target>
+      </trans-unit>
+      <trans-unit id="statsSvaef1c236" resname="stats.analysis_explorer.system_view.urgency-distribution.title">
+        <source>stats.analysis_explorer.system_view.urgency-distribution.title</source>
+        <target>Dringlichkeitsverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSve6993834" resname="stats.analysis_explorer.system_view.urgency-distribution.description">
+        <source>stats.analysis_explorer.system_view.urgency-distribution.description</source>
+        <target>Allokationszahlen nach Dringlichkeitsstufe.</target>
+      </trans-unit>
+      <trans-unit id="statsSva4b33e1d" resname="stats.analysis_explorer.system_view.urgency-over-time.title">
+        <source>stats.analysis_explorer.system_view.urgency-over-time.title</source>
+        <target>Dringlichkeit im Zeitverlauf</target>
+      </trans-unit>
+      <trans-unit id="statsSv5d0672ed" resname="stats.analysis_explorer.system_view.urgency-over-time.description">
+        <source>stats.analysis_explorer.system_view.urgency-over-time.description</source>
+        <target>Jährliche Allokationszahlen gestapelt nach Dringlichkeit.</target>
+      </trans-unit>
+      <trans-unit id="statsSvcbf401a9" resname="stats.analysis_explorer.system_view.age-group-distribution.title">
+        <source>stats.analysis_explorer.system_view.age-group-distribution.title</source>
+        <target>Altersgruppenverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSvbb559f93" resname="stats.analysis_explorer.system_view.age-group-distribution.description">
+        <source>stats.analysis_explorer.system_view.age-group-distribution.description</source>
+        <target>Allokationszahlen nach Patientenaltersgruppe.</target>
+      </trans-unit>
+      <trans-unit id="statsSvbfb7743c" resname="stats.analysis_explorer.system_view.allocations-by-weekday.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-weekday.title</source>
+        <target>Allokationen nach Wochentag</target>
+      </trans-unit>
+      <trans-unit id="statsSv0c086cc6" resname="stats.analysis_explorer.system_view.allocations-by-weekday.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-weekday.description</source>
+        <target>Allokationszahlen verteilt auf Wochentage.</target>
+      </trans-unit>
+      <trans-unit id="statsSvf9285cec" resname="stats.analysis_explorer.system_view.allocations-by-department.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-department.title</source>
+        <target>Allokationen nach Abteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSv18d041c8" resname="stats.analysis_explorer.system_view.allocations-by-department.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-department.description</source>
+        <target>Welche Abteilungen die meisten Allokationen bearbeiten.</target>
+      </trans-unit>
+      <trans-unit id="statsSvea0b797f" resname="stats.analysis_explorer.system_view.transport-type-distribution.title">
+        <source>stats.analysis_explorer.system_view.transport-type-distribution.title</source>
+        <target>Transportartverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSvd0ceea20" resname="stats.analysis_explorer.system_view.transport-type-distribution.description">
+        <source>stats.analysis_explorer.system_view.transport-type-distribution.description</source>
+        <target>Allokationszahlen für Boden- versus Lufttransport.</target>
+      </trans-unit>
+      <trans-unit id="statsSva5c8c02e" resname="stats.analysis_explorer.system_view.day-time-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.day-time-bucket-distribution.title</source>
+        <target>Tageszeitverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSv5a0aade1" resname="stats.analysis_explorer.system_view.day-time-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.day-time-bucket-distribution.description</source>
+        <target>Allokationszahlen nach Tageszeit-Bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSve1881e1f" resname="stats.analysis_explorer.system_view.shift-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.shift-bucket-distribution.title</source>
+        <target>Schichtverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSve8c60089" resname="stats.analysis_explorer.system_view.shift-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.shift-bucket-distribution.description</source>
+        <target>Allokationszahlen nach Schicht-Bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSvef25ae5d" resname="stats.analysis_explorer.system_view.with-physician-distribution.title">
+        <source>stats.analysis_explorer.system_view.with-physician-distribution.title</source>
+        <target>Arztbegleitung</target>
+      </trans-unit>
+      <trans-unit id="statsSv5200a298" resname="stats.analysis_explorer.system_view.with-physician-distribution.description">
+        <source>stats.analysis_explorer.system_view.with-physician-distribution.description</source>
+        <target>Allokationen mit versus ohne Arztbegleitung.</target>
+      </trans-unit>
+      <trans-unit id="statsSv03e6731e" resname="stats.analysis_explorer.system_view.secondary-indication-distribution.title">
+        <source>stats.analysis_explorer.system_view.secondary-indication-distribution.title</source>
+        <target>Sekundärindikationsverteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSvf6ca1139" resname="stats.analysis_explorer.system_view.secondary-indication-distribution.description">
+        <source>stats.analysis_explorer.system_view.secondary-indication-distribution.description</source>
+        <target>Allokationszahlen nach Sekundärindikation.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc787cf34" resname="stats.analysis_explorer.system_view.transport-time-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.transport-time-bucket-distribution.title</source>
+        <target>Transportzeit-Bucket-Verteilung</target>
+      </trans-unit>
+      <trans-unit id="statsSv46cad464" resname="stats.analysis_explorer.system_view.transport-time-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.transport-time-bucket-distribution.description</source>
+        <target>Allokationszahlen nach Transportdauer-Bucket in Minuten.</target>
+      </trans-unit>
+      <trans-unit id="statsSva2457723" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.title">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.title</source>
+        <target>Transportzeitverteilung nach Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="statsSv1d1293b7" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.description">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.description</source>
+        <target>Verteilung der Transportzeiten in Minuten pro Dringlichkeitsstufe als Boxplot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv21215c60" resname="stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.title">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.title</source>
+        <target>Allokationen nach Wochentag und Tageszeit</target>
+      </trans-unit>
+      <trans-unit id="statsSvc6cd18c8" resname="stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.description">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.description</source>
+        <target>Allokationszahlen als Heatmap von Wochentag versus Tageszeit-Bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSv503b9f69" resname="stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.title">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.title</source>
+        <target>Allokationen nach Wochentag und Schicht</target>
+      </trans-unit>
+      <trans-unit id="statsSv257f8f9b" resname="stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.description">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.description</source>
+        <target>Allokationszahlen als Heatmap von Wochentag versus Schicht-Bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSv17dce39e" resname="stats.analysis_explorer.system_view.allocations-by-hour.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-hour.title</source>
+        <target>Allokationen nach Stunde</target>
+      </trans-unit>
+      <trans-unit id="statsSva2586c09" resname="stats.analysis_explorer.system_view.allocations-by-hour.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-hour.description</source>
+        <target>Allokationszahlen verteilt auf Tagesstunden (0–23).</target>
+      </trans-unit>
+      <trans-unit id="statsSvd786c9ee" resname="stats.analysis_explorer.system_view.overview-clinical-resources.title">
+        <source>stats.analysis_explorer.system_view.overview-clinical-resources.title</source>
+        <target>Übersicht klinische Ressourcen</target>
+      </trans-unit>
+      <trans-unit id="statsSvef952b8f" resname="stats.analysis_explorer.system_view.overview-clinical-resources.description">
+        <source>stats.analysis_explorer.system_view.overview-clinical-resources.description</source>
+        <target>Reanimationsraum- und Herzkatheterlabor-Raten im gewählten Zeitraum im Vergleich.</target>
+      </trans-unit>
+      <trans-unit id="statsSvd4609154" resname="stats.analysis_explorer.system_view.overview-clinical-features.title">
+        <source>stats.analysis_explorer.system_view.overview-clinical-features.title</source>
+        <target>Übersicht klinische Merkmale</target>
+      </trans-unit>
+      <trans-unit id="statsSv0b15aba6" resname="stats.analysis_explorer.system_view.overview-clinical-features.description">
+        <source>stats.analysis_explorer.system_view.overview-clinical-features.description</source>
+        <target>Raten klinischer Merkmale im gewählten Zeitraum im Vergleich.</target>
+      </trans-unit>
+      <trans-unit id="statsSv8d9a09d7" resname="stats.analysis_explorer.system_view.clinical-resources-by-gender.title">
+        <source>stats.analysis_explorer.system_view.clinical-resources-by-gender.title</source>
+        <target>Klinische Ressourcen nach Geschlecht</target>
+      </trans-unit>
+      <trans-unit id="statsSv2c5ce05f" resname="stats.analysis_explorer.system_view.clinical-resources-by-gender.description">
+        <source>stats.analysis_explorer.system_view.clinical-resources-by-gender.description</source>
+        <target>Reanimationsraum- und Herzkatheterlabor-Raten nach Geschlecht.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc4a87594" resname="stats.analysis_explorer.system_view.clinical-features-by-urgency.title">
+        <source>stats.analysis_explorer.system_view.clinical-features-by-urgency.title</source>
+        <target>Klinische Merkmale nach Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="statsSvb2e0a370" resname="stats.analysis_explorer.system_view.clinical-features-by-urgency.description">
+        <source>stats.analysis_explorer.system_view.clinical-features-by-urgency.description</source>
+        <target>Raten klinischer Merkmale nach Dringlichkeitsstufe.</target>
+      </trans-unit>
+      <trans-unit id="statsSv2b30908a" resname="stats.analysis_explorer.system_view.resus-distribution.title">
+        <source>stats.analysis_explorer.system_view.resus-distribution.title</source>
+        <target>Reanimationsraum erforderlich</target>
+      </trans-unit>
+      <trans-unit id="statsSv2691454a" resname="stats.analysis_explorer.system_view.resus-distribution.description">
+        <source>stats.analysis_explorer.system_view.resus-distribution.description</source>
+        <target>Allokationszahlen danach, ob bei der Anmeldung ein Reanimationsraum angefordert wurde.</target>
+      </trans-unit>
+      <trans-unit id="statsSvaec53cf7" resname="stats.analysis_explorer.system_view.cathlab-distribution.title">
+        <source>stats.analysis_explorer.system_view.cathlab-distribution.title</source>
+        <target>Herzkatheterlabor erforderlich</target>
+      </trans-unit>
+      <trans-unit id="statsSv636bd3ff" resname="stats.analysis_explorer.system_view.cathlab-distribution.description">
+        <source>stats.analysis_explorer.system_view.cathlab-distribution.description</source>
+        <target>Allokationszahlen danach, ob bei der Anmeldung ein Herzkatheterlabor angefordert wurde.</target>
+      </trans-unit>
+      <trans-unit id="statsSv70f2a4fe" resname="stats.analysis_explorer.system_view.cpr-distribution.title">
+        <source>stats.analysis_explorer.system_view.cpr-distribution.title</source>
+        <target>CPR-Fälle</target>
+      </trans-unit>
+      <trans-unit id="statsSv8d3f2325" resname="stats.analysis_explorer.system_view.cpr-distribution.description">
+        <source>stats.analysis_explorer.system_view.cpr-distribution.description</source>
+        <target>Allokationszahlen nach CPR-Fallkennzeichen.</target>
+      </trans-unit>
+      <trans-unit id="statsSv505fd7ff" resname="stats.analysis_explorer.system_view.ventilation-distribution.title">
+        <source>stats.analysis_explorer.system_view.ventilation-distribution.title</source>
+        <target>Beatmungsfälle</target>
+      </trans-unit>
+      <trans-unit id="statsSv38d7f9c7" resname="stats.analysis_explorer.system_view.ventilation-distribution.description">
+        <source>stats.analysis_explorer.system_view.ventilation-distribution.description</source>
+        <target>Allokationszahlen nach Beatmungsfallkennzeichen.</target>
+      </trans-unit>
+      <trans-unit id="statsSvd77b6aaf" resname="stats.analysis_explorer.system_view.shock-distribution.title">
+        <source>stats.analysis_explorer.system_view.shock-distribution.title</source>
+        <target>Schockfälle</target>
+      </trans-unit>
+      <trans-unit id="statsSvcf1c98d9" resname="stats.analysis_explorer.system_view.shock-distribution.description">
+        <source>stats.analysis_explorer.system_view.shock-distribution.description</source>
+        <target>Allokationszahlen nach Schockfallkennzeichen.</target>
+      </trans-unit>
+      <trans-unit id="statsSvac2d0696" resname="stats.analysis_explorer.system_view.allocations-by-speciality.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-speciality.title</source>
+        <target>Allokationen nach Fachrichtung</target>
+      </trans-unit>
+      <trans-unit id="statsSv1025bb50" resname="stats.analysis_explorer.system_view.allocations-by-speciality.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-speciality.description</source>
+        <target>Welche medizinischen Fachrichtungen die meisten Allokationen bearbeiten.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc72eebaa" resname="stats.analysis_explorer.system_view.allocations-by-occasion.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-occasion.title</source>
+        <target>Allokationen nach Anlass</target>
+      </trans-unit>
+      <trans-unit id="statsSv5083b54e" resname="stats.analysis_explorer.system_view.allocations-by-occasion.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-occasion.description</source>
+        <target>Allokationszahlen nach Anlass.</target>
+      </trans-unit>
+      <trans-unit id="statsSv421702a5" resname="stats.analysis_explorer.system_view.allocations-by-infection.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-infection.title</source>
+        <target>Allokationen nach Infektion</target>
+      </trans-unit>
+      <trans-unit id="statsSv24445748" resname="stats.analysis_explorer.system_view.allocations-by-infection.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-infection.description</source>
+        <target>Allokationszahlen nach Infektionskennzeichen.</target>
+      </trans-unit>
+      <trans-unit id="statsSv8bb57528" resname="stats.analysis_explorer.system_view.hospitals-by-cohort.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-cohort.title</source>
+        <target>Krankenhäuser nach Master-Kohorte</target>
+      </trans-unit>
+      <trans-unit id="statsSva2c79a3c" resname="stats.analysis_explorer.system_view.hospitals-by-cohort.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-cohort.description</source>
+        <target>Zahlen teilnehmender Krankenhäuser nach Master-Kohorte.</target>
+      </trans-unit>
+      <trans-unit id="statsSv0be85ed4" resname="stats.analysis_explorer.system_view.hospitals-by-tier.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier.title</source>
+        <target>Krankenhäuser nach Versorgungsstufe</target>
+      </trans-unit>
+      <trans-unit id="statsSv45e90aaf" resname="stats.analysis_explorer.system_view.hospitals-by-tier.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier.description</source>
+        <target>Zahlen teilnehmender Krankenhäuser nach Versorgungsstufe.</target>
+      </trans-unit>
+      <trans-unit id="statsSv31e07cdc" resname="stats.analysis_explorer.system_view.hospitals-by-tier-compare.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier-compare.title</source>
+        <target>Krankenhäuser nach Versorgungsstufe (Teilnahmevergleich)</target>
+      </trans-unit>
+      <trans-unit id="statsSvb1edf18b" resname="stats.analysis_explorer.system_view.hospitals-by-tier-compare.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier-compare.description</source>
+        <target>Krankenhauszahlen nach Versorgungsstufe aufgeteilt in teilnehmend und nicht teilnehmend.</target>
+      </trans-unit>
+      <trans-unit id="statsSvbc639bc0" resname="stats.analysis_explorer.system_view.hospitals-by-size.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-size.title</source>
+        <target>Krankenhäuser nach Größe</target>
+      </trans-unit>
+      <trans-unit id="statsSv50459702" resname="stats.analysis_explorer.system_view.hospitals-by-size.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-size.description</source>
+        <target>Zahlen teilnehmender Krankenhäuser und durchschnittliche Betten nach Größenklasse.</target>
+      </trans-unit>
+      <trans-unit id="statsSv5f7809dc" resname="stats.analysis_explorer.system_view.hospital-tier-by-location.title">
+        <source>stats.analysis_explorer.system_view.hospital-tier-by-location.title</source>
+        <target>Krankenhausstufe nach Standort</target>
+      </trans-unit>
+      <trans-unit id="statsSvb9c925cc" resname="stats.analysis_explorer.system_view.hospital-tier-by-location.description">
+        <source>stats.analysis_explorer.system_view.hospital-tier-by-location.description</source>
+        <target>Zahlen teilnehmender Krankenhäuser in einer Matrix aus Versorgungsstufe und Standort.</target>
+      </trans-unit>
+      <trans-unit id="statsSvf4ba0449" resname="stats.analysis_explorer.system_view.allocations-per-hospital-tier.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-tier.title</source>
+        <target>Allokationen pro Krankenhausstufe</target>
+      </trans-unit>
+      <trans-unit id="statsSv7f174ca7" resname="stats.analysis_explorer.system_view.allocations-per-hospital-tier.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-tier.description</source>
+        <target>Wie viele Allokationen teilnehmende Krankenhäuser pro Versorgungsstufe bearbeiten.</target>
+      </trans-unit>
+      <trans-unit id="statsSvb371fe1e" resname="stats.analysis_explorer.system_view.beds-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-tier.title</source>
+        <target>Bettenverteilung nach Versorgungsstufe</target>
+      </trans-unit>
+      <trans-unit id="statsSvb53ad9d0" resname="stats.analysis_explorer.system_view.beds-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-tier.description</source>
+        <target>Verteilung der Krankenhausbetten pro Versorgungsstufe als Boxplot.</target>
+      </trans-unit>
+      <trans-unit id="statsSva4978daf" resname="stats.analysis_explorer.system_view.allocations-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.allocations-distribution-by-tier.title</source>
+        <target>Allokationsverteilung nach Versorgungsstufe</target>
+      </trans-unit>
+      <trans-unit id="statsSv444f76e5" resname="stats.analysis_explorer.system_view.allocations-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.allocations-distribution-by-tier.description</source>
+        <target>Verteilung der Allokationen pro Krankenhaus nach Versorgungsstufe als Boxplot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv1e17d522" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-tier.title</source>
+        <target>Transportzeitverteilung nach Versorgungsstufe</target>
+      </trans-unit>
+      <trans-unit id="statsSv5f379603" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-tier.description</source>
+        <target>Verteilung der medianen Transportzeiten pro Krankenhaus nach Versorgungsstufe als Boxplot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv064077b1" resname="stats.analysis_explorer.system_view.hospitals-by-location.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-location.title</source>
+        <target>Krankenhäuser nach Standort</target>
+      </trans-unit>
+      <trans-unit id="statsSvccd56425" resname="stats.analysis_explorer.system_view.hospitals-by-location.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-location.description</source>
+        <target>Zahlen teilnehmender Krankenhäuser nach Standorttyp.</target>
+      </trans-unit>
+      <trans-unit id="statsSv3c1801c2" resname="stats.analysis_explorer.system_view.beds-distribution-by-location.title">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-location.title</source>
+        <target>Bettenverteilung nach Standort</target>
+      </trans-unit>
+      <trans-unit id="statsSv0b410d6e" resname="stats.analysis_explorer.system_view.beds-distribution-by-location.description">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-location.description</source>
+        <target>Verteilung der Krankenhausbetten pro Standorttyp als Boxplot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv66da63ca" resname="stats.analysis_explorer.system_view.allocations-per-hospital-size.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-size.title</source>
+        <target>Allokationen pro Krankenhausgröße</target>
+      </trans-unit>
+      <trans-unit id="statsSv7e8a70e5" resname="stats.analysis_explorer.system_view.allocations-per-hospital-size.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-size.description</source>
+        <target>Wie viele Allokationen teilnehmende Krankenhäuser pro Größenklasse bearbeiten.</target>
+      </trans-unit>
+      <trans-unit id="statsSv56532599" resname="stats.analysis_explorer.system_view.allocations-per-hospital-location.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-location.title</source>
+        <target>Allokationen pro Krankenhausstandort</target>
+      </trans-unit>
+      <trans-unit id="statsSvf1c4b376" resname="stats.analysis_explorer.system_view.allocations-per-hospital-location.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-location.description</source>
+        <target>Wie viele Allokationen teilnehmende Krankenhäuser pro Standorttyp bearbeiten.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -4625,6 +4625,358 @@
         <source>stats.analysis_explorer.edit.additional_table_metrics_help</source>
         <target>Optional extra columns in the results table. The chart always uses the chart metric above.</target>
       </trans-unit>
+      <trans-unit id="statsSvc3ed06c6" resname="stats.analysis_explorer.system_view.allocations-over-time.title">
+        <source>stats.analysis_explorer.system_view.allocations-over-time.title</source>
+        <target>Allocations over time</target>
+      </trans-unit>
+      <trans-unit id="statsSv56914bf1" resname="stats.analysis_explorer.system_view.allocations-over-time.description">
+        <source>stats.analysis_explorer.system_view.allocations-over-time.description</source>
+        <target>Monthly allocation counts over the selected period.</target>
+      </trans-unit>
+      <trans-unit id="statsSv143a1766" resname="stats.analysis_explorer.system_view.allocations-by-year.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-year.title</source>
+        <target>Allocations by year</target>
+      </trans-unit>
+      <trans-unit id="statsSvc2901c41" resname="stats.analysis_explorer.system_view.allocations-by-year.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-year.description</source>
+        <target>Yearly allocation totals as a line chart.</target>
+      </trans-unit>
+      <trans-unit id="statsSva7de68ae" resname="stats.analysis_explorer.system_view.gender-distribution.title">
+        <source>stats.analysis_explorer.system_view.gender-distribution.title</source>
+        <target>Gender distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSva78386f9" resname="stats.analysis_explorer.system_view.gender-distribution.description">
+        <source>stats.analysis_explorer.system_view.gender-distribution.description</source>
+        <target>Allocation counts grouped by patient gender.</target>
+      </trans-unit>
+      <trans-unit id="statsSvad6e9fb0" resname="stats.analysis_explorer.system_view.gender-over-time.title">
+        <source>stats.analysis_explorer.system_view.gender-over-time.title</source>
+        <target>Gender over time</target>
+      </trans-unit>
+      <trans-unit id="statsSv816a93f0" resname="stats.analysis_explorer.system_view.gender-over-time.description">
+        <source>stats.analysis_explorer.system_view.gender-over-time.description</source>
+        <target>Monthly allocation counts split by gender.</target>
+      </trans-unit>
+      <trans-unit id="statsSvaef1c236" resname="stats.analysis_explorer.system_view.urgency-distribution.title">
+        <source>stats.analysis_explorer.system_view.urgency-distribution.title</source>
+        <target>Urgency distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSve6993834" resname="stats.analysis_explorer.system_view.urgency-distribution.description">
+        <source>stats.analysis_explorer.system_view.urgency-distribution.description</source>
+        <target>Allocation counts grouped by urgency level.</target>
+      </trans-unit>
+      <trans-unit id="statsSva4b33e1d" resname="stats.analysis_explorer.system_view.urgency-over-time.title">
+        <source>stats.analysis_explorer.system_view.urgency-over-time.title</source>
+        <target>Urgency over time</target>
+      </trans-unit>
+      <trans-unit id="statsSv5d0672ed" resname="stats.analysis_explorer.system_view.urgency-over-time.description">
+        <source>stats.analysis_explorer.system_view.urgency-over-time.description</source>
+        <target>Yearly allocation counts stacked by urgency.</target>
+      </trans-unit>
+      <trans-unit id="statsSvcbf401a9" resname="stats.analysis_explorer.system_view.age-group-distribution.title">
+        <source>stats.analysis_explorer.system_view.age-group-distribution.title</source>
+        <target>Age group distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSvbb559f93" resname="stats.analysis_explorer.system_view.age-group-distribution.description">
+        <source>stats.analysis_explorer.system_view.age-group-distribution.description</source>
+        <target>Allocation counts grouped by patient age group.</target>
+      </trans-unit>
+      <trans-unit id="statsSvbfb7743c" resname="stats.analysis_explorer.system_view.allocations-by-weekday.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-weekday.title</source>
+        <target>Allocations by weekday</target>
+      </trans-unit>
+      <trans-unit id="statsSv0c086cc6" resname="stats.analysis_explorer.system_view.allocations-by-weekday.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-weekday.description</source>
+        <target>Allocation counts distributed across weekdays.</target>
+      </trans-unit>
+      <trans-unit id="statsSvf9285cec" resname="stats.analysis_explorer.system_view.allocations-by-department.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-department.title</source>
+        <target>Allocations by department</target>
+      </trans-unit>
+      <trans-unit id="statsSv18d041c8" resname="stats.analysis_explorer.system_view.allocations-by-department.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-department.description</source>
+        <target>Which departments handle the most allocations.</target>
+      </trans-unit>
+      <trans-unit id="statsSvea0b797f" resname="stats.analysis_explorer.system_view.transport-type-distribution.title">
+        <source>stats.analysis_explorer.system_view.transport-type-distribution.title</source>
+        <target>Transport type distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSvd0ceea20" resname="stats.analysis_explorer.system_view.transport-type-distribution.description">
+        <source>stats.analysis_explorer.system_view.transport-type-distribution.description</source>
+        <target>Ground versus air transport allocation counts.</target>
+      </trans-unit>
+      <trans-unit id="statsSva5c8c02e" resname="stats.analysis_explorer.system_view.day-time-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.day-time-bucket-distribution.title</source>
+        <target>Day-time distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSv5a0aade1" resname="stats.analysis_explorer.system_view.day-time-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.day-time-bucket-distribution.description</source>
+        <target>Allocation counts by time-of-day bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSve1881e1f" resname="stats.analysis_explorer.system_view.shift-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.shift-bucket-distribution.title</source>
+        <target>Shift distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSve8c60089" resname="stats.analysis_explorer.system_view.shift-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.shift-bucket-distribution.description</source>
+        <target>Allocation counts by shift bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSvef25ae5d" resname="stats.analysis_explorer.system_view.with-physician-distribution.title">
+        <source>stats.analysis_explorer.system_view.with-physician-distribution.title</source>
+        <target>Physician accompaniment</target>
+      </trans-unit>
+      <trans-unit id="statsSv5200a298" resname="stats.analysis_explorer.system_view.with-physician-distribution.description">
+        <source>stats.analysis_explorer.system_view.with-physician-distribution.description</source>
+        <target>Allocations with versus without physician accompaniment.</target>
+      </trans-unit>
+      <trans-unit id="statsSv03e6731e" resname="stats.analysis_explorer.system_view.secondary-indication-distribution.title">
+        <source>stats.analysis_explorer.system_view.secondary-indication-distribution.title</source>
+        <target>Secondary indication distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSvf6ca1139" resname="stats.analysis_explorer.system_view.secondary-indication-distribution.description">
+        <source>stats.analysis_explorer.system_view.secondary-indication-distribution.description</source>
+        <target>Allocation counts grouped by secondary indication.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc787cf34" resname="stats.analysis_explorer.system_view.transport-time-bucket-distribution.title">
+        <source>stats.analysis_explorer.system_view.transport-time-bucket-distribution.title</source>
+        <target>Transport time bucket distribution</target>
+      </trans-unit>
+      <trans-unit id="statsSv46cad464" resname="stats.analysis_explorer.system_view.transport-time-bucket-distribution.description">
+        <source>stats.analysis_explorer.system_view.transport-time-bucket-distribution.description</source>
+        <target>Allocation counts grouped by transport duration bucket in minutes.</target>
+      </trans-unit>
+      <trans-unit id="statsSva2457723" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.title">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.title</source>
+        <target>Transport time distribution by urgency</target>
+      </trans-unit>
+      <trans-unit id="statsSv1d1293b7" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.description">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-urgency.description</source>
+        <target>Distribution of transport times in minutes per urgency level as a box plot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv21215c60" resname="stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.title">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.title</source>
+        <target>Allocations by weekday and day-time</target>
+      </trans-unit>
+      <trans-unit id="statsSvc6cd18c8" resname="stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.description">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-day-time-heatmap.description</source>
+        <target>Allocation counts as a heatmap of weekday versus time-of-day bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSv503b9f69" resname="stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.title">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.title</source>
+        <target>Allocations by weekday and shift</target>
+      </trans-unit>
+      <trans-unit id="statsSv257f8f9b" resname="stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.description">
+        <source>stats.analysis_explorer.system_view.allocations-weekday-by-shift-heatmap.description</source>
+        <target>Allocation counts as a heatmap of weekday versus shift bucket.</target>
+      </trans-unit>
+      <trans-unit id="statsSv17dce39e" resname="stats.analysis_explorer.system_view.allocations-by-hour.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-hour.title</source>
+        <target>Allocations by hour</target>
+      </trans-unit>
+      <trans-unit id="statsSva2586c09" resname="stats.analysis_explorer.system_view.allocations-by-hour.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-hour.description</source>
+        <target>Allocation counts distributed across hours of the day (0–23).</target>
+      </trans-unit>
+      <trans-unit id="statsSvd786c9ee" resname="stats.analysis_explorer.system_view.overview-clinical-resources.title">
+        <source>stats.analysis_explorer.system_view.overview-clinical-resources.title</source>
+        <target>Clinical resources overview</target>
+      </trans-unit>
+      <trans-unit id="statsSvef952b8f" resname="stats.analysis_explorer.system_view.overview-clinical-resources.description">
+        <source>stats.analysis_explorer.system_view.overview-clinical-resources.description</source>
+        <target>Resuscitation room and cath lab rates compared for the selected period.</target>
+      </trans-unit>
+      <trans-unit id="statsSvd4609154" resname="stats.analysis_explorer.system_view.overview-clinical-features.title">
+        <source>stats.analysis_explorer.system_view.overview-clinical-features.title</source>
+        <target>Clinical features overview</target>
+      </trans-unit>
+      <trans-unit id="statsSv0b15aba6" resname="stats.analysis_explorer.system_view.overview-clinical-features.description">
+        <source>stats.analysis_explorer.system_view.overview-clinical-features.description</source>
+        <target>Clinical feature rates compared for the selected period.</target>
+      </trans-unit>
+      <trans-unit id="statsSv8d9a09d7" resname="stats.analysis_explorer.system_view.clinical-resources-by-gender.title">
+        <source>stats.analysis_explorer.system_view.clinical-resources-by-gender.title</source>
+        <target>Clinical resources by gender</target>
+      </trans-unit>
+      <trans-unit id="statsSv2c5ce05f" resname="stats.analysis_explorer.system_view.clinical-resources-by-gender.description">
+        <source>stats.analysis_explorer.system_view.clinical-resources-by-gender.description</source>
+        <target>Resuscitation room and cath lab rates grouped by gender.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc4a87594" resname="stats.analysis_explorer.system_view.clinical-features-by-urgency.title">
+        <source>stats.analysis_explorer.system_view.clinical-features-by-urgency.title</source>
+        <target>Clinical features by urgency</target>
+      </trans-unit>
+      <trans-unit id="statsSvb2e0a370" resname="stats.analysis_explorer.system_view.clinical-features-by-urgency.description">
+        <source>stats.analysis_explorer.system_view.clinical-features-by-urgency.description</source>
+        <target>Clinical feature rates grouped by urgency level.</target>
+      </trans-unit>
+      <trans-unit id="statsSv2b30908a" resname="stats.analysis_explorer.system_view.resus-distribution.title">
+        <source>stats.analysis_explorer.system_view.resus-distribution.title</source>
+        <target>Resuscitation room required</target>
+      </trans-unit>
+      <trans-unit id="statsSv2691454a" resname="stats.analysis_explorer.system_view.resus-distribution.description">
+        <source>stats.analysis_explorer.system_view.resus-distribution.description</source>
+        <target>Allocation counts grouped by whether a resuscitation room was requested at registration.</target>
+      </trans-unit>
+      <trans-unit id="statsSvaec53cf7" resname="stats.analysis_explorer.system_view.cathlab-distribution.title">
+        <source>stats.analysis_explorer.system_view.cathlab-distribution.title</source>
+        <target>Cath lab required</target>
+      </trans-unit>
+      <trans-unit id="statsSv636bd3ff" resname="stats.analysis_explorer.system_view.cathlab-distribution.description">
+        <source>stats.analysis_explorer.system_view.cathlab-distribution.description</source>
+        <target>Allocation counts grouped by whether a cath lab was requested at registration.</target>
+      </trans-unit>
+      <trans-unit id="statsSv70f2a4fe" resname="stats.analysis_explorer.system_view.cpr-distribution.title">
+        <source>stats.analysis_explorer.system_view.cpr-distribution.title</source>
+        <target>CPR cases</target>
+      </trans-unit>
+      <trans-unit id="statsSv8d3f2325" resname="stats.analysis_explorer.system_view.cpr-distribution.description">
+        <source>stats.analysis_explorer.system_view.cpr-distribution.description</source>
+        <target>Allocation counts grouped by CPR case flag.</target>
+      </trans-unit>
+      <trans-unit id="statsSv505fd7ff" resname="stats.analysis_explorer.system_view.ventilation-distribution.title">
+        <source>stats.analysis_explorer.system_view.ventilation-distribution.title</source>
+        <target>Ventilation cases</target>
+      </trans-unit>
+      <trans-unit id="statsSv38d7f9c7" resname="stats.analysis_explorer.system_view.ventilation-distribution.description">
+        <source>stats.analysis_explorer.system_view.ventilation-distribution.description</source>
+        <target>Allocation counts grouped by ventilation case flag.</target>
+      </trans-unit>
+      <trans-unit id="statsSvd77b6aaf" resname="stats.analysis_explorer.system_view.shock-distribution.title">
+        <source>stats.analysis_explorer.system_view.shock-distribution.title</source>
+        <target>Shock cases</target>
+      </trans-unit>
+      <trans-unit id="statsSvcf1c98d9" resname="stats.analysis_explorer.system_view.shock-distribution.description">
+        <source>stats.analysis_explorer.system_view.shock-distribution.description</source>
+        <target>Allocation counts grouped by shock case flag.</target>
+      </trans-unit>
+      <trans-unit id="statsSvac2d0696" resname="stats.analysis_explorer.system_view.allocations-by-speciality.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-speciality.title</source>
+        <target>Allocations by speciality</target>
+      </trans-unit>
+      <trans-unit id="statsSv1025bb50" resname="stats.analysis_explorer.system_view.allocations-by-speciality.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-speciality.description</source>
+        <target>Which medical specialities handle the most allocations.</target>
+      </trans-unit>
+      <trans-unit id="statsSvc72eebaa" resname="stats.analysis_explorer.system_view.allocations-by-occasion.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-occasion.title</source>
+        <target>Allocations by occasion</target>
+      </trans-unit>
+      <trans-unit id="statsSv5083b54e" resname="stats.analysis_explorer.system_view.allocations-by-occasion.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-occasion.description</source>
+        <target>Allocation counts grouped by occasion.</target>
+      </trans-unit>
+      <trans-unit id="statsSv421702a5" resname="stats.analysis_explorer.system_view.allocations-by-infection.title">
+        <source>stats.analysis_explorer.system_view.allocations-by-infection.title</source>
+        <target>Allocations by infection</target>
+      </trans-unit>
+      <trans-unit id="statsSv24445748" resname="stats.analysis_explorer.system_view.allocations-by-infection.description">
+        <source>stats.analysis_explorer.system_view.allocations-by-infection.description</source>
+        <target>Allocation counts grouped by infection flag.</target>
+      </trans-unit>
+      <trans-unit id="statsSv8bb57528" resname="stats.analysis_explorer.system_view.hospitals-by-cohort.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-cohort.title</source>
+        <target>Hospitals by master cohort</target>
+      </trans-unit>
+      <trans-unit id="statsSva2c79a3c" resname="stats.analysis_explorer.system_view.hospitals-by-cohort.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-cohort.description</source>
+        <target>Participating hospital counts grouped by master cohort.</target>
+      </trans-unit>
+      <trans-unit id="statsSv0be85ed4" resname="stats.analysis_explorer.system_view.hospitals-by-tier.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier.title</source>
+        <target>Hospitals by tier</target>
+      </trans-unit>
+      <trans-unit id="statsSv45e90aaf" resname="stats.analysis_explorer.system_view.hospitals-by-tier.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier.description</source>
+        <target>Participating hospital counts grouped by care tier.</target>
+      </trans-unit>
+      <trans-unit id="statsSv31e07cdc" resname="stats.analysis_explorer.system_view.hospitals-by-tier-compare.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier-compare.title</source>
+        <target>Hospitals by tier (participation compare)</target>
+      </trans-unit>
+      <trans-unit id="statsSvb1edf18b" resname="stats.analysis_explorer.system_view.hospitals-by-tier-compare.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-tier-compare.description</source>
+        <target>Hospital counts by tier split into participating and non-participating.</target>
+      </trans-unit>
+      <trans-unit id="statsSvbc639bc0" resname="stats.analysis_explorer.system_view.hospitals-by-size.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-size.title</source>
+        <target>Hospitals by size</target>
+      </trans-unit>
+      <trans-unit id="statsSv50459702" resname="stats.analysis_explorer.system_view.hospitals-by-size.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-size.description</source>
+        <target>Participating hospital counts and average beds grouped by size class.</target>
+      </trans-unit>
+      <trans-unit id="statsSv5f7809dc" resname="stats.analysis_explorer.system_view.hospital-tier-by-location.title">
+        <source>stats.analysis_explorer.system_view.hospital-tier-by-location.title</source>
+        <target>Hospital tier by location</target>
+      </trans-unit>
+      <trans-unit id="statsSvb9c925cc" resname="stats.analysis_explorer.system_view.hospital-tier-by-location.description">
+        <source>stats.analysis_explorer.system_view.hospital-tier-by-location.description</source>
+        <target>Participating hospital counts in a tier-by-location matrix.</target>
+      </trans-unit>
+      <trans-unit id="statsSvf4ba0449" resname="stats.analysis_explorer.system_view.allocations-per-hospital-tier.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-tier.title</source>
+        <target>Allocations per hospital tier</target>
+      </trans-unit>
+      <trans-unit id="statsSv7f174ca7" resname="stats.analysis_explorer.system_view.allocations-per-hospital-tier.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-tier.description</source>
+        <target>How many allocations participating hospitals handle per care tier.</target>
+      </trans-unit>
+      <trans-unit id="statsSvb371fe1e" resname="stats.analysis_explorer.system_view.beds-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-tier.title</source>
+        <target>Beds distribution by tier</target>
+      </trans-unit>
+      <trans-unit id="statsSvb53ad9d0" resname="stats.analysis_explorer.system_view.beds-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-tier.description</source>
+        <target>Distribution of hospital bed counts per care tier as a box plot.</target>
+      </trans-unit>
+      <trans-unit id="statsSva4978daf" resname="stats.analysis_explorer.system_view.allocations-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.allocations-distribution-by-tier.title</source>
+        <target>Allocations distribution by tier</target>
+      </trans-unit>
+      <trans-unit id="statsSv444f76e5" resname="stats.analysis_explorer.system_view.allocations-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.allocations-distribution-by-tier.description</source>
+        <target>Distribution of allocations per hospital by care tier as a box plot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv1e17d522" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-tier.title">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-tier.title</source>
+        <target>Transport time distribution by tier</target>
+      </trans-unit>
+      <trans-unit id="statsSv5f379603" resname="stats.analysis_explorer.system_view.transport-time-distribution-by-tier.description">
+        <source>stats.analysis_explorer.system_view.transport-time-distribution-by-tier.description</source>
+        <target>Distribution of median transport times per hospital by care tier as a box plot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv064077b1" resname="stats.analysis_explorer.system_view.hospitals-by-location.title">
+        <source>stats.analysis_explorer.system_view.hospitals-by-location.title</source>
+        <target>Hospitals by location</target>
+      </trans-unit>
+      <trans-unit id="statsSvccd56425" resname="stats.analysis_explorer.system_view.hospitals-by-location.description">
+        <source>stats.analysis_explorer.system_view.hospitals-by-location.description</source>
+        <target>Participating hospital counts grouped by location type.</target>
+      </trans-unit>
+      <trans-unit id="statsSv3c1801c2" resname="stats.analysis_explorer.system_view.beds-distribution-by-location.title">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-location.title</source>
+        <target>Beds distribution by location</target>
+      </trans-unit>
+      <trans-unit id="statsSv0b410d6e" resname="stats.analysis_explorer.system_view.beds-distribution-by-location.description">
+        <source>stats.analysis_explorer.system_view.beds-distribution-by-location.description</source>
+        <target>Distribution of hospital bed counts per location type as a box plot.</target>
+      </trans-unit>
+      <trans-unit id="statsSv66da63ca" resname="stats.analysis_explorer.system_view.allocations-per-hospital-size.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-size.title</source>
+        <target>Allocations per hospital size</target>
+      </trans-unit>
+      <trans-unit id="statsSv7e8a70e5" resname="stats.analysis_explorer.system_view.allocations-per-hospital-size.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-size.description</source>
+        <target>How many allocations participating hospitals handle per size class.</target>
+      </trans-unit>
+      <trans-unit id="statsSv56532599" resname="stats.analysis_explorer.system_view.allocations-per-hospital-location.title">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-location.title</source>
+        <target>Allocations per hospital location</target>
+      </trans-unit>
+      <trans-unit id="statsSvf1c4b376" resname="stats.analysis_explorer.system_view.allocations-per-hospital-location.description">
+        <source>stats.analysis_explorer.system_view.allocations-per-hospital-location.description</source>
+        <target>How many allocations participating hospitals handle per location type.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

Closes #304.

Predefined Analysis Library entries now display localized titles and descriptions in English and German, while user-created views continue to use plain-text metadata.

- System views store translation keys in `title`, `description`, and `config_json.title` (e.g. `stats.analysis_explorer.system_view.allocations-over-time.title`)
- A small `SavedExplorerViewLabelResolver` resolves those keys at display time via the existing Symfony `statistics` translation domain
- User views (`isSystem = false`) are unchanged and remain free-form text
- 88 new translation entries added (44 system views × title + description)

## Implementation notes

- `ExplorerSystemViewSeeder` now writes translation keys derived from each view slug
- Label resolution is wired into:
  - Analysis Library cards and search
  - Explorer page header
  - Saved view loader (chart title and CSV export filename)
- Save As from a system view copies the **visible localized title** into the new user view
- No database schema changes required

## Deployment

After merging, run once per environment to update existing seeded rows:

```bash
bin/console app:statistics:explorer-views:sync
```

## Test plan

- [x] Unit: `SavedExplorerViewLabelResolverTest`
- [x] Unit: `SystemViewTranslationCoverageTest` (all 44 slugs have EN + DE keys)
- [x] Integration: library view model, saved view loader, favorites
- [x] Functional: library and explorer show German titles after locale switch
- [x] Existing EN functional tests remain green
- [ ] Manual: open Analysis Library with `de` locale and verify card titles/descriptions
- [ ] Manual: open a system view in explorer and verify header + chart title in DE
- [ ] Manual: Save As from a system view creates a user view with localized plain-text title
