### PR TITLE
feat(architecture): introduce Deptrac report-only with baseline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,6 +92,11 @@ jobs:
             - name: Run PHPStan
               run: ./vendor/bin/phpstan analyze
 
+            - name: Run Deptrac (architecture report)
+              continue-on-error: true
+              run: vendor/bin/deptrac analyse --no-progress
+              # Report-only for now; remove continue-on-error when baseline violations are reduced (ADR 010).
+
             - name: Set up Node.js
               uses: actions/setup-node@v7
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ security-audit/
 # Production DB dumps (never commit)
 /prod-dump.sql.gz
 /var/dumps/
+
+###> deptrac/deptrac ###
+/.deptrac.cache
+###< deptrac/deptrac ###

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ PHPSTAN       = ./vendor/bin/phpstan
 PHP_CS_FIXER  = ./vendor/bin/php-cs-fixer
 PSALM         = ./vendor/bin/psalm
 RECTOR        = ./vendor/bin/rector
+DEPTRAC       = ./vendor/bin/deptrac
 SWISS_KNIFE   = ./vendor/bin/swiss-knife
 SWISS_KNIFE_FINALIZE_OPTS = --skip-mocked --skip-file 'src/**/Domain/Entity/*' --skip-file 'src/**/Infrastructure/Entity/*'
 TWIG_CS_FIXER = ./vendor/bin/twig-cs-fixer
@@ -200,6 +201,12 @@ psalm: ## Run Psalm
 
 rector: ## Run Rector
 	@$(RECTOR)
+
+deptrac: ## Run Deptrac architecture analysis
+	@$(DEPTRAC) analyse --no-progress
+
+deptrac-baseline: ## Regenerate deptrac.baseline.yaml from current violations
+	@$(DEPTRAC) analyse --formatter=baseline --output=deptrac.baseline.yaml --no-progress
 
 swiss-knife: ## Apply Swiss Knife fixes (conflicts, commented code, finalize)
 	@$(SWISS_KNIFE) check-conflicts . --exclude vendor --exclude var

--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,12 @@
         ],
         "check-deprecations": [
             "@php bin/check-deprecations"
+        ],
+        "architecture:analyse": [
+            "deptrac analyse --no-progress"
+        ],
+        "architecture:baseline": [
+            "deptrac analyse --formatter=baseline --output=deptrac.baseline.yaml --no-progress"
         ]
     },
     "conflict": {
@@ -158,6 +164,7 @@
         "brianium/paratest": "^7.20",
         "dama/doctrine-test-bundle": "^8.6",
         "deployer/deployer": "^8.0.5",
+        "deptrac/deptrac": "^4.7",
         "doctrine/doctrine-fixtures-bundle": "^4.3.1",
         "friendsofphp/php-cs-fixer": "^3.95.10",
         "phpstan/extension-installer": "^1.4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c41f805971f8adb804467ffafc4ab5b4",
+    "content-hash": "8b8b428a79d57e29b67aed5a745e463a",
     "packages": [
         {
             "name": "azuyalabs/yasumi",
@@ -11687,6 +11687,91 @@
             "time": "2026-05-18T16:59:34+00:00"
         },
         {
+            "name": "deptrac/deptrac",
+            "version": "4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deptrac/deptrac.git",
+                "reference": "ef6daf9cef2aae88366269f7d65d299ed5cb6ab7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deptrac/deptrac/zipball/ef6daf9cef2aae88366269f7d65d299ed5cb6ab7",
+                "reference": "ef6daf9cef2aae88366269f7d65d299ed5cb6ab7",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^3.0",
+                "jetbrains/phpstorm-stubs": "2024.3 || 2025.3 || 2026.1",
+                "nikic/php-parser": "^5",
+                "php": "^8.2",
+                "phpdocumentor/graphviz": "^2.1",
+                "phpdocumentor/type-resolver": "^1.9.0 || ^2.0.0",
+                "phpstan/phpdoc-parser": "^1.5.0 || ^2.1.0",
+                "phpstan/phpstan": "^2.0",
+                "psr/container": "^2.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/config": "^6.4 || ^7.4 || ^8.0",
+                "symfony/console": "^6.4 || ^7.4 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.4 || ^8.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.4 || ^8.0",
+                "symfony/event-dispatcher-contracts": "^3.4",
+                "symfony/filesystem": "^6.4 || ^7.4 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.4 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "ergebnis/composer-normalize": "^2.45",
+                "ext-libxml": "*",
+                "symfony/stopwatch": "^6.4 || ^7.4 || ^8.0"
+            },
+            "suggest": {
+                "ext-dom": "For using the JUnit output formatter"
+            },
+            "bin": [
+                "deptrac"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Deptrac\\Deptrac\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Glabisch"
+                },
+                {
+                    "name": "Simon Mönch"
+                },
+                {
+                    "name": "Denis Brumann"
+                }
+            ],
+            "description": "Deptrac is a static code analysis tool that helps to enforce rules for dependencies between software layers.",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/deptrac/deptrac/issues",
+                "source": "https://github.com/deptrac/deptrac/tree/4.7.0"
+            },
+            "time": "2026-07-21T06:03:25+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -12346,6 +12431,50 @@
             "time": "2026-07-15T09:51:47+00:00"
         },
         {
+            "name": "jetbrains/phpstorm-stubs",
+            "version": "v2026.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JetBrains/phpstorm-stubs",
+                "reference": "2cdd054c4109dfb76667c9198bf9427606354243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/2cdd054c4109dfb76667c9198bf9427606354243",
+                "reference": "2cdd054c4109dfb76667c9198bf9427606354243",
+                "shasum": ""
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.86",
+                "nikic/php-parser": "^v5.6",
+                "phpdocumentor/reflection-docblock": "^5.6",
+                "phpunit/phpunit": "^12.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpStormStubsMap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "PHP runtime & extensions header files for PhpStorm",
+            "homepage": "https://www.jetbrains.com/phpstorm",
+            "keywords": [
+                "autocomplete",
+                "code",
+                "inference",
+                "inspection",
+                "jetbrains",
+                "phpstorm",
+                "stubs",
+                "type"
+            ],
+            "time": "2026-02-19T20:12:01+00:00"
+        },
+        {
             "name": "kelunik/certificate",
             "version": "v1.1.3",
             "source": {
@@ -12905,6 +13034,59 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/graphviz",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/GraphViz.git",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/GraphViz/zipball/115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "reference": "115999dc7f31f2392645aa825a94a6b165e1cedf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "mockery/mockery": "^1.2",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^8.2 || ^9.2",
+                "psalm/phar": "^4.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\GraphViz\\": "src/phpDocumentor/GraphViz",
+                    "phpDocumentor\\GraphViz\\PHPStan\\": "./src/phpDocumentor/PHPStan"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "description": "Wrapper for Graphviz",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/GraphViz/issues",
+                "source": "https://github.com/phpDocumentor/GraphViz/tree/2.1.0"
+            },
+            "time": "2021-12-13T19:03:21+00:00"
         },
         {
             "name": "phpstan/extension-installer",

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -1,0 +1,450 @@
+deptrac:
+  skip_violations:
+    App\Allocation\Application\Allocations\AllocationListFilterCriteriaFactory:
+      - App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO
+    App\Allocation\Application\Allocations\AllocationListHospitalScopeOptionsProvider:
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\Application\Explore\ExploreFilterOptionsProvider:
+      - App\Allocation\Infrastructure\Repository\AssignmentRepository
+      - App\Allocation\Infrastructure\Repository\DepartmentRepository
+      - App\Allocation\Infrastructure\Repository\DispatchAreaRepository
+      - App\Allocation\Infrastructure\Repository\IndicationGroupRepository
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+      - App\Allocation\Infrastructure\Repository\InfectionRepository
+      - App\Allocation\Infrastructure\Repository\OccasionRepository
+      - App\Allocation\Infrastructure\Repository\SecondaryTransportRepository
+      - App\Allocation\Infrastructure\Repository\SpecialityRepository
+      - App\Allocation\Infrastructure\Repository\StateRepository
+    App\Allocation\Application\Export\ExportHospitalFormOptionsProvider:
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\Application\Export\OwnHospitalAllocationsExportFilterMapper:
+      - App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData
+    App\Allocation\Application\Export\OwnHospitalAllocationsExporter:
+      - App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery
+    App\Allocation\Application\Indication\IndicationMatchSuggestionService:
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+      - App\Import\Infrastructure\Indication\IndicationKey
+    App\Allocation\Application\Indication\IndicationRawReviewNavigator:
+      - App\Allocation\Infrastructure\Repository\IndicationRawRepository
+      - App\Allocation\UI\Http\DTO\IndicationRawReviewWorklistQueryDTO
+    App\Allocation\Application\Indication\IndicationRawReviewService:
+      - App\Allocation\Infrastructure\Security\Voter\IndicationRawReviewVoter
+    App\Allocation\Application\Service\HospitalPermissionAccess:
+      - App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\Domain\Entity\Allocation:
+      - App\Allocation\Infrastructure\Repository\AllocationRepository
+    App\Allocation\Domain\Entity\Assessment:
+      - App\Allocation\Infrastructure\Repository\AssessmentRepository
+    App\Allocation\Domain\Entity\Assignment:
+      - App\Allocation\Infrastructure\Repository\AssignmentRepository
+    App\Allocation\Domain\Entity\Department:
+      - App\Allocation\Infrastructure\Repository\DepartmentRepository
+    App\Allocation\Domain\Entity\DispatchArea:
+      - App\Allocation\Infrastructure\Repository\DispatchAreaRepository
+    App\Allocation\Domain\Entity\Hospital:
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\Domain\Entity\HospitalAccessGrant:
+      - App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository
+    App\Allocation\Domain\Entity\IndicationGroup:
+      - App\Allocation\Infrastructure\Repository\IndicationGroupRepository
+    App\Allocation\Domain\Entity\IndicationNormalized:
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+    App\Allocation\Domain\Entity\IndicationRaw:
+      - App\Allocation\Infrastructure\Repository\IndicationRawRepository
+    App\Allocation\Domain\Entity\Infection:
+      - App\Allocation\Infrastructure\Repository\InfectionRepository
+    App\Allocation\Domain\Entity\MciCase:
+      - App\Allocation\Infrastructure\Repository\MciCaseRepository
+    App\Allocation\Domain\Entity\Occasion:
+      - App\Allocation\Infrastructure\Repository\OccasionRepository
+    App\Allocation\Domain\Entity\SecondaryTransport:
+      - App\Allocation\Infrastructure\Repository\SecondaryTransportRepository
+    App\Allocation\Domain\Entity\Speciality:
+      - App\Allocation\Infrastructure\Repository\SpecialityRepository
+    App\Allocation\Domain\Entity\State:
+      - App\Allocation\Infrastructure\Repository\StateRepository
+    App\Allocation\Infrastructure\Query\ListAllocationsQuery:
+      - App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\AssignmentRepository:
+      - App\Allocation\UI\Http\DTO\AssignmentQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\DepartmentRepository:
+      - App\Allocation\UI\Http\DTO\SpecialityQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\DispatchAreaRepository:
+      - App\Allocation\UI\Http\DTO\AreaListQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\HospitalRepository:
+      - App\Allocation\UI\Http\DTO\HospitalQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository:
+      - App\Allocation\UI\Http\DTO\IndicationQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\IndicationRawRepository:
+      - App\Allocation\UI\Http\DTO\IndicationQueryParametersDTO
+      - App\Allocation\UI\Http\DTO\IndicationRawReviewWorklistQueryDTO
+    App\Allocation\Infrastructure\Repository\InfectionRepository:
+      - App\Allocation\UI\Http\DTO\InfectionQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\MciCaseRepository:
+      - App\Allocation\UI\Http\DTO\MciCaseQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\OccasionRepository:
+      - App\Allocation\UI\Http\DTO\OccasionQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\SecondaryTransportRepository:
+      - App\Allocation\UI\Http\DTO\SecondaryTransportQueryParametersDTO
+    App\Allocation\Infrastructure\Repository\SpecialityRepository:
+      - App\Allocation\UI\Http\DTO\SpecialityQueryParametersDTO
+    App\Allocation\Infrastructure\Security\Voter\HospitalVoter:
+      - App\Import\Application\Service\ImportListAccess
+    App\Allocation\UI\Console\Command\AuditIndicationReviewCommand:
+      - App\Allocation\Infrastructure\Query\IndicationRawReviewHealthCheckQuery
+      - App\Allocation\Infrastructure\Query\IndicationRawReviewHealthCheckResult
+      - App\Allocation\Infrastructure\Query\IndicationRawReviewHealthCheckSeverity
+    App\Allocation\UI\Console\Command\BackfillAllocationIndicationNormalizedCommand:
+      - App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface
+    App\Allocation\UI\Form\IndicationRawReviewType:
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+    App\Allocation\UI\Form\OwnHospitalAllocationsExportType:
+      - App\Allocation\Infrastructure\Repository\AssignmentRepository
+      - App\Allocation\Infrastructure\Repository\DepartmentRepository
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+      - App\Allocation\Infrastructure\Repository\InfectionRepository
+      - App\Allocation\Infrastructure\Repository\OccasionRepository
+      - App\Allocation\Infrastructure\Repository\SecondaryTransportRepository
+      - App\Allocation\Infrastructure\Repository\SpecialityRepository
+    App\Allocation\UI\Form\Transformer\IndicationToIdTransformer:
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+    App\Allocation\UI\Http\Controller\Allocations\ListAllocationsController:
+      - App\Allocation\Infrastructure\Query\ListAllocationsQuery
+    App\Allocation\UI\Http\Controller\Allocations\ShowAllocationController:
+      - App\Allocation\Infrastructure\Security\Voter\AllocationVoter
+    App\Allocation\UI\Http\Controller\Assignments\ListAssignmentController:
+      - App\Allocation\Infrastructure\Repository\AssignmentRepository
+    App\Allocation\UI\Http\Controller\DispatchAreas\ListDispatchAreasController:
+      - App\Allocation\Infrastructure\Repository\DispatchAreaRepository
+    App\Allocation\UI\Http\Controller\Export\DownloadAllocationsExportController:
+      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
+    App\Allocation\UI\Http\Controller\Export\EstimateAllocationsExportController:
+      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
+    App\Allocation\UI\Http\Controller\Export\ShowAllocationsExportController:
+      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
+    App\Allocation\UI\Http\Controller\Hospitals\DeleteHospitalAccessGrantController:
+      - App\Allocation\Infrastructure\Security\Voter\HospitalVoter
+    App\Allocation\UI\Http\Controller\Hospitals\EditHospitalAccessGrantController:
+      - App\Allocation\Infrastructure\Security\Voter\HospitalVoter
+    App\Allocation\UI\Http\Controller\Hospitals\EditOwnedHospitalController:
+      - App\Allocation\Infrastructure\Security\Voter\HospitalVoter
+    App\Allocation\UI\Http\Controller\Hospitals\ListHospitalAccessGrantsController:
+      - App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository
+      - App\Allocation\Infrastructure\Security\Voter\HospitalVoter
+    App\Allocation\UI\Http\Controller\Hospitals\ListHospitalsController:
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\UI\Http\Controller\Hospitals\ListOwnedHospitalsController:
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\UI\Http\Controller\Hospitals\NewHospitalAccessGrantController:
+      - App\Allocation\Infrastructure\Repository\HospitalAccessGrantRepository
+      - App\Allocation\Infrastructure\Security\Voter\HospitalVoter
+    App\Allocation\UI\Http\Controller\Indications\IndicationRawReviewWorklistController:
+      - App\Allocation\Infrastructure\Query\IndicationRawOccurrenceQuery
+      - App\Allocation\Infrastructure\Repository\IndicationRawRepository
+      - App\Allocation\Infrastructure\Security\Voter\IndicationRawReviewVoter
+    App\Allocation\UI\Http\Controller\Indications\ListIndicationController:
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+      - App\Allocation\Infrastructure\Repository\IndicationRawRepository
+    App\Allocation\UI\Http\Controller\Indications\ReviewIndicationRawController:
+      - App\Allocation\Infrastructure\Query\IndicationRawOccurrenceQuery
+      - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
+      - App\Allocation\Infrastructure\Security\Voter\IndicationRawReviewVoter
+    App\Allocation\UI\Http\Controller\Infections\ListInfectionController:
+      - App\Allocation\Infrastructure\Repository\InfectionRepository
+    App\Allocation\UI\Http\Controller\MciCases\ListMciCasesController:
+      - App\Allocation\Infrastructure\Repository\MciCaseRepository
+    App\Allocation\UI\Http\Controller\Occasions\ListOccasionsController:
+      - App\Allocation\Infrastructure\Repository\OccasionRepository
+    App\Allocation\UI\Http\Controller\SecondaryTransports\ListSecondaryTransportsController:
+      - App\Allocation\Infrastructure\Repository\SecondaryTransportRepository
+    App\Allocation\UI\Http\Controller\Specialities\ListDepartmentController:
+      - App\Allocation\Infrastructure\Repository\DepartmentRepository
+    App\Allocation\UI\Http\Controller\Specialities\ListSpecialitiesController:
+      - App\Allocation\Infrastructure\Repository\SpecialityRepository
+    App\Content\Application\Media\MediaDimensionsBackfillService:
+      - App\Content\Infrastructure\Media\LocalMediaFileLocator
+      - App\Content\Infrastructure\Media\MediaDimensionsExtractor
+      - App\Content\Infrastructure\Repository\MediaRepository
+    App\Content\Application\Media\MediaLibraryAdminUrlProvider:
+      - App\Admin\UI\Http\Controller\Media\MediaCrudController
+    App\Content\Application\Page\PageContentMediaResolver:
+      - App\Content\Infrastructure\Repository\MediaRepository
+    App\Content\Application\Page\PageImageContentAnalyzer:
+      - App\Content\Infrastructure\Media\LocalMediaFileLocator
+      - App\Content\Infrastructure\Media\MediaDimensionsExtractor
+      - App\Content\Infrastructure\Repository\MediaRepository
+      - App\Content\Infrastructure\Repository\PageRepository
+    App\Content\Application\Page\PageImageContentMigrationService:
+      - App\Content\Infrastructure\Repository\PageRepository
+    App\Content\Application\Page\PageNavigationProvider:
+      - App\Content\Infrastructure\Repository\PageRepository
+    App\Content\Application\Page\PageSidebarDataProvider:
+      - App\Content\Infrastructure\Repository\PageRepository
+      - App\Content\Infrastructure\Repository\PostRepository
+    App\Content\Domain\Entity\Media:
+      - App\Content\Infrastructure\Repository\MediaRepository
+    App\Content\Domain\Entity\Page:
+      - App\Content\Infrastructure\Repository\PageRepository
+    App\Content\Domain\Entity\Post:
+      - App\Content\Infrastructure\Repository\PostRepository
+    App\Content\Domain\Entity\PostCategory:
+      - App\Content\Infrastructure\Repository\PostCategoryRepository
+    App\Content\Domain\Entity\PostComment:
+      - App\Content\Infrastructure\Repository\PostCommentRepository
+    App\Content\Domain\Entity\PostTag:
+      - App\Content\Infrastructure\Repository\PostTagRepository
+    App\Content\Infrastructure\Repository\PostRepository:
+      - App\Content\UI\Http\DTO\BlogListQueryParametersDTO
+    App\Content\UI\Http\Controller\BlogController:
+      - App\Content\Infrastructure\Repository\PostCategoryRepository
+      - App\Content\Infrastructure\Repository\PostCommentRepository
+      - App\Content\Infrastructure\Repository\PostRepository
+      - App\Content\Infrastructure\Repository\PostTagRepository
+    App\Content\UI\Http\Controller\DefaultController:
+      - App\Allocation\Infrastructure\Repository\AllocationRepository
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+      - App\Content\Infrastructure\Repository\PostRepository
+      - App\Import\Infrastructure\Repository\ImportRepository
+      - App\Onboarding\Application\OnboardingProgressService
+    App\Content\UI\Http\Controller\PageController:
+      - App\Content\Infrastructure\Repository\PageRepository
+    App\Engagement\Application\MonthlyReminderSender:
+      - App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository
+      - App\User\Domain\Entity\User
+    App\Engagement\Domain\Entity\MonthlyReminderDispatch:
+      - App\Engagement\Infrastructure\Repository\MonthlyReminderDispatchRepository
+    App\Feedback\Domain\Entity\Feedback:
+      - App\Feedback\Infrastructure\Repository\FeedbackRepository
+    App\Import\Application\Analysis\ImportRejectAnalysisService:
+      - App\Import\Infrastructure\Repository\ImportRejectRepository
+    App\Import\Application\Analysis\RejectMessageNormalizer:
+      - App\Import\Infrastructure\Mapping\DispatchAreaSourceResolver
+    App\Import\Application\Factory\RowReaderFactory:
+      - App\Import\Infrastructure\Adapter\SplCsvRowReader
+      - App\Import\Infrastructure\Adapter\SplCsvStreamFactory
+      - App\Import\Infrastructure\Charset\EncodingDetector
+    App\Import\Application\MessageHandler\ImportAllocationsMessageHandler:
+      - App\Import\Infrastructure\Repository\ImportRepository
+    App\Import\Application\Service\AllocationRowProcessor:
+      - App\Import\Infrastructure\Mapping\AllocationImportFactory
+    App\Import\Application\Service\ImportAllocationsDispatcher:
+      - App\Import\Infrastructure\Repository\ImportRepository
+      - App\User\Domain\Entity\User
+    App\Import\Application\Service\ImportDeletionService:
+      - App\Import\Infrastructure\Repository\ImportBatchRunItemRepository
+    App\Import\Application\Service\ImportListAccess:
+      - App\User\Domain\Entity\User
+    App\Import\Application\Service\ImportRelatedDataCleanupService:
+      - App\Import\Infrastructure\Repository\ImportRejectRepository
+      - App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups
+    App\Import\Application\Service\ImportRequeueBatchOrchestrator:
+      - App\Import\Infrastructure\Repository\ImportBatchRunRepository
+      - App\Import\Infrastructure\Repository\ImportRepository
+    App\Import\Application\Service\MciCaseRowProcessor:
+      - App\Import\Infrastructure\Mapping\MciCaseImportFactory
+    App\Import\Domain\Entity\Import:
+      - App\Import\Infrastructure\Repository\ImportRepository
+      - App\User\Domain\Entity\User
+    App\Import\Domain\Entity\ImportBatchRun:
+      - App\Import\Infrastructure\Repository\ImportBatchRunRepository
+    App\Import\Domain\Entity\ImportBatchRunItem:
+      - App\Import\Infrastructure\Repository\ImportBatchRunItemRepository
+    App\Import\Domain\Entity\ImportReject:
+      - App\Import\Infrastructure\Repository\ImportRejectRepository
+    App\Import\Domain\Service\ImportEvaluation:
+      - App\Import\Application\DTO\ImportSummary
+    App\Import\Domain\Validation\Constraints\ImportSourceFileValidator:
+      - App\Import\Application\Service\ImportUploadGuard
+    App\Import\Infrastructure\Query\ListImportRejectsQuery:
+      - App\Import\UI\Http\DTO\ImportRejectQueryParametersDTO
+    App\Import\Infrastructure\Query\ListImportsQuery:
+      - App\Import\UI\Http\DTO\ListImportQueryParametersDTO
+      - App\User\Domain\Entity\User
+    App\Import\Infrastructure\Repository\ImportRepository:
+      - App\User\Domain\Entity\User
+    App\Import\Infrastructure\Resolver\Strategy\IndicationCreationStrategy:
+      - App\User\Domain\Entity\User
+    App\Import\Infrastructure\Security\Voter\ImportVoter:
+      - App\User\Domain\Entity\User
+      - App\User\Domain\Security\UserRole
+    App\Import\UI\Console\Command\AnalyzeImportRejectsCommand:
+      - App\Import\Infrastructure\Analysis\Export\RejectAnalysisExporterRegistry
+    App\Import\UI\Form\ImportCreateType:
+      - App\User\Domain\Entity\User
+    App\Import\UI\Http\Controller\DeleteImportController:
+      - App\Import\Infrastructure\Security\Voter\ImportVoter
+    App\Import\UI\Http\Controller\DownloadImportSourceFileController:
+      - App\Import\Infrastructure\Security\Voter\ImportVoter
+    App\Import\UI\Http\Controller\ImportStatusController:
+      - App\Import\Infrastructure\Security\Voter\ImportVoter
+    App\Import\UI\Http\Controller\ListImportController:
+      - App\Import\Infrastructure\Query\ListImportsQuery
+      - App\User\Domain\Entity\User
+    App\Import\UI\Http\Controller\NewImportController:
+      - App\User\Domain\Entity\User
+    App\Import\UI\Http\Controller\ProcessingImportController:
+      - App\Import\Infrastructure\Security\Voter\ImportVoter
+    App\Import\UI\Http\Controller\ShowImportController:
+      - App\Import\Infrastructure\Security\Voter\ImportVoter
+    App\Kpi\Application\Service\KpiAggregationService:
+      - App\Allocation\Domain\Entity\Hospital
+      - App\Allocation\Infrastructure\Repository\HospitalRepository
+      - App\Kpi\Infrastructure\Query\KpiDayAggregationQuery
+      - App\Kpi\Infrastructure\Repository\KpiDailyRepository
+    App\Kpi\Application\Service\KpiDashboardService:
+      - App\Admin\UI\Http\Controller\Allocation\AllocationCrudController
+      - App\Admin\UI\Http\Controller\DashboardController
+      - App\Admin\UI\Http\Controller\Hospital\HospitalCrudController
+      - App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController
+      - App\Admin\UI\Http\Controller\Import\ImportCrudController
+      - App\Kpi\Infrastructure\Repository\KpiDailyRepository
+    App\Kpi\Domain\Entity\KpiDaily:
+      - App\Allocation\Domain\Entity\Hospital
+      - App\Kpi\Infrastructure\Repository\KpiDailyRepository
+    App\Kpi\Infrastructure\Scheduler\KpiScheduleProvider:
+      - App\Engagement\Application\Message\SendMonthlySubmissionRemindersMessage
+    App\Onboarding\Application\OnboardingProgressService:
+      - App\Onboarding\Infrastructure\Repository\UserOnboardingStepRepository
+    App\Onboarding\Application\OnboardingStepCatalog:
+      - App\Allocation\Application\Allocations\AllocationListHospitalScopeResolver
+      - App\Allocation\Application\Service\HospitalPermissionAccess
+      - App\Allocation\Domain\Enum\HospitalPermission
+      - App\Import\Application\Service\ImportListAccess
+    App\Onboarding\Domain\Entity\UserOnboardingStep:
+      - App\Onboarding\Infrastructure\Repository\UserOnboardingStepRepository
+    App\Shared\Application\Navigation\FooterNavigationProvider:
+      - App\Content\Application\Page\PageNavigationProvider
+      - App\Content\Domain\Entity\Page
+      - App\Content\Domain\Enum\PageKey
+    App\Shared\Application\Navigation\SitemapProvider:
+      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
+      - App\Content\Application\Page\PageNavigationProvider
+    App\Shared\Infrastructure\Audit\AuditValueNormalizer:
+      - App\Allocation\Domain\Entity\Address
+    App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery:
+      - App\Allocation\Domain\Entity\Assessment
+    App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer:
+      - App\Feedback\Domain\Entity\Feedback
+      - App\Feedback\Domain\Enum\FeedbackCategory
+    App\Shared\Infrastructure\Mail\TransactionalMailer:
+      - App\Feedback\Domain\Entity\Feedback
+      - App\Feedback\Domain\Enum\FeedbackCategory
+    App\Statistics\Application\ClinicalFeaturesProvider:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+    App\Statistics\Application\ClinicalFeaturesQuery:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+    App\Statistics\Application\Cohort\HospitalCohortEligibilityChecker:
+      - App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsByCohortQuery
+    App\Statistics\Application\ComparisonFilterInputFactory:
+      - App\Statistics\UI\Http\Navigation\StatisticsQueryKeys
+    App\Statistics\Application\ComparisonScopeResolver:
+      - App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery
+    App\Statistics\Application\HospitalSummaryProvider:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+    App\Statistics\Application\HospitalSummaryQuery:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+    App\Statistics\Application\IndicationCompare\IndicationCompareBenchmarkAdapter:
+      - App\Statistics\Infrastructure\Query\IndicationCompare\Dto\IndicationCompareAggregationResult
+      - App\Statistics\Infrastructure\Query\IndicationCompare\Dto\IndicationCompareDistributionRow
+      - App\Statistics\Infrastructure\Query\IndicationCompare\Dto\IndicationCompareSideCounts
+    App\Statistics\Application\IndicationCompare\IndicationCompareInsightEngine:
+      - App\Statistics\Infrastructure\Query\IndicationCompare\Dto\IndicationCompareSideCounts
+    App\Statistics\Application\IndicationCompare\IndicationCompareReportService:
+      - App\Statistics\Infrastructure\Query\IndicationCompare\Dto\IndicationCompareAggregationResult
+      - App\Statistics\Infrastructure\Query\IndicationCompare\IndicationCompareMetricsQuery
+      - App\Statistics\Infrastructure\Query\IndicationCompare\IndicationCompareSliceQuery
+    App\Statistics\Application\IndicationCompare\IndicationCompareSubjectRequestParser:
+      - App\Statistics\UI\Http\Navigation\StatisticsQueryKeys
+    App\Statistics\Application\IndicationDashboard\DTO\IndicationDashboardResult:
+      - App\Statistics\Infrastructure\Query\IndicationDashboard\Dto\IndicationDashboardMetricsRow
+    App\Statistics\Application\IndicationDashboard\IndicationDashboardAssembler:
+      - App\Statistics\Infrastructure\Query\IndicationDashboard\Dto\IndicationDashboardMetricsRow
+    App\Statistics\Application\IndicationDashboard\IndicationDashboardService:
+      - App\Statistics\Infrastructure\Query\IndicationDashboard\IndicationDashboardMetricsQuery
+      - App\Statistics\Infrastructure\Query\IndicationDashboard\IndicationDashboardSliceQuery
+    App\Statistics\Application\IndicationDashboard\IndicationInsightEngine:
+      - App\Statistics\Infrastructure\Query\IndicationDashboard\Dto\IndicationDashboardMetricsRow
+    App\Statistics\Application\IndicationGroup\IndicationGroupMemberCompareService:
+      - App\Statistics\Infrastructure\Query\IndicationGroup\IndicationGroupMemberMetricsQuery
+    App\Statistics\Application\MessageHandler\RebuildAllocationStatsProjectionHandler:
+      - App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups
+    App\Statistics\Application\OverviewDashboardProvider:
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\Statistics\Application\Overview\OverviewChartsFactory:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+      - App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria
+      - App\Statistics\Infrastructure\Query\Overview\OverviewSliceQuery
+    App\Statistics\Application\Overview\OverviewDefaultPeriodResolver:
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\Statistics\Application\Overview\OverviewExecutiveDashboardAssembler:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+      - App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria
+      - App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder
+    App\Statistics\Application\Overview\OverviewIndicationSectionFactory:
+      - App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder
+    App\Statistics\Application\Overview\OverviewPeriodComparisonService:
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\Statistics\Application\Overview\OverviewPopulationProfileFactory:
+      - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
+    App\Statistics\Application\Overview\OverviewTopReportsFactory:
+      - App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria
+      - App\Statistics\Infrastructure\Query\Overview\OverviewTopEntitiesBatchQuery
+      - App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder
+    App\Statistics\Application\StatisticsDrawerFilterFactory:
+      - App\Statistics\UI\Http\Navigation\StatisticsQueryKeys
+    App\Statistics\Application\StatisticsFilterFactory:
+      - App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForDispatchAreaQuery
+      - App\Statistics\Infrastructure\Query\Overview\CountDistinctHospitalsForStateQuery
+    App\Statistics\Application\StatisticsScopeResolver:
+      - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByCohortQuery
+      - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByDispatchAreaQuery
+      - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery
+    App\Statistics\Application\TopDiagnosesQuery:
+      - App\Statistics\Infrastructure\Query\ProjectionDiagnosisQuery
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\Statistics\Application\TopEntityQuery:
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+      - App\Statistics\Infrastructure\Query\ProjectionTopEntityQuery
+    App\Statistics\Application\TopIndicationGroupsQuery:
+      - App\Statistics\Infrastructure\Query\IndicationGroup\ProjectionTopIndicationGroupsQuery
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\Statistics\Domain\Entity\SavedExplorerView:
+      - App\Statistics\Infrastructure\Repository\SavedExplorerViewRepository
+    App\Statistics\Domain\Entity\SavedExplorerViewFavorite:
+      - App\Statistics\Infrastructure\Repository\SavedExplorerViewFavoriteRepository
+    App\Statistics\UI\Application\StatisticsFilterFormChoiceProvider:
+      - App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery
+      - App\Statistics\Infrastructure\Query\Overview\GetEligibleDispatchAreaIdsQuery
+      - App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery
+    App\Statistics\UI\Console\Command\DeduplicateProjectionCommand:
+      - App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher
+      - App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups
+    App\Statistics\UI\Console\Command\RebuildAllocationStatsProjectionCommand:
+      - App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher
+      - App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups
+    App\Statistics\UI\Console\Command\RefreshMaterializedViewsCommand:
+      - App\Statistics\Infrastructure\MaterializedView\MaterializedViewRefresher
+      - App\Statistics\Infrastructure\MaterializedView\StatisticsMaterializedViewGroups
+    App\Statistics\UI\Http\Controller\DashboardController:
+      - App\Statistics\Infrastructure\Query\Overview\GetOverviewDashboardMetricsQuery
+      - App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria
+    App\Statistics\UI\Http\Controller\OverviewTopReportsController:
+      - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery
+    App\User\Domain\Entity\ResetPasswordRequest:
+      - App\User\Infrastructure\Repository\ResetPasswordRequestRepository
+    App\User\Domain\Entity\User:
+      - App\User\Infrastructure\Repository\UserRepository
+    App\User\Infrastructure\EventSubscriber\UserRegisteredNotificationSubscriber:
+      - App\Admin\Application\Service\AdminUserUrlGenerator
+      - App\Admin\Application\Service\GrantParticipantUrlGenerator
+    App\User\Infrastructure\Security\ConfirmPasswordAuthenticator:
+      - App\User\UI\Form\ConfirmPasswordType
+      - App\User\UI\Http\DTO\ConfirmPasswordTypeDTO
+    App\User\Infrastructure\Security\LoginFormAuthenticator:
+      - App\User\UI\Form\LoginType
+      - App\User\UI\Http\DTO\LoginTypeDTO
+    App\User\UI\Http\Controller\RegistrationController:
+      - App\User\Infrastructure\Security\EmailVerifier
+    App\User\UI\Http\Controller\SettingsController:
+      - App\User\Infrastructure\Security\EmailVerifier

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,890 @@
+imports:
+    - deptrac.baseline.yaml
+
+deptrac:
+    paths:
+        - ./src
+    exclude_files:
+        - '#src/DataFixtures/.*#'
+        - '#.*/Infrastructure/Factory/.*#'
+        - '#.*/Infrastructure/Faker/.*#'
+        - '#.*/Domain/Factory/.*#'
+    layers:
+        -
+            name: Allocation_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Allocation/Domain/.*
+        -
+            name: Allocation_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Allocation/Application/.*
+        -
+            name: Allocation_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Allocation/Infrastructure/.*
+        -
+            name: Allocation_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Allocation/UI/.*
+        -
+            name: Import_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Import/Domain/.*
+        -
+            name: Import_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Import/Application/.*
+        -
+            name: Import_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Import/Infrastructure/.*
+        -
+            name: Import_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Import/UI/.*
+        -
+            name: Statistics_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Statistics/Domain/.*
+        -
+            name: Statistics_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Statistics/Application/.*
+        -
+            name: Statistics_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Statistics/Infrastructure/.*
+        -
+            name: Statistics_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Statistics/UI/.*
+        -
+            name: User_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/User/Domain/.*
+        -
+            name: User_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/User/Application/.*
+        -
+            name: User_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/User/Infrastructure/.*
+        -
+            name: User_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/User/UI/.*
+        -
+            name: Content_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Content/Domain/.*
+        -
+            name: Content_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Content/Application/.*
+        -
+            name: Content_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Content/Infrastructure/.*
+        -
+            name: Content_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Content/UI/.*
+        -
+            name: Onboarding_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Onboarding/Domain/.*
+        -
+            name: Onboarding_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Onboarding/Application/.*
+        -
+            name: Onboarding_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Onboarding/Infrastructure/.*
+        -
+            name: Onboarding_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Onboarding/UI/.*
+        -
+            name: Engagement_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Engagement/Domain/.*
+        -
+            name: Engagement_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Engagement/Application/.*
+        -
+            name: Engagement_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Engagement/Infrastructure/.*
+        -
+            name: Engagement_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Engagement/UI/.*
+        -
+            name: Kpi_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Kpi/Domain/.*
+        -
+            name: Kpi_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Kpi/Application/.*
+        -
+            name: Kpi_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Kpi/Infrastructure/.*
+        -
+            name: Kpi_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Kpi/UI/.*
+        -
+            name: Feedback_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Feedback/Domain/.*
+        -
+            name: Feedback_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Feedback/Application/.*
+        -
+            name: Feedback_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Feedback/Infrastructure/.*
+        -
+            name: Feedback_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Feedback/UI/.*
+        -
+            name: Shared_Domain
+            collectors:
+                -
+                    type: directory
+                    value: src/Shared/Domain/.*
+        -
+            name: Shared_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Shared/Application/.*
+        -
+            name: Shared_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Shared/Infrastructure/.*
+        -
+            name: Shared_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Shared/UI/.*
+        -
+            name: Admin_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Admin/Application/.*
+        -
+            name: Admin_Infrastructure
+            collectors:
+                -
+                    type: directory
+                    value: src/Admin/Infrastructure/.*
+        -
+            name: Admin_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Admin/UI/.*
+        -
+            name: Install_Application
+            collectors:
+                -
+                    type: directory
+                    value: src/Install/Application/.*
+        -
+            name: Install_UI
+            collectors:
+                -
+                    type: directory
+                    value: src/Install/UI/.*
+    ruleset:
+        Admin_Application:
+            - Admin_Application
+            - Admin_Infrastructure
+            - Admin_UI
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Content_Application
+            - Content_Domain
+            - Content_Infrastructure
+            - Content_UI
+            - Engagement_Application
+            - Engagement_Domain
+            - Engagement_Infrastructure
+            - Engagement_UI
+            - Feedback_Application
+            - Feedback_Domain
+            - Feedback_Infrastructure
+            - Feedback_UI
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Install_Application
+            - Install_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Kpi_Infrastructure
+            - Kpi_UI
+            - Onboarding_Application
+            - Onboarding_Domain
+            - Onboarding_Infrastructure
+            - Onboarding_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Admin_Infrastructure:
+            - Admin_Application
+            - Admin_Infrastructure
+            - Admin_UI
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Content_Application
+            - Content_Domain
+            - Content_Infrastructure
+            - Content_UI
+            - Engagement_Application
+            - Engagement_Domain
+            - Engagement_Infrastructure
+            - Engagement_UI
+            - Feedback_Application
+            - Feedback_Domain
+            - Feedback_Infrastructure
+            - Feedback_UI
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Install_Application
+            - Install_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Kpi_Infrastructure
+            - Kpi_UI
+            - Onboarding_Application
+            - Onboarding_Domain
+            - Onboarding_Infrastructure
+            - Onboarding_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Admin_UI:
+            - Admin_Application
+            - Admin_Infrastructure
+            - Admin_UI
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Content_Application
+            - Content_Domain
+            - Content_Infrastructure
+            - Content_UI
+            - Engagement_Application
+            - Engagement_Domain
+            - Engagement_Infrastructure
+            - Engagement_UI
+            - Feedback_Application
+            - Feedback_Domain
+            - Feedback_Infrastructure
+            - Feedback_UI
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Install_Application
+            - Install_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Kpi_Infrastructure
+            - Kpi_UI
+            - Onboarding_Application
+            - Onboarding_Domain
+            - Onboarding_Infrastructure
+            - Onboarding_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Allocation_Application:
+            - Allocation_Domain
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Allocation_Domain:
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Allocation_Infrastructure:
+            - Allocation_Application
+            - Allocation_Domain
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Allocation_UI:
+            - Allocation_Application
+            - Allocation_Domain
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Content_Application:
+            - Content_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Content_Domain:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Content_Infrastructure:
+            - Content_Application
+            - Content_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Content_UI:
+            - Content_Application
+            - Content_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Engagement_Application:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Engagement_Domain
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Kpi_Infrastructure
+            - Kpi_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+        Engagement_Domain:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+        Engagement_Infrastructure:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Engagement_Application
+            - Engagement_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+        Engagement_UI:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Engagement_Application
+            - Engagement_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - Statistics_Infrastructure
+            - Statistics_UI
+        Feedback_Application:
+            - Feedback_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Feedback_Domain:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Feedback_Infrastructure:
+            - Feedback_Application
+            - Feedback_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Feedback_UI:
+            - Feedback_Application
+            - Feedback_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Import_Application:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+        Import_Domain:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Import_Infrastructure:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Import_Application
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+        Import_UI:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Import_Application
+            - Import_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Install_Application:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Install_UI:
+            - Install_Application
+            - Install_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Kpi_Application:
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Kpi_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Kpi_Domain:
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Kpi_Infrastructure:
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Kpi_UI:
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Kpi_Application
+            - Kpi_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        Onboarding_Application:
+            - Onboarding_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Onboarding_Domain:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Onboarding_Infrastructure:
+            - Onboarding_Application
+            - Onboarding_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Onboarding_UI:
+            - Onboarding_Application
+            - Onboarding_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Shared_Application:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Shared_Domain:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Shared_Infrastructure:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Shared_UI:
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Statistics_Application:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Domain
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Statistics_Domain:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Statistics_Infrastructure:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Import_Application
+            - Import_Domain
+            - Import_Infrastructure
+            - Import_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        Statistics_UI:
+            - Allocation_Application
+            - Allocation_Domain
+            - Allocation_Infrastructure
+            - Allocation_UI
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - Statistics_Application
+            - Statistics_Domain
+            - User_Application
+            - User_Domain
+            - User_Infrastructure
+            - User_UI
+        User_Application:
+            - Allocation_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Domain
+        User_Domain:
+            - Allocation_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+        User_Infrastructure:
+            - Allocation_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain
+        User_UI:
+            - Allocation_Domain
+            - Shared_Application
+            - Shared_Domain
+            - Shared_Infrastructure
+            - Shared_UI
+            - User_Application
+            - User_Domain

--- a/docs/02-architecture/README.md
+++ b/docs/02-architecture/README.md
@@ -14,6 +14,7 @@
 | [permission-model.md](permission-model.md) | Concept | Roles, hospital grants, voters |
 | [messenger-and-scheduler.md](messenger-and-scheduler.md) | Concept | Async processing and scheduled jobs |
 | [extension-points.md](extension-points.md) | Reference | Tagged service registries |
+| [deptrac.md](deptrac.md) | Reference | Deptrac layers, baseline, commands |
 | [decisions/](decisions/) | ADR | Architecture decision records |
 
 ## Reading order

--- a/docs/02-architecture/deptrac.md
+++ b/docs/02-architecture/deptrac.md
@@ -1,0 +1,82 @@
+# Deptrac architecture checks
+
+**Related:** [decisions/007-bounded-contexts-and-dependency-directions.md](decisions/007-bounded-contexts-and-dependency-directions.md), [decisions/008-shared-platform-and-domain-framework-coupling.md](decisions/008-shared-platform-and-domain-framework-coupling.md), [decisions/009-ports-repositories-query-objects-and-naming.md](decisions/009-ports-repositories-query-objects-and-naming.md), [decisions/010-architecture-guardrails-and-beta-scope.md](decisions/010-architecture-guardrails-and-beta-scope.md)
+
+[Deptrac](https://github.com/deptrac/deptrac) enforces dependency rules between bounded contexts and layers. Configuration lives in [`deptrac.yaml`](../../deptrac.yaml) at the project root.
+
+## Package
+
+- **Package:** `deptrac/deptrac` (^4.6)
+- **Not used:** `qossmic/deptrac`, `qossmic/deptrac-shim` (abandoned)
+
+## Layer model
+
+Each production bounded context has up to four layers:
+
+| Layer | Path pattern |
+|-------|----------------|
+| `{Context}_Domain` | `src/{Context}/Domain/**` |
+| `{Context}_Application` | `src/{Context}/Application/**` |
+| `{Context}_Infrastructure` | `src/{Context}/Infrastructure/**` |
+| `{Context}_UI` | `src/{Context}/UI/**` |
+
+**Statistics** is one bounded context — all `src/Statistics/**` including submodules (ADR 009).
+
+**Admin** has Application, Infrastructure, UI (no Domain). **Install** has Application and UI only.
+
+Excluded from analysis: `DataFixtures`, Foundry factories, Faker providers, domain factories (same excludes as production routing in `config/routes/attributes.php`).
+
+## Rules summary (target)
+
+Aligned with ADR 007–009:
+
+- **Intra-context:** UI may use Application/Domain; Application may use Domain; Infrastructure may use Domain/Application; Domain may use Shared layers and documented cross-context domain partnerships (e.g. `Allocation` ↔ `Import`, `User` ↔ `Hospital`)
+- **Shared:** may depend on Shared layers and `User` only (ADR 008 exception); must not depend on feature contexts such as Feedback, Content, or Allocation
+- **Admin:** may depend on all production context layers (CRUD back office)
+- **No production context → Admin UI** (e.g. no imports of `Admin\UI\…Controller` for URL generation)
+- **Documented partnerships:** Import/Allocation/Statistics/Engagement edges as defined in ADR 007
+
+Pragmatic gaps (Doctrine `repositoryClass` on entities, Application → Infrastructure queries, UI → Infrastructure forms) are recorded in the baseline until refactors remove them.
+
+## Baseline
+
+Known existing violations are recorded in [`deptrac.baseline.yaml`](../../deptrac.baseline.yaml) (379 skipped violations as of Phase 3 introduction).
+
+| Category | ADR | Examples |
+|----------|-----|----------|
+| Domain → own Infrastructure (`repositoryClass`) | 008 | Entity `repositoryClass` references |
+| Application → Infrastructure (queries) | 009 | Application services using query classes |
+| UI → Infrastructure (forms, DTOs) | Pragmatic gap | Form types referencing repositories |
+| Shared → feature contexts | 007, 008 | Feedback mail types, Content navigation |
+| Cross-context beyond strict matrix | 007 | `Content` → `Admin_UI`, `User` → `Admin` URL helpers |
+| Layer direction within a context | Pragmatic gap | Application → UI in some Statistics paths |
+
+**Do not** add skip rules for new violations without documenting the reason. When fixing a baseline entry, remove it from `deptrac.baseline.yaml`.
+
+Regenerate baseline after intentional architecture changes:
+
+```bash
+make deptrac-baseline
+# or
+composer architecture:baseline
+```
+
+Review the diff carefully before committing.
+
+## Commands
+
+```bash
+make deptrac
+# or
+composer architecture:analyse
+```
+
+## CI
+
+The lint workflow runs Deptrac in **report-only** mode (`continue-on-error: true`) per ADR 010. Switch to a failing check once the baseline is small enough.
+
+## References
+
+- Issue [#258](https://github.com/nplhse/collaborative-ivena-statistics/issues/258)
+- [bounded-contexts.md](bounded-contexts.md)
+- [extension-points.md](extension-points.md)

--- a/symfony.lock
+++ b/symfony.lock
@@ -11,6 +11,18 @@
             "config/packages/dama_doctrine_test_bundle.yaml"
         ]
     },
+    "deptrac/deptrac": {
+        "version": "4.7",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "05ab8813714080c7bc915cb10c780e6cfdbdb991"
+        },
+        "files": [
+            "deptrac.yaml"
+        ]
+    },
     "doctrine/deprecations": {
         "version": "1.1",
         "recipe": {


### PR DESCRIPTION
## Summary
- add Deptrac (`deptrac/deptrac`) with layer and context rules aligned to ADRs 007–010
- commit a baseline for known violations (379 skipped) so existing debt does not block merges
- run Deptrac in the lint workflow in report-only mode (`continue-on-error: true`)
- add local entry points (`make deptrac`, `composer architecture:analyse` / `architecture:baseline`) and short docs under `docs/02-architecture/deptrac.md`

## Test plan
- [x] Run `vendor/bin/deptrac analyse --no-progress` locally (expect 0 violations, skipped baseline entries)
- [x] Confirm CI lint job shows the Deptrac step without failing the workflow on baseline debt
- [x] Spot-check `deptrac.yaml` Shared / Admin / partnership rules against ADR 007–008
- [x] Confirm docs links from `docs/02-architecture/README.md` to `deptrac.md` and ADRs 007–010 render correctly

Closes a part of #258 (Phase 3 only; decoupling and complexity work follow in separate PRs).