### PR TITLE
chore(deps): Group PHPStan and Psalm Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,14 @@ updates:
           doctrine:
               patterns:
                   - "doctrine/*"
+          phpstan:
+              patterns:
+                  - "phpstan/*"
+          psalm:
+              patterns:
+                  - "vimeo/psalm"
+                  - "psalm/*"
+                  - "weirdan/doctrine-psalm-plugin"
       ignore:
           - dependency-name: "roave/security-advisories"
 


### PR DESCRIPTION
## Summary

- Group Composer Dependabot updates for PHPStan packages (`phpstan/*`) into a single weekly PR.
- Group Psalm-related updates (`vimeo/psalm`, `psalm/*`, and `weirdan/doctrine-psalm-plugin`) the same way.
- Reduces PR noise and keeps static-analysis tooling updates aligned, similar to the existing Symfony and Doctrine groups.

## Test plan

- [x] Verify `.github/dependabot.yml` is valid YAML
- [ ] Confirm the next Dependabot run creates grouped PRs when multiple PHPStan or Psalm packages have updates available