### PR TITLE
refactor(architecture): decouple non-Admin contexts from Admin UI controllers

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -166,8 +166,6 @@ deptrac:
       - App\Content\Infrastructure\Media\LocalMediaFileLocator
       - App\Content\Infrastructure\Media\MediaDimensionsExtractor
       - App\Content\Infrastructure\Repository\MediaRepository
-    App\Content\Application\Media\MediaLibraryAdminUrlProvider:
-      - App\Admin\UI\Http\Controller\Media\MediaCrudController
     App\Content\Application\Page\PageContentMediaResolver:
       - App\Content\Infrastructure\Repository\MediaRepository
     App\Content\Application\Page\PageImageContentAnalyzer:
@@ -293,11 +291,6 @@ deptrac:
       - App\Kpi\Infrastructure\Query\KpiDayAggregationQuery
       - App\Kpi\Infrastructure\Repository\KpiDailyRepository
     App\Kpi\Application\Service\KpiDashboardService:
-      - App\Admin\UI\Http\Controller\Allocation\AllocationCrudController
-      - App\Admin\UI\Http\Controller\DashboardController
-      - App\Admin\UI\Http\Controller\Hospital\HospitalCrudController
-      - App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController
-      - App\Admin\UI\Http\Controller\Import\ImportCrudController
       - App\Kpi\Infrastructure\Repository\KpiDailyRepository
     App\Kpi\Domain\Entity\KpiDaily:
       - App\Allocation\Domain\Entity\Hospital
@@ -435,9 +428,6 @@ deptrac:
       - App\User\Infrastructure\Repository\ResetPasswordRequestRepository
     App\User\Domain\Entity\User:
       - App\User\Infrastructure\Repository\UserRepository
-    App\User\Infrastructure\EventSubscriber\UserRegisteredNotificationSubscriber:
-      - App\Admin\Application\Service\AdminUserUrlGenerator
-      - App\Admin\Application\Service\GrantParticipantUrlGenerator
     App\User\Infrastructure\Security\ConfirmPasswordAuthenticator:
       - App\User\UI\Form\ConfirmPasswordType
       - App\User\UI\Http\DTO\ConfirmPasswordTypeDTO

--- a/src/Admin/Application/Service/AdminUserUrlGenerator.php
+++ b/src/Admin/Application/Service/AdminUserUrlGenerator.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Admin\Application\Service;
 
+use App\User\Application\Contract\AdminUserDetailUrlGeneratorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-final readonly class AdminUserUrlGenerator
+#[AsAlias(AdminUserDetailUrlGeneratorInterface::class)]
+final readonly class AdminUserUrlGenerator implements AdminUserDetailUrlGeneratorInterface
 {
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(

--- a/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
+++ b/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Admin\Application\Service;
 
+use App\User\Application\Contract\GrantParticipantUrlGeneratorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-final readonly class GrantParticipantUrlGenerator
+#[AsAlias(GrantParticipantUrlGeneratorInterface::class)]
+final readonly class GrantParticipantUrlGenerator implements GrantParticipantUrlGeneratorInterface
 {
     private const int EXPIRATION_SECONDS = 604800;
 

--- a/src/Admin/Infrastructure/EasyAdminAdminLinkGenerator.php
+++ b/src/Admin/Infrastructure/EasyAdminAdminLinkGenerator.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Infrastructure;
+
+use App\Admin\UI\Http\Controller\Allocation\AllocationCrudController;
+use App\Admin\UI\Http\Controller\DashboardController;
+use App\Admin\UI\Http\Controller\Hospital\HospitalCrudController;
+use App\Admin\UI\Http\Controller\Import\ImportCrudController;
+use App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Kpi\Application\Contract\AdminLinkGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(AdminLinkGeneratorInterface::class)]
+final readonly class EasyAdminAdminLinkGenerator implements AdminLinkGeneratorInterface
+{
+    public function __construct(
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+    ) {
+    }
+
+    public function hospitalCrudIndexUrl(): string
+    {
+        return $this->crudIndexUrl(HospitalCrudController::class);
+    }
+
+    public function importCrudIndexUrl(): string
+    {
+        return $this->crudIndexUrl(ImportCrudController::class);
+    }
+
+    public function allocationCrudIndexUrl(): string
+    {
+        return $this->crudIndexUrl(AllocationCrudController::class);
+    }
+
+    public function importRejectCrudIndexUrl(): string
+    {
+        return $this->crudIndexUrl(ImportRejectCrudController::class);
+    }
+
+    public function failedImportsCrudIndexUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->unsetAll()
+            ->setDashboard(DashboardController::class)
+            ->setController(ImportCrudController::class)
+            ->setAction(Action::INDEX)
+            ->set(EA::FILTERS, [
+                'status' => [
+                    'comparison' => ComparisonType::EQ,
+                    'value' => ImportStatus::FAILED->value,
+                ],
+            ])
+            ->generateUrl();
+    }
+
+    public function importDetailUrl(int $importId): string
+    {
+        return $this->adminUrlGenerator
+            ->setController(ImportCrudController::class)
+            ->setAction('detail')
+            ->setEntityId($importId)
+            ->generateUrl();
+    }
+
+    /**
+     * @param class-string $controller
+     */
+    private function crudIndexUrl(string $controller): string
+    {
+        return $this->adminUrlGenerator
+            ->setController($controller)
+            ->generateUrl();
+    }
+}

--- a/src/Admin/Infrastructure/EasyAdminMediaLibraryUrlProvider.php
+++ b/src/Admin/Infrastructure/EasyAdminMediaLibraryUrlProvider.php
@@ -2,15 +2,17 @@
 
 declare(strict_types=1);
 
-namespace App\Content\Application\Media;
+namespace App\Admin\Infrastructure;
 
 use App\Admin\UI\Http\Controller\Media\MediaCrudController;
+use App\Content\Application\Contract\MediaLibraryAdminUrlProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
-final readonly class MediaLibraryAdminUrlProvider
+#[AsAlias(MediaLibraryAdminUrlProviderInterface::class)]
+final readonly class EasyAdminMediaLibraryUrlProvider implements MediaLibraryAdminUrlProviderInterface
 {
-    /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private AdminUrlGeneratorInterface $adminUrlGenerator,
     ) {

--- a/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
+++ b/src/Admin/UI/Form/PageContentBlockDataFieldsConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Admin\UI\Form;
 
-use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
+use App\Content\Application\Contract\MediaLibraryAdminUrlProviderInterface;
 use App\Content\Domain\Entity\Media;
 use App\Content\Domain\Enum\MediaType;
 use App\Content\Domain\Enum\PageContentBlockType;
@@ -37,7 +37,7 @@ final readonly class PageContentBlockDataFieldsConfigurator
     /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
     public function __construct(
         private MediaRepository $mediaRepository,
-        private MediaLibraryAdminUrlProvider $mediaLibraryAdminUrlProvider,
+        private MediaLibraryAdminUrlProviderInterface $mediaLibraryAdminUrlProvider,
         private TranslatorInterface $translator,
     ) {
     }

--- a/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
+++ b/src/Admin/UI/Http/Controller/Blog/PostCrudController.php
@@ -6,7 +6,7 @@ namespace App\Admin\UI\Http\Controller\Blog;
 
 use App\Content\Application\Blog\PostContentSanitizer;
 use App\Content\Application\Blog\PostSlugResolver;
-use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
+use App\Content\Application\Contract\MediaLibraryAdminUrlProviderInterface;
 use App\Content\Domain\Entity\Post;
 use App\Content\Domain\Enum\PostStatus;
 use Doctrine\ORM\EntityManagerInterface;
@@ -42,7 +42,7 @@ final class PostCrudController extends AbstractCrudController
         private readonly PostSlugResolver $postSlugResolver,
         private readonly TranslatorInterface $translator,
         private readonly PostContentSanitizer $postContentSanitizer,
-        private readonly MediaLibraryAdminUrlProvider $mediaLibraryAdminUrlProvider,
+        private readonly MediaLibraryAdminUrlProviderInterface $mediaLibraryAdminUrlProvider,
     ) {
     }
 

--- a/src/Admin/UI/Http/Controller/Page/PageCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageCrudController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Admin\UI\Http\Controller\Page;
 
 use App\Admin\UI\Form\PageContentBlockType;
-use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
+use App\Content\Application\Contract\MediaLibraryAdminUrlProviderInterface;
 use App\Content\Application\Page\PageContentBlockDataNormalizer;
 use App\Content\Application\Page\PageContentMediaResolver;
 use App\Content\Application\Page\PageContentSanitizer;
@@ -49,7 +49,7 @@ final class PageCrudController extends AbstractCrudController
         private readonly PageContentMediaResolver $pageContentMediaResolver,
         private readonly PageContentSanitizer $pageContentSanitizer,
         private readonly PagePathResolver $pagePathResolver,
-        private readonly MediaLibraryAdminUrlProvider $mediaLibraryAdminUrlProvider,
+        private readonly MediaLibraryAdminUrlProviderInterface $mediaLibraryAdminUrlProvider,
         private readonly TranslatorInterface $translator,
     ) {
     }

--- a/src/Content/Application/Contract/MediaLibraryAdminUrlProviderInterface.php
+++ b/src/Content/Application/Contract/MediaLibraryAdminUrlProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Contract;
+
+interface MediaLibraryAdminUrlProviderInterface
+{
+    public function getIndexUrl(): string;
+}

--- a/src/Kpi/Application/Contract/AdminLinkGeneratorInterface.php
+++ b/src/Kpi/Application/Contract/AdminLinkGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Kpi\Application\Contract;
+
+interface AdminLinkGeneratorInterface
+{
+    public function hospitalCrudIndexUrl(): string;
+
+    public function importCrudIndexUrl(): string;
+
+    public function allocationCrudIndexUrl(): string;
+
+    public function importRejectCrudIndexUrl(): string;
+
+    public function failedImportsCrudIndexUrl(): string;
+
+    public function importDetailUrl(int $importId): string;
+}

--- a/src/Kpi/Application/Service/KpiDashboardService.php
+++ b/src/Kpi/Application/Service/KpiDashboardService.php
@@ -4,24 +4,16 @@ declare(strict_types=1);
 
 namespace App\Kpi\Application\Service;
 
-use App\Admin\UI\Http\Controller\Allocation\AllocationCrudController;
-use App\Admin\UI\Http\Controller\DashboardController;
-use App\Admin\UI\Http\Controller\Hospital\HospitalCrudController;
-use App\Admin\UI\Http\Controller\Import\ImportCrudController;
-use App\Admin\UI\Http\Controller\ImportReject\ImportRejectCrudController;
 use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Kpi\Application\Contract\AdminLinkGeneratorInterface;
 use App\Kpi\Application\DTO\FailedImportRowDto;
 use App\Kpi\Application\DTO\FailedImportsDashboardDto;
 use App\Kpi\Application\DTO\KpiCardDto;
 use App\Kpi\Application\DTO\KpiCardsDto;
 use App\Kpi\Application\DTO\KpiChartSeriesDto;
 use App\Kpi\Infrastructure\Repository\KpiDailyRepository;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 
 final readonly class KpiDashboardService
@@ -32,7 +24,7 @@ final readonly class KpiDashboardService
         private KpiDailyRepository $kpiDailyRepository,
         private ImportRepository $importRepository,
         private ImportFailureReasonResolver $failureReasonResolver,
-        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private AdminLinkGeneratorInterface $adminLinkGenerator,
     ) {
     }
 
@@ -49,25 +41,25 @@ final readonly class KpiDashboardService
             new KpiCardDto(
                 label: new TranslatableMessage('kpi.card.active_hospitals', domain: 'admin'),
                 value: (string) $activeHospitals,
-                detailUrl: $this->generateCrudUrl(HospitalCrudController::class),
+                detailUrl: $this->adminLinkGenerator->hospitalCrudIndexUrl(),
                 icon: 'fas fa-hospital',
             ),
             new KpiCardDto(
                 label: new TranslatableMessage('kpi.card.imports', domain: 'admin'),
                 value: (string) $sums['importsCount'],
-                detailUrl: $this->generateCrudUrl(ImportCrudController::class),
+                detailUrl: $this->adminLinkGenerator->importCrudIndexUrl(),
                 icon: 'fa fa-database',
             ),
             new KpiCardDto(
                 label: new TranslatableMessage('kpi.card.records_processed', domain: 'admin'),
                 value: number_format($sums['recordsProcessed'], 0, ',', '.'),
-                detailUrl: $this->generateCrudUrl(AllocationCrudController::class),
+                detailUrl: $this->adminLinkGenerator->allocationCrudIndexUrl(),
                 icon: 'fas fa-list-ol',
             ),
             new KpiCardDto(
                 label: new TranslatableMessage('kpi.card.rejection_rate', domain: 'admin'),
                 value: sprintf('%.2f%%', $rejectionRate),
-                detailUrl: $this->generateCrudUrl(ImportRejectCrudController::class),
+                detailUrl: $this->adminLinkGenerator->importRejectCrudIndexUrl(),
                 icon: 'fas fa-chart-line',
             ),
         ]);
@@ -112,7 +104,7 @@ final readonly class KpiDashboardService
                 $this->importRepository->findRecentFailedImports($limit, $since),
             ),
             totalFailedCount: $this->importRepository->countFailedImports(),
-            allFailedImportsUrl: $this->generateFailedImportsIndexUrl(),
+            allFailedImportsUrl: $this->adminLinkGenerator->failedImportsCrudIndexUrl(),
         );
     }
 
@@ -131,6 +123,7 @@ final readonly class KpiDashboardService
             }
 
             $hospital = $import->getHospital();
+            $id = $import->getId();
             $rows[] = new FailedImportRowDto(
                 createdAt: $import->getCreatedAt(),
                 hospitalName: $hospital?->getName() ?? '—',
@@ -139,50 +132,10 @@ final readonly class KpiDashboardService
                 failureReasonKey: $this->failureReasonResolver->resolve($import),
                 recordCount: $import->getRowCount() ?? 0,
                 rejectionCount: $import->getRowsRejected() ?? 0,
-                detailUrl: $this->generateImportDetailUrl($import),
+                detailUrl: null !== $id ? $this->adminLinkGenerator->importDetailUrl($id) : null,
             );
         }
 
         return $rows;
-    }
-
-    private function generateFailedImportsIndexUrl(): string
-    {
-        return $this->adminUrlGenerator
-            ->unsetAll()
-            ->setDashboard(DashboardController::class)
-            ->setController(ImportCrudController::class)
-            ->setAction(Action::INDEX)
-            ->set(EA::FILTERS, [
-                'status' => [
-                    'comparison' => ComparisonType::EQ,
-                    'value' => ImportStatus::FAILED->value,
-                ],
-            ])
-            ->generateUrl();
-    }
-
-    /**
-     * @param class-string $controller
-     */
-    private function generateCrudUrl(string $controller): string
-    {
-        return $this->adminUrlGenerator
-            ->setController($controller)
-            ->generateUrl();
-    }
-
-    private function generateImportDetailUrl(Import $import): ?string
-    {
-        $id = $import->getId();
-        if (null === $id) {
-            return null;
-        }
-
-        return $this->adminUrlGenerator
-            ->setController(ImportCrudController::class)
-            ->setAction('detail')
-            ->setEntityId($id)
-            ->generateUrl();
     }
 }

--- a/src/User/Application/Contract/AdminUserDetailUrlGeneratorInterface.php
+++ b/src/User/Application/Contract/AdminUserDetailUrlGeneratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Contract;
+
+interface AdminUserDetailUrlGeneratorInterface
+{
+    public function detailUrl(int $userId): string;
+}

--- a/src/User/Application/Contract/GrantParticipantUrlGeneratorInterface.php
+++ b/src/User/Application/Contract/GrantParticipantUrlGeneratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Contract;
+
+interface GrantParticipantUrlGeneratorInterface
+{
+    public function generate(int $userId): string;
+}

--- a/src/User/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriber.php
+++ b/src/User/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriber.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\User\Infrastructure\EventSubscriber;
 
-use App\Admin\Application\Service\AdminUserUrlGenerator;
-use App\Admin\Application\Service\GrantParticipantUrlGenerator;
 use App\Shared\Application\Notification\AdminNotification;
 use App\Shared\Application\Notification\AdminNotificationSenderInterface;
 use App\Shared\Application\Notification\AdminNotificationType;
+use App\User\Application\Contract\AdminUserDetailUrlGeneratorInterface;
+use App\User\Application\Contract\GrantParticipantUrlGeneratorInterface;
 use App\User\Application\Event\UserRegistered;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
@@ -20,8 +20,8 @@ final readonly class UserRegisteredNotificationSubscriber
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private UserRepository $userRepository,
-        private AdminUserUrlGenerator $adminUserUrlGenerator,
-        private GrantParticipantUrlGenerator $grantParticipantUrlGenerator,
+        private AdminUserDetailUrlGeneratorInterface $adminUserUrlGenerator,
+        private GrantParticipantUrlGeneratorInterface $grantParticipantUrlGenerator,
         private AdminNotificationSenderInterface $adminNotificationSender,
     ) {
     }

--- a/tests/Admin/Unit/Infrastructure/EasyAdminAdminLinkGeneratorTest.php
+++ b/tests/Admin/Unit/Infrastructure/EasyAdminAdminLinkGeneratorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Admin\Unit\Infrastructure;
+
+use App\Admin\Infrastructure\EasyAdminAdminLinkGenerator;
+use App\Admin\UI\Http\Controller\Hospital\HospitalCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EasyAdminAdminLinkGeneratorTest extends TestCase
+{
+    public function testHospitalCrudIndexUrlUsesHospitalController(): void
+    {
+        $generator = $this->createMock(AdminUrlGeneratorInterface::class);
+        $generator->expects(self::once())
+            ->method('setController')
+            ->with(HospitalCrudController::class)
+            ->willReturnSelf();
+        $generator->expects(self::once())
+            ->method('generateUrl')
+            ->willReturn('/admin/hospital');
+
+        self::assertSame(
+            '/admin/hospital',
+            new EasyAdminAdminLinkGenerator($generator)->hospitalCrudIndexUrl(),
+        );
+    }
+}

--- a/tests/Admin/Unit/Infrastructure/EasyAdminMediaLibraryUrlProviderTest.php
+++ b/tests/Admin/Unit/Infrastructure/EasyAdminMediaLibraryUrlProviderTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Content\Unit\Media;
+namespace App\Tests\Admin\Unit\Infrastructure;
 
+use App\Admin\Infrastructure\EasyAdminMediaLibraryUrlProvider;
 use App\Admin\UI\Http\Controller\Media\MediaCrudController;
-use App\Content\Application\Media\MediaLibraryAdminUrlProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
-final class MediaLibraryAdminUrlProviderTest extends TestCase
+final class EasyAdminMediaLibraryUrlProviderTest extends TestCase
 {
     public function testGetIndexUrlTargetsMediaLibraryIndex(): void
     {
@@ -29,7 +29,7 @@ final class MediaLibraryAdminUrlProviderTest extends TestCase
 
         self::assertSame(
             '/admin/media',
-            new MediaLibraryAdminUrlProvider($generator)->getIndexUrl(),
+            new EasyAdminMediaLibraryUrlProvider($generator)->getIndexUrl(),
         );
     }
 }

--- a/tests/User/Integration/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriberTest.php
+++ b/tests/User/Integration/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriberTest.php
@@ -43,8 +43,8 @@ final class UserRegisteredNotificationSubscriberTest extends KernelTestCase
 
         $subscriber = new UserRegisteredNotificationSubscriber(
             self::getContainer()->get(UserRepository::class),
-            self::getContainer()->get(\App\Admin\Application\Service\AdminUserUrlGenerator::class),
-            self::getContainer()->get(\App\Admin\Application\Service\GrantParticipantUrlGenerator::class),
+            self::getContainer()->get(\App\User\Application\Contract\AdminUserDetailUrlGeneratorInterface::class),
+            self::getContainer()->get(\App\User\Application\Contract\GrantParticipantUrlGeneratorInterface::class),
             $sender,
         );
 


### PR DESCRIPTION
## Summary
- introduce `AdminLinkGeneratorInterface` in Kpi with EasyAdmin implementation in Admin
- replace Content `MediaLibraryAdminUrlProvider` with a Content contract implemented by Admin
- let User registration notifications depend on User URL contracts implemented by Admin Application services
- remove related Deptrac baseline skips for Admin UI / Admin Application edges

## Test plan
- [x] `vendor/bin/deptrac analyse --no-progress` (0 violations)
- [x] PHPUnit: `tests/Admin/Unit/Infrastructure/EasyAdminAdminLinkGeneratorTest.php`, `EasyAdminMediaLibraryUrlProviderTest.php`, `tests/User/Integration/Infrastructure/EventSubscriber/UserRegisteredNotificationSubscriberTest.php`
- [x] Smoke: Admin KPI dashboard links, media library picker in Page/Post CRUD, registration admin notification URLs