### PR TITLE
docs(architecture): add and accept ADRs 007–010 for beta-architecture

### DIFF
--- a/docs/02-architecture/decisions/007-bounded-contexts-and-dependency-directions.md
+++ b/docs/02-architecture/decisions/007-bounded-contexts-and-dependency-directions.md
@@ -1,0 +1,78 @@
+# ADR 007: Bounded contexts, typing, and allowed dependency directions
+
+**Status:** accepted
+
+## Context
+
+The monolith under `src/` is organized by bounded contexts, documented in [bounded-contexts.md](../bounded-contexts.md). An architecture review before beta (Issue #258) confirmed that most top-level directories are coherent, but dependency directions between contexts are uneven: some bidirectional cycles are accidental (e.g. foreign contexts importing EasyAdmin controller classes), while others reflect real domain relationships (e.g. `Allocation` ↔ `Import`, `User` ↔ `Hospital`).
+
+Without an explicit map of context types and allowed edges, automated checks (Deptrac) and refactors risk either blocking legitimate partnerships or allowing new cycles by default.
+
+## Decision
+
+### Official top-level contexts
+
+The following directories under `src/` are the official bounded contexts / modules:
+
+| Name | Type | Notes |
+|------|------|-------|
+| `Allocation` | Domain context | Core EMS allocation and master data |
+| `Import` | Domain context | CSV import pipeline |
+| `Statistics` | Domain context | Projections and analytics (internal submodules are not separate top-level contexts) |
+| `User` | Domain context | Identity, auth, registration |
+| `Content` | Domain context | Pages, blog, media |
+| `Feedback` | Domain context | Feedback widget |
+| `Engagement` | Domain context | Monthly submission reminders |
+| `Kpi` | Domain context | Daily KPI aggregation |
+| `Onboarding` | Domain context | Participant onboarding progress |
+| `Admin` | Technical UI module | EasyAdmin back office; no own domain model |
+| `Shared` | Platform / shared kernel | Cross-cutting infrastructure (see ADR 008) |
+| `Install` | Technical module | Install and environment checks |
+| `DataFixtures` | Dev-only | Excluded from production routing and services |
+
+`App\Kernel` remains outside these contexts.
+
+### Documented partnerships (allowed)
+
+These couplings are intentional and may remain until a dedicated follow-up ADR changes them:
+
+- **Allocation ↔ Import** at the domain association level (`Allocation` / `MciCase` reference `Import`)
+- **User ↔ Allocation** for hospital ownership (`User` ↔ `Hospital`)
+- **Import → Statistics** for projection rebuild / deduplication via Statistics application contracts
+- **Statistics → Allocation / User** as a read model over allocation domain types and identity
+- **Engagement** may read Statistics, Kpi, Allocation, and Import application/infrastructure read APIs to compose reminder content
+- **Admin** may depend on other contexts’ domain entities and application services for CRUD
+
+### Edges to avoid or remove over time
+
+- Other contexts must not import `Admin\UI\…Controller` (or other Admin UI types) for URL generation; use named routes or thin URL-generator contracts instead
+- `Shared` must not depend on Feedback, Content, Allocation, Import, Statistics, Engagement, or Admin feature types (User exception: ADR 008)
+- Do not introduce new bidirectional context cycles without an ADR
+- `DataFixtures` may depend on any context; production code must not depend on `DataFixtures`
+
+## Consequences
+
+**Positive:**
+
+- Clear vocabulary for reviews and Deptrac layers
+- Accidental Admin/Shared cycles become actionable instead of “style opinions”
+- Legitimate domain partnerships are not treated as defects
+
+**Negative:**
+
+- Some existing edges remain until follow-up PRs (Admin controller imports, Shared feature leaks)
+- Partnership list must be kept in sync when Deptrac rules land (ADR 010)
+
+## Alternatives
+
+- **Strict acyclic context graph immediately** — rejected for beta; would force large domain refactors (e.g. replace ORM associations with IDs) without proportional benefit
+- **Treat Admin as a full domain context** — rejected; Admin has no own aggregates
+- **Leave directions undocumented** — rejected; blocks reliable architecture automation
+
+## References
+
+- [../bounded-contexts.md](../bounded-contexts.md)
+- [../overview.md](../overview.md)
+- [008-shared-platform-and-domain-framework-coupling.md](008-shared-platform-and-domain-framework-coupling.md)
+- [010-architecture-guardrails-and-beta-scope.md](010-architecture-guardrails-and-beta-scope.md)
+- Issue [#258](https://github.com/nplhse/collaborative-ivena-statistics/issues/258)

--- a/docs/02-architecture/decisions/008-shared-platform-and-domain-framework-coupling.md
+++ b/docs/02-architecture/decisions/008-shared-platform-and-domain-framework-coupling.md
@@ -1,0 +1,78 @@
+# ADR 008: Shared platform role and domain framework coupling
+
+**Status:** accepted
+
+## Context
+
+`App\Shared` provides audit, mail, export orchestration, locale, health checks, layouts, and the custom DI extension. Domain entities across contexts are Doctrine-mapped classes that often reference concrete repositories via `repositoryClass` and, in some cases, Symfony Security or Validator APIs (notably `User`).
+
+A pure “framework-free domain” ideal would require a large rewrite before beta and would fight Symfony/Doctrine conventions the team already uses productively. At the same time, Shared currently leaks into feature contexts (e.g. Feedback types in transactional mail, Content navigation, Allocation-specific audit purge), which undermines Shared as a stable lower layer.
+
+## Decision
+
+### Role of Shared
+
+Treat `Shared` as the **application platform / shared kernel**, not as a dumping ground for feature logic:
+
+**Belongs in Shared:**
+
+- Cross-cutting infrastructure (audit pipeline, monitoring/Sentry hooks, pagination helpers)
+- Mail *transport* and generic transactional sending mechanics
+- Export registry / orchestration contracts used by multiple contexts
+- Locale, health, public-id helpers, colocated layout/Twig building blocks
+- Kernel DI extension and app configuration tree
+
+**Does not belong in Shared (move over time):**
+
+- Feature-specific mail content tied to Feedback (or other) domain entities
+- Feature navigation/sitemap knowledge that belongs in Content or other contexts
+- Allocation-/Import-specific purge or domain rules that are not generic audit tooling
+
+### User dependency exception
+
+`Shared` may depend on `User` (entity / security identity) for audit actor, locale preference, consent, and notification recipient resolution. This is an explicit exception until a thinner identity port is justified.
+
+### Domain layer and Symfony / Doctrine
+
+For this project, the following are **accepted** in domain code:
+
+- Doctrine ORM mapping attributes on entities
+- `repositoryClass` pointing at infrastructure repositories
+- Doctrine collections on associations where needed
+- Symfony Security user interfaces and Validator constraints on identity/content entities where they are the natural place for invariants
+
+Domain code must **not** depend on:
+
+- HTTP controllers, Live Components, or Twig
+- EasyAdmin types
+- Messenger handlers / transport configuration types
+- Other contexts’ UI or Admin modules
+
+Long-term “persistence ignorance” (removing Doctrine from domain) is **out of scope** before beta and is not a current goal.
+
+## Consequences
+
+**Positive:**
+
+- Aligns written architecture with how the codebase actually works
+- Avoids a high-cost purity refactor before beta
+- Gives a clear rule for cleaning Shared feature leaks in later PRs
+
+**Negative:**
+
+- Domain remains coupled to Doctrine; swapping persistence would be expensive
+- Shared→User exception must stay documented so Deptrac can allow it deliberately
+- Existing Shared feature leaks remain until dedicated cleanup PRs
+
+## Alternatives
+
+- **Strict hexagonal domain (no Doctrine in Domain)** — rejected for beta; disproportionate churn
+- **Shared as anything-goes utilities** — rejected; increases cross-context coupling
+- **Ban Shared→User immediately** — rejected; audit/locale/consent would need a larger identity port first
+
+## References
+
+- [../bounded-contexts.md](../bounded-contexts.md)
+- [007-bounded-contexts-and-dependency-directions.md](007-bounded-contexts-and-dependency-directions.md)
+- [009-ports-repositories-query-objects-and-naming.md](009-ports-repositories-query-objects-and-naming.md)
+- Issue [#258](https://github.com/nplhse/collaborative-ivena-statistics/issues/258)

--- a/docs/02-architecture/decisions/009-ports-repositories-query-objects-and-naming.md
+++ b/docs/02-architecture/decisions/009-ports-repositories-query-objects-and-naming.md
@@ -1,0 +1,75 @@
+# ADR 009: Ports, repositories, query objects, and naming
+
+**Status:** accepted
+
+## Context
+
+The codebase uses concrete Doctrine `*Repository` classes extensively and has **no** repository interfaces. Cross-cutting extension points (import processors, report definitions, exporters) already use application contracts with tagged iterators. Analytical read paths have started to appear as dedicated query classes under `Infrastructure/Query/`, while large repositories such as `AllocationRepository` still accumulate many specialized read methods.
+
+Statistics is one bounded context with internal submodules (`AnalysisExplorer`, `GenericAnalysis`, `Benchmarking`, …). Naming of DTO folders (`Dto` vs `DTO`) and contract folders (`Contract` vs `Contracts`) is inconsistent.
+
+## Decision
+
+### Repository interfaces
+
+Do **not** introduce repository interfaces by default. Concrete Doctrine repositories are the standard persistence API inside a context.
+
+Introduce interfaces / application contracts only when they provide clear value:
+
+- Tagged extension points and registries
+- Cross-context ports (e.g. projection rebuild)
+- Swappable strategies (e.g. reject writers)
+
+### Query objects for specialized reads
+
+Keep repositories focused on aggregate persistence and simple lookups (find, save-related helpers, small scoped queries).
+
+Specialized read paths—especially statistics, explore, dashboard, and reporting SQL—belong in dedicated query (or SQL builder) classes under the owning context’s `Infrastructure/Query/` (or an equivalent infrastructure query location already used by a submodule).
+
+Rules of thumb:
+
+- **New** analytical / multi-join / report-style queries should be added as query classes, not as additional public methods on a large repository
+- Existing oversized repositories (notably `AllocationRepository`) are reduced **incrementally** on touchpoints or in dedicated complexity PRs—not as a single big-bang move before beta
+- Query classes may use DBAL/ORM directly; they do not need a repository wrapper unless reuse inside the aggregate API is natural
+
+### Statistics internal model
+
+`Statistics` remains a **single** bounded context. Submodules are internal modules for organization and optional future Deptrac layers; they are not separate top-level contexts.
+
+### Naming conventions (forward-looking)
+
+For **new** code:
+
+- Use `DTO` (uppercase) for DTO directories
+- Use `Contract` (singular) for application contract directories
+
+Bulk renames of existing `Dto` / `Contracts` trees are not required before beta; rename opportunistically when a file or folder is already being touched.
+
+## Consequences
+
+**Positive:**
+
+- Matches existing successful patterns (contracts for extension points, query objects for analytics)
+- Gives a durable strategy to shrink repository hotspots without mandating interface noise
+- Clarifies Statistics as one context for dependency rules
+
+**Negative:**
+
+- Boundary between “simple repository query” and “query object” still needs judgment
+- More classes for read paths
+- Naming debt remains until touchpoint cleanups
+
+## Alternatives
+
+- **Repository interfaces everywhere** — rejected; little test/isolation benefit given Doctrine-centric design
+- **Keep growing repositories** — rejected; `AllocationRepository` size already harms changeability
+- **Full CQRS framework / separate read DB** — rejected as operational and conceptual overhead for current scale
+- **Immediate global DTO/Contract rename** — rejected; noisy diff without behavioral gain
+
+## References
+
+- [../extension-points.md](../extension-points.md)
+- [../bounded-contexts.md](../bounded-contexts.md)
+- [001-projection-and-materialized-views.md](001-projection-and-materialized-views.md)
+- [010-architecture-guardrails-and-beta-scope.md](010-architecture-guardrails-and-beta-scope.md)
+- Issue [#258](https://github.com/nplhse/collaborative-ivena-statistics/issues/258)

--- a/docs/02-architecture/decisions/010-architecture-guardrails-and-beta-scope.md
+++ b/docs/02-architecture/decisions/010-architecture-guardrails-and-beta-scope.md
@@ -1,0 +1,71 @@
+# ADR 010: Architecture guardrails and beta complexity scope
+
+**Status:** accepted
+
+## Context
+
+Issue #258 calls for architecture review and reduced software complexity before beta. Phase 1 inventory found solid structure, missing automated boundary checks on `main`, and a few large hotspots (especially `AllocationRepository` and Analysis Explorer UI/application classes). Experimental Deptrac work exists on branch `refactor/architecture-review` but is not wired on `main`.
+
+Enforcing every ideal boundary and refactoring every large class before beta would delay release without matching risk reduction.
+
+## Decision
+
+### Architecture automation (Deptrac)
+
+After ADRs 007–009 are accepted:
+
+1. Introduce Deptrac on `main`, aligned with those ADRs
+2. Start in **report-only** mode with a baseline of known violations
+3. Add CI visibility without failing the build until the baseline is stable and the team agrees to ratchet
+4. Treat `refactor/architecture-review` as **input to review**, not as an automatic merge
+
+Deptrac rules should encode the policies in ADRs 007–009 (context directions, Shared limits, pragmatic domain/Doctrine allowance, query/repository intent where expressible). Exact YAML is out of scope for this ADR and belongs to the Deptrac introduction PR.
+
+### Complexity work before beta
+
+Before beta, schedule **at most one** dedicated complexity-reduction PR, preferring:
+
+1. **Preferred:** extract specialized reads from `AllocationRepository` into query classes (implements ADR 009)
+2. **Alternative:** split a single Analysis Explorer hotspot if product risk there is higher at the time of execution
+
+Do not run both large hotspot refactors in parallel before beta. Further hotspots (`AnalysisExplorerShell`, Engagement content builder, large view-model factories, …) stay in the post-beta backlog unless a concrete bug forces a touchpoint.
+
+### Out of scope before beta
+
+- Removing Doctrine from the domain layer
+- Introducing repository interfaces project-wide
+- Resolving every documented context partnership into an acyclic graph
+- Homogenizing the entire Statistics folder layout
+- Switching Deptrac to fail-CI on day one
+
+### Delivery style
+
+Architecture follow-ups for Issue #258 are delivered as **small, single-purpose PRs** (docs/ADRs, Deptrac report-only, one decoupling edge, one hotspot). No big-bang architecture commit.
+
+## Consequences
+
+**Positive:**
+
+- Beta stays focused on enforceable guardrails and one high-value simplification
+- Deptrac can land without blocking all merges
+- ADR 009’s query-object goal gets a concrete first execution path
+
+**Negative:**
+
+- Known violations remain until baseline ratchets
+- Explorer and other hotspots may stay large through beta
+- Report-only mode requires discipline so new violations are still noticed
+
+## Alternatives
+
+- **Fail-CI Deptrac immediately with zero baseline** — rejected; would block unrelated feature work
+- **Broad pre-beta refactor wave** — rejected; PR and review risk too high
+- **Skip automation until after beta** — rejected; regressions in boundaries would be invisible
+
+## References
+
+- [007-bounded-contexts-and-dependency-directions.md](007-bounded-contexts-and-dependency-directions.md)
+- [008-shared-platform-and-domain-framework-coupling.md](008-shared-platform-and-domain-framework-coupling.md)
+- [009-ports-repositories-query-objects-and-naming.md](009-ports-repositories-query-objects-and-naming.md)
+- [../overview.md](../overview.md)
+- Issue [#258](https://github.com/nplhse/collaborative-ivena-statistics/issues/258)

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -22,6 +22,10 @@ Each ADR includes:
 | [004](004-colocated-templates.md) | Colocated Twig templates | accepted |
 | [005](005-reject-writer-strategy.md) | Reject writer strategy (db vs. csv) | accepted |
 | [006](006-analysis-explorer-saved-views.md) | Analysis Explorer saved views (JSON schema v3) | accepted |
+| [007](007-bounded-contexts-and-dependency-directions.md) | Bounded contexts, typing, and allowed dependency directions | accepted |
+| [008](008-shared-platform-and-domain-framework-coupling.md) | Shared platform role and domain framework coupling | accepted |
+| [009](009-ports-repositories-query-objects-and-naming.md) | Ports, repositories, query objects, and naming | accepted |
+| [010](010-architecture-guardrails-and-beta-scope.md) | Architecture guardrails and beta complexity scope | accepted |
 
 ## Template
 


### PR DESCRIPTION
## Summary
- add ADR 007 to define official bounded contexts, context typing, allowed partnerships, and disallowed dependency directions
- add ADR 008 to define the role of `Shared` and pragmatic Symfony/Doctrine coupling boundaries in domain code
- add ADR 009 to document repository policy, query-object extraction strategy (especially for analytics/statistics), and naming conventions
- add ADR 010 to define Deptrac rollout guardrails and a beta-focused complexity scope based on small, single-purpose PR waves
- update the ADR index in `docs/02-architecture/decisions/README.md` and mark ADRs 007–010 as accepted

## Test plan
- [x] Verify all new ADR files render correctly in GitHub Markdown
- [x] Verify `docs/02-architecture/decisions/README.md` links to ADR 007–010 correctly
- [x] Confirm all ADRs use `**Status:** accepted`
- [x] Team review of architecture decisions before starting Phase 3 (Deptrac branch)