### PR TITLE
feat: Add Content-Security-Policy report-only mode for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,9 @@ SENTRY_RELEASE=
 SENTRY_TRACES_SAMPLE_RATE=0.2
 SENTRY_ENABLE_LOGS=true
 ###< sentry/sentry-symfony ###
+
+###> sentry/csp-reporting ###
+# Optional. Copy from Sentry UI: Project Settings → Security Headers → Content Security Policy
+# Leave empty to skip Sentry CSP reporting (CSP report-only header still active in prod)
+SENTRY_CSP_REPORT_URI=
+###< sentry/csp-reporting ###

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -26,3 +26,14 @@ when@prod:
             hsts_max_age: 31536000
             hsts_subdomains: true
             hsts_preload: false
+        csp:
+            report:
+                default-src: ["'self'"]
+                base-uri: ["'self'"]
+                object-src: ["'none'"]
+                script-src: ["'self'", "'unsafe-inline'", "data:"]
+                style-src: ["'self'", "'unsafe-inline'"]
+                img-src: ["'self'", "data:", "https://*.tile.openstreetmap.org"]
+                font-src: ["'self'", "data:"]
+                connect-src: ["'self'", "https://*.tile.openstreetmap.org", "https://*.ingest.sentry.io"]
+                form-action: ["'self'"]

--- a/config/packages/nelmio_security_csp_report_uri.php
+++ b/config/packages/nelmio_security_csp_report_uri.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void {
+    if ('prod' !== $configurator->env()) {
+        return;
+    }
+
+    $reportUri = trim((string) ($_SERVER['SENTRY_CSP_REPORT_URI'] ?? $_ENV['SENTRY_CSP_REPORT_URI'] ?? getenv('SENTRY_CSP_REPORT_URI') ?: ''));
+
+    if ('' === $reportUri) {
+        return;
+    }
+
+    $configurator->extension('nelmio_security', [
+        'csp' => [
+            'report' => [
+                'report-uri' => [$reportUri],
+            ],
+        ],
+    ]);
+};

--- a/config/reference.php
+++ b/config/reference.php
@@ -1475,7 +1475,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     generate_final_entities?: bool|Param, // Default: false
  * }
  * @psalm-type TwigComponentConfig = array{
- *     defaults?: array<string, string|array{ // Default: ["__deprecated__use_old_naming_behavior"]
+ *     defaults?: array<string, string|array{ // Default: []
  *         template_directory?: scalar|Param|null, // Default: "components"
  *         name_prefix?: scalar|Param|null, // Default: ""
  *     }>,
@@ -1484,7 +1484,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: "%kernel.debug%"
  *         collect_components?: bool|Param, // Collect components instances // Default: true
  *     },
- *     controllers_json?: scalar|Param|null, // Deprecated: The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0. // Default: null
  * }
  * @psalm-type ZenstruckFoundryConfig = array{
  *     auto_refresh_proxies?: bool|Param|null, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,6 +22,7 @@ parameters:
     app.mailer_from: '%env(MAILER_FROM)%'
     app.mailer_reply_to: '%env(MAILER_REPLY_TO)%'
     env(SENTRY_DSN): ''
+    env(SENTRY_CSP_REPORT_URI): ''
     env(SENTRY_TRACES_SAMPLE_RATE): '0'
     env(SENTRY_ENABLE_LOGS): 'true'
     env(APP_ADMIN_STORAGE_LIMIT_BYTES): '0'

--- a/docs/05-operations/README.md
+++ b/docs/05-operations/README.md
@@ -13,6 +13,7 @@
 | [transactional-mail.md](transactional-mail.md) | Guide | Mail transport, `APP_URL`, deliverability |
 | [backup-restore.md](backup-restore.md) | Guide | Database and file backups |
 | [observability-sentry.md](observability-sentry.md) | Guide | Sentry integration and monitoring |
+| [content-security-policy.md](content-security-policy.md) | Guide | CSP report-only, Sentry triage, beta checklist |
 | [health-check.md](health-check.md) | Reference | `GET /health` endpoint |
 | [troubleshooting.md](troubleshooting.md) | Guide | Symptom → cause → fix |
 | [audit-log-maintenance.md](audit-log-maintenance.md) | Guide | Audit log maintenance; purge import-generated Assessment entries |

--- a/docs/05-operations/content-security-policy.md
+++ b/docs/05-operations/content-security-policy.md
@@ -1,0 +1,215 @@
+# Content Security Policy (report-only)
+
+Related: [observability-sentry.md](observability-sentry.md) (Sentry SDK), [deployment.md](deployment.md) (pre-deploy checks)
+
+Production uses **Content-Security-Policy-Report-Only** via [NelmioSecurityBundle](https://symfony.com/bundles/NelmioSecurityBundle). The browser reports violations but **does not block** resources. This prepares beta monitoring before a future enforce phase (P2).
+
+## When CSP is active
+
+| Environment | CSP header | Sentry reporting |
+|-------------|------------|------------------|
+| `dev` / `test` | No | No |
+| `prod`, `SENTRY_CSP_REPORT_URI` empty | Yes (`Content-Security-Policy-Report-Only`) | DevTools only |
+| `prod`, `SENTRY_CSP_REPORT_URI` set | Yes, includes `report-uri` | Browser POSTs to Sentry **Issues** |
+
+## Configuration
+
+| Piece | Location |
+|-------|----------|
+| Policy directives | [`config/packages/nelmio_security.yaml`](../../config/packages/nelmio_security.yaml) (`when@prod` → `csp.report`) |
+| Optional `report-uri` | [`config/packages/nelmio_security_csp_report_uri.php`](../../config/packages/nelmio_security_csp_report_uri.php) (only when `SENTRY_CSP_REPORT_URI` is set) |
+| Env default | [`config/services.yaml`](../../config/services.yaml) — `env(SENTRY_CSP_REPORT_URI): ''` |
+| Example env | [`.env.example`](../../.env.example) |
+
+Clickjacking protection (`X-Frame-Options: DENY`) stays in the same Nelmio file and is independent of CSP.
+
+### Environment variable
+
+`SENTRY_CSP_REPORT_URI` — optional. Copy the **Report URI** from Sentry (**Project Settings → Security Headers → Content Security Policy**) or build it from `SENTRY_DSN`:
+
+```
+DSN:         https://{PUBLIC_KEY}@o{ORG}.ingest[.region].sentry.io/{PROJECT_ID}
+Report URI:  https://o{ORG}.ingest[.region].sentry.io/api/{PROJECT_ID}/security/?sentry_key={PUBLIC_KEY}
+```
+
+Set in `shared/.env.local` on the server when you want violations in Sentry.
+
+## Current policy (report-only)
+
+| Directive | Value | Notes |
+|-----------|-------|-------|
+| `default-src` | `'self'` | Baseline |
+| `base-uri` | `'self'` | |
+| `object-src` | `'none'` | |
+| `script-src` | `'self'`, `'unsafe-inline'`, `data:` | Legacy inline scripts; AssetMapper CSS importmap (`data:application/javascript,`) |
+| `style-src` | `'self'`, `'unsafe-inline'` | Twig `style=""`, inline `<style>` |
+| `img-src` | `'self'`, `data:`, `https://*.tile.openstreetmap.org` | Favicon, Leaflet |
+| `font-src` | `'self'`, `data:` | |
+| `connect-src` | `'self'`, `https://*.tile.openstreetmap.org`, `https://*.ingest.sentry.io` | Fetch/XHR, OSM tiles, CSP report POST to Sentry |
+| `form-action` | `'self'` | |
+
+`frame-ancestors` is intentionally omitted from report-only (browsers ignore it there). Use `X-Frame-Options: DENY` for clickjacking instead.
+
+## Verification
+
+### Response header
+
+```bash
+curl -sI https://<APP_URL>/statistics/ | grep -i content-security-policy
+```
+
+Expect `Content-Security-Policy-Report-Only` with `default-src 'self'`. When `SENTRY_CSP_REPORT_URI` is set, the header should also contain `report-uri https://o….ingest….sentry.io/...`.
+
+### Manual violation (browser console)
+
+On any prod page, open DevTools → **Console** and run:
+
+```javascript
+const s = document.createElement('script');
+s.src = 'https://cdn.jsdelivr.net/npm/lodash@4/lodash.min.js';
+document.body.appendChild(s);
+```
+
+Expect `[Report Only] Refused to load …` — the page keeps working.
+
+With Sentry configured, check **Issues** (not Logs) within a few minutes. In **Network**, look for a POST to `…ingest….sentry.io/…/security/`.
+
+### Automated test
+
+[`tests/Shared/Functional/Security/ContentSecurityPolicyTest.php`](../../tests/Shared/Functional/Security/ContentSecurityPolicyTest.php) asserts the prod header and smoke-loads `/explore/allocation` and `/statistics/`.
+
+## Sentry integration
+
+CSP violations are **not** PHP exceptions. They appear under **Issues**, often titled with the violated directive and `blocked_uri` (for example `script-src-elem` / `cdn.jsdelivr.net`).
+
+| Channel | CSP violations? |
+|---------|-------------------|
+| **Issues** | Yes |
+| **Logs** | No (unless you log them yourself) |
+| **Performance** | No |
+
+The browser sends reports only when:
+
+1. `SENTRY_CSP_REPORT_URI` is set (adds `report-uri` to the header), and
+2. `connect-src` allows `https://*.ingest.sentry.io` (already in the policy).
+
+See [observability-sentry.md](observability-sentry.md) for general Sentry setup (`SENTRY_DSN`, environment, traces).
+
+## Browser console messages
+
+| Message | Cause | Action |
+|---------|-------|--------|
+| `does not specify a report-to` | No `SENTRY_CSP_REPORT_URI` | Set URI for Sentry, or ignore (DevTools reporting still works) |
+| Report not in Sentry | Missing URI or blocked POST | Set URI; confirm `connect-src` includes `*.ingest.sentry.io` |
+| `[Report Only] Refused to load …` | Expected on policy mismatch | Normal in report-only; see triage below |
+
+## Triage checklist (beta)
+
+A CSP issue is **not** automatically a security incident. Classify before escalating.
+
+### Quick decision
+
+```
+New CSP issue in Sentry
+        │
+        ▼
+Known test / deploy / single event from you?
+   YES → Resolve, add note ("manual test", etc.)
+   NO
+        ▼
+blocked_uri known and expected in your stack?
+   YES → Policy backlog (P2) or false positive
+   NO
+        ▼
+Multiple users / many events / unknown domain?
+   YES → Investigate (see Escalate)
+   NO → Watch 24–48h
+```
+
+### Ignore / low priority
+
+| Pattern | Example | Why |
+|---------|---------|-----|
+| Your own test | `cdn.jsdelivr.net`, `example.com` | Manual console test |
+| Browser extension | `chrome-extension://`, `moz-extension://` | Not your application |
+| Single event, single user, you were testing | lodash script test | Reproducible |
+
+**Action:** Resolve the issue; comment with the reason.
+
+### Policy gap (fix later, not an attack)
+
+| Pattern | Example | Action |
+|---------|---------|--------|
+| Known CDN you plan to allow | New analytics or font host | Add to CSP in P2 or refactor to `'self'` |
+| Same route after a feature deploy | New external asset on one page | Extend policy or self-host |
+| OpenStreetMap variant | Unexpected tile subdomain | Adjust `img-src` / `connect-src` if legitimate |
+
+**Action:** Open a P2 ticket; resolve the issue if it is understood backlog.
+
+### Watch (24–48 hours)
+
+| Pattern | Example |
+|---------|---------|
+| Few events, few users | Same `blocked_uri` on one route |
+| Admin-only routes | `/admin/…` after a template change |
+
+**Action:** Leave open briefly; resolve if it does not repeat.
+
+### Escalate (security concern)
+
+| Pattern | Example | Why |
+|---------|---------|-----|
+| Unknown domain | Random TLDs, raw IPs | Not in your stack |
+| `javascript:` or suspicious `data:` in `blocked_uri` | Injection vectors | |
+| Many users or rapid spike | 50+ events in minutes | Possible active abuse |
+| Suspicious `document_uri` | Query string with `%3Cscript%3E`, encoded payloads | Reflected XSS attempt |
+| Unknown script on core routes | `/login`, `/import`, `/explore` | Targeted |
+
+**Action:** Do not resolve immediately. Capture `document_uri`, `blocked_uri`, time, and user (if visible). Check whether the URI appears in templates, user content, or logs. Treat as a security review if the pattern persists.
+
+### Report fields
+
+| Field | Question |
+|-------|----------|
+| `document_uri` | Which page/route? Suspicious query? |
+| `blocked_uri` | What was loaded? Known CDN or unknown? |
+| `violated_directive` | `script-src-elem` = external script; `connect-src` = fetch; `img-src` = image |
+| `original_policy` | Matches deployed config? |
+| Event count | One-off vs wave? |
+
+### Known-good sources (this project)
+
+These should align with the current policy:
+
+- Scripts/styles: `'self'`, `'unsafe-inline'`, `data:` (AssetMapper)
+- Images: `'self'`, `data:`, `*.tile.openstreetmap.org`
+- Connect: `'self'`, OSM tiles, `*.ingest.sentry.io`
+
+Reports outside these patterns on your own pages deserve a closer look.
+
+### Sentry workflow (beta)
+
+| Step | Recommendation |
+|------|----------------|
+| New CSP issue | Label `csp` or `security` if you use labels |
+| After triage | `test`, `extension`, `policy-gap`, or `investigate` |
+| Manual tests | Resolve with note |
+| Real suspicion | Assign owner; do not only rely on report-only long term |
+
+> **CSP issue ≠ hack.** Clarify the source first: test, extension, policy gap, or genuine concern. Escalate mainly on unknown `blocked_uri`, many users/events, or suspicious URLs.
+
+## P2 roadmap (enforce)
+
+Not in scope for the initial report-only rollout:
+
+- Remove `'unsafe-inline'` where possible (nonces, Stimulus, extracted CSS)
+- Inline event handlers (`onclick`, `onsubmit`) → Stimulus
+- AssetMapper: consider `strict-dynamic` + nonces instead of `data:` in `script-src`
+- Add `enforce` block in Nelmio (keep `report` for monitoring)
+- Re-add `frame-ancestors 'none'` under enforce (with `X-Frame-Options` as fallback)
+
+## Further reading
+
+- [deployment.md](deployment.md#pre-deploy-verification) — pre-deploy CSP header check
+- [configuration.md](../06-reference/configuration.md) — `SENTRY_CSP_REPORT_URI`
+- [observability-sentry.md](observability-sentry.md) — errors, logs, traces, uptime

--- a/docs/05-operations/deployment.md
+++ b/docs/05-operations/deployment.md
@@ -82,6 +82,8 @@ Manual checks that `app:env:check` cannot perform:
 - [ ] No stuck failed messages: `php bin/console messenger:failed:show`
 - [ ] Transactional mail works (registration or password reset test) — see [transactional-mail.md](transactional-mail.md)
 - [ ] Sentry receives a test event (if `SENTRY_DSN` is set) — see [observability-sentry.md](observability-sentry.md)
+- [ ] CSP report-only header present: `curl -sI https://<APP_URL>/statistics/ | grep -i content-security-policy` — see [content-security-policy.md](content-security-policy.md#verification)
+- [ ] Optional: `SENTRY_CSP_REPORT_URI` set and CSP violations appear in Sentry — see [content-security-policy.md#sentry-integration](content-security-policy.md#sentry-integration)
 - [ ] Backups scheduled on Uberspace (cron — see [backup-restore.md](backup-restore.md))
 - [ ] Sentry Uptime Monitor on `GET /health` — see [health-check.md](health-check.md)
 

--- a/docs/05-operations/observability-sentry.md
+++ b/docs/05-operations/observability-sentry.md
@@ -11,6 +11,7 @@ This application uses `sentry/sentry-symfony` for error monitoring, structured l
 | `SENTRY_RELEASE` | Optional; falls back to `App\Kernel::APP_VERSION` (`app.version`) |
 | `SENTRY_TRACES_SAMPLE_RATE` | Share of transactions to trace (`0.0`–`1.0`) |
 | `SENTRY_ENABLE_LOGS` | Enable structured logs (`true` / `false`) |
+| `SENTRY_CSP_REPORT_URI` | Optional Sentry CSP report endpoint; prod only — see [content-security-policy.md](content-security-policy.md) |
 
 For alpha deployments, set a DSN, `SENTRY_ENVIRONMENT=alpha`, and `SENTRY_TRACES_SAMPLE_RATE` between `0.2` and `1.0`. Keep the DSN empty locally and in CI; structured logs are disabled in the `test` environment.
 
@@ -20,6 +21,10 @@ For alpha deployments, set a DSN, `SENTRY_ENVIRONMENT=alpha`, and `SENTRY_TRACES
 - **Monolog:** [`config/packages/monolog.yaml`](../../config/packages/monolog.yaml) — `sentry_logs_import` (`import` channel, info and above) and `sentry_logs_main` (other channels, warning and above).
 - **Scrubbing:** [`SentryEventScrubber`](../../src/Shared/Infrastructure/Monitoring/Sentry/SentryEventScrubber.php) and [`SentryLogScrubber`](../../src/Shared/Infrastructure/Monitoring/Sentry/SentryLogScrubber.php) filter events, breadcrumbs, and log attributes before send.
 - **Request context:** [`SentryRequestContextSubscriber`](../../src/Shared/Infrastructure/Monitoring/Http/SentryRequestContextSubscriber.php) sets user (ID/username), `route`, `bounded_context`, `origin`, and `request_id`.
+
+## CSP violation reports
+
+CSP is configured separately via Nelmio (report-only in prod). Violations appear in Sentry under **Issues**, not Logs. Setup, policy, verification, and triage: [content-security-policy.md](content-security-policy.md).
 
 ## Issues vs. logs
 

--- a/docs/05-operations/troubleshooting.md
+++ b/docs/05-operations/troubleshooting.md
@@ -58,3 +58,4 @@ php bin/console app:import:analyze-rejects --format=md
 - Deployment / ops: [deployment.md](deployment.md)
 - Import flow: [../04-features/import/import-pipeline.md](../04-features/import/import-pipeline.md)
 - Sentry / observability: [observability-sentry.md](observability-sentry.md)
+- CSP report-only / Sentry triage: [content-security-policy.md](content-security-policy.md)

--- a/docs/06-reference/configuration.md
+++ b/docs/06-reference/configuration.md
@@ -30,6 +30,7 @@
 | `SENTRY_RELEASE` | Sentry release | optional; falls back to `App\Kernel::APP_VERSION` |
 | `SENTRY_TRACES_SAMPLE_RATE` | Trace sampling rate | `0.0`–`1.0` |
 | `SENTRY_ENABLE_LOGS` | Structured logs | `true` / `false` |
+| `SENTRY_CSP_REPORT_URI` | Sentry CSP report endpoint | optional; prod only; adds `report-uri` when set (see [content-security-policy.md](../05-operations/content-security-policy.md)) |
 | `FIXTURES_SCALE` | Dev fixture volume multiplier | `1`–`10`; see [../03-development/fixtures.md](../03-development/fixtures.md) |
 
 ## Application configuration (`app.yaml`)
@@ -109,4 +110,5 @@ Production verification checklist: [../05-operations/deployment.md](../05-operat
 
 - [../05-operations/deployment.md](../05-operations/deployment.md)
 - [../05-operations/observability-sentry.md](../05-operations/observability-sentry.md)
+- [../05-operations/content-security-policy.md](../05-operations/content-security-policy.md)
 - [../05-operations/transactional-mail.md](../05-operations/transactional-mail.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,3 +53,4 @@ Role-based reading orders live in each section's README:
 - [Participant onboarding](04-features/onboarding/participant-onboarding.md)
 - [Explore allocation list](04-features/allocation/explore-allocation-list.md)
 - [Sentry observability](05-operations/observability-sentry.md)
+- [Content Security Policy (report-only)](05-operations/content-security-policy.md)

--- a/tests/Shared/Functional/Security/ContentSecurityPolicyTest.php
+++ b/tests/Shared/Functional/Security/ContentSecurityPolicyTest.php
@@ -63,6 +63,11 @@ final class ContentSecurityPolicyTest extends WebTestCase
      */
     private function assertProdHealthCspHeader(?string $expectedReportUri = null, array $env = []): void
     {
+        $databaseUrl = $this->resolveProdDatabaseUrl();
+        if (null !== $databaseUrl) {
+            $env['DATABASE_URL'] = $databaseUrl;
+        }
+
         $cacheDir = sys_get_temp_dir().'/ivena_csp_test_'.uniqid('', true);
         $envKeys = array_keys($env);
         $envKeys[] = 'APP_CACHE_DIR';
@@ -106,6 +111,35 @@ final class ContentSecurityPolicyTest extends WebTestCase
                 new Filesystem()->remove($cacheDir);
             }
         }
+    }
+
+    /**
+     * Prod kernels do not apply Doctrine's test dbname suffix; point them at the same
+     * migrated database ParaTest uses so /health does not fail on missing tables in CI.
+     */
+    private function resolveProdDatabaseUrl(): ?string
+    {
+        $databaseUrl = $_ENV['DATABASE_URL'] ?? $_SERVER['DATABASE_URL'] ?? getenv('DATABASE_URL');
+        if (!is_string($databaseUrl) || '' === $databaseUrl) {
+            return null;
+        }
+
+        $path = parse_url($databaseUrl, PHP_URL_PATH);
+        $databaseName = is_string($path) ? ltrim($path, '/') : '';
+        if ('' === $databaseName || preg_match('/_test\d*$/', $databaseName)) {
+            return $databaseUrl;
+        }
+
+        $token = $_ENV['TEST_TOKEN'] ?? $_SERVER['TEST_TOKEN'] ?? getenv('TEST_TOKEN');
+        $token = is_string($token) ? $token : '';
+
+        $resolved = preg_replace(
+            '#^(postgres(?:ql)?://[^/]+/)([^/?]+)(.*)$#i',
+            '$1$2_test'.$token.'$3',
+            $databaseUrl,
+        );
+
+        return is_string($resolved) ? $resolved : $databaseUrl;
     }
 
     /**

--- a/tests/Shared/Functional/Security/ContentSecurityPolicyTest.php
+++ b/tests/Shared/Functional/Security/ContentSecurityPolicyTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Functional\Security;
+
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class ContentSecurityPolicyTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+
+    public function testProdIncludesCspReportOnlyHeader(): void
+    {
+        $this->assertProdHealthCspHeader(env: [
+            'SENTRY_CSP_REPORT_URI' => '',
+        ]);
+    }
+
+    public function testProdIncludesReportUriWhenSentryCspReportUriIsSet(): void
+    {
+        $reportUri = 'https://o1234567890.ingest.sentry.io/api/1/security/?sentry_key=test';
+
+        $this->assertProdHealthCspHeader(
+            expectedReportUri: $reportUri,
+            env: ['SENTRY_CSP_REPORT_URI' => $reportUri],
+        );
+    }
+
+    public function testTestEnvHasNoCspHeader(): void
+    {
+        $client = self::createClient();
+        $this->loginAsRoleUser($client);
+        $client->request(Request::METHOD_GET, '/statistics/');
+
+        self::assertResponseIsSuccessful();
+        self::assertNull($client->getResponse()->headers->get('Content-Security-Policy-Report-Only'));
+        self::assertNull($client->getResponse()->headers->get('Content-Security-Policy'));
+    }
+
+    public function testExploreAllocationAndStatisticsLoad(): void
+    {
+        $client = self::createClient();
+        $this->loginAsParticipant($client);
+
+        $client->request(Request::METHOD_GET, '/explore/allocation');
+        self::assertResponseIsSuccessful();
+
+        $this->loginAsRoleUser($client);
+        $client->request(Request::METHOD_GET, '/statistics/');
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @param array<string, string> $env
+     */
+    private function assertProdHealthCspHeader(?string $expectedReportUri = null, array $env = []): void
+    {
+        $cacheDir = sys_get_temp_dir().'/ivena_csp_test_'.uniqid('', true);
+        $envKeys = array_keys($env);
+        $envKeys[] = 'APP_CACHE_DIR';
+        $envSnapshot = $this->snapshotEnv($envKeys);
+
+        try {
+            foreach ($env as $key => $value) {
+                $this->setEnv($key, $value);
+            }
+            $this->setEnv('APP_CACHE_DIR', $cacheDir);
+
+            self::ensureKernelShutdown();
+
+            $kernel = self::bootKernel([
+                'environment' => 'prod',
+                'debug' => false,
+            ]);
+
+            $response = $kernel->handle(Request::create('https://localhost/health', Request::METHOD_GET));
+
+            self::assertSame(200, $response->getStatusCode());
+
+            $header = $response->headers->get('Content-Security-Policy-Report-Only');
+            self::assertNotNull($header);
+            self::assertStringContainsString("default-src 'self'", $header);
+            self::assertStringContainsString("connect-src 'self'", $header);
+            self::assertStringContainsString('https://*.ingest.sentry.io', $header);
+            self::assertStringContainsString("script-src 'self'", $header);
+            self::assertStringContainsString("'unsafe-inline'", $header);
+
+            if (null !== $expectedReportUri) {
+                self::assertStringContainsString('report-uri '.$expectedReportUri, $header);
+            } else {
+                self::assertStringNotContainsString('report-uri', $header);
+            }
+        } finally {
+            self::ensureKernelShutdown();
+            $this->restoreEnv($envSnapshot);
+
+            if (is_dir($cacheDir)) {
+                new Filesystem()->remove($cacheDir);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $keys
+     *
+     * @return array<string, array{env: mixed, server: mixed, getenv: string|false}>
+     */
+    private function snapshotEnv(array $keys): array
+    {
+        $snapshot = [];
+
+        foreach ($keys as $key) {
+            $snapshot[$key] = [
+                'env' => $_ENV[$key] ?? null,
+                'server' => $_SERVER[$key] ?? null,
+                'getenv' => getenv($key),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+        putenv(sprintf('%s=%s', $key, $value));
+    }
+
+    /**
+     * @param array<string, array{env: mixed, server: mixed, getenv: string|false}> $snapshot
+     */
+    private function restoreEnv(array $snapshot): void
+    {
+        foreach ($snapshot as $key => $values) {
+            if (null === $values['env']) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $values['env'];
+            }
+
+            if (null === $values['server']) {
+                unset($_SERVER[$key]);
+            } else {
+                $_SERVER[$key] = $values['server'];
+            }
+
+            if (false === $values['getenv']) {
+                putenv($key);
+            } else {
+                putenv(sprintf('%s=%s', $key, $values['getenv']));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Enable **Content-Security-Policy-Report-Only** in production via NelmioSecurityBundle, with directives aligned to the current app (self-hosted assets, OpenStreetMap tiles, inline scripts/styles, AssetMapper `data:` scripts, and Sentry ingest for CSP reports).
- Add optional Sentry CSP reporting through `SENTRY_CSP_REPORT_URI`; when set, the prod header includes `report-uri` and browsers can POST violations to Sentry **Issues**.
- Add functional coverage for the prod header (with and without `report-uri`), test-env absence of CSP, and smoke checks for `/explore/allocation` and `/statistics/`.
- Document setup, verification, Sentry integration, and a beta triage checklist in `docs/05-operations/content-security-policy.md`.

## Configuration

| Piece | Location |
|-------|----------|
| CSP directives | `config/packages/nelmio_security.yaml` (`when@prod` → `csp.report`) |
| Optional `report-uri` | `config/packages/nelmio_security_csp_report_uri.php` |
| Env default | `config/services.yaml` — `env(SENTRY_CSP_REPORT_URI): ''` |

CSP is **report-only** (no blocking). Enforce mode and removing `'unsafe-inline'` are intentionally out of scope (P2).

## Test plan

- [x] `php bin/phpunit tests/Shared/Functional/Security/ContentSecurityPolicyTest.php`
- [x] Deploy to prod (or boot prod locally) and confirm header:
      `curl -sI https://<APP_URL>/health | grep -i content-security-policy-report-only`
- [x] With `SENTRY_CSP_REPORT_URI` set, confirm header contains `report-uri` and a deliberate violation (e.g. external script in DevTools) appears in Sentry **Issues**
- [x] Confirm `test` / `dev` environments send **no** CSP header