### PR TITLE
feat(shared): add permission-aware application sitemap page

### DIFF
--- a/src/Content/Application/Page/DTO/PublishedPageLink.php
+++ b/src/Content/Application/Page/DTO/PublishedPageLink.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page\DTO;
+
+final readonly class PublishedPageLink
+{
+    public function __construct(
+        public string $url,
+        public string $label,
+    ) {
+    }
+}

--- a/src/Content/Application/Page/PageNavigationProvider.php
+++ b/src/Content/Application/Page/PageNavigationProvider.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Content\Application\Page;
 
 use App\Content\Application\Page\DTO\PageNavigationLink;
+use App\Content\Application\Page\DTO\PublishedPageLink;
 use App\Content\Domain\Entity\Page;
 use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Repository\PageRepository;
+use App\Shared\Application\Navigation\DTO\SitemapPageNode;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -32,6 +34,7 @@ final class PageNavigationProvider
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly PageAccessChecker $pageAccessChecker,
         private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly PageNavigationTreeBuilder $pageNavigationTreeBuilder,
     ) {
     }
 
@@ -82,6 +85,72 @@ final class PageNavigationProvider
             PageKey::Privacy,
             PageKey::Terms,
         );
+    }
+
+    /**
+     * @return list<PublishedPageLink>
+     */
+    public function getVisiblePublishedPageLinks(): array
+    {
+        return $this->flattenPageTree($this->getVisiblePublishedPageTree());
+    }
+
+    /**
+     * @return list<SitemapPageNode>
+     */
+    public function getVisiblePublishedPageTree(): array
+    {
+        $pages = array_values(array_filter(
+            $this->pageRepository->findAllPublished(),
+            $this->pageAccessChecker->canView(...),
+        ));
+
+        return $this->buildSitemapPageNodes($this->pageNavigationTreeBuilder->build($pages));
+    }
+
+    /**
+     * @param array<int, array{page: Page, children: array<int, mixed>}> $nodes
+     *
+     * @return list<SitemapPageNode>
+     */
+    private function buildSitemapPageNodes(array $nodes): array
+    {
+        $tree = [];
+
+        foreach ($nodes as $node) {
+            $url = $this->buildUrl($node['page']);
+            if (null === $url) {
+                continue;
+            }
+
+            $tree[] = new SitemapPageNode(
+                url: $url,
+                label: (string) $node['page']->getTitle(),
+                children: $this->buildSitemapPageNodes($node['children']),
+            );
+        }
+
+        return $tree;
+    }
+
+    /**
+     * @param list<SitemapPageNode> $nodes
+     *
+     * @return list<PublishedPageLink>
+     */
+    private function flattenPageTree(array $nodes): array
+    {
+        $links = [];
+
+        foreach ($nodes as $node) {
+            $links[] = new PublishedPageLink(
+                url: $node->url,
+                label: $node->label,
+            );
+            $links = [...$links, ...$this->flattenPageTree($node->children)];
+        }
+
+        return $links;
     }
 
     /**

--- a/src/Shared/Application/Navigation/DTO/SitemapLink.php
+++ b/src/Shared/Application/Navigation/DTO/SitemapLink.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Navigation\DTO;
+
+final readonly class SitemapLink
+{
+    public function __construct(
+        public string $url,
+        public string $label,
+    ) {
+    }
+}

--- a/src/Shared/Application/Navigation/DTO/SitemapPageNode.php
+++ b/src/Shared/Application/Navigation/DTO/SitemapPageNode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Navigation\DTO;
+
+final readonly class SitemapPageNode
+{
+    /**
+     * @param list<SitemapPageNode> $children
+     */
+    public function __construct(
+        public string $url,
+        public string $label,
+        public array $children = [],
+    ) {
+    }
+}

--- a/src/Shared/Application/Navigation/DTO/SitemapSection.php
+++ b/src/Shared/Application/Navigation/DTO/SitemapSection.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Navigation\DTO;
+
+final readonly class SitemapSection
+{
+    /**
+     * @param list<SitemapLink>     $links
+     * @param list<SitemapPageNode> $pageTree
+     */
+    public function __construct(
+        public string $key,
+        public string $labelKey,
+        public array $links,
+        public array $pageTree = [],
+    ) {
+    }
+}

--- a/src/Shared/Application/Navigation/FooterNavigationProvider.php
+++ b/src/Shared/Application/Navigation/FooterNavigationProvider.php
@@ -17,6 +17,7 @@ final readonly class FooterNavigationProvider
     private const array ROUTE_LABEL_KEYS = [
         'app_blog_index' => 'link.blog',
         'app_cookie_preferences' => 'link.cookie_preferences',
+        'app_sitemap' => 'link.sitemap',
     ];
 
     /**
@@ -50,7 +51,7 @@ final readonly class FooterNavigationProvider
             'key' => 'more',
             'labelKey' => 'footer.column.more',
             'pageKeys' => [],
-            'routes' => ['app_cookie_preferences'],
+            'routes' => ['app_sitemap', 'app_cookie_preferences'],
         ],
     ];
 

--- a/src/Shared/Application/Navigation/SitemapProvider.php
+++ b/src/Shared/Application/Navigation/SitemapProvider.php
@@ -216,8 +216,35 @@ final readonly class SitemapProvider
     {
         return match ($sectionKey) {
             'public', 'account' => $links,
+            'statistics' => $this->pinFirstRouteLink('app_stats_dashboard', $links),
             default => $this->sortAlphabetically($links),
         };
+    }
+
+    /**
+     * @param list<SitemapLink> $links
+     *
+     * @return list<SitemapLink>
+     */
+    private function pinFirstRouteLink(string $routeName, array $links): array
+    {
+        $pinnedUrl = $this->urlGenerator->generate($routeName);
+        $pinned = null;
+        $rest = [];
+
+        foreach ($links as $link) {
+            if ($link->url === $pinnedUrl) {
+                $pinned = $link;
+
+                continue;
+            }
+
+            $rest[] = $link;
+        }
+
+        $orderedRest = $this->sortAlphabetically($rest);
+
+        return null === $pinned ? $orderedRest : [$pinned, ...$orderedRest];
     }
 
     /**

--- a/src/Shared/Application/Navigation/SitemapProvider.php
+++ b/src/Shared/Application/Navigation/SitemapProvider.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Navigation;
+
+use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
+use App\Content\Application\Page\PageNavigationProvider;
+use App\Shared\Application\Navigation\DTO\SitemapLink;
+use App\Shared\Application\Navigation\DTO\SitemapSection;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class SitemapProvider
+{
+    private const string VISIBILITY_ALWAYS = 'always';
+    private const string VISIBILITY_GUEST = 'guest';
+    private const string VISIBILITY_AUTHENTICATED = 'authenticated';
+    private const string VISIBILITY_PARTICIPANT = 'participant';
+    private const string VISIBILITY_EXPORT = 'export';
+    private const string VISIBILITY_ADMIN = 'admin';
+
+    /**
+     * @var array<string, array{labelKey: string, labelDomain: string}>
+     */
+    private const array ROUTE_LABELS = [
+        'app_default' => ['labelKey' => 'link.home', 'labelDomain' => 'shared'],
+        'app_login' => ['labelKey' => 'label.login', 'labelDomain' => 'messages'],
+        'app_register' => ['labelKey' => 'label.register', 'labelDomain' => 'messages'],
+        'app_forgot_password_request' => ['labelKey' => 'label.forgot_password', 'labelDomain' => 'user'],
+        'app_blog_index' => ['labelKey' => 'link.blog', 'labelDomain' => 'shared'],
+        'app_cookie_preferences' => ['labelKey' => 'link.cookie_preferences', 'labelDomain' => 'shared'],
+        'app_import_index' => ['labelKey' => 'link.import', 'labelDomain' => 'shared'],
+        'app_hospitals_export_allocations' => ['labelKey' => 'link.export', 'labelDomain' => 'shared'],
+        'app_stats_dashboard' => ['labelKey' => 'link.stats.dashboard', 'labelDomain' => 'shared'],
+        'app_stats_analysis_library' => ['labelKey' => 'link.stats.analysis', 'labelDomain' => 'shared'],
+        'app_stats_reports' => ['labelKey' => 'link.stats.reports', 'labelDomain' => 'shared'],
+        'app_stats_indication_insights' => ['labelKey' => 'link.stats.indication_insights', 'labelDomain' => 'shared'],
+        'app_stats_benchmarking' => ['labelKey' => 'link.stats.benchmarking', 'labelDomain' => 'shared'],
+        'app_stats_case_flow' => ['labelKey' => 'link.stats.case_flow', 'labelDomain' => 'shared'],
+        'app_stats_hospital_population' => ['labelKey' => 'link.stats.hospital_population', 'labelDomain' => 'shared'],
+        'app_explore_allocation_list' => ['labelKey' => 'link.allocations', 'labelDomain' => 'shared'],
+        'app_explore_assignment_list' => ['labelKey' => 'link.assignments', 'labelDomain' => 'shared'],
+        'app_explore_department_list' => ['labelKey' => 'link.departments', 'labelDomain' => 'shared'],
+        'app_explore_dispatch_area_list' => ['labelKey' => 'link.dispatch_areas', 'labelDomain' => 'shared'],
+        'app_explore_hospital_list' => ['labelKey' => 'link.hospitals', 'labelDomain' => 'shared'],
+        'app_explore_indication_list' => ['labelKey' => 'link.indications', 'labelDomain' => 'shared'],
+        'app_explore_infection_list' => ['labelKey' => 'link.infections', 'labelDomain' => 'shared'],
+        'app_explore_mci_case_list' => ['labelKey' => 'link.mci_cases', 'labelDomain' => 'shared'],
+        'app_explore_occasion_list' => ['labelKey' => 'link.occasions', 'labelDomain' => 'shared'],
+        'app_explore_secondary_transport_list' => ['labelKey' => 'link.secondary_transports', 'labelDomain' => 'shared'],
+        'app_explore_speciality_list' => ['labelKey' => 'link.specialities', 'labelDomain' => 'shared'],
+        'app_explore_indication_raw_review_worklist' => ['labelKey' => 'title.indication.review_worklist', 'labelDomain' => 'allocation'],
+        'app_settings_index' => ['labelKey' => 'label.settings.my_account', 'labelDomain' => 'user'],
+        'app_settings_email' => ['labelKey' => 'label.settings.change_email', 'labelDomain' => 'user'],
+        'app_settings_password' => ['labelKey' => 'label.settings.set_new_password', 'labelDomain' => 'user'],
+        'app_settings_notifications' => ['labelKey' => 'label.settings.notifications', 'labelDomain' => 'user'],
+        'app_hospitals_index' => ['labelKey' => 'label.my_hospitals', 'labelDomain' => 'messages'],
+        'app_admin_dashboard' => ['labelKey' => 'label.backend', 'labelDomain' => 'messages'],
+    ];
+
+    /**
+     * @var list<array{
+     *   key: string,
+     *   labelKey: string,
+     *   entries: list<array{
+     *     route?: string,
+     *     visibility: string
+     *   }>
+     * }>
+     */
+    private const array SECTIONS = [
+        [
+            'key' => 'public',
+            'labelKey' => 'sitemap.section.public',
+            'entries' => [
+                ['route' => 'app_default', 'visibility' => self::VISIBILITY_ALWAYS],
+                ['route' => 'app_login', 'visibility' => self::VISIBILITY_GUEST],
+                ['route' => 'app_register', 'visibility' => self::VISIBILITY_GUEST],
+                ['route' => 'app_forgot_password_request', 'visibility' => self::VISIBILITY_GUEST],
+                ['route' => 'app_cookie_preferences', 'visibility' => self::VISIBILITY_ALWAYS],
+            ],
+        ],
+        [
+            'key' => 'content',
+            'labelKey' => 'sitemap.section.content',
+            'entries' => [
+                ['route' => 'app_blog_index', 'visibility' => self::VISIBILITY_ALWAYS],
+            ],
+        ],
+        [
+            'key' => 'explore',
+            'labelKey' => 'sitemap.section.explore',
+            'entries' => [
+                ['route' => 'app_explore_allocation_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_assignment_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_department_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_dispatch_area_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_hospital_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_indication_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_infection_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_mci_case_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_occasion_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_secondary_transport_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_speciality_list', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_explore_indication_raw_review_worklist', 'visibility' => self::VISIBILITY_PARTICIPANT],
+            ],
+        ],
+        [
+            'key' => 'statistics',
+            'labelKey' => 'sitemap.section.statistics',
+            'entries' => [
+                ['route' => 'app_stats_dashboard', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_analysis_library', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_reports', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_indication_insights', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_benchmarking', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_case_flow', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_stats_hospital_population', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+            ],
+        ],
+        [
+            'key' => 'data_exchange',
+            'labelKey' => 'sitemap.section.data_exchange',
+            'entries' => [
+                ['route' => 'app_import_index', 'visibility' => self::VISIBILITY_PARTICIPANT],
+                ['route' => 'app_hospitals_export_allocations', 'visibility' => self::VISIBILITY_EXPORT],
+            ],
+        ],
+        [
+            'key' => 'account',
+            'labelKey' => 'sitemap.section.account',
+            'entries' => [
+                ['route' => 'app_settings_index', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_settings_email', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_settings_password', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_settings_notifications', 'visibility' => self::VISIBILITY_AUTHENTICATED],
+                ['route' => 'app_hospitals_index', 'visibility' => self::VISIBILITY_PARTICIPANT],
+            ],
+        ],
+        [
+            'key' => 'admin',
+            'labelKey' => 'sitemap.section.admin',
+            'entries' => [
+                ['route' => 'app_admin_dashboard', 'visibility' => self::VISIBILITY_ADMIN],
+            ],
+        ],
+    ];
+
+    public function __construct(
+        private PageNavigationProvider $pageNavigationProvider,
+        private UrlGeneratorInterface $urlGenerator,
+        private TranslatorInterface $translator,
+        private AuthorizationCheckerInterface $authorizationChecker,
+    ) {
+    }
+
+    /**
+     * @return list<SitemapSection>
+     */
+    public function getSections(): array
+    {
+        $sections = [];
+
+        foreach (self::SECTIONS as $sectionDefinition) {
+            $pageTree = [];
+            $links = $this->orderSectionLinks(
+                $sectionDefinition['key'],
+                $this->buildSectionLinks($sectionDefinition),
+            );
+
+            if ('content' === $sectionDefinition['key']) {
+                $pageTree = $this->pageNavigationProvider->getVisiblePublishedPageTree();
+            }
+
+            if ([] === $links && [] === $pageTree) {
+                continue;
+            }
+
+            $sections[] = new SitemapSection(
+                key: $sectionDefinition['key'],
+                labelKey: $sectionDefinition['labelKey'],
+                links: $links,
+                pageTree: $pageTree,
+            );
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param array{
+     *   key: string,
+     *   labelKey: string,
+     *   entries: list<array{route?: string, visibility: string}>
+     * } $sectionDefinition
+     *
+     * @return list<SitemapLink>
+     */
+    private function buildSectionLinks(array $sectionDefinition): array
+    {
+        $links = [];
+
+        foreach ($sectionDefinition['entries'] as $entry) {
+            if (!$this->isVisible($entry['visibility'])) {
+                continue;
+            }
+
+            $link = $this->buildRouteLink($entry['route'] ?? '');
+            if ($link instanceof SitemapLink) {
+                $links[] = $link;
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * @param list<SitemapLink> $links
+     *
+     * @return list<SitemapLink>
+     */
+    private function orderSectionLinks(string $sectionKey, array $links): array
+    {
+        return match ($sectionKey) {
+            'public', 'account' => $links,
+            default => $this->sortAlphabetically($links),
+        };
+    }
+
+    /**
+     * @param list<SitemapLink> $links
+     *
+     * @return list<SitemapLink>
+     */
+    private function sortAlphabetically(array $links): array
+    {
+        usort(
+            $links,
+            static fn (SitemapLink $left, SitemapLink $right): int => strcasecmp($left->label, $right->label),
+        );
+
+        return $links;
+    }
+
+    private function isVisible(string $visibility): bool
+    {
+        return match ($visibility) {
+            self::VISIBILITY_ALWAYS => true,
+            self::VISIBILITY_GUEST => !$this->authorizationChecker->isGranted('ROLE_USER'),
+            self::VISIBILITY_AUTHENTICATED => $this->authorizationChecker->isGranted('ROLE_USER'),
+            self::VISIBILITY_PARTICIPANT => $this->authorizationChecker->isGranted('ROLE_PARTICIPANT'),
+            self::VISIBILITY_EXPORT => $this->authorizationChecker->isGranted(ExportVoter::EXPORT),
+            self::VISIBILITY_ADMIN => $this->authorizationChecker->isGranted('ROLE_ADMIN'),
+            default => false,
+        };
+    }
+
+    private function buildRouteLink(string $routeName): ?SitemapLink
+    {
+        if ('' === $routeName) {
+            return null;
+        }
+
+        $labelDefinition = self::ROUTE_LABELS[$routeName] ?? null;
+        if (null === $labelDefinition) {
+            return null;
+        }
+
+        return new SitemapLink(
+            url: $this->urlGenerator->generate($routeName),
+            label: $this->translator->trans(
+                $labelDefinition['labelKey'],
+                [],
+                $labelDefinition['labelDomain'],
+            ),
+        );
+    }
+}

--- a/src/Shared/Application/Navigation/SitemapProvider.php
+++ b/src/Shared/Application/Navigation/SitemapProvider.php
@@ -19,7 +19,6 @@ final readonly class SitemapProvider
     private const string VISIBILITY_AUTHENTICATED = 'authenticated';
     private const string VISIBILITY_PARTICIPANT = 'participant';
     private const string VISIBILITY_EXPORT = 'export';
-    private const string VISIBILITY_ADMIN = 'admin';
 
     /**
      * @var array<string, array{labelKey: string, labelDomain: string}>
@@ -57,7 +56,6 @@ final readonly class SitemapProvider
         'app_settings_password' => ['labelKey' => 'label.settings.set_new_password', 'labelDomain' => 'user'],
         'app_settings_notifications' => ['labelKey' => 'label.settings.notifications', 'labelDomain' => 'user'],
         'app_hospitals_index' => ['labelKey' => 'label.my_hospitals', 'labelDomain' => 'messages'],
-        'app_admin_dashboard' => ['labelKey' => 'label.backend', 'labelDomain' => 'messages'],
     ];
 
     /**
@@ -137,13 +135,6 @@ final readonly class SitemapProvider
                 ['route' => 'app_settings_password', 'visibility' => self::VISIBILITY_AUTHENTICATED],
                 ['route' => 'app_settings_notifications', 'visibility' => self::VISIBILITY_AUTHENTICATED],
                 ['route' => 'app_hospitals_index', 'visibility' => self::VISIBILITY_PARTICIPANT],
-            ],
-        ],
-        [
-            'key' => 'admin',
-            'labelKey' => 'sitemap.section.admin',
-            'entries' => [
-                ['route' => 'app_admin_dashboard', 'visibility' => self::VISIBILITY_ADMIN],
             ],
         ],
     ];
@@ -252,7 +243,6 @@ final readonly class SitemapProvider
             self::VISIBILITY_AUTHENTICATED => $this->authorizationChecker->isGranted('ROLE_USER'),
             self::VISIBILITY_PARTICIPANT => $this->authorizationChecker->isGranted('ROLE_PARTICIPANT'),
             self::VISIBILITY_EXPORT => $this->authorizationChecker->isGranted(ExportVoter::EXPORT),
-            self::VISIBILITY_ADMIN => $this->authorizationChecker->isGranted('ROLE_ADMIN'),
             default => false,
         };
     }

--- a/src/Shared/UI/Http/Controller/SitemapController.php
+++ b/src/Shared/UI/Http/Controller/SitemapController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Http\Controller;
+
+use App\Shared\Application\Navigation\SitemapProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class SitemapController extends AbstractController
+{
+    public function __construct(
+        private readonly SitemapProvider $sitemapProvider,
+    ) {
+    }
+
+    #[Route('/sitemap', name: 'app_sitemap', methods: ['GET'])]
+    public function __invoke(): Response
+    {
+        return $this->render('@Shared/sitemap/index.html.twig', [
+            'sections' => $this->sitemapProvider->getSections(),
+        ]);
+    }
+}

--- a/src/Shared/UI/Twig/Components/Breadcrumbs.php
+++ b/src/Shared/UI/Twig/Components/Breadcrumbs.php
@@ -89,6 +89,7 @@ final class Breadcrumbs
             'monthly_reminder.',
             'onboarding.',
             'public.',
+            'sitemap.',
             'stats.',
             'statistics.',
             'text.',
@@ -99,7 +100,7 @@ final class Breadcrumbs
 
     private function resolveLabelDomain(string $label): string
     {
-        if (str_starts_with($label, 'link.')) {
+        if (str_starts_with($label, 'link.') || str_starts_with($label, 'sitemap.') || str_starts_with($label, 'cookie.')) {
             return 'shared';
         }
 

--- a/src/Shared/UI/Twig/NavigationExtension.php
+++ b/src/Shared/UI/Twig/NavigationExtension.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Shared\UI\Twig;
 
 use App\Shared\Application\Navigation\DTO\FooterNavigationColumn;
+use App\Shared\Application\Navigation\DTO\SitemapSection;
 use App\Shared\Application\Navigation\FooterNavigationProvider;
+use App\Shared\Application\Navigation\SitemapProvider;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -13,6 +15,7 @@ final class NavigationExtension extends AbstractExtension
 {
     public function __construct(
         private readonly FooterNavigationProvider $footerNavigationProvider,
+        private readonly SitemapProvider $sitemapProvider,
     ) {
     }
 
@@ -21,6 +24,7 @@ final class NavigationExtension extends AbstractExtension
     {
         return [
             new TwigFunction('footer_nav_columns', $this->footerNavColumns(...)),
+            new TwigFunction('sitemap_sections', $this->sitemapSections(...)),
         ];
     }
 
@@ -30,5 +34,13 @@ final class NavigationExtension extends AbstractExtension
     public function footerNavColumns(): array
     {
         return $this->footerNavigationProvider->getColumns();
+    }
+
+    /**
+     * @return list<SitemapSection>
+     */
+    public function sitemapSections(): array
+    {
+        return $this->sitemapProvider->getSections();
     }
 }

--- a/src/Shared/UI/Twig/templates/sitemap/_page_tree_nodes.html.twig
+++ b/src/Shared/UI/Twig/templates/sitemap/_page_tree_nodes.html.twig
@@ -1,0 +1,22 @@
+{% for node in nodes %}
+    {% set currentDepth = depth|default(0) %}
+    {% if currentDepth == 0 %}
+        <li class="list-group-item">
+            <a href="{{ node.url }}" class="link-secondary">{{ node.label }}</a>
+            {% if node.children is not empty %}
+                <ul class="list-unstyled mb-0 mt-2 ms-2">
+                    {{ include('@Shared/sitemap/_page_tree_nodes.html.twig', {nodes: node.children, depth: currentDepth + 1}) }}
+                </ul>
+            {% endif %}
+        </li>
+    {% else %}
+        <li class="mb-1">
+            <a href="{{ node.url }}" class="link-secondary">{{ node.label }}</a>
+            {% if node.children is not empty %}
+                <ul class="list-unstyled mb-0 mt-1 ms-2">
+                    {{ include('@Shared/sitemap/_page_tree_nodes.html.twig', {nodes: node.children, depth: currentDepth + 1}) }}
+                </ul>
+            {% endif %}
+        </li>
+    {% endif %}
+{% endfor %}

--- a/src/Shared/UI/Twig/templates/sitemap/index.html.twig
+++ b/src/Shared/UI/Twig/templates/sitemap/index.html.twig
@@ -1,0 +1,54 @@
+{% extends '@Shared/_layout_vertical.html.twig' %}
+
+{% block title %}{{ 'sitemap.title'|trans({}, 'shared') }} - {{ parent() }}{% endblock %}
+
+{% block page_header %}
+    <div class="container-xl">
+        <twig:Breadcrumbs :items="[
+            { label: 'sitemap.title' }
+        ]" />
+
+        <div class="page-header d-print-none">
+            <div class="row g-2 align-items-center">
+                <div class="col">
+                    <h2 class="page-title">{{ 'sitemap.title'|trans({}, 'shared') }}</h2>
+                    <div class="text-secondary mt-1">{{ 'sitemap.intro'|trans({}, 'shared') }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block page_body %}
+    <div class="page-body">
+        <div class="container-xl">
+            {% if sections is empty %}
+                <div class="card">
+                    <div class="card-body text-secondary">{{ 'sitemap.empty'|trans({}, 'shared') }}</div>
+                </div>
+            {% else %}
+                <div class="row row-cards">
+                    {% for section in sections %}
+                        <div class="col-12 col-md-6 col-lg-4" data-testid="sitemap-section-{{ section.key }}">
+                            <div class="card h-100">
+                                <div class="card-header">
+                                    <h3 class="card-title">{{ section.labelKey|trans({}, 'shared') }}</h3>
+                                </div>
+                                <ul class="list-group list-group-flush">
+                                    {% for link in section.links %}
+                                        <li class="list-group-item">
+                                            <a href="{{ link.url }}" class="link-secondary">{{ link.label }}</a>
+                                        </li>
+                                    {% endfor %}
+                                    {% if section.pageTree is not empty %}
+                                        {{ include('@Shared/sitemap/_page_tree_nodes.html.twig', {nodes: section.pageTree}) }}
+                                    {% endif %}
+                                </ul>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Content/Integration/Page/PageNavigationProviderTest.php
+++ b/tests/Content/Integration/Page/PageNavigationProviderTest.php
@@ -176,4 +176,78 @@ final class PageNavigationProviderTest extends KernelTestCase
 
         self::assertSame([PageKey::Imprint, PageKey::Terms], $keys);
     }
+
+    public function testGetVisiblePublishedPageLinksIncludesPagesWithoutKeyAndRespectsVisibility(): void
+    {
+        PageFactory::createOne([
+            'title' => 'Public guide',
+            'slug' => 'public-guide',
+            'path' => '/guides/public-guide',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Members only',
+            'slug' => 'members-only',
+            'path' => '/members-only',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+
+        $guestLinks = $this->provider->getVisiblePublishedPageLinks();
+        $guestLabels = array_map(static fn (\App\Content\Application\Page\DTO\PublishedPageLink $link): string => $link->label, $guestLinks);
+
+        self::assertContains('Public guide', $guestLabels);
+        self::assertNotContains('Members only', $guestLabels);
+
+        $user = \App\User\Domain\Factory\UserFactory::createOne(['username' => 'page-nav-user']);
+        $tokenStorage = self::getContainer()->get(\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface::class);
+        $tokenStorage->setToken(new \Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken(
+            $user,
+            'main',
+            $user->getRoles(),
+        ));
+
+        $authenticatedLabels = array_map(
+            static fn (\App\Content\Application\Page\DTO\PublishedPageLink $link): string => $link->label,
+            $this->provider->getVisiblePublishedPageLinks(),
+        );
+
+        self::assertContains('Public guide', $authenticatedLabels);
+        self::assertContains('Members only', $authenticatedLabels);
+    }
+
+    public function testGetVisiblePublishedPageTreePreservesHierarchy(): void
+    {
+        $parent = PageFactory::createOne([
+            'title' => 'Documentation',
+            'slug' => 'documentation',
+            'path' => '/documentation',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Getting started',
+            'slug' => 'getting-started',
+            'path' => '/documentation/getting-started',
+            'parent' => $parent,
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        $tree = $this->provider->getVisiblePublishedPageTree();
+
+        self::assertCount(1, $tree);
+        self::assertSame('Documentation', $tree[0]->label);
+        self::assertCount(1, $tree[0]->children);
+        self::assertSame('Getting started', $tree[0]->children[0]->label);
+    }
 }

--- a/tests/Shared/Functional/Controller/SitemapControllerTest.php
+++ b/tests/Shared/Functional/Controller/SitemapControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Functional\Controller;
+
+use App\Content\Domain\Entity\Page;
+use App\Content\Infrastructure\Factory\PageFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class SitemapControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testGuestCanViewPublicSitemapPage(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/sitemap');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h2.page-title', 'Sitemap');
+        self::assertSelectorExists('[data-testid="sitemap-section-public"]');
+        self::assertSelectorExists('[data-testid="sitemap-section-content"]');
+        self::assertSelectorNotExists('[data-testid="sitemap-section-explore"]');
+        self::assertStringNotContainsString('sitemap.title', (string) $client->getResponse()->getContent());
+        self::assertStringContainsString('Overview of available pages', (string) $client->getResponse()->getContent());
+    }
+
+    public function testSitemapRendersNestedContentPageTree(): void
+    {
+        $client = self::createClient();
+        $this->seedContentPages();
+        $client->request(Request::METHOD_GET, '/sitemap');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('[data-testid="sitemap-section-content"]', 'Blog');
+        self::assertSelectorTextContains('[data-testid="sitemap-section-content"]', 'Guides');
+        self::assertSelectorTextContains('[data-testid="sitemap-section-content"]', 'Child page');
+        self::assertSelectorTextNotContains('[data-testid="sitemap-section-content"]', 'Members only');
+    }
+
+    public function testParticipantSeesExploreSectionOnSitemap(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]));
+        $client->request(Request::METHOD_GET, '/sitemap');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="sitemap-section-explore"]');
+    }
+
+    public function testFooterContainsSitemapLink(): void
+    {
+        $client = self::createClient();
+        $crawler = $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertGreaterThan(0, $crawler->filter('a[href="/sitemap"]')->count());
+    }
+
+    private function seedContentPages(): void
+    {
+        $guidesParent = PageFactory::createOne([
+            'title' => 'Guides',
+            'slug' => 'guides',
+            'path' => '/guides',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Custom guide',
+            'slug' => 'custom-guide',
+            'path' => '/guides/custom-guide',
+            'parent' => $guidesParent,
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Child page',
+            'slug' => 'child-page',
+            'path' => '/guides/child-page',
+            'parent' => $guidesParent,
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 2,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Members only',
+            'slug' => 'members-only',
+            'path' => '/members-only',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+    }
+}

--- a/tests/Shared/Integration/Navigation/FooterNavigationProviderTest.php
+++ b/tests/Shared/Integration/Navigation/FooterNavigationProviderTest.php
@@ -121,8 +121,9 @@ final class FooterNavigationProviderTest extends KernelTestCase
 
         $moreColumn = $columns[3];
         self::assertSame('more', $moreColumn->key);
-        self::assertCount(1, $moreColumn->links);
-        self::assertStringContainsString('/cookies/preferences', $moreColumn->links[0]->url);
+        self::assertCount(2, $moreColumn->links);
+        self::assertStringContainsString('/sitemap', $moreColumn->links[0]->url);
+        self::assertStringContainsString('/cookies/preferences', $moreColumn->links[1]->url);
     }
 
     public function testGetColumnsSkipsDraftPages(): void
@@ -150,5 +151,12 @@ final class FooterNavigationProviderTest extends KernelTestCase
         ))[0];
         self::assertCount(1, $projectColumn->links);
         self::assertStringContainsString('/blog', $projectColumn->links[0]->url);
+
+        $moreColumn = array_values(array_filter(
+            $this->provider->getColumns(),
+            static fn (\App\Shared\Application\Navigation\DTO\FooterNavigationColumn $column): bool => 'more' === $column->key,
+        ))[0];
+        self::assertCount(2, $moreColumn->links);
+        self::assertStringContainsString('/sitemap', $moreColumn->links[0]->url);
     }
 }

--- a/tests/Shared/Integration/Navigation/SitemapProviderTest.php
+++ b/tests/Shared/Integration/Navigation/SitemapProviderTest.php
@@ -192,18 +192,15 @@ final class SitemapProviderTest extends KernelTestCase
         self::assertTrue($this->sectionContainsRoute($this->provider->getSections(), 'app_hospitals_export_allocations'));
     }
 
-    public function testAdminSeesAdministrationSection(): void
+    public function testAdminDoesNotSeeAdministrationSection(): void
     {
         $this->seedContentPages();
         $this->authenticate(UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_PARTICIPANT']]));
 
         $sectionKeys = $this->sectionKeys($this->provider->getSections());
 
-        self::assertContains('admin', $sectionKeys);
-
-        $adminSection = $this->findSection('admin');
-        self::assertCount(1, $adminSection->links);
-        self::assertStringContainsString('/admin', $adminSection->links[0]->url);
+        self::assertNotContains('admin', $sectionKeys);
+        self::assertFalse($this->sectionContainsRoute($this->provider->getSections(), 'app_admin_dashboard'));
     }
 
     public function testContentSectionShowsBlogWithoutPublishedPages(): void

--- a/tests/Shared/Integration/Navigation/SitemapProviderTest.php
+++ b/tests/Shared/Integration/Navigation/SitemapProviderTest.php
@@ -122,10 +122,12 @@ final class SitemapProviderTest extends KernelTestCase
 
         $statisticsSection = $this->findSection('statistics');
         self::assertCount(7, $statisticsSection->links);
-        $this->assertLabelsAreAlphabetical(array_map(
+        $statisticsLabels = array_map(
             static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->label,
             $statisticsSection->links,
-        ));
+        );
+        self::assertSame('Overview', $statisticsLabels[0]);
+        $this->assertLabelsAreAlphabetical(array_slice($statisticsLabels, 1));
     }
 
     public function testParticipantSeesExploreDataExchangeAndMyHospitalsInAccount(): void

--- a/tests/Shared/Integration/Navigation/SitemapProviderTest.php
+++ b/tests/Shared/Integration/Navigation/SitemapProviderTest.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Integration\Navigation;
+
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Enum\PageKey;
+use App\Content\Infrastructure\Factory\PageFactory;
+use App\Shared\Application\Navigation\DTO\SitemapPageNode;
+use App\Shared\Application\Navigation\DTO\SitemapSection;
+use App\Shared\Application\Navigation\SitemapProvider;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class SitemapProviderTest extends KernelTestCase
+{
+    use Factories;
+
+    private SitemapProvider $provider;
+
+    private TokenStorageInterface $tokenStorage;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->provider = self::getContainer()->get(SitemapProvider::class);
+        $this->tokenStorage = self::getContainer()->get(TokenStorageInterface::class);
+    }
+
+    public function testGuestSeesPublicAndContentSections(): void
+    {
+        $this->seedContentPages();
+
+        $sectionKeys = $this->sectionKeys($this->provider->getSections());
+
+        self::assertSame(['public', 'content'], $sectionKeys);
+        self::assertNotContains('statistics', $sectionKeys);
+        self::assertNotContains('explore', $sectionKeys);
+        self::assertNotContains('account', $sectionKeys);
+        self::assertNotContains('admin', $sectionKeys);
+
+        $publicSection = $this->findSection('public');
+        $publicLabels = array_map(static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->label, $publicSection->links);
+        $publicUrls = array_map(static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->url, $publicSection->links);
+
+        self::assertContains('Login', $publicLabels);
+        self::assertContains('Register', $publicLabels);
+        self::assertSame('Home', $publicSection->links[0]->label);
+        self::assertFalse(
+            (bool) array_filter($publicUrls, static fn (string $url): bool => str_contains($url, '/blog')),
+        );
+        self::assertSame(
+            ['Home', 'Login', 'Register', 'Forgot password?', 'Cookie settings'],
+            $publicLabels,
+        );
+
+        $contentSection = $this->findSection('content');
+        self::assertCount(1, $contentSection->links);
+        self::assertSame('Blog', $contentSection->links[0]->label);
+        self::assertNotEmpty($contentSection->pageTree);
+
+        $pageTreeLabels = $this->flattenPageTreeLabels($contentSection->pageTree);
+        self::assertContains('Page about', $pageTreeLabels);
+        self::assertContains('Custom guide', $pageTreeLabels);
+        self::assertContains('Child page', $pageTreeLabels);
+        self::assertNotContains('Members only', $pageTreeLabels);
+    }
+
+    public function testContentSectionRendersNestedPagesAsTree(): void
+    {
+        $this->seedContentPages();
+
+        $contentSection = $this->findSection('content');
+        $guidesNode = $this->findPageTreeNodeByLabel($contentSection->pageTree, 'Guides');
+
+        self::assertNotNull($guidesNode);
+        self::assertCount(2, $guidesNode->children);
+
+        $childLabels = array_map(
+            static fn (SitemapPageNode $node): string => $node->label,
+            $guidesNode->children,
+        );
+
+        self::assertSame(['Custom guide', 'Child page'], $childLabels);
+        self::assertStringContainsString('/guides/child-page', $guidesNode->children[1]->url);
+    }
+
+    public function testAuthenticatedUserSeesStatisticsAndAccountSections(): void
+    {
+        $this->seedContentPages();
+        $this->authenticate(UserFactory::createOne(['roles' => ['ROLE_USER']]));
+
+        $sectionKeys = $this->sectionKeys($this->provider->getSections());
+
+        self::assertSame(['public', 'content', 'statistics', 'account'], $sectionKeys);
+        self::assertNotContains('explore', $sectionKeys);
+        self::assertNotContains('data_exchange', $sectionKeys);
+        self::assertNotContains('admin', $sectionKeys);
+
+        $publicSection = $this->findSection('public');
+        $publicLabels = array_map(static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->label, $publicSection->links);
+
+        self::assertNotContains('Login', $publicLabels);
+        self::assertNotContains('Register', $publicLabels);
+
+        $contentSection = $this->findSection('content');
+        $pageTreeLabels = $this->flattenPageTreeLabels($contentSection->pageTree);
+
+        self::assertContains('Members only', $pageTreeLabels);
+
+        $statisticsSection = $this->findSection('statistics');
+        self::assertCount(7, $statisticsSection->links);
+        $this->assertLabelsAreAlphabetical(array_map(
+            static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->label,
+            $statisticsSection->links,
+        ));
+    }
+
+    public function testParticipantSeesExploreDataExchangeAndMyHospitalsInAccount(): void
+    {
+        $this->seedContentPages();
+        $this->authenticate(UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]));
+
+        $sectionKeys = $this->sectionKeys($this->provider->getSections());
+
+        self::assertSame(
+            ['public', 'content', 'explore', 'statistics', 'data_exchange', 'account'],
+            $sectionKeys,
+        );
+
+        $exploreSection = $this->findSection('explore');
+        self::assertCount(12, $exploreSection->links);
+        $this->assertLabelsAreAlphabetical(array_map(
+            static fn (\App\Shared\Application\Navigation\DTO\SitemapLink $link): string => $link->label,
+            $exploreSection->links,
+        ));
+
+        $dataExchangeSection = $this->findSection('data_exchange');
+        self::assertCount(1, $dataExchangeSection->links);
+        self::assertSame('Import', $dataExchangeSection->links[0]->label);
+
+        $accountSection = $this->findSection('account');
+        self::assertCount(5, $accountSection->links);
+        self::assertSame('My hospitals', $accountSection->links[4]->label);
+        self::assertSame('My Account', $accountSection->links[0]->label);
+    }
+
+    public function testExportLinkOnlyVisibleInDataExchangeSectionWhenUserCanExport(): void
+    {
+        $this->seedContentPages();
+
+        $participantWithoutExport = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $this->authenticate($participantWithoutExport);
+
+        self::assertFalse($this->sectionContainsRoute($this->provider->getSections(), 'app_hospitals_export_allocations'));
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        HospitalFactory::createOne(['owner' => $owner]);
+        $this->authenticate($owner);
+
+        self::assertTrue($this->sectionContainsRoute($this->provider->getSections(), 'app_hospitals_export_allocations'));
+
+        $dataExchangeSection = $this->findSection('data_exchange');
+        self::assertCount(2, $dataExchangeSection->links);
+        self::assertSame('Export', $dataExchangeSection->links[0]->label);
+        self::assertSame('Import', $dataExchangeSection->links[1]->label);
+
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([
+                HospitalPermission::View,
+                HospitalPermission::Export,
+            ]),
+        ]);
+        $this->authenticate($grantee);
+
+        self::assertTrue($this->sectionContainsRoute($this->provider->getSections(), 'app_hospitals_export_allocations'));
+    }
+
+    public function testAdminSeesAdministrationSection(): void
+    {
+        $this->seedContentPages();
+        $this->authenticate(UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_PARTICIPANT']]));
+
+        $sectionKeys = $this->sectionKeys($this->provider->getSections());
+
+        self::assertContains('admin', $sectionKeys);
+
+        $adminSection = $this->findSection('admin');
+        self::assertCount(1, $adminSection->links);
+        self::assertStringContainsString('/admin', $adminSection->links[0]->url);
+    }
+
+    public function testContentSectionShowsBlogWithoutPublishedPages(): void
+    {
+        $sectionKeys = $this->sectionKeys($this->provider->getSections());
+
+        self::assertContains('content', $sectionKeys);
+
+        $publicSection = $this->findSection('public');
+        self::assertSame('Home', $publicSection->links[0]->label);
+
+        $contentSection = $this->findSection('content');
+        self::assertCount(1, $contentSection->links);
+        self::assertSame('Blog', $contentSection->links[0]->label);
+        self::assertSame([], $contentSection->pageTree);
+    }
+
+    private function seedContentPages(): void
+    {
+        foreach ([PageKey::About, PageKey::Features, PageKey::Faq, PageKey::Imprint, PageKey::Privacy, PageKey::Terms] as $pageKey) {
+            PageFactory::createOne([
+                'title' => 'Page '.$pageKey->value,
+                'slug' => $pageKey->value,
+                'path' => '/'.$pageKey->value,
+                'key' => $pageKey,
+                'status' => Page::STATUS_PUBLISHED,
+                'visibility' => Page::VISIBILITY_PUBLIC,
+            ]);
+        }
+
+        $guidesParent = PageFactory::createOne([
+            'title' => 'Guides',
+            'slug' => 'guides',
+            'path' => '/guides',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Custom guide',
+            'slug' => 'custom-guide',
+            'path' => '/guides/custom-guide',
+            'parent' => $guidesParent,
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 1,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Child page',
+            'slug' => 'child-page',
+            'path' => '/guides/child-page',
+            'parent' => $guidesParent,
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'sortOrder' => 2,
+        ]);
+
+        PageFactory::createOne([
+            'title' => 'Members only',
+            'slug' => 'members-only',
+            'path' => '/members-only',
+            'key' => null,
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+        ]);
+    }
+
+    private function authenticate(User $user): void
+    {
+        $this->tokenStorage->setToken(new UsernamePasswordToken(
+            $user,
+            'main',
+            $user->getRoles(),
+        ));
+    }
+
+    /**
+     * @param list<SitemapPageNode> $nodes
+     *
+     * @return list<string>
+     */
+    private function flattenPageTreeLabels(array $nodes): array
+    {
+        $labels = [];
+
+        foreach ($nodes as $node) {
+            $labels[] = $node->label;
+            $labels = [...$labels, ...$this->flattenPageTreeLabels($node->children)];
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @param list<SitemapPageNode> $nodes
+     */
+    private function findPageTreeNodeByLabel(array $nodes, string $label): ?SitemapPageNode
+    {
+        foreach ($nodes as $node) {
+            if ($node->label === $label) {
+                return $node;
+            }
+
+            $match = $this->findPageTreeNodeByLabel($node->children, $label);
+            if ($match instanceof SitemapPageNode) {
+                return $match;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $labels
+     */
+    private function assertLabelsAreAlphabetical(array $labels): void
+    {
+        $sorted = $labels;
+        usort($sorted, strcasecmp(...));
+
+        self::assertSame($sorted, $labels);
+    }
+
+    /**
+     * @param list<SitemapSection> $sections
+     *
+     * @return list<string>
+     */
+    private function sectionKeys(array $sections): array
+    {
+        return array_map(static fn (SitemapSection $section): string => $section->key, $sections);
+    }
+
+    private function findSection(string $key): SitemapSection
+    {
+        foreach ($this->provider->getSections() as $section) {
+            if ($section->key === $key) {
+                return $section;
+            }
+        }
+
+        self::fail(sprintf('Expected sitemap section "%s" to exist.', $key));
+    }
+
+    /**
+     * @param list<SitemapSection> $sections
+     */
+    private function sectionContainsRoute(array $sections, string $routeName): bool
+    {
+        $url = self::getContainer()->get(\Symfony\Component\Routing\Generator\UrlGeneratorInterface::class)->generate($routeName);
+
+        foreach ($sections as $section) {
+            foreach ($section->links as $link) {
+                if ($link->url === $url) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Shared/Unit/Twig/Components/BreadcrumbsTest.php
+++ b/tests/Shared/Unit/Twig/Components/BreadcrumbsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Twig\Components;
+
+use App\Shared\UI\Twig\Components\Breadcrumbs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class BreadcrumbsTest extends TestCase
+{
+    public function testSitemapTitleIsTranslatedFromSharedDomain(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->with('app_default')->willReturn('/');
+
+        $component = new Breadcrumbs($urlGenerator);
+        $component->items = [
+            ['label' => 'sitemap.title'],
+        ];
+
+        $items = $component->getFullItems();
+
+        self::assertCount(2, $items);
+        self::assertSame('sitemap.title', $items[1]['label']);
+        self::assertSame('shared', $items[1]['label_domain']);
+        self::assertNotSame(false, $items[1]['translatable'] ?? true);
+    }
+
+    public function testCookiePreferencesTitleIsTranslatedFromSharedDomain(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->with('app_default')->willReturn('/');
+
+        $component = new Breadcrumbs($urlGenerator);
+        $component->items = [
+            ['label' => 'cookie.preferences.title'],
+        ];
+
+        $items = $component->getFullItems();
+
+        self::assertSame('shared', $items[1]['label_domain']);
+        self::assertNotSame(false, $items[1]['translatable'] ?? true);
+    }
+}

--- a/tests/System/AppRoutesTest.php
+++ b/tests/System/AppRoutesTest.php
@@ -60,6 +60,7 @@ final class AppRoutesTest extends SystemWebTestCase
         yield 'app_forgot_password_request' => ['/reset-password'];
         yield 'app_check_email' => ['/reset-password/check-email'];
         yield 'app_cookie_preferences' => ['/cookies/preferences'];
+        yield 'app_sitemap' => ['/sitemap'];
         yield 'app_blog_index' => ['/blog'];
         yield 'app_blog_rss' => ['/blog/rss.xml'];
     }

--- a/translations/shared+intl-icu.de.xlf
+++ b/translations/shared+intl-icu.de.xlf
@@ -277,6 +277,54 @@
         <source>footer.hoster</source>
         <target>Gehostet bei {hoster}</target>
       </trans-unit>
+      <trans-unit id="LnkSitemapDe" resname="link.sitemap">
+        <source>link.sitemap</source>
+        <target>Sitemap</target>
+      </trans-unit>
+      <trans-unit id="SitemapTitleDe" resname="sitemap.title">
+        <source>sitemap.title</source>
+        <target>Sitemap</target>
+      </trans-unit>
+      <trans-unit id="SitemapIntroDe" resname="sitemap.intro">
+        <source>sitemap.intro</source>
+        <target>Übersicht über verfügbare Seiten und Funktionen dieser Anwendung.</target>
+      </trans-unit>
+      <trans-unit id="SitemapEmptyDe" resname="sitemap.empty">
+        <source>sitemap.empty</source>
+        <target>Für Ihr aktuelles Konto sind keine Seiten verfügbar.</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecPublicDe" resname="sitemap.section.public">
+        <source>sitemap.section.public</source>
+        <target>Öffentlich</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecDocDe" resname="sitemap.section.content">
+        <source>sitemap.section.content</source>
+        <target>Inhalte</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAppDe" resname="sitemap.section.data_exchange">
+        <source>sitemap.section.data_exchange</source>
+        <target>Import &amp; Export</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecStatsDe" resname="sitemap.section.statistics">
+        <source>sitemap.section.statistics</source>
+        <target>Statistik &amp; Analyse</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecExploreDe" resname="sitemap.section.explore">
+        <source>sitemap.section.explore</source>
+        <target>Daten erkunden</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAccountDe" resname="sitemap.section.account">
+        <source>sitemap.section.account</source>
+        <target>Benutzerkonto</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecClinicDe" resname="sitemap.section.clinic">
+        <source>sitemap.section.clinic</source>
+        <target>Klinik</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAdminDe" resname="sitemap.section.admin">
+        <source>sitemap.section.admin</source>
+        <target>Administration</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/shared+intl-icu.de.xlf
+++ b/translations/shared+intl-icu.de.xlf
@@ -321,10 +321,6 @@
         <source>sitemap.section.clinic</source>
         <target>Klinik</target>
       </trans-unit>
-      <trans-unit id="SitemapSecAdminDe" resname="sitemap.section.admin">
-        <source>sitemap.section.admin</source>
-        <target>Administration</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/shared+intl-icu.en.xlf
+++ b/translations/shared+intl-icu.en.xlf
@@ -321,10 +321,6 @@
         <source>sitemap.section.clinic</source>
         <target>Clinic</target>
       </trans-unit>
-      <trans-unit id="SitemapSecAdminEn" resname="sitemap.section.admin">
-        <source>sitemap.section.admin</source>
-        <target>Administration</target>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/shared+intl-icu.en.xlf
+++ b/translations/shared+intl-icu.en.xlf
@@ -277,6 +277,54 @@
         <source>footer.hoster</source>
         <target>Hosted on {hoster}</target>
       </trans-unit>
+      <trans-unit id="LnkSitemapEn" resname="link.sitemap">
+        <source>link.sitemap</source>
+        <target>Sitemap</target>
+      </trans-unit>
+      <trans-unit id="SitemapTitleEn" resname="sitemap.title">
+        <source>sitemap.title</source>
+        <target>Sitemap</target>
+      </trans-unit>
+      <trans-unit id="SitemapIntroEn" resname="sitemap.intro">
+        <source>sitemap.intro</source>
+        <target>Overview of available pages and features in this application.</target>
+      </trans-unit>
+      <trans-unit id="SitemapEmptyEn" resname="sitemap.empty">
+        <source>sitemap.empty</source>
+        <target>No pages are available for your current account.</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecPublicEn" resname="sitemap.section.public">
+        <source>sitemap.section.public</source>
+        <target>Public</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecDocEn" resname="sitemap.section.content">
+        <source>sitemap.section.content</source>
+        <target>Content</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAppEn" resname="sitemap.section.data_exchange">
+        <source>sitemap.section.data_exchange</source>
+        <target>Import &amp; Export</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecStatsEn" resname="sitemap.section.statistics">
+        <source>sitemap.section.statistics</source>
+        <target>Statistics &amp; Analysis</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecExploreEn" resname="sitemap.section.explore">
+        <source>sitemap.section.explore</source>
+        <target>Explore Data</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAccountEn" resname="sitemap.section.account">
+        <source>sitemap.section.account</source>
+        <target>User Account</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecClinicEn" resname="sitemap.section.clinic">
+        <source>sitemap.section.clinic</source>
+        <target>Clinic</target>
+      </trans-unit>
+      <trans-unit id="SitemapSecAdminEn" resname="sitemap.section.admin">
+        <source>sitemap.section.admin</source>
+        <target>Administration</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

Adds a new public `/sitemap` page that gives users a structured, permission-aware overview of available routes and CMS content. Closes #264.

- **New sitemap page** at `GET /sitemap` (`app_sitemap`) with curated sections filtered by the current user's roles and voters
- **Section order:** Public → Content → Explore → Statistics → Import/Export → Account → Admin
- **Public section:** Home first, then Login / Register / Forgot password / Cookie settings (fixed order)
- **Content section:** Blog link plus a nested tree of all user-visible published CMS pages
- **Sorting:** Alphabetical within sections (except Public fixed order and Account fixed order with “My hospitals” last)
- **Footer integration:** Sitemap link added to the “More” column for discoverability
- **Breadcrumb fix:** `sitemap.*` and `cookie.*` translation keys resolve in the shared domain

## Architecture

- `SitemapProvider` builds a curated manifest and filters links via Symfony security voters
- `PageNavigationProvider` exposes `getVisiblePublishedPageLinks()` and `getVisiblePublishedPageTree()` for CMS navigation
- Twig function `sitemap_sections()` via `NavigationExtension`
- Templates: `sitemap/index.html.twig`, `sitemap/_page_tree_nodes.html.twig`

## Test plan

- [x] `make ci` passes (PHPStan, Psalm, Rector, fixers)
- [x] `SitemapProviderTest` — guest, authenticated, participant, export, admin, tree nesting
- [x] `PageNavigationProviderTest` — visible page tree hierarchy
- [x] `FooterNavigationProviderTest` — sitemap link in footer
- [x] `BreadcrumbsTest` — translated sitemap breadcrumb
- [x] `SitemapControllerTest` — HTTP smoke tests for rendering, tree, roles, footer link
- [x] `AppRoutesTest` — `/sitemap` is publicly accessible
- [x] Manual: open `/sitemap` as guest, logged-in user, participant, and admin — verify sections match expectations
- [x] Manual: verify nested CMS pages render correctly in the Content section
- [x] Manual: verify footer “Sitemap” link on the homepage