### PR TITLE
feat(allocation): replace explore detail integer IDs with UUID v4 public IDs

### DIFF
--- a/bin/backfill-public-ids-until-done
+++ b/bin/backfill-public-ids-until-done
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-300}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+while true; do
+    php bin/console app:explore:backfill-public-ids --max-runtime="$MAX_RUNTIME_SECONDS"
+    EXIT_CODE=$?
+
+    if [[ "$EXIT_CODE" -eq 0 ]]; then
+        echo "All explore resources have public_id values."
+        exit 0
+    fi
+
+    if [[ "$EXIT_CODE" -eq 2 ]]; then
+        echo "Critical failure (exit $EXIT_CODE); not restarting." >&2
+        exit 2
+    fi
+
+    echo "More work remains (exit $EXIT_CODE); restarting after ${SLEEP_SECONDS}s…"
+    sleep "$SLEEP_SECONDS"
+done

--- a/docs/04-features/allocation/explore-public-ids.md
+++ b/docs/04-features/allocation/explore-public-ids.md
@@ -1,0 +1,75 @@
+# Explore public ID backfill
+
+One-time (or resumable) backfill of `public_id` UUID v4 (RFC 4122) columns for explore detail resources.
+
+## Prerequisites
+
+- Migration `Version20260708183000` applied (`public_id` nullable `VARCHAR(36)` + partial unique indexes)
+- Sufficient DB time budget for `allocation` (~2M rows: plan for multiple runs or use the wrapper script)
+
+## Commands
+
+Dry-run:
+
+```bash
+php bin/console app:explore:backfill-public-ids --dry-run
+```
+
+Single table:
+
+```bash
+php bin/console app:explore:backfill-public-ids --table=allocation --batch-size=5000
+```
+
+Time-limited chunk (resume-safe):
+
+```bash
+php bin/console app:explore:backfill-public-ids --max-runtime=300
+```
+
+Automatic restart until complete:
+
+```bash
+./bin/backfill-public-ids-until-done
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Backfill complete (or dry-run finished) |
+| `1` | More rows need `public_id` (e.g. `--max-runtime` reached) |
+| `2` | Critical error |
+
+## Resume behaviour
+
+No checkpoint table is required. Each run continues with:
+
+```sql
+SELECT id FROM <table> WHERE public_id IS NULL ORDER BY id ASC LIMIT <batch-size>
+```
+
+Interrupted runs (SIGINT/SIGTERM, timeout, OOM) can be restarted safely.
+
+Each backfilled ID is an independent `Uuid::v4()` — no sequential predictability within batches.
+
+## Deploy sequence
+
+1. `doctrine:migrations:migrate` (adds nullable `public_id`)
+2. Deploy application code (routes expect UUID v4; rows without `public_id` return 404 on detail pages)
+3. `./bin/backfill-public-ids-until-done`
+
+New rows created via import or ORM receive `public_id` immediately via `HasPublicId` `PrePersist`.
+
+## Security note
+
+UUID v4 improves opacity versus integer IDs but does not replace authentication and rate limiting. Treat `public_id` as an opaque handle, not a secret.
+
+## Follow-up (separate PR)
+
+After backfill is complete in all environments, a follow-up migration should:
+
+- Set `public_id` to `NOT NULL` on all five tables
+- Replace partial unique indexes with full unique indexes
+
+This step is intentionally deferred from the initial rollout so alpha can run backfill and validate UUID routing before locking the schema.

--- a/docs/06-reference/console-commands.md
+++ b/docs/06-reference/console-commands.md
@@ -62,6 +62,7 @@ Commands are invokable classes with `#[AsCommand]` and autoconfiguration via `co
 |---|---|
 | `app:allocation:backfill-indications` | Repair tool: sync normalized indication fields (not for routine use). |
 | `app:allocation:audit-indication-review` | Health check for indication raw review data consistency. |
+| `app:explore:backfill-public-ids` | Backfill `public_id` UUID v4 values for explore detail resources. See [../04-features/allocation/explore-public-ids.md](../04-features/allocation/explore-public-ids.md). |
 
 ### Statistics
 

--- a/migrations/Version20260708183119.php
+++ b/migrations/Version20260708183119.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260708183119 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add nullable public_id (UUID v4 RFC 4122) columns to explore detail resources with partial unique indexes.';
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->addSql(sprintf(
+                'ALTER TABLE %s ADD COLUMN IF NOT EXISTS public_id VARCHAR(36) DEFAULT NULL',
+                $table,
+            ));
+            $this->addSql(sprintf(
+                'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uniq_%s_public_id ON %s (public_id) WHERE public_id IS NOT NULL',
+                $table,
+                $table,
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TABLES as $table) {
+            $this->addSql(sprintf('DROP INDEX CONCURRENTLY IF EXISTS uniq_%s_public_id', $table));
+            $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN IF EXISTS public_id', $table));
+        }
+    }
+
+    /** @var list<string> */
+    private const array TABLES = [
+        'hospital',
+        'allocation',
+        'mci_case',
+        'secondary_transport',
+        'indication_raw',
+    ];
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -111,6 +111,7 @@
             <errorLevel type="suppress">
                 <file name="src/Import/Application/ImportDispatchExitCode.php" />
                 <file name="src/Import/Application/ImportAllowedFileTypes.php" />
+                <file name="src/Shared/Application/PublicId/PublicIdBackfillExitCode.php" />
             </errorLevel>
         </UnusedConstructor>
     </issueHandlers>

--- a/src/Allocation/Domain/Entity/Allocation.php
+++ b/src/Allocation/Domain/Entity/Allocation.php
@@ -9,14 +9,17 @@ use App\Allocation\Domain\Enum\AllocationTransportType;
 use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Infrastructure\Repository\AllocationRepository;
 use App\Import\Domain\Entity\Import;
+use App\Shared\Domain\Traits\HasPublicId;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[Audit\Audited]
 #[ORM\Entity(repositoryClass: AllocationRepository::class)]
+#[ORM\HasLifecycleCallbacks]
 class Allocation
 {
+    use HasPublicId;
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]

--- a/src/Allocation/Domain/Entity/Hospital.php
+++ b/src/Allocation/Domain/Entity/Hospital.php
@@ -9,6 +9,7 @@ use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
 use App\Shared\Domain\Traits\Blamable;
+use App\Shared\Domain\Traits\HasPublicId;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -21,6 +22,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Hospital implements \Stringable
 {
     use Blamable;
+    use HasPublicId;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Allocation/Domain/Entity/IndicationRaw.php
+++ b/src/Allocation/Domain/Entity/IndicationRaw.php
@@ -7,6 +7,7 @@ namespace App\Allocation\Domain\Entity;
 use App\Allocation\Domain\Enum\IndicationRawReviewStatus;
 use App\Allocation\Infrastructure\Repository\IndicationRawRepository;
 use App\Shared\Domain\Traits\Blamable;
+use App\Shared\Domain\Traits\HasPublicId;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
@@ -17,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 class IndicationRaw implements \Stringable
 {
     use Blamable;
+    use HasPublicId;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Allocation/Domain/Entity/MciCase.php
+++ b/src/Allocation/Domain/Entity/MciCase.php
@@ -9,13 +9,16 @@ use App\Allocation\Domain\Enum\AllocationTransportType;
 use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Infrastructure\Repository\MciCaseRepository;
 use App\Import\Domain\Entity\Import;
+use App\Shared\Domain\Traits\HasPublicId;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use Doctrine\ORM\Mapping as ORM;
 
 #[Audit\Audited]
 #[ORM\Entity(repositoryClass: MciCaseRepository::class)]
+#[ORM\HasLifecycleCallbacks]
 class MciCase
 {
+    use HasPublicId;
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]

--- a/src/Allocation/Domain/Entity/SecondaryTransport.php
+++ b/src/Allocation/Domain/Entity/SecondaryTransport.php
@@ -6,6 +6,7 @@ namespace App\Allocation\Domain\Entity;
 
 use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
 use App\Shared\Domain\Traits\Blamable;
+use App\Shared\Domain\Traits\HasPublicId;
 use App\Shared\Infrastructure\Audit\Attribute as Audit;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
@@ -16,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 class SecondaryTransport implements \Stringable
 {
     use Blamable;
+    use HasPublicId;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Allocation/Infrastructure/Query/IndicationRawOccurrenceQuery.php
+++ b/src/Allocation/Infrastructure/Query/IndicationRawOccurrenceQuery.php
@@ -92,14 +92,15 @@ SQL,
     }
 
     /**
-     * @return list<array{id: int, created_at: string, hospital_name: string|null}>
+     * @return list<array{id: int, public_id: string, created_at: string, hospital_name: string|null}>
      */
     public function fetchSampleAllocations(int $rawId, int $limit = 5): array
     {
-        /** @var list<array{id: int|string, created_at: string, hospital_name: string|null}> $rows */
+        /** @var list<array{id: int|string, public_id: string, created_at: string, hospital_name: string|null}> $rows */
         $rows = $this->connection->executeQuery(
             <<<'SQL'
 SELECT a.id,
+       a.public_id,
        a.created_at,
        h.name AS hospital_name
 FROM allocation a
@@ -114,6 +115,7 @@ SQL,
 
         return array_map(static fn (array $row): array => [
             'id' => (int) $row['id'],
+            'public_id' => $row['public_id'],
             'created_at' => $row['created_at'],
             'hospital_name' => $row['hospital_name'],
         ], $rows);

--- a/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
+++ b/src/Allocation/Infrastructure/Query/ListAllocationsQuery.php
@@ -35,8 +35,8 @@ final readonly class ListAllocationsQuery
     public function getPaginator(AllocationQueryParametersDTO $queryParametersDTO, ?User $user = null): CursorPaginator
     {
         $qb = $this->entityManager->createQueryBuilder();
-        $qb->select('a.id, a.createdAt, a.arrivalAt, a.departmentWasClosed, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
-                h.id as hospital_id, h.name as hospital, h.tier, h.size, h.location, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock,
+        $qb->select('a.id, a.publicId, a.createdAt, a.arrivalAt, a.departmentWasClosed, s.id as state_id, s.name as state, da.id as dispatchArea_id, da.name as dispatchArea,
+                h.id as hospital_id, h.publicId as hospital_public_id, h.name as hospital, h.tier, h.size, h.location, a.gender, a.age, a.requiresResus, a.requiresCathlab, a.isCPR, a.isVentilated, a.isShock,
                 a.isPregnant, a.isWorkAccident, a.isWithPhysician, a.urgency, i.name as infection, iraw.name as indicationRawName, iraw.code indicationRawCode,
                 inor.name as indicationNormalizedName, inor.code as indicationNormalizedCode,
                 iraw2.name as secondaryIndicationRawName, iraw2.code as secondaryIndicationRawCode,

--- a/src/Allocation/Infrastructure/Repository/AllocationRepository.php
+++ b/src/Allocation/Infrastructure/Repository/AllocationRepository.php
@@ -8,16 +8,20 @@ use App\Allocation\Domain\Entity\Allocation;
 use App\Allocation\Domain\Enum\AllocationGender;
 use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Import\Domain\Entity\Import;
+use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<Allocation>
  */
 final class AllocationRepository extends ServiceEntityRepository
 {
+    use PublicIdRepositoryTrait;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Allocation::class);
@@ -73,6 +77,54 @@ final class AllocationRepository extends ServiceEntityRepository
             ->leftJoin('hospital.state', 'hospitalState')
             ->where('a.id = :id')
             ->setParameter('id', $id, Types::INTEGER)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $allocation;
+    }
+
+    public function findOneForShowByPublicId(Uuid|string $publicId): ?Allocation
+    {
+        $resolved = $publicId instanceof Uuid ? $publicId : Uuid::fromString($publicId);
+
+        /** @var Allocation|null $allocation */
+        $allocation = $this->createQueryBuilder('a')
+            ->addSelect(
+                'dispatchArea',
+                'state',
+                'department',
+                'speciality',
+                'indicationRaw',
+                'indicationNormalized',
+                'secondaryIndicationRaw',
+                'secondaryIndicationNormalized',
+                'assignment',
+                'occasion',
+                'secondaryTransport',
+                'infection',
+                'assessment',
+                'hospital',
+                'hospitalDispatchArea',
+                'hospitalState',
+            )
+            ->join('a.dispatchArea', 'dispatchArea')
+            ->join('a.state', 'state')
+            ->join('a.department', 'department')
+            ->join('a.speciality', 'speciality')
+            ->join('a.indicationRaw', 'indicationRaw')
+            ->leftJoin('a.indicationNormalized', 'indicationNormalized')
+            ->leftJoin('a.secondaryIndicationRaw', 'secondaryIndicationRaw')
+            ->leftJoin('a.secondaryIndicationNormalized', 'secondaryIndicationNormalized')
+            ->join('a.assignment', 'assignment')
+            ->leftJoin('a.occasion', 'occasion')
+            ->leftJoin('a.secondaryTransport', 'secondaryTransport')
+            ->leftJoin('a.infection', 'infection')
+            ->leftJoin('a.assessment', 'assessment')
+            ->join('a.hospital', 'hospital')
+            ->leftJoin('hospital.dispatchArea', 'hospitalDispatchArea')
+            ->leftJoin('hospital.state', 'hospitalState')
+            ->where('a.publicId = :publicId')
+            ->setParameter('publicId', $resolved->toRfc4122())
             ->getQuery()
             ->getOneOrNullResult();
 

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -14,6 +14,7 @@ use App\Allocation\Domain\Enum\HospitalSize;
 use App\Allocation\Domain\Enum\HospitalTier;
 use App\Allocation\UI\Http\DTO\HospitalQueryParametersDTO;
 use App\Shared\Infrastructure\Pagination\Paginator;
+use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -26,6 +27,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class HospitalRepository extends ServiceEntityRepository implements HospitalLookupInterface
 {
+    use PublicIdRepositoryTrait;
+
     public function __construct(
         ManagerRegistry $registry,
         private readonly HospitalAccessGrantRepository $hospitalAccessGrantRepository,

--- a/src/Allocation/Infrastructure/Repository/IndicationRawRepository.php
+++ b/src/Allocation/Infrastructure/Repository/IndicationRawRepository.php
@@ -11,6 +11,7 @@ use App\Allocation\Domain\Enum\IndicationRawReviewWorklistSegment;
 use App\Allocation\UI\Http\DTO\IndicationQueryParametersDTO;
 use App\Allocation\UI\Http\DTO\IndicationRawReviewWorklistQueryDTO;
 use App\Shared\Infrastructure\Pagination\Paginator;
+use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
@@ -22,6 +23,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class IndicationRawRepository extends ServiceEntityRepository
 {
+    use PublicIdRepositoryTrait;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, IndicationRaw::class);

--- a/src/Allocation/Infrastructure/Repository/MciCaseRepository.php
+++ b/src/Allocation/Infrastructure/Repository/MciCaseRepository.php
@@ -14,6 +14,7 @@ use App\Allocation\Domain\Entity\State;
 use App\Allocation\UI\Http\DTO\MciCaseQueryParametersDTO;
 use App\Import\Domain\Entity\Import;
 use App\Shared\Infrastructure\Pagination\Paginator;
+use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
@@ -23,6 +24,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class MciCaseRepository extends ServiceEntityRepository
 {
+    use PublicIdRepositoryTrait;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, MciCase::class);
@@ -41,8 +44,8 @@ final class MciCaseRepository extends ServiceEntityRepository
     public function getListPaginator(MciCaseQueryParametersDTO $queryParametersDTO): Paginator
     {
         $qb = $this->createQueryBuilder('m')
-            ->select('m.id, m.createdAt, m.arrivalAt,
-                h.id as hospital_id, h.name as hospital,
+            ->select('m.id, m.publicId, m.createdAt, m.arrivalAt,
+                h.id as hospital_id, h.publicId as hospital_public_id, h.name as hospital,
                 da.id as dispatch_area_id, da.name as dispatchArea,
                 s.id as state_id, s.name as state,
                 m.mciId, m.mciTitle,

--- a/src/Allocation/Infrastructure/Repository/SecondaryTransportRepository.php
+++ b/src/Allocation/Infrastructure/Repository/SecondaryTransportRepository.php
@@ -7,6 +7,7 @@ namespace App\Allocation\Infrastructure\Repository;
 use App\Allocation\Domain\Entity\SecondaryTransport;
 use App\Allocation\UI\Http\DTO\SecondaryTransportQueryParametersDTO;
 use App\Shared\Infrastructure\Pagination\Paginator;
+use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -15,6 +16,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class SecondaryTransportRepository extends ServiceEntityRepository
 {
+    use PublicIdRepositoryTrait;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, SecondaryTransport::class);

--- a/src/Allocation/UI/Http/Controller/Allocations/ShowAllocationController.php
+++ b/src/Allocation/UI/Http/Controller/Allocations/ShowAllocationController.php
@@ -21,7 +21,7 @@ final class ShowAllocationController extends AbstractController
         methods: ['GET'],
     )]
     public function index(
-        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] Allocation $allocation,
+        #[MapEntity(expr: 'repository.findOneForShowByPublicId(publicId)')] Allocation $allocation,
     ): Response {
         $this->denyAccessUnlessGranted(AllocationVoter::VIEW, $allocation);
 

--- a/src/Allocation/UI/Http/Controller/Allocations/ShowAllocationController.php
+++ b/src/Allocation/UI/Http/Controller/Allocations/ShowAllocationController.php
@@ -5,27 +5,24 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\Allocations;
 
 use App\Allocation\Domain\Entity\Allocation;
-use App\Allocation\Infrastructure\Repository\AllocationRepository;
 use App\Allocation\Infrastructure\Security\Voter\AllocationVoter;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 
 final class ShowAllocationController extends AbstractController
 {
-    public function __construct(
-        private readonly AllocationRepository $allocationRepository,
-    ) {
-    }
-
-    #[Route('/explore/allocation/{id}', name: 'app_explore_allocation_show', methods: ['GET'])]
-    public function index(int $id): Response
-    {
-        $allocation = $this->allocationRepository->findOneForShow($id);
-        if (!$allocation instanceof Allocation) {
-            throw $this->createNotFoundException();
-        }
-
+    #[Route(
+        '/explore/allocation/{publicId}',
+        name: 'app_explore_allocation_show',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function index(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] Allocation $allocation,
+    ): Response {
         $this->denyAccessUnlessGranted(AllocationVoter::VIEW, $allocation);
 
         return $this->render('@Allocation/allocations/show.html.twig', [

--- a/src/Allocation/UI/Http/Controller/Hospitals/EditOwnedHospitalController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/EditOwnedHospitalController.php
@@ -71,7 +71,7 @@ final class EditOwnedHospitalController extends AbstractController
 
             $this->addFlash('success', new TranslatableMessage('flash.hospital.updated', domain: 'allocation'));
 
-            return $this->redirectToRoute('app_explore_hospital_show', ['id' => $hospital->getId()]);
+            return $this->redirectToRoute('app_explore_hospital_show', ['publicId' => $hospital->getPublicIdString()]);
         }
 
         return $this->render('@Allocation/hospitals/edit_owned.html.twig', [

--- a/src/Allocation/UI/Http/Controller/Hospitals/ShowHospitalController.php
+++ b/src/Allocation/UI/Http/Controller/Hospitals/ShowHospitalController.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\Hospitals;
 
 use App\Allocation\Domain\Entity\Hospital;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 
 final class ShowHospitalController extends AbstractController
 {
-    #[Route('/explore/hospital/{id}', name: 'app_explore_hospital_show', methods: ['GET'])]
-    public function index(Hospital $hospital): Response
-    {
+    #[Route(
+        '/explore/hospital/{publicId}',
+        name: 'app_explore_hospital_show',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function index(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] Hospital $hospital,
+    ): Response {
         return $this->render('@Allocation/hospitals/show.html.twig', [
             'hospital' => $hospital,
         ]);

--- a/src/Allocation/UI/Http/Controller/Indications/AssignIndicationRawController.php
+++ b/src/Allocation/UI/Http/Controller/Indications/AssignIndicationRawController.php
@@ -5,16 +5,24 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\Indications;
 
 use App\Allocation\Domain\Entity\IndicationRaw;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted('ROLE_PARTICIPANT')]
 final class AssignIndicationRawController extends AbstractController
 {
-    #[Route('/explore/indication/raw/assign/{id}', name: 'app_explore_indication_raw_assign', methods: ['GET', 'POST'])]
-    public function edit(IndicationRaw $raw): \Symfony\Component\HttpFoundation\RedirectResponse
-    {
-        return $this->redirectToRoute('app_explore_indication_raw_review', ['id' => $raw->getId()]);
+    #[Route(
+        '/explore/indication/raw/assign/{publicId}',
+        name: 'app_explore_indication_raw_assign',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET', 'POST'],
+    )]
+    public function edit(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] IndicationRaw $raw,
+    ): \Symfony\Component\HttpFoundation\RedirectResponse {
+        return $this->redirectToRoute('app_explore_indication_raw_review', ['publicId' => $raw->getPublicIdString()]);
     }
 }

--- a/src/Allocation/UI/Http/Controller/Indications/ReviewIndicationRawController.php
+++ b/src/Allocation/UI/Http/Controller/Indications/ReviewIndicationRawController.php
@@ -18,12 +18,14 @@ use App\Allocation\UI\Form\IndicationRawReviewType;
 use App\Allocation\UI\Http\DTO\IndicationRawReviewWorklistQueryDTO;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\ClickableInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -40,9 +42,14 @@ final class ReviewIndicationRawController extends AbstractController
     ) {
     }
 
-    #[Route('/explore/indication/raw/review/{id}', name: 'app_explore_indication_raw_review', methods: ['GET', 'POST'])]
+    #[Route(
+        '/explore/indication/raw/review/{publicId}',
+        name: 'app_explore_indication_raw_review',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET', 'POST'],
+    )]
     public function __invoke(
-        IndicationRaw $raw,
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] IndicationRaw $raw,
         Request $request,
     ): Response {
         $context = $this->buildContextFromRequest($request);
@@ -65,7 +72,7 @@ final class ReviewIndicationRawController extends AbstractController
                 $this->addFlash('danger', $exception->getMessage());
 
                 return $this->redirectToRoute('app_explore_indication_raw_review', [
-                    'id' => $raw->getId(),
+                    'publicId' => $raw->getPublicIdString(),
                     ...$this->contextQueryParams($context),
                 ]);
             }
@@ -94,9 +101,16 @@ final class ReviewIndicationRawController extends AbstractController
         ]);
     }
 
-    #[Route('/explore/indication/raw/review/{id}/skip', name: 'app_explore_indication_raw_review_skip', methods: ['GET'])]
-    public function skip(IndicationRaw $raw, Request $request): \Symfony\Component\HttpFoundation\RedirectResponse
-    {
+    #[Route(
+        '/explore/indication/raw/review/{publicId}/skip',
+        name: 'app_explore_indication_raw_review_skip',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function skip(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] IndicationRaw $raw,
+        Request $request,
+    ): \Symfony\Component\HttpFoundation\RedirectResponse {
         $context = $this->buildContextFromRequest($request);
         $next = $this->navigator->findNext($context, $raw->getId());
 
@@ -107,7 +121,7 @@ final class ReviewIndicationRawController extends AbstractController
         }
 
         return $this->redirectToRoute('app_explore_indication_raw_review', [
-            'id' => $next->getId(),
+            'publicId' => $next->getPublicIdString(),
             ...$this->contextQueryParams($context),
         ]);
     }
@@ -140,7 +154,7 @@ final class ReviewIndicationRawController extends AbstractController
         }
 
         return $this->redirectToRoute('app_explore_indication_raw_review', [
-            'id' => $first->getId(),
+            'publicId' => $first->getPublicIdString(),
             'segment' => $segment->value,
         ]);
     }
@@ -211,7 +225,7 @@ final class ReviewIndicationRawController extends AbstractController
             $this->addFlash('success', $this->translator->trans('flash.indication.review.reopened', [], 'allocation'));
 
             return $this->redirectToRoute('app_explore_indication_raw_review', [
-                'id' => $raw->getId(),
+                'publicId' => $raw->getPublicIdString(),
                 ...$this->contextQueryParams($context),
             ]);
         }
@@ -221,13 +235,13 @@ final class ReviewIndicationRawController extends AbstractController
             $this->addFlash('success', $this->translator->trans('flash.indication.review.comment_saved', [], 'allocation'));
 
             return $this->redirectToRoute('app_explore_indication_raw_review', [
-                'id' => $raw->getId(),
+                'publicId' => $raw->getPublicIdString(),
                 ...$this->contextQueryParams($context),
             ]);
         }
 
         return $this->redirectToRoute('app_explore_indication_raw_review', [
-            'id' => $raw->getId(),
+            'publicId' => $raw->getPublicIdString(),
             ...$this->contextQueryParams($context),
         ]);
     }
@@ -242,7 +256,7 @@ final class ReviewIndicationRawController extends AbstractController
         }
 
         return $this->redirectToRoute('app_explore_indication_raw_review', [
-            'id' => $next->getId(),
+            'publicId' => $next->getPublicIdString(),
             ...$this->contextQueryParams($context),
         ]);
     }

--- a/src/Allocation/UI/Http/Controller/MciCases/ShowMciCaseController.php
+++ b/src/Allocation/UI/Http/Controller/MciCases/ShowMciCaseController.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\MciCases;
 
 use App\Allocation\Domain\Entity\MciCase;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 
 final class ShowMciCaseController extends AbstractController
 {
-    #[Route('/explore/mci_case/{id}', name: 'app_explore_mci_case_show', methods: ['GET'])]
-    public function index(MciCase $mciCase): Response
-    {
+    #[Route(
+        '/explore/mci_case/{publicId}',
+        name: 'app_explore_mci_case_show',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function index(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] MciCase $mciCase,
+    ): Response {
         return $this->render('@Allocation/mci_cases/show.html.twig', [
             'mciCase' => $mciCase,
         ]);

--- a/src/Allocation/UI/Http/Controller/SecondaryTransports/ShowSecondaryTransportController.php
+++ b/src/Allocation/UI/Http/Controller/SecondaryTransports/ShowSecondaryTransportController.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Allocation\UI\Http\Controller\SecondaryTransports;
 
 use App\Allocation\Domain\Entity\SecondaryTransport;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
 
 final class ShowSecondaryTransportController extends AbstractController
 {
-    #[Route('/explore/secondary_transport/{id}', name: 'app_explore_secondary_transport_show', methods: ['GET'])]
-    public function __invoke(SecondaryTransport $secondaryTransport): Response
-    {
+    #[Route(
+        '/explore/secondary_transport/{publicId}',
+        name: 'app_explore_secondary_transport_show',
+        requirements: ['publicId' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function __invoke(
+        #[MapEntity(expr: 'repository.findOneByPublicId(publicId)')] SecondaryTransport $secondaryTransport,
+    ): Response {
         return $this->render('@Allocation/secondary_transports/show.html.twig', [
             'secondaryTransport' => $secondaryTransport,
         ]);

--- a/src/Allocation/UI/Twig/templates/allocations/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/list.html.twig
@@ -136,7 +136,7 @@
                             {{ allocation.age }}
                         </td>
                         <td>
-                            <a href="{{ path('app_explore_hospital_show', {id: allocation.hospital_id}) }}" target="_top">{{ allocation.hospital }}</a><br />
+                            <a href="{{ path('app_explore_hospital_show', {publicId: allocation.hospital_public_id}) }}" target="_top">{{ allocation.hospital }}</a><br />
                             {{ allocation.dispatchArea }} - {{ allocation.state }}
                         </td>
                         <td>
@@ -197,7 +197,7 @@
                         </td>
                         <td>
                             <div class="btn-actions">
-                                <a href="{{ path('app_explore_allocation_show', {id: allocation.id}) }}" class="btn btn-action" target="_top">
+                                <a href="{{ path('app_explore_allocation_show', {publicId: allocation.publicId}) }}" class="btn btn-action" target="_top">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
                                         <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
                                             <path d="M10 12a2 2 0 1 0 4 0a2 2 0 0 0-4 0"/>

--- a/src/Allocation/UI/Twig/templates/hospitals/_hospital_edit_page_header.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/_hospital_edit_page_header.html.twig
@@ -2,7 +2,7 @@
     <twig:Breadcrumbs
         :items="[
             { label: 'title.hospitals.my', path: path('app_hospitals_index') },
-            { label: hospital.name, path: path('app_explore_hospital_show', {id: hospital.id}), translatable: false },
+            { label: hospital.name, path: path('app_explore_hospital_show', {publicId: hospital.publicId}), translatable: false },
             { label: 'title.hospital.edit' }
         ]"
     />

--- a/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
@@ -14,7 +14,7 @@
     } %}
         {% block edit_card_title %}{{ 'label.hospital.access_grants.overview'|trans({}, 'messages') }}{% endblock %}
         {% block edit_card_actions %}
-            <a class="btn btn-primary" href="{{ path('app_hospitals_edit_access_new', {publicId: hospital.publicId}) }}">{{ 'label.hospital_access_grants.add'|trans({}, 'messages') }}</a>
+            <a class="btn btn-primary" href="{{ path('app_hospitals_edit_access_new', {id: hospital.id}) }}">{{ 'label.hospital_access_grants.add'|trans({}, 'messages') }}</a>
         {% endblock %}
         {% block edit_content %}
             {{ include('@Allocation/hospitals/_access_grants_matrix.html.twig', {

--- a/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/access/index.html.twig
@@ -14,7 +14,7 @@
     } %}
         {% block edit_card_title %}{{ 'label.hospital.access_grants.overview'|trans({}, 'messages') }}{% endblock %}
         {% block edit_card_actions %}
-            <a class="btn btn-primary" href="{{ path('app_hospitals_edit_access_new', {id: hospital.id}) }}">{{ 'label.hospital_access_grants.add'|trans({}, 'messages') }}</a>
+            <a class="btn btn-primary" href="{{ path('app_hospitals_edit_access_new', {publicId: hospital.publicId}) }}">{{ 'label.hospital_access_grants.add'|trans({}, 'messages') }}</a>
         {% endblock %}
         {% block edit_content %}
             {{ include('@Allocation/hospitals/_access_grants_matrix.html.twig', {
@@ -24,7 +24,7 @@
             }) }}
         {% endblock %}
         {% block edit_footer %}
-            <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">{{ 'label.hospital.back_to_profile'|trans({}, 'messages') }}</a>
+            <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {publicId: hospital.publicId}) }}">{{ 'label.hospital.back_to_profile'|trans({}, 'messages') }}</a>
         {% endblock %}
     {% endembed %}
 {% endblock %}

--- a/src/Allocation/UI/Twig/templates/hospitals/edit_owned.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/edit_owned.html.twig
@@ -38,7 +38,7 @@
                 {% endif %}
             </div>
             <div class="card-footer d-flex justify-content-end gap-2">
-                <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">{{ 'label.hospital.back_to_profile'|trans({}, 'messages') }}</a>
+                <a class="btn btn-link" href="{{ path('app_explore_hospital_show', {publicId: hospital.publicId}) }}">{{ 'label.hospital.back_to_profile'|trans({}, 'messages') }}</a>
                 <button type="submit" class="btn btn-primary">{{ 'action.save_changes'|trans({}, 'messages') }}</button>
             </div>
             {{ form_end(form) }}

--- a/src/Allocation/UI/Twig/templates/hospitals/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/list.html.twig
@@ -248,7 +248,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            <a href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}" target="_top">{{ hospital.name }}</a>
+                            <a href="{{ path('app_explore_hospital_show', {publicId: hospital.publicId}) }}" target="_top">{{ hospital.name }}</a>
                         </td>
                         <td>
                             {{ hospital.dispatchArea }}

--- a/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
@@ -54,11 +54,11 @@
                             <td>{{ badges.render('hospital_size', hospital.size.value, hospital.beds) }}</td>
                             <td class="text-nowrap">
                                 {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\HospitalVoter::MANAGE_ACCESS_GRANTS'), hospital) %}
-                                    <a class="btn btn-sm btn-outline-secondary me-1" href="{{ path('app_hospitals_edit_access', {publicId: hospital.publicId}) }}">
+                                    <a class="btn btn-sm btn-outline-secondary me-1" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">
                                         {{ 'label.hospital_access_grants.manage'|trans({}, 'messages') }}
                                     </a>
                                 {% endif %}
-                                <a class="btn btn-sm btn-outline-primary" href="{{ path('app_hospitals_edit', {publicId: hospital.publicId}) }}">
+                                <a class="btn btn-sm btn-outline-primary" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
                                     {{ 'label.edit'|trans({}, 'messages') }}
                                 </a>
                             </td>

--- a/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/owned_list.html.twig
@@ -43,7 +43,7 @@
                     {% for hospital in hospitals %}
                         <tr>
                             <td>
-                                <a href="{{ path('app_explore_hospital_show', {id: hospital.id}) }}">
+                                <a href="{{ path('app_explore_hospital_show', {publicId: hospital.publicId}) }}">
                                     {{ hospital.name }}
                                 </a>
                             </td>
@@ -54,11 +54,11 @@
                             <td>{{ badges.render('hospital_size', hospital.size.value, hospital.beds) }}</td>
                             <td class="text-nowrap">
                                 {% if is_granted(constant('App\\Allocation\\Infrastructure\\Security\\Voter\\HospitalVoter::MANAGE_ACCESS_GRANTS'), hospital) %}
-                                    <a class="btn btn-sm btn-outline-secondary me-1" href="{{ path('app_hospitals_edit_access', {id: hospital.id}) }}">
+                                    <a class="btn btn-sm btn-outline-secondary me-1" href="{{ path('app_hospitals_edit_access', {publicId: hospital.publicId}) }}">
                                         {{ 'label.hospital_access_grants.manage'|trans({}, 'messages') }}
                                     </a>
                                 {% endif %}
-                                <a class="btn btn-sm btn-outline-primary" href="{{ path('app_hospitals_edit', {id: hospital.id}) }}">
+                                <a class="btn btn-sm btn-outline-primary" href="{{ path('app_hospitals_edit', {publicId: hospital.publicId}) }}">
                                     {{ 'label.edit'|trans({}, 'messages') }}
                                 </a>
                             </td>

--- a/src/Allocation/UI/Twig/templates/indications/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/indications/list.html.twig
@@ -162,7 +162,7 @@
                         </td>
                         {% if active_type == 'raw' %}
                             <td>
-                                <a href="{{ path('app_explore_indication_raw_review', {id: indication.id}) }}" target="_top">
+                                <a href="{{ path('app_explore_indication_raw_review', {publicId: indication.publicId}) }}" target="_top">
                                     {{ indication.name }}
                                 </a>
                             </td>

--- a/src/Allocation/UI/Twig/templates/indications/review_raw.html.twig
+++ b/src/Allocation/UI/Twig/templates/indications/review_raw.html.twig
@@ -45,7 +45,7 @@
                             attr: {class: 'btn btn-outline-secondary', form: 'indication-raw-review-form'},
                         }) }}
                     {% endif %}
-                    <a href="{{ path('app_explore_indication_raw_review_skip', {id: raw.id, segment: context.segment.value, search: context.search}) }}" class="btn">
+                    <a href="{{ path('app_explore_indication_raw_review_skip', {publicId: raw.publicId, segment: context.segment.value, search: context.search}) }}" class="btn">
                         {{ 'btn.indication.skip'|trans({}, 'allocation') }}
                         <twig:ux:icon name="tabler:player-skip-forward" class="w-3 h-3 ms-1" />
                     </a>
@@ -113,7 +113,7 @@
                         <ul class="list-unstyled">
                             {% for allocation in sample_allocations %}
                                 <li>
-                                    <a href="{{ path('app_explore_allocation_show', {id: allocation.id}) }}" target="_top">
+                                    <a href="{{ path('app_explore_allocation_show', {publicId: allocation.public_id}) }}" target="_top">
                                         #{{ allocation.id }} — {{ allocation.created_at|date('d.m.Y') }}
                                         {% if allocation.hospital_name %} ({{ allocation.hospital_name }}){% endif %}
                                     </a>

--- a/src/Allocation/UI/Twig/templates/indications/review_worklist.html.twig
+++ b/src/Allocation/UI/Twig/templates/indications/review_worklist.html.twig
@@ -150,7 +150,7 @@
                         <td>{{ counts.occurrence_count }}</td>
                         <td>{{ raw.createdAt|date('d.m.Y H:i') }}</td>
                         <td class="text-end">
-                            <a class="btn btn-sm btn-outline-primary" href="{{ path('app_explore_indication_raw_review', {id: raw.id, segment: query.segment.value, search: query.search}) }}" target="_top">
+                            <a class="btn btn-sm btn-outline-primary" href="{{ path('app_explore_indication_raw_review', {publicId: raw.publicId, segment: query.segment.value, search: query.search}) }}" target="_top">
                                 {{ 'btn.indication.review'|trans({}, 'allocation') }}
                             </a>
                         </td>

--- a/src/Allocation/UI/Twig/templates/mci_cases/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/mci_cases/list.html.twig
@@ -92,7 +92,7 @@
                             <twig:ux:icon name="tabler:clock-check" class="w-3 h-3" /> {{ mciCase.arrivalAt|date('d.m.Y H:i') }}
                         </td>
                         <td>
-                            <a href="{{ path('app_explore_hospital_show', {id: mciCase.hospital_id}) }}" target="_top">{{ mciCase.hospital }}</a><br/>
+                            <a href="{{ path('app_explore_hospital_show', {publicId: mciCase.hospital_public_id}) }}" target="_top">{{ mciCase.hospital }}</a><br/>
                             {{ mciCase.dispatchArea }} - {{ mciCase.state }}
                         </td>
                         <td>
@@ -116,7 +116,7 @@
                         </td>
                         <td>
                             <div class="btn-actions">
-                                <a href="{{ path('app_explore_mci_case_show', {id: mciCase.id}) }}" class="btn btn-action" target="_top">
+                                <a href="{{ path('app_explore_mci_case_show', {publicId: mciCase.publicId}) }}" class="btn btn-action" target="_top">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
                                         <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
                                             <path d="M10 12a2 2 0 1 0 4 0a2 2 0 0 0-4 0"/>

--- a/src/Allocation/UI/Twig/templates/secondary_transports/list.html.twig
+++ b/src/Allocation/UI/Twig/templates/secondary_transports/list.html.twig
@@ -122,7 +122,7 @@
                 {% for st in paginator.results %}
                     <tr>
                         <td>
-                            <a href="{{ path('app_explore_secondary_transport_show', {id: st.id}) }}">{{ st.name }}</a>
+                            <a href="{{ path('app_explore_secondary_transport_show', {publicId: st.publicId}) }}">{{ st.name }}</a>
                         </td>
                         <td>
                             {{ st.updatedAt ? st.updatedAt|date('d.m.Y H:i') : st.createdAt|date('d.m.Y H:i') }}

--- a/src/Import/UI/Twig/templates/index.html.twig
+++ b/src/Import/UI/Twig/templates/index.html.twig
@@ -222,7 +222,7 @@
                             {{ macros.import_status(import.status.value) }}
                         </td>
                         <td>
-                            <a href="{{ path('app_explore_hospital_show', {id: import.hospital.id}) }}" target="_top">{{ import.hospital }}</a>
+                            <a href="{{ path('app_explore_hospital_show', {publicId: import.hospital.publicId}) }}" target="_top">{{ import.hospital }}</a>
                         </td>
                         <td>{{ import.createdAt|date('d.m.Y H:i') }}</td>
                         <td>

--- a/src/Import/UI/Twig/templates/show.html.twig
+++ b/src/Import/UI/Twig/templates/show.html.twig
@@ -68,7 +68,7 @@
                     <div class="col-12 mb-3">
                         <twig:Card title="{{ 'label.hospital'|trans({}, 'messages') }}">
                             <h3 class="card-title mb-1 fs-3">
-                                <a href="{{ path('app_explore_hospital_show', {id: import.hospital.id}) }}">{{ import.hospital.name }}</a>
+                                <a href="{{ path('app_explore_hospital_show', {publicId: import.hospital.publicId}) }}">{{ import.hospital.name }}</a>
                             </h3>
 
                             <div class="text-muted small mb-3 d-flex align-items-center gap-2">

--- a/src/Shared/Application/PublicId/PublicIdBackfillExitCode.php
+++ b/src/Shared/Application/PublicId/PublicIdBackfillExitCode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\PublicId;
+
+final class PublicIdBackfillExitCode
+{
+    public const int SUCCESS = 0;
+
+    public const int MORE_WORK = 1;
+
+    public const int CRITICAL = 2;
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Shared/Application/PublicId/PublicIdBackfillInterruptedException.php
+++ b/src/Shared/Application/PublicId/PublicIdBackfillInterruptedException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\PublicId;
+
+final class PublicIdBackfillInterruptedException extends \RuntimeException
+{
+    public function __construct(
+        private readonly int $signal,
+    ) {
+        parent::__construct(sprintf('Public ID backfill interrupted by signal %d.', $signal));
+    }
+
+    public function getSignal(): int
+    {
+        return $this->signal;
+    }
+}

--- a/src/Shared/Application/PublicId/PublicIdBackfillResult.php
+++ b/src/Shared/Application/PublicId/PublicIdBackfillResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\PublicId;
+
+final readonly class PublicIdBackfillResult
+{
+    /**
+     * @param array<string, int> $updatedByTable
+     * @param array<string, int> $remainingByTable
+     */
+    public function __construct(
+        public array $updatedByTable,
+        public array $remainingByTable,
+        public bool $completed,
+    ) {
+    }
+}

--- a/src/Shared/Application/PublicId/PublicIdBackfillRunControl.php
+++ b/src/Shared/Application/PublicId/PublicIdBackfillRunControl.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\PublicId;
+
+final class PublicIdBackfillRunControl
+{
+    private bool $stopRequested = false;
+
+    private ?int $signal = null;
+
+    public function requestStop(int $signal): void
+    {
+        $this->stopRequested = true;
+        $this->signal = $signal;
+    }
+
+    public function isStopRequested(): bool
+    {
+        return $this->stopRequested;
+    }
+
+    public function getSignal(): ?int
+    {
+        return $this->signal;
+    }
+
+    public function throwIfStopRequested(): void
+    {
+        if (!$this->isStopRequested()) {
+            return;
+        }
+
+        throw new PublicIdBackfillInterruptedException($this->getSignal() ?? 0);
+    }
+}

--- a/src/Shared/Application/PublicId/PublicIdBackfillService.php
+++ b/src/Shared/Application/PublicId/PublicIdBackfillService.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\PublicId;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class PublicIdBackfillService
+{
+    /** @var list<string> */
+    public const array TABLE_ORDER = [
+        'hospital',
+        'secondary_transport',
+        'indication_raw',
+        'mci_case',
+        'allocation',
+    ];
+
+    /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param list<string>|null $tables
+     */
+    public function run(
+        bool $dryRun = false,
+        ?array $tables = null,
+        int $batchSize = 5000,
+        int $maxRuntimeSeconds = 0,
+        ?PublicIdBackfillRunControl $runControl = null,
+    ): PublicIdBackfillResult {
+        $selectedTables = $this->resolveTables($tables);
+        $updatedByTable = [];
+        $remainingByTable = [];
+        $startedAt = microtime(true);
+
+        foreach ($selectedTables as $table) {
+            if ($dryRun) {
+                $remaining = $this->countRemaining($table);
+                $remainingByTable[$table] = $remaining;
+                $updatedByTable[$table] = 0;
+
+                continue;
+            }
+
+            $updatedByTable[$table] = $this->backfillTable(
+                $table,
+                $batchSize,
+                $maxRuntimeSeconds,
+                $startedAt,
+                $runControl,
+            );
+            $remainingByTable[$table] = $this->countRemaining($table);
+
+            if (
+                $maxRuntimeSeconds > 0
+                && (microtime(true) - $startedAt) >= $maxRuntimeSeconds
+                && $remainingByTable[$table] > 0
+            ) {
+                foreach (self::TABLE_ORDER as $remainingTable) {
+                    if (!\array_key_exists($remainingTable, $remainingByTable)) {
+                        $remainingByTable[$remainingTable] = $this->countRemaining($remainingTable);
+                        $updatedByTable[$remainingTable] ??= 0;
+                    }
+                }
+
+                break;
+            }
+        }
+
+        $completed = !$dryRun && [] === array_filter($remainingByTable);
+
+        return new PublicIdBackfillResult(
+            $updatedByTable,
+            $remainingByTable,
+            $completed,
+        );
+    }
+
+    /**
+     * @param list<string>|null $tables
+     *
+     * @return list<string>
+     */
+    private function resolveTables(?array $tables): array
+    {
+        if (null === $tables || [] === $tables || ['all'] === $tables) {
+            return self::TABLE_ORDER;
+        }
+
+        $invalid = array_diff($tables, self::TABLE_ORDER);
+        if ([] !== $invalid) {
+            throw new \InvalidArgumentException(sprintf('Unknown table(s): %s. Allowed: %s', implode(', ', $invalid), implode(', ', self::TABLE_ORDER)));
+        }
+
+        return array_values(array_intersect(self::TABLE_ORDER, $tables));
+    }
+
+    private function backfillTable(
+        string $table,
+        int $batchSize,
+        int $maxRuntimeSeconds,
+        float $startedAt,
+        ?PublicIdBackfillRunControl $runControl,
+    ): int {
+        $updated = 0;
+        $lastId = 0;
+
+        while (true) {
+            $runControl?->throwIfStopRequested();
+
+            if ($maxRuntimeSeconds > 0 && (microtime(true) - $startedAt) >= $maxRuntimeSeconds) {
+                break;
+            }
+
+            $ids = $this->fetchNextIds($table, $lastId, $batchSize);
+            if ([] === $ids) {
+                break;
+            }
+
+            $updated += $this->assignPublicIds($table, $ids);
+            $lastId = $ids[array_key_last($ids)];
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function fetchNextIds(string $table, int $lastId, int $batchSize): array
+    {
+        /** @var list<int|string> $rows */
+        $rows = $this->connection->fetchFirstColumn(
+            sprintf(
+                'SELECT id FROM %s WHERE public_id IS NULL AND id > :lastId ORDER BY id ASC LIMIT :batchSize',
+                $table,
+            ),
+            [
+                'lastId' => $lastId,
+                'batchSize' => $batchSize,
+            ],
+            [
+                'lastId' => ParameterType::INTEGER,
+                'batchSize' => ParameterType::INTEGER,
+            ],
+        );
+
+        return array_map(static fn (int|string $id): int => (int) $id, $rows);
+    }
+
+    /**
+     * @param list<int> $ids
+     */
+    private function assignPublicIds(string $table, array $ids): int
+    {
+        if ([] === $ids) {
+            return 0;
+        }
+
+        $values = [];
+        $params = [];
+        foreach ($ids as $index => $id) {
+            $values[] = sprintf('(:id%d, :pid%d)', $index, $index);
+            $params[sprintf('id%d', $index)] = $id;
+            $params[sprintf('pid%d', $index)] = Uuid::v4()->toRfc4122();
+        }
+
+        return $this->connection->executeStatement(
+            sprintf(
+                'UPDATE %s AS t SET public_id = v.pid FROM (VALUES %s) AS v(id, pid) WHERE t.id = v.id::int',
+                $table,
+                implode(', ', $values),
+            ),
+            $params,
+        );
+    }
+
+    private function countRemaining(string $table): int
+    {
+        return (int) $this->connection->fetchOne(
+            sprintf('SELECT COUNT(*) FROM %s WHERE public_id IS NULL', $table),
+        );
+    }
+}

--- a/src/Shared/Domain/Traits/HasPublicId.php
+++ b/src/Shared/Domain/Traits/HasPublicId.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Traits;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+trait HasPublicId
+{
+    #[ORM\Column(type: 'uuid', unique: true, nullable: true)]
+    private ?Uuid $publicId = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod Doctrine lifecycle callback
+     */
+    #[ORM\PrePersist]
+    public function ensurePublicId(): void
+    {
+        $this->publicId ??= Uuid::v4();
+    }
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function getPublicId(): ?Uuid
+    {
+        return $this->publicId;
+    }
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function setPublicId(Uuid $publicId): static
+    {
+        $this->publicId = $publicId;
+
+        return $this;
+    }
+
+    public function getPublicIdString(): string
+    {
+        if (!$this->publicId instanceof Uuid) {
+            throw new \LogicException(sprintf('%s is missing publicId.', static::class));
+        }
+
+        return $this->publicId->toRfc4122();
+    }
+}

--- a/src/Shared/Infrastructure/Repository/PublicIdRepositoryTrait.php
+++ b/src/Shared/Infrastructure/Repository/PublicIdRepositoryTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Repository;
+
+use Symfony\Component\Uid\Uuid;
+
+trait PublicIdRepositoryTrait
+{
+    public function findOneByPublicId(Uuid|string $publicId): ?object
+    {
+        $resolved = (string) ($publicId instanceof Uuid ? $publicId : Uuid::fromString($publicId));
+
+        return $this->createQueryBuilder('e')
+            ->where('e.publicId = :publicId')
+            ->setParameter('publicId', $resolved)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Shared/UI/Console/Command/BackfillPublicIdsCommand.php
+++ b/src/Shared/UI/Console/Command/BackfillPublicIdsCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Console\Command;
+
+use App\Shared\Application\PublicId\PublicIdBackfillExitCode;
+use App\Shared\Application\PublicId\PublicIdBackfillInterruptedException;
+use App\Shared\Application\PublicId\PublicIdBackfillRunControl;
+use App\Shared\Application\PublicId\PublicIdBackfillService;
+use App\Shared\UI\Console\Input\BackfillPublicIdsInput;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:explore:backfill-public-ids',
+    description: 'Backfill public_id UUID v4 values for explore detail resources. Exit codes: 0=complete, 1=more work remains, 2=critical.',
+)]
+final class BackfillPublicIdsCommand implements SignalableCommandInterface
+{
+    private ?PublicIdBackfillRunControl $runControl = null;
+
+    public function __construct(
+        private readonly PublicIdBackfillService $backfillService,
+    ) {
+    }
+
+    /**
+     * @return list<int>
+     */
+    #[\Override]
+    public function getSubscribedSignals(): array
+    {
+        if (!\function_exists('pcntl_signal')) {
+            return [];
+        }
+
+        return [\SIGINT, \SIGTERM];
+    }
+
+    #[\Override]
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    {
+        $this->runControl?->requestStop($signal);
+
+        return false;
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] BackfillPublicIdsInput $input,
+    ): int {
+        $tables = $input->table;
+
+        $io->title('Backfill explore public_id (UUID v4)');
+
+        if ($input->dryRun) {
+            $io->note('Dry run: no rows will be written.');
+        }
+
+        $this->runControl = new PublicIdBackfillRunControl();
+        $startedAt = microtime(true);
+
+        try {
+            $result = $this->backfillService->run(
+                dryRun: $input->dryRun,
+                tables: $tables,
+                batchSize: $input->batchSize,
+                maxRuntimeSeconds: $input->maxRuntime,
+                runControl: $this->runControl,
+            );
+        } catch (PublicIdBackfillInterruptedException $exception) {
+            $io->warning(sprintf('Interrupted by signal %d.', $exception->getSignal()));
+
+            return PublicIdBackfillExitCode::MORE_WORK;
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return PublicIdBackfillExitCode::CRITICAL;
+        }
+
+        $rows = [];
+        foreach (PublicIdBackfillService::TABLE_ORDER as $table) {
+            if (!\array_key_exists($table, $result->remainingByTable)) {
+                continue;
+            }
+            $rows[] = [
+                $table,
+                (string) ($result->updatedByTable[$table] ?? 0),
+                (string) $result->remainingByTable[$table],
+            ];
+        }
+
+        $io->table(['Table', $input->dryRun ? 'Would update' : 'Updated', 'Remaining'], $rows);
+
+        if ($input->dryRun) {
+            $io->success('Dry run finished. Re-run without --dry-run to apply changes.');
+
+            return PublicIdBackfillExitCode::SUCCESS;
+        }
+
+        $elapsed = microtime(true) - $startedAt;
+        if ($result->completed) {
+            $io->success(sprintf('Backfill finished in %.2fs.', $elapsed));
+
+            return PublicIdBackfillExitCode::SUCCESS;
+        }
+
+        $io->warning(sprintf(
+            'Backfill paused after %.2fs with rows still missing public_id. Re-run the command or use bin/backfill-public-ids-until-done.',
+            $elapsed,
+        ));
+
+        return PublicIdBackfillExitCode::MORE_WORK;
+    }
+}

--- a/src/Shared/UI/Console/Input/BackfillPublicIdsInput.php
+++ b/src/Shared/UI/Console/Input/BackfillPublicIdsInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+
+final class BackfillPublicIdsInput
+{
+    #[Option(description: 'Only report how many rows still need public_id', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    /** @var list<string> */
+    #[Option(
+        description: 'Table(s) to backfill: hospital, secondary_transport, indication_raw, mci_case, allocation, or all',
+        name: 'table',
+        shortcut: 't',
+    )]
+    public array $table = ['all'];
+
+    #[Option(description: 'Rows per batch for large tables', name: 'batch-size')]
+    public int $batchSize = 5000;
+
+    #[Option(description: 'Stop gracefully after this many seconds (0 = unlimited)', name: 'max-runtime')]
+    public int $maxRuntime = 0;
+}

--- a/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ListAllocationsControllerTest.php
@@ -158,7 +158,7 @@ final class ListAllocationsControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $matchingAllocation->getId()], $ids);
+        self::assertSame([$matchingAllocation->getPublicIdString()], $ids);
     }
 
     public function testIsVentilatedFilterOnlyReturnsVentilatedAllocations(): void
@@ -176,7 +176,7 @@ final class ListAllocationsControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $ventilatedAllocation->getId()], $ids);
+        self::assertSame([$ventilatedAllocation->getPublicIdString()], $ids);
     }
 
     public function testDepartmentSpecialityAndTransportTypeFilters(): void
@@ -214,7 +214,7 @@ final class ListAllocationsControllerTest extends WebTestCase
         self::assertSelectorExists('[data-testid="allocation-filters-apply"]');
         self::assertSelectorExists('[data-testid="allocation-filters-reset"].btn-outline-secondary');
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $matchingAllocation->getId()], $ids);
+        self::assertSame([$matchingAllocation->getPublicIdString()], $ids);
     }
 
     public function testMyHospitalsScopeFiltersToAccessibleHospitals(): void
@@ -261,7 +261,7 @@ final class ListAllocationsControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('[data-testid="allocation-filter-hospital"]');
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $ownAllocation->getId()], $ids);
+        self::assertSame([$ownAllocation->getPublicIdString()], $ids);
     }
 
     public function testSingleHospitalFilterSelectsAccessibleHospital(): void
@@ -302,7 +302,7 @@ final class ListAllocationsControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $allocationA->getId()], $ids);
+        self::assertSame([$allocationA->getPublicIdString()], $ids);
     }
 
     public function testLegacyHospitalScopeQueryStillWorks(): void
@@ -332,7 +332,7 @@ final class ListAllocationsControllerTest extends WebTestCase
         );
 
         self::assertResponseIsSuccessful();
-        self::assertSame([(int) $allocation->getId()], $this->extractAllocationIds($crawler));
+        self::assertSame([$allocation->getPublicIdString()], $this->extractAllocationIds($crawler));
     }
 
     public function testMyHospitalsScopeWithHospitalDetailFiltersToSingleHospital(): void
@@ -376,7 +376,7 @@ final class ListAllocationsControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $allocationA->getId()], $ids);
+        self::assertSame([$allocationA->getPublicIdString()], $ids);
     }
 
     public function testAssignmentOccasionAndDepartmentWasClosedFilters(): void
@@ -410,7 +410,7 @@ final class ListAllocationsControllerTest extends WebTestCase
         self::assertSelectorExists('select[name="occasion"]');
         self::assertSelectorExists('[data-testid="allocation-filter-department-was-closed"]');
         $ids = $this->extractAllocationIds($crawler);
-        self::assertSame([(int) $matchingAllocation->getId()], $ids);
+        self::assertSame([$matchingAllocation->getPublicIdString()], $ids);
         self::assertSelectorExists('.alert.alert-info');
         self::assertSelectorTextContains('.alert.alert-info', 'Test Assignment');
         self::assertSelectorTextContains('.alert.alert-info', 'Test Occasion');
@@ -463,7 +463,7 @@ final class ListAllocationsControllerTest extends WebTestCase
     }
 
     /**
-     * @return list<int>
+     * @return list<string>
      */
     private function extractAllocationIds(Crawler $crawler): array
     {
@@ -473,8 +473,8 @@ final class ListAllocationsControllerTest extends WebTestCase
                 continue;
             }
             $href = $node->getAttribute('href');
-            if (preg_match('/\/explore\/allocation\/(\d+)$/', $href, $matches)) {
-                $ids[] = (int) $matches[1];
+            if (preg_match('/\/explore\/allocation\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/', $href, $matches)) {
+                $ids[] = $matches[1];
             }
         }
 

--- a/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
@@ -97,15 +97,14 @@ final class ShowAllocationControllerTest extends WebTestCase
             'occasion' => OccasionFactory::createOne(),
             'assessment' => AssessmentFactory::createOne(),
         ]);
-        $allocationId = $allocation->getId();
-        self::assertNotNull($allocationId);
+        $allocationPublicId = $allocation->getPublicIdString();
 
         self::ensureKernelShutdown();
 
         $client = $this->createClientAsParticipant();
         $client->enableProfiler();
 
-        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocationId);
+        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocationPublicId);
 
         self::assertResponseIsSuccessful();
 
@@ -184,7 +183,7 @@ final class ShowAllocationControllerTest extends WebTestCase
         ]);
 
         // Act
-        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getId());
+        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getPublicIdString());
 
         // Assert
         self::assertResponseIsSuccessful();
@@ -244,7 +243,7 @@ final class ShowAllocationControllerTest extends WebTestCase
             'departmentWasClosed' => true,
         ]);
 
-        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getId());
+        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getPublicIdString());
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('.department-line [data-testid="department-was-closed-indicator"]');
@@ -254,7 +253,7 @@ final class ShowAllocationControllerTest extends WebTestCase
     public function testShowRejectsPostMethod(): void
     {
         $client = $this->createClientAsParticipant();
-        $client->request(Request::METHOD_POST, '/explore/allocation/1');
+        $client->request(Request::METHOD_POST, '/explore/allocation/00000000-0000-4000-8000-000000000000');
 
         self::assertResponseStatusCodeSame(405);
     }
@@ -262,7 +261,7 @@ final class ShowAllocationControllerTest extends WebTestCase
     public function testShow404ForUnknownAllocation(): void
     {
         $client = $this->createClientAsParticipant();
-        $client->request(Request::METHOD_GET, '/explore/allocation/999999');
+        $client->request(Request::METHOD_GET, '/explore/allocation/00000000-0000-4000-8000-000000000000');
         self::assertResponseStatusCodeSame(404);
     }
 }

--- a/tests/Allocation/Functional/Controller/Hospitals/ParticipantHospitalsControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Hospitals/ParticipantHospitalsControllerTest.php
@@ -200,7 +200,7 @@ final class ParticipantHospitalsControllerTest extends WebTestCase
 
         $client->submit($form);
 
-        self::assertResponseRedirects('/explore/hospital/'.$hospital->getId());
+        self::assertResponseRedirects('/explore/hospital/'.$hospital->getPublicIdString());
 
         /** @var Hospital|null $updatedHospital */
         $updatedHospital = self::getContainer()->get('doctrine')->getRepository(Hospital::class)->find($hospital->getId());
@@ -272,7 +272,7 @@ final class ParticipantHospitalsControllerTest extends WebTestCase
 
         $client->submit($form);
 
-        self::assertResponseRedirects('/explore/hospital/'.$hospital->getId());
+        self::assertResponseRedirects('/explore/hospital/'.$hospital->getPublicIdString());
 
         /** @var Hospital|null $updatedHospital */
         $updatedHospital = self::getContainer()->get('doctrine')->getRepository(Hospital::class)->find($hospital->getId());

--- a/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
@@ -55,7 +55,7 @@ final class ShowHospitalControllerTest extends WebTestCase
             'createdAt' => new \DateTimeImmutable('2025-01-02 03:04:05'),
         ]);
 
-        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
+        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getPublicIdString());
 
         self::assertResponseIsSuccessful();
 
@@ -82,7 +82,7 @@ final class ShowHospitalControllerTest extends WebTestCase
         $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Owned Clinic']);
 
         $client->loginUser($owner);
-        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
+        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getPublicIdString());
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
@@ -99,7 +99,7 @@ final class ShowHospitalControllerTest extends WebTestCase
         $hospital = HospitalFactory::createOne(['owner' => $owner, 'name' => 'Foreign Clinic']);
 
         $client->loginUser($admin);
-        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getId());
+        $client->request(Request::METHOD_GET, '/explore/hospital/'.$hospital->getPublicIdString());
 
         self::assertResponseIsSuccessful();
         self::assertSelectorExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
@@ -116,7 +116,7 @@ final class ShowHospitalControllerTest extends WebTestCase
             'dispatchArea' => $dispatch,
         ]);
 
-        $client->request(Request::METHOD_POST, '/explore/hospital/'.$hospital->getId());
+        $client->request(Request::METHOD_POST, '/explore/hospital/'.$hospital->getPublicIdString());
 
         self::assertResponseStatusCodeSame(405);
     }
@@ -124,7 +124,7 @@ final class ShowHospitalControllerTest extends WebTestCase
     public function testShow404ForUnknownHospital(): void
     {
         $client = $this->createClientAsParticipant();
-        $client->request(Request::METHOD_GET, '/explore/hospital/999999');
+        $client->request(Request::METHOD_GET, '/explore/hospital/00000000-0000-4000-8000-000000000000');
         self::assertResponseStatusCodeSame(404);
     }
 }

--- a/tests/Allocation/Functional/Controller/Indications/AssignIndicationRawControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/AssignIndicationRawControllerTest.php
@@ -24,8 +24,8 @@ final class AssignIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne();
         $client->loginUser($user);
 
-        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/assign/%d', $raw->getId()));
+        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/assign/%s', $raw->getPublicIdString()));
 
-        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
     }
 }

--- a/tests/Allocation/Functional/Controller/Indications/IndicationRawReviewWorklistControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/IndicationRawReviewWorklistControllerTest.php
@@ -83,7 +83,7 @@ final class IndicationRawReviewWorklistControllerTest extends WebTestCase
 
         $client->request(Request::METHOD_GET, '/explore/indication/raw/review/start/matching');
 
-        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%d?segment=unreviewed', $raw->getId()));
+        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%s?segment=unreviewed', $raw->getPublicIdString()));
     }
 
     public function testStartReviewingRedirectsToFirstNeedsReviewItem(): void
@@ -108,7 +108,7 @@ final class IndicationRawReviewWorklistControllerTest extends WebTestCase
 
         $client->request(Request::METHOD_GET, '/explore/indication/raw/review/start/reviewing');
 
-        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%d?segment=needs_review', $raw->getId()));
+        self::assertResponseRedirects(sprintf('/explore/indication/raw/review/%s?segment=needs_review', $raw->getPublicIdString()));
     }
 
     public function testWorklistCanSortByOccurrence(): void

--- a/tests/Allocation/Functional/Controller/Indications/ReviewIndicationRawControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/ReviewIndicationRawControllerTest.php
@@ -50,7 +50,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::NeedsReview, $reloaded->getReviewStatus());
         self::assertNotNull($reloaded->getFirstMatchedBy());
@@ -83,7 +83,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
     }
@@ -107,7 +107,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
         self::assertSame($admin->getId(), $reloaded->getFirstMatchedBy()?->getId());
@@ -202,7 +202,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
         self::assertSame($admin->getId(), $reloaded->getReviewedBy()?->getId());
@@ -252,7 +252,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Unreviewed, $reloaded->getReviewStatus());
         self::assertNull($reloaded->getTarget());
@@ -276,8 +276,8 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloadedIgnore = $repo->find($ignoreRaw->getPublicIdString());
-        $reloadedNotMatchable = $repo->find($notMatchableRaw->getPublicIdString());
+        $reloadedIgnore = $repo->find($ignoreRaw->getId());
+        $reloadedNotMatchable = $repo->find($notMatchableRaw->getId());
         self::assertNotNull($reloadedIgnore);
         self::assertNotNull($reloadedNotMatchable);
         self::assertSame(IndicationRawReviewStatus::Ignored, $reloadedIgnore->getReviewStatus());
@@ -302,7 +302,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Unreviewed, $reloaded->getReviewStatus());
     }
@@ -323,7 +323,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getPublicIdString());
+        $reloaded = $repo->find($raw->getId());
         self::assertNotNull($reloaded);
         self::assertSame('Needs second opinion', $reloaded->getReviewComment());
     }

--- a/tests/Allocation/Functional/Controller/Indications/ReviewIndicationRawControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/ReviewIndicationRawControllerTest.php
@@ -27,7 +27,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne();
         $client->loginUser($user);
 
-        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
     }
 
@@ -41,7 +41,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne(['code' => 111, 'name' => 'Test Raw']);
         $client->loginUser($user);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
         $form = $crawler->selectButton('Propose match')->form();
         $form['indication_raw_review[target_label]'] = 'Test Norm (111)';
@@ -50,7 +50,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::NeedsReview, $reloaded->getReviewStatus());
         self::assertNotNull($reloaded->getFirstMatchedBy());
@@ -76,14 +76,14 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
 
         $client->loginUser($reviewer);
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
         $form = $crawler->selectButton('Accept')->form();
         $client->submit($form);
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
     }
@@ -98,7 +98,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne(['code' => 333, 'name' => 'Fast Raw']);
         $client->loginUser($admin);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
         $form = $crawler->selectButton('Match and approve')->form();
         $form['indication_raw_review[target_label]'] = 'Fast Norm (333)';
@@ -107,7 +107,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
         self::assertSame($admin->getId(), $reloaded->getFirstMatchedBy()?->getId());
@@ -134,7 +134,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
 
         $client->loginUser($reviewer);
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
         self::assertStringContainsString('Indication: Review Raw (444)', $crawler->filter('h2.page-title')->text());
         self::assertStringContainsString($proposer->getUserIdentifier(), $crawler->filter('.card-body dl')->text());
@@ -167,7 +167,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
 
         $client->loginUser($admin);
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         self::assertResponseIsSuccessful();
 
         $actions = $crawler->filter('#indication-review-actions');
@@ -196,13 +196,13 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
 
         $client->loginUser($admin);
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         $form = $crawler->selectButton('Approve match')->form();
         $client->submit($form);
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Matched, $reloaded->getReviewStatus());
         self::assertSame($admin->getId(), $reloaded->getReviewedBy()?->getId());
@@ -220,8 +220,8 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $client->loginUser($admin);
 
         $client->request(Request::METHOD_GET, sprintf(
-            '/explore/indication/raw/review/%d?segment=not_matchable',
-            $raw->getId(),
+            '/explore/indication/raw/review/%s?segment=not_matchable',
+            $raw->getPublicIdString(),
         ));
 
         self::assertResponseIsSuccessful();
@@ -247,12 +247,12 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
 
         $client->loginUser($reviewer);
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         $client->submit($crawler->selectButton('Reject match')->form());
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Unreviewed, $reloaded->getReviewStatus());
         self::assertNull($reloaded->getTarget());
@@ -268,16 +268,16 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $notMatchableRaw = IndicationRawFactory::createOne(['code' => 558, 'name' => 'NM Raw']);
         $client->loginUser($reviewer);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $ignoreRaw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $ignoreRaw->getPublicIdString()));
         $client->submit($crawler->selectButton('Ignore')->form());
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $notMatchableRaw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $notMatchableRaw->getPublicIdString()));
         $client->submit($crawler->selectButton('Not matchable')->form());
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloadedIgnore = $repo->find($ignoreRaw->getId());
-        $reloadedNotMatchable = $repo->find($notMatchableRaw->getId());
+        $reloadedIgnore = $repo->find($ignoreRaw->getPublicIdString());
+        $reloadedNotMatchable = $repo->find($notMatchableRaw->getPublicIdString());
         self::assertNotNull($reloadedIgnore);
         self::assertNotNull($reloadedNotMatchable);
         self::assertSame(IndicationRawReviewStatus::Ignored, $reloadedIgnore->getReviewStatus());
@@ -297,12 +297,12 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
         $client->loginUser($reviewer);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         $client->submit($crawler->selectButton('Reopen for review')->form());
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame(IndicationRawReviewStatus::Unreviewed, $reloaded->getReviewStatus());
     }
@@ -316,14 +316,14 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne(['code' => 560, 'name' => 'Comment Raw']);
         $client->loginUser($reviewer);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         $form = $crawler->selectButton('Save comment')->form();
         $form['indication_raw_review[reviewComment]'] = 'Needs second opinion';
         $client->submit($form);
 
         /** @var IndicationRawRepository $repo */
         $repo = self::getContainer()->get(IndicationRawRepository::class);
-        $reloaded = $repo->find($raw->getId());
+        $reloaded = $repo->find($raw->getPublicIdString());
         self::assertNotNull($reloaded);
         self::assertSame('Needs second opinion', $reloaded->getReviewComment());
     }
@@ -346,11 +346,11 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
         $client->loginUser($reviewer);
 
-        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d/skip', $first->getId()));
+        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s/skip', $first->getPublicIdString()));
 
         self::assertResponseStatusCodeSame(302);
         self::assertStringContainsString(
-            sprintf('/explore/indication/raw/review/%d', $second->getId()),
+            sprintf('/explore/indication/raw/review/%s', $second->getPublicIdString()),
             (string) $client->getResponse()->headers->get('Location'),
         );
     }
@@ -364,7 +364,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne(['code' => 563, 'name' => 'Only Raw']);
         $client->loginUser($reviewer);
 
-        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d/skip', $raw->getId()));
+        $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s/skip', $raw->getPublicIdString()));
 
         self::assertResponseStatusCodeSame(302);
         self::assertStringContainsString(
@@ -382,7 +382,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         $raw = IndicationRawFactory::createOne(['code' => 564, 'name' => 'No Target Raw']);
         $client->loginUser($reviewer);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
         $client->submit($crawler->selectButton('Propose match')->form());
 
         self::assertResponseStatusCodeSame(302);
@@ -410,7 +410,7 @@ final class ReviewIndicationRawControllerTest extends WebTestCase
         ]);
         $client->loginUser($viewer);
 
-        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%d', $raw->getId()));
+        $crawler = $client->request(Request::METHOD_GET, sprintf('/explore/indication/raw/review/%s', $raw->getPublicIdString()));
 
         self::assertResponseIsSuccessful();
         self::assertStringContainsString($reviewer->getUserIdentifier(), $crawler->filter('.card-body dl')->text());

--- a/tests/Allocation/Functional/Controller/MciCases/ShowMciCaseControllerTest.php
+++ b/tests/Allocation/Functional/Controller/MciCases/ShowMciCaseControllerTest.php
@@ -33,10 +33,7 @@ final class ShowMciCaseControllerTest extends WebTestCase
     {
         $client = $this->createClientAsParticipant();
         $mciCase = $this->createMciCase('Mass casualty incident alpha');
-        $id = $mciCase->getId();
-        self::assertNotNull($id);
-
-        $client->request(Request::METHOD_GET, '/explore/mci_case/'.$id);
+        $client->request(Request::METHOD_GET, '/explore/mci_case/'.$mciCase->getPublicIdString());
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('h1.fw-bold', 'Mass casualty incident alpha');
@@ -48,10 +45,7 @@ final class ShowMciCaseControllerTest extends WebTestCase
     {
         $client = $this->createClientAsParticipant();
         $mciCase = $this->createMciCase();
-        $id = $mciCase->getId();
-        self::assertNotNull($id);
-
-        $client->request(Request::METHOD_POST, '/explore/mci_case/'.$id);
+        $client->request(Request::METHOD_POST, '/explore/mci_case/'.$mciCase->getPublicIdString());
 
         self::assertResponseStatusCodeSame(405);
     }

--- a/tests/Allocation/Functional/Controller/SecondaryTransports/ShowSecondaryTransportControllerTest.php
+++ b/tests/Allocation/Functional/Controller/SecondaryTransports/ShowSecondaryTransportControllerTest.php
@@ -21,10 +21,7 @@ final class ShowSecondaryTransportControllerTest extends WebTestCase
     {
         $client = $this->createClientAsAreaUser();
         $st = SecondaryTransportFactory::createOne(['name' => 'Kapazitätsengpass']);
-        $id = $st->getId();
-        self::assertNotNull($id);
-
-        $client->request(Request::METHOD_GET, '/explore/secondary_transport/'.$id);
+        $client->request(Request::METHOD_GET, '/explore/secondary_transport/'.$st->getPublicIdString());
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('#secondary-transport-name', 'Kapazitätsengpass');

--- a/tests/Shared/Functional/Command/BackfillPublicIdsCommandTest.php
+++ b/tests/Shared/Functional/Command/BackfillPublicIdsCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Functional\Command;
+
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Shared\Application\PublicId\PublicIdBackfillExitCode;
+use App\Shared\UI\Console\Command\BackfillPublicIdsCommand;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class BackfillPublicIdsCommandTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testDryRunThenBackfillHospitalPublicId(): void
+    {
+        self::bootKernel();
+        HospitalFactory::createOne(['name' => 'Coverage Hospital']);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $connection->executeStatement('UPDATE hospital SET public_id = NULL');
+
+        $tester = $this->createCommandTester();
+
+        self::assertSame(
+            PublicIdBackfillExitCode::SUCCESS,
+            $tester->execute(['--dry-run' => true, '--table' => ['hospital']]),
+        );
+        self::assertStringContainsString('Dry run finished', $tester->getDisplay());
+        self::assertNull($connection->fetchOne('SELECT public_id FROM hospital LIMIT 1'));
+
+        self::assertSame(
+            PublicIdBackfillExitCode::SUCCESS,
+            $tester->execute(['--table' => ['hospital']]),
+        );
+        self::assertStringContainsString('Backfill finished in', $tester->getDisplay());
+        self::assertNotNull($connection->fetchOne('SELECT public_id FROM hospital LIMIT 1'));
+    }
+
+    public function testInvalidTableReturnsCriticalExitCode(): void
+    {
+        self::bootKernel();
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--table' => ['unknown_table']]);
+
+        self::assertSame(PublicIdBackfillExitCode::CRITICAL, $exitCode);
+        self::assertStringContainsString('Unknown table(s)', $tester->getDisplay());
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        /** @var BackfillPublicIdsCommand $command */
+        $command = self::getContainer()->get(BackfillPublicIdsCommand::class);
+
+        return new CommandTester($command);
+    }
+}

--- a/tests/Shared/Unit/Application/PublicId/PublicIdBackfillInterruptedExceptionTest.php
+++ b/tests/Shared/Unit/Application/PublicId/PublicIdBackfillInterruptedExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Application\PublicId;
+
+use App\Shared\Application\PublicId\PublicIdBackfillInterruptedException;
+use PHPUnit\Framework\TestCase;
+
+final class PublicIdBackfillInterruptedExceptionTest extends TestCase
+{
+    public function testStoresSignal(): void
+    {
+        $exception = new PublicIdBackfillInterruptedException(\SIGTERM);
+
+        self::assertSame(\SIGTERM, $exception->getSignal());
+        self::assertStringContainsString('signal 15', $exception->getMessage());
+    }
+}

--- a/tests/Shared/Unit/Application/PublicId/PublicIdBackfillRunControlTest.php
+++ b/tests/Shared/Unit/Application/PublicId/PublicIdBackfillRunControlTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Application\PublicId;
+
+use App\Shared\Application\PublicId\PublicIdBackfillInterruptedException;
+use App\Shared\Application\PublicId\PublicIdBackfillRunControl;
+use PHPUnit\Framework\TestCase;
+
+final class PublicIdBackfillRunControlTest extends TestCase
+{
+    public function testRequestStopIsObserved(): void
+    {
+        $control = new PublicIdBackfillRunControl();
+
+        self::assertFalse($control->isStopRequested());
+        self::assertNull($control->getSignal());
+
+        $control->requestStop(\SIGTERM);
+
+        self::assertTrue($control->isStopRequested());
+        self::assertSame(\SIGTERM, $control->getSignal());
+    }
+
+    public function testThrowIfStopRequestedRaisesException(): void
+    {
+        $control = new PublicIdBackfillRunControl();
+        $control->requestStop(\SIGINT);
+
+        $this->expectException(PublicIdBackfillInterruptedException::class);
+        $this->expectExceptionMessage('signal 2');
+
+        $control->throwIfStopRequested();
+    }
+
+    public function testThrowIfStopRequestedDoesNothingWhenNotStopped(): void
+    {
+        $control = new PublicIdBackfillRunControl();
+
+        $control->throwIfStopRequested();
+
+        self::assertFalse($control->isStopRequested());
+    }
+}

--- a/tests/Shared/Unit/Application/PublicId/PublicIdBackfillServiceTest.php
+++ b/tests/Shared/Unit/Application/PublicId/PublicIdBackfillServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Shared\Unit\Application\PublicId;
 
+use App\Shared\Application\PublicId\PublicIdBackfillInterruptedException;
+use App\Shared\Application\PublicId\PublicIdBackfillRunControl;
 use App\Shared\Application\PublicId\PublicIdBackfillService;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +33,22 @@ final class PublicIdBackfillServiceTest extends TestCase
         self::assertSame(0, $result->updatedByTable['hospital']);
     }
 
+    public function testDryRunWithAllTableSelector(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $service = new PublicIdBackfillService($connection);
+
+        $resultAll = $service->run(dryRun: true, tables: ['all']);
+        $resultNull = $service->run(dryRun: true, tables: null);
+        $resultEmpty = $service->run(dryRun: true, tables: []);
+
+        self::assertCount(5, $resultAll->remainingByTable);
+        self::assertCount(5, $resultNull->remainingByTable);
+        self::assertCount(5, $resultEmpty->remainingByTable);
+    }
+
     public function testInvalidTableThrows(): void
     {
         $connection = $this->createMock(Connection::class);
@@ -39,6 +57,98 @@ final class PublicIdBackfillServiceTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $service->run(tables: ['unknown_table']);
+    }
+
+    public function testBackfillAssignsPublicIdsForSelectedTable(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $fetchCalls = 0;
+        $connection->method('fetchFirstColumn')
+            ->willReturnCallback(function (string $sql) use (&$fetchCalls): array {
+                if (!str_contains($sql, 'FROM hospital')) {
+                    return [];
+                }
+
+                return 0 === $fetchCalls++ ? [10, 11] : [];
+            });
+        $connection->expects(self::once())
+            ->method('executeStatement')
+            ->with(
+                self::callback(static fn (string $sql): bool => str_contains($sql, 'UPDATE hospital')),
+                self::callback(static function (array $params): bool {
+                    self::assertSame(10, $params['id0']);
+                    self::assertSame(11, $params['id1']);
+                    self::assertTrue(Uuid::isValid($params['pid0']));
+                    self::assertTrue(Uuid::isValid($params['pid1']));
+
+                    return true;
+                }),
+            )
+            ->willReturn(2);
+        $connection->method('fetchOne')
+            ->willReturnCallback(static fn (string $sql): int => str_contains($sql, 'COUNT') ? 0 : 0);
+
+        $service = new PublicIdBackfillService($connection);
+        $result = $service->run(tables: ['hospital']);
+
+        self::assertTrue($result->completed);
+        self::assertSame(2, $result->updatedByTable['hospital']);
+        self::assertSame(0, $result->remainingByTable['hospital']);
+    }
+
+    public function testTableSelectionPreservesConfiguredOrder(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(0);
+        $connection->method('fetchFirstColumn')->willReturn([]);
+
+        $service = new PublicIdBackfillService($connection);
+        $result = $service->run(dryRun: true, tables: ['allocation', 'hospital']);
+
+        self::assertSame(['hospital', 'allocation'], array_keys($result->remainingByTable));
+    }
+
+    public function testRunControlInterruptsBackfill(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $control = new PublicIdBackfillRunControl();
+        $control->requestStop(\SIGINT);
+
+        $service = new PublicIdBackfillService($connection);
+
+        $this->expectException(PublicIdBackfillInterruptedException::class);
+
+        $service->run(tables: ['hospital'], runControl: $control);
+    }
+
+    public function testMaxRuntimePausesAndReportsRemainingTables(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')
+            ->willReturnCallback(static function (): array {
+                usleep(1_100_000);
+
+                return [42];
+            });
+        $connection->method('executeStatement')->willReturn(1);
+        $connection->method('fetchOne')
+            ->willReturnCallback(static fn (string $sql): int => match (true) {
+                str_contains($sql, 'FROM hospital') => 1,
+                str_contains($sql, 'FROM secondary_transport') => 2,
+                str_contains($sql, 'FROM indication_raw') => 3,
+                str_contains($sql, 'FROM mci_case') => 4,
+                str_contains($sql, 'FROM allocation') => 5,
+                default => 0,
+            });
+
+        $service = new PublicIdBackfillService($connection);
+        $result = $service->run(tables: ['hospital'], batchSize: 1, maxRuntimeSeconds: 1);
+
+        self::assertFalse($result->completed);
+        self::assertSame(1, $result->updatedByTable['hospital']);
+        self::assertSame(1, $result->remainingByTable['hospital']);
+        self::assertSame(2, $result->remainingByTable['secondary_transport']);
+        self::assertSame(5, $result->remainingByTable['allocation']);
     }
 
     public function testGeneratedUuidsAreValidV4(): void

--- a/tests/Shared/Unit/Application/PublicId/PublicIdBackfillServiceTest.php
+++ b/tests/Shared/Unit/Application/PublicId/PublicIdBackfillServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Application\PublicId;
+
+use App\Shared\Application\PublicId\PublicIdBackfillService;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class PublicIdBackfillServiceTest extends TestCase
+{
+    public function testDryRunCountsRemainingRows(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnMap([
+            ['SELECT COUNT(*) FROM hospital WHERE public_id IS NULL', [], [], 2],
+            ['SELECT COUNT(*) FROM secondary_transport WHERE public_id IS NULL', [], [], 0],
+            ['SELECT COUNT(*) FROM indication_raw WHERE public_id IS NULL', [], [], 1],
+            ['SELECT COUNT(*) FROM mci_case WHERE public_id IS NULL', [], [], 0],
+            ['SELECT COUNT(*) FROM allocation WHERE public_id IS NULL', [], [], 5],
+        ]);
+
+        $service = new PublicIdBackfillService($connection);
+        $result = $service->run(dryRun: true);
+
+        self::assertFalse($result->completed);
+        self::assertSame(2, $result->remainingByTable['hospital']);
+        self::assertSame(5, $result->remainingByTable['allocation']);
+        self::assertSame(0, $result->updatedByTable['hospital']);
+    }
+
+    public function testInvalidTableThrows(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $service = new PublicIdBackfillService($connection);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $service->run(tables: ['unknown_table']);
+    }
+
+    public function testGeneratedUuidsAreValidV4(): void
+    {
+        $uuid = Uuid::v4();
+
+        self::assertSame(36, \strlen($uuid->toRfc4122()));
+        self::assertTrue(Uuid::isValid($uuid->toRfc4122()));
+    }
+}

--- a/tests/Shared/Unit/Domain/Traits/HasPublicIdTest.php
+++ b/tests/Shared/Unit/Domain/Traits/HasPublicIdTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Domain\Traits;
+
+use App\Shared\Domain\Traits\HasPublicId;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class HasPublicIdTest extends TestCase
+{
+    public function testEnsurePublicIdGeneratesUuidV4(): void
+    {
+        $entity = new class {
+            use HasPublicId {
+                ensurePublicId as public;
+            }
+        };
+
+        $entity->ensurePublicId();
+
+        self::assertInstanceOf(Uuid::class, $entity->getPublicId());
+        self::assertSame(36, \strlen($entity->getPublicIdString()));
+        self::assertTrue(Uuid::isValid($entity->getPublicIdString()));
+    }
+
+    public function testExistingPublicIdIsNotOverwritten(): void
+    {
+        $entity = new class {
+            use HasPublicId {
+                ensurePublicId as public;
+            }
+        };
+
+        $existing = Uuid::fromString('550e8400-e29b-41d4-a716-446655440000');
+        $entity->setPublicId($existing);
+        $entity->ensurePublicId();
+
+        self::assertTrue($existing->equals($entity->getPublicId()));
+    }
+}

--- a/tests/Shared/Unit/Domain/Traits/HasPublicIdTest.php
+++ b/tests/Shared/Unit/Domain/Traits/HasPublicIdTest.php
@@ -39,4 +39,16 @@ final class HasPublicIdTest extends TestCase
 
         self::assertTrue($existing->equals($entity->getPublicId()));
     }
+
+    public function testGetPublicIdStringThrowsWhenMissing(): void
+    {
+        $entity = new class {
+            use HasPublicId;
+        };
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('missing publicId');
+
+        $entity->getPublicIdString();
+    }
 }

--- a/tests/Shared/Unit/UI/Console/Command/BackfillPublicIdsCommandTest.php
+++ b/tests/Shared/Unit/UI/Console/Command/BackfillPublicIdsCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\UI\Console\Command;
+
+use App\Shared\Application\PublicId\PublicIdBackfillExitCode;
+use App\Shared\Application\PublicId\PublicIdBackfillRunControl;
+use App\Shared\Application\PublicId\PublicIdBackfillService;
+use App\Shared\UI\Console\Command\BackfillPublicIdsCommand;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class BackfillPublicIdsCommandTest extends TestCase
+{
+    public function testDryRunReturnsSuccess(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturn(2);
+
+        $tester = $this->createCommandTester($connection);
+
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(PublicIdBackfillExitCode::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dry run finished', $tester->getDisplay());
+        self::assertStringContainsString('Would update', $tester->getDisplay());
+    }
+
+    public function testCompletedBackfillReturnsSuccess(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([]);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $tester = $this->createCommandTester($connection);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(PublicIdBackfillExitCode::SUCCESS, $exitCode);
+        self::assertStringContainsString('Backfill finished in', $tester->getDisplay());
+    }
+
+    public function testIncompleteBackfillReturnsMoreWork(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')
+            ->willReturnCallback(static function (): array {
+                usleep(1_100_000);
+
+                return [42];
+            });
+        $connection->method('executeStatement')->willReturn(1);
+        $connection->method('fetchOne')
+            ->willReturnCallback(static fn (string $sql): int => str_contains($sql, 'FROM hospital') ? 1 : 0);
+
+        $tester = $this->createCommandTester($connection);
+
+        $exitCode = $tester->execute([
+            '--table' => ['hospital'],
+            '--batch-size' => 1,
+            '--max-runtime' => 1,
+        ]);
+
+        self::assertSame(PublicIdBackfillExitCode::MORE_WORK, $exitCode);
+        self::assertStringContainsString('Backfill paused after', $tester->getDisplay());
+    }
+
+    public function testInterruptedBackfillReturnsMoreWork(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $command = new BackfillPublicIdsCommand(new PublicIdBackfillService($connection));
+        $connection->method('fetchFirstColumn')->willReturn([10]);
+        $connection->method('executeStatement')->willReturnCallback(
+            static function () use ($command): int {
+                $command->handleSignal(\SIGINT);
+
+                return 1;
+            },
+        );
+
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['--table' => ['hospital']]);
+
+        self::assertSame(PublicIdBackfillExitCode::MORE_WORK, $exitCode);
+        self::assertStringContainsString('Interrupted by signal 2', $tester->getDisplay());
+    }
+
+    public function testCriticalFailureReturnsCriticalExitCode(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $tester = $this->createCommandTester($connection);
+
+        $exitCode = $tester->execute(['--table' => ['unknown_table']]);
+
+        self::assertSame(PublicIdBackfillExitCode::CRITICAL, $exitCode);
+        self::assertStringContainsString('Unknown table(s)', $tester->getDisplay());
+    }
+
+    public function testHandleSignalRequestsStop(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([]);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $command = new BackfillPublicIdsCommand(new PublicIdBackfillService($connection));
+        $tester = new CommandTester($command);
+        $tester->execute(['--table' => ['hospital']]);
+
+        self::assertFalse($command->handleSignal(\SIGTERM));
+
+        $runControl = $this->readRunControl($command);
+        self::assertTrue($runControl->isStopRequested());
+        self::assertSame(\SIGTERM, $runControl->getSignal());
+    }
+
+    public function testSubscribedSignalsDependsOnPcntl(): void
+    {
+        $command = new BackfillPublicIdsCommand(new PublicIdBackfillService($this->createMock(Connection::class)));
+
+        $signals = $command->getSubscribedSignals();
+
+        if (\function_exists('pcntl_signal')) {
+            self::assertSame([\SIGINT, \SIGTERM], $signals);
+        } else {
+            self::assertSame([], $signals);
+        }
+    }
+
+    private function createCommandTester(Connection $connection): CommandTester
+    {
+        return new CommandTester(new BackfillPublicIdsCommand(new PublicIdBackfillService($connection)));
+    }
+
+    private function readRunControl(BackfillPublicIdsCommand $command): PublicIdBackfillRunControl
+    {
+        $property = new \ReflectionProperty(BackfillPublicIdsCommand::class, 'runControl');
+        $runControl = $property->getValue($command);
+
+        self::assertInstanceOf(PublicIdBackfillRunControl::class, $runControl);
+
+        return $runControl;
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce opaque `public_id` (UUID v4, RFC 4122) for explore detail resources: Hospital, Allocation, MCI Case, Secondary Transport, and Indication Raw
- Add nullable `public_id` columns with partial unique indexes, a resumable backfill command (`app:explore:backfill-public-ids`), and a restart wrapper script for large tables
- Switch explore show/workflow routes and Twig links from integer `{id}` to `{publicId}`; list filter query params remain internal integer IDs

UUID v4 was chosen over ULID to avoid predictable sequential IDs during batch backfill and improve opacity against trivial enumeration.

Closes #294.

## Changes

### Domain & persistence
- `HasPublicId` trait generates `Uuid::v4()` on `PrePersist`
- Shared `findOneByPublicId()` repository lookup via QueryBuilder string parameter (Doctrine UID lookup fix)
- Migration `Version20260708183119`: `VARCHAR(36)` + partial unique indexes on 5 tables (`isTransactional: false` for `CONCURRENTLY`)

### Backfill & ops
- Keyset-batched, resume-safe backfill with `--dry-run`, `--table`, `--batch-size`, `--max-runtime`
- SIGINT/SIGTERM handling; exit codes `0` = complete, `1` = more work, `2` = critical
- `bin/backfill-public-ids-until-done` for unattended completion

### Routing & UI
- Explore detail routes use `Requirement::UUID` and `MapEntity(expr: 'repository.findOneByPublicId(publicId)')`
- List queries and Twig templates updated to emit `publicId` in detail URLs

### Deferred (follow-up PR)
- `NOT NULL` constraint and full unique indexes after backfill completes in all environments

## Deploy sequence

1. `doctrine:migrations:migrate`
2. Deploy application code (detail pages without `public_id` return 404 until backfilled)
3. `./bin/backfill-public-ids-until-done`

## Test plan

- [x] Unit tests: `HasPublicId`, `PublicIdBackfillService`
- [x] Functional tests: explore show/workflow controllers updated for UUID URLs
- [x] Run full backfill on alpha after merge
- [x] Smoke-test explore detail pages for all five resource types after backfill