### PR TITLE
refactor(feedback): move admin feedback mail out of Shared TransactionalMailer

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -324,12 +324,6 @@ deptrac:
       - App\Allocation\Domain\Entity\Address
     App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery:
       - App\Allocation\Domain\Entity\Assessment
-    App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer:
-      - App\Feedback\Domain\Entity\Feedback
-      - App\Feedback\Domain\Enum\FeedbackCategory
-    App\Shared\Infrastructure\Mail\TransactionalMailer:
-      - App\Feedback\Domain\Entity\Feedback
-      - App\Feedback\Domain\Enum\FeedbackCategory
     App\Statistics\Application\ClinicalFeaturesProvider:
       - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
     App\Statistics\Application\ClinicalFeaturesQuery:

--- a/src/Feedback/Application/Contract/AdminFeedbackNotifierInterface.php
+++ b/src/Feedback/Application/Contract/AdminFeedbackNotifierInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feedback\Application\Contract;
+
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+
+interface AdminFeedbackNotifierInterface
+{
+    public function notify(
+        Feedback $feedback,
+        FeedbackCategory $category,
+        string $contextJsonPreview,
+    ): void;
+}

--- a/src/Feedback/Application/RecordFeedbackHandler.php
+++ b/src/Feedback/Application/RecordFeedbackHandler.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Feedback\Application;
 
+use App\Feedback\Application\Contract\AdminFeedbackNotifierInterface;
 use App\Feedback\Domain\Entity\Feedback;
 use App\Feedback\Domain\Enum\FeedbackCategory;
-use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -15,7 +15,7 @@ final readonly class RecordFeedbackHandler
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private TransactionalMailer $transactionalMailer,
+        private AdminFeedbackNotifierInterface $adminFeedbackNotifier,
     ) {
     }
 
@@ -51,7 +51,7 @@ final readonly class RecordFeedbackHandler
         $this->entityManager->persist($feedback);
         $this->entityManager->flush();
 
-        $this->transactionalMailer->sendAdminFeedbackEmail(
+        $this->adminFeedbackNotifier->notify(
             $feedback,
             $category,
             $this->encodeContextPreview($feedback->getContext()),

--- a/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
+++ b/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feedback\Infrastructure\Mail;
+
+use App\Feedback\Application\Contract\AdminFeedbackNotifierInterface;
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Shared\Application\Locale\LocaleResolver;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsAlias(AdminFeedbackNotifierInterface::class)]
+final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterface
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        private MailConfig $mailConfig,
+        private FeedbackRecipientEmailResolver $feedbackRecipientResolver,
+        private TranslatorInterface $translator,
+        private LocaleResolver $localeResolver,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function notify(
+        Feedback $feedback,
+        FeedbackCategory $category,
+        string $contextJsonPreview,
+    ): void {
+        $recipientsByLocale = $this->localeResolver->groupEmailsByLocale(
+            $this->feedbackRecipientResolver->resolveRecipientUsers(),
+        );
+        if ([] === $recipientsByLocale) {
+            $this->logger->info('feedback.admin_mail_skipped', [
+                'reason' => 'no_feedback_recipients',
+                'feedback_id' => $feedback->getId(),
+            ]);
+
+            return;
+        }
+
+        foreach ($recipientsByLocale as $locale => $recipients) {
+            $email = $this->createTemplatedEmail($locale)
+                ->to(...$recipients)
+                ->subject(sprintf(
+                    '[%s] %s (%s)',
+                    $this->mailConfig->appName,
+                    $this->translator->trans('feedback.email.title', [], 'feedback', $locale),
+                    $category->value,
+                ))
+                ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
+                ->context([
+                    'feedback' => $feedback,
+                    'categoryLabel' => $category->value,
+                    'contextJson' => $contextJsonPreview,
+                ]);
+
+            $this->mailer->send($email);
+        }
+    }
+
+    private function createTemplatedEmail(string $locale): TemplatedEmail
+    {
+        $email = new TemplatedEmail()
+            ->from(new Address($this->mailConfig->fromEmail, $this->mailConfig->fromName))
+            ->locale($locale);
+
+        $replyTo = $this->mailConfig->replyTo();
+        if (null !== $replyTo) {
+            $email->replyTo($replyTo);
+        }
+
+        return $email;
+    }
+}

--- a/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/SymfonyTransactionalMailer.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Mail;
 
-use App\Feedback\Domain\Entity\Feedback;
-use App\Feedback\Domain\Enum\FeedbackCategory;
-use App\Shared\Application\Locale\LocaleResolver;
-use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
-use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Mailer\MailerInterface;
@@ -25,11 +20,8 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
     public function __construct(
         private MailerInterface $mailer,
         private MailConfig $mailConfig,
-        private FeedbackRecipientEmailResolver $feedbackRecipientResolver,
         private UrlGeneratorInterface $urlGenerator,
         private TranslatorInterface $translator,
-        private LocaleResolver $localeResolver,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -79,44 +71,6 @@ final readonly class SymfonyTransactionalMailer implements TransactionalMailer
             ]);
 
         $this->mailer->send($email);
-    }
-
-    #[\Override]
-    public function sendAdminFeedbackEmail(
-        Feedback $feedback,
-        FeedbackCategory $category,
-        string $contextJsonPreview,
-    ): void {
-        $recipientsByLocale = $this->localeResolver->groupEmailsByLocale(
-            $this->feedbackRecipientResolver->resolveRecipientUsers(),
-        );
-        if ([] === $recipientsByLocale) {
-            $this->logger->info('feedback.admin_mail_skipped', [
-                'reason' => 'no_feedback_recipients',
-                'feedback_id' => $feedback->getId(),
-            ]);
-
-            return;
-        }
-
-        foreach ($recipientsByLocale as $locale => $recipients) {
-            $email = $this->createTemplatedEmail($locale)
-                ->to(...$recipients)
-                ->subject(sprintf(
-                    '[%s] %s (%s)',
-                    $this->mailConfig->appName,
-                    $this->translator->trans('feedback.email.title', [], 'feedback', $locale),
-                    $category->value,
-                ))
-                ->htmlTemplate('@Feedback/email/admin_feedback_notification.html.twig')
-                ->context([
-                    'feedback' => $feedback,
-                    'categoryLabel' => $category->value,
-                    'contextJson' => $contextJsonPreview,
-                ]);
-
-            $this->mailer->send($email);
-        }
     }
 
     private function createTemplatedEmail(string $locale): TemplatedEmail

--- a/src/Shared/Infrastructure/Mail/TransactionalMailer.php
+++ b/src/Shared/Infrastructure/Mail/TransactionalMailer.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Mail;
 
-use App\Feedback\Domain\Entity\Feedback;
-use App\Feedback\Domain\Enum\FeedbackCategory;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 
 interface TransactionalMailer
@@ -26,11 +24,5 @@ interface TransactionalMailer
         string $recipientEmail,
         ResetPasswordToken $resetToken,
         string $locale,
-    ): void;
-
-    public function sendAdminFeedbackEmail(
-        Feedback $feedback,
-        FeedbackCategory $category,
-        string $contextJsonPreview,
     ): void;
 }

--- a/tests/Feedback/Unit/Application/RecordFeedbackHandlerWiringTest.php
+++ b/tests/Feedback/Unit/Application/RecordFeedbackHandlerWiringTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Feedback\Unit\Application;
+
+use App\Feedback\Application\Contract\AdminFeedbackNotifierInterface;
+use App\Feedback\Application\RecordFeedbackHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+
+final class RecordFeedbackHandlerWiringTest extends TestCase
+{
+    public function testHandlerUsesAdminFeedbackNotifierNotMailerInterface(): void
+    {
+        $constructor = new \ReflectionClass(RecordFeedbackHandler::class)->getConstructor();
+        self::assertNotNull($constructor);
+
+        $parameterTypes = array_map(
+            static fn (\ReflectionParameter $parameter): ?string => $parameter->getType() instanceof \ReflectionNamedType
+                ? $parameter->getType()->getName()
+                : null,
+            $constructor->getParameters(),
+        );
+
+        self::assertContains(AdminFeedbackNotifierInterface::class, $parameterTypes);
+        self::assertNotContains(MailerInterface::class, $parameterTypes);
+    }
+}

--- a/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
+++ b/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Feedback\Unit\Infrastructure\Mail;
+
+use App\Feedback\Domain\Entity\Feedback;
+use App\Feedback\Domain\Enum\FeedbackCategory;
+use App\Feedback\Infrastructure\Mail\AdminFeedbackMailer;
+use App\Shared\Application\Locale\LocaleResolver;
+use App\Shared\Infrastructure\Locale\LocaleCookieManager;
+use App\Shared\Infrastructure\Mail\MailConfig;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AdminFeedbackMailerTest extends TestCase
+{
+    public function testNotifySendsLocalizedAdminFeedbackMail(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([
+            $this->createAdminUser('admin-a@example.test', 'de'),
+            $this->createAdminUser('admin-b@example.test', 'de'),
+        ]);
+
+        $translator = $this->createTranslatorMock();
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                self::assertSame(
+                    ['admin-a@example.test', 'admin-b@example.test'],
+                    array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
+                );
+                self::assertSame('[Test App] Feedback (bug)', $email->getSubject());
+                self::assertSame('de', $email->getLocale());
+                self::assertSame('@Feedback/email/admin_feedback_notification.html.twig', $email->getHtmlTemplate());
+
+                return true;
+            }));
+
+        $this->createMailer($mailer, $recipientResolver, translator: $translator)->notify(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    public function testNotifySendsSeparateMailsPerLocale(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([
+            $this->createAdminUser('de-admin@example.test', 'de'),
+            $this->createAdminUser('en-admin@example.test', 'en'),
+        ]);
+
+        $localeResolver = new LocaleResolver(new LocaleCookieManager());
+
+        $translator = $this->createTranslatorMock();
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::exactly(2))
+            ->method('send')
+            ->with(self::callback(function (TemplatedEmail $email): bool {
+                $locale = $email->getLocale();
+                self::assertContains($locale, ['de', 'en']);
+
+                return true;
+            }));
+
+        $this->createMailer($mailer, $recipientResolver, translator: $translator, localeResolver: $localeResolver)->notify(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    public function testNotifySkipsWhenNoRecipients(): void
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage('Broken filter')
+            ->setPageUrl('https://example.test/page');
+
+        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects(self::never())->method('send');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(
+                'feedback.admin_mail_skipped',
+                self::callback(static fn (array $context): bool => 'no_feedback_recipients' === ($context['reason'] ?? null)),
+            );
+
+        $this->createMailer($mailer, $recipientResolver, $logger)->notify(
+            $feedback,
+            FeedbackCategory::BUG,
+            '{}',
+        );
+    }
+
+    private function createMailer(
+        MailerInterface $mailer,
+        ?FeedbackRecipientEmailResolver $recipientResolver = null,
+        ?LoggerInterface $logger = null,
+        ?TranslatorInterface $translator = null,
+        ?LocaleResolver $localeResolver = null,
+    ): AdminFeedbackMailer {
+        return new AdminFeedbackMailer(
+            $mailer,
+            new MailConfig(
+                fromEmail: 'no-reply@example.test',
+                fromName: 'Test App',
+                appName: 'Test App',
+                replyTo: '',
+            ),
+            $recipientResolver ?? $this->createMock(FeedbackRecipientEmailResolver::class),
+            $translator ?? $this->createTranslatorMock(),
+            $localeResolver ?? new LocaleResolver(new LocaleCookieManager()),
+            $logger ?? $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    private function createTranslatorMock(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'feedback.email.title' => 'Feedback',
+                default => $id,
+            },
+        );
+
+        return $translator;
+    }
+
+    private function createAdminUser(string $email, string $locale): User
+    {
+        $user = new User();
+        $user->setUsername(str_replace('@', '-', $email));
+        $user->setEmail($email);
+        $user->setPassword('hashed');
+        $user->setLocale($locale);
+
+        return $user;
+    }
+}

--- a/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
@@ -4,16 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Shared\Unit\Infrastructure\Mail;
 
-use App\Feedback\Domain\Entity\Feedback;
-use App\Feedback\Domain\Enum\FeedbackCategory;
-use App\Shared\Application\Locale\LocaleResolver;
-use App\Shared\Infrastructure\Locale\LocaleCookieManager;
 use App\Shared\Infrastructure\Mail\MailConfig;
 use App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer;
-use App\User\Domain\Entity\User;
-use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -80,10 +73,9 @@ final class SymfonyTransactionalMailerTest extends TestCase
                     static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(),
                     $email->getTo(),
                 ));
-                self::assertSame('Reset your password', $email->getSubject());
-                self::assertSame('en', $email->getLocale());
+                self::assertSame('Passwort zurücksetzen', $email->getSubject());
+                self::assertSame('de', $email->getLocale());
                 self::assertSame('@User/reset_password/email.html.twig', $email->getHtmlTemplate());
-                self::assertInstanceOf(ResetPasswordToken::class, $email->getContext()['resetToken'] ?? null);
                 self::assertSame(
                     'https://example.test/reset-password/reset/selector_verifier',
                     $email->getContext()['resetUrl'] ?? null,
@@ -95,104 +87,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
         $this->createMailer($mailer, urlGenerator: $urlGenerator, translator: $translator)->sendPasswordResetEmail(
             'reset@example.test',
             $resetToken,
-            'en',
-        );
-    }
-
-    public function testSendAdminFeedbackEmailUsesAllResolvedRecipientsGroupedByLocale(): void
-    {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
-
-        $adminA = $this->createAdminUser('admin-a@example.test', 'de');
-        $adminB = $this->createAdminUser('admin-b@example.test', 'de');
-
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientUsers')->willReturn([$adminA, $adminB]);
-
-        $translator = $this->createTranslatorMock();
-        $mailer = $this->createMock(MailerInterface::class);
-        $mailer->expects(self::once())
-            ->method('send')
-            ->with(self::callback(function (TemplatedEmail $email): bool {
-                self::assertSame(
-                    ['admin-a@example.test', 'admin-b@example.test'],
-                    array_map(static fn (\Symfony\Component\Mime\Address $address): string => $address->getAddress(), $email->getTo()),
-                );
-                self::assertSame('[Test App] Feedback (bug)', $email->getSubject());
-                self::assertSame('de', $email->getLocale());
-                self::assertSame('@Feedback/email/admin_feedback_notification.html.twig', $email->getHtmlTemplate());
-
-                return true;
-            }));
-
-        $this->createMailer($mailer, $recipientResolver, translator: $translator)->sendAdminFeedbackEmail(
-            $feedback,
-            FeedbackCategory::BUG,
-            '{}',
-        );
-    }
-
-    public function testSendAdminFeedbackEmailSendsSeparateMailsPerLocale(): void
-    {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
-
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientUsers')->willReturn([
-            $this->createAdminUser('de-admin@example.test', 'de'),
-            $this->createAdminUser('en-admin@example.test', 'en'),
-        ]);
-
-        $localeResolver = new LocaleResolver(new LocaleCookieManager());
-
-        $translator = $this->createTranslatorMock();
-        $mailer = $this->createMock(MailerInterface::class);
-        $mailer->expects(self::exactly(2))
-            ->method('send')
-            ->with(self::callback(function (TemplatedEmail $email): bool {
-                $locale = $email->getLocale();
-                self::assertContains($locale, ['de', 'en']);
-
-                return true;
-            }));
-
-        $this->createMailer($mailer, $recipientResolver, translator: $translator, localeResolver: $localeResolver)->sendAdminFeedbackEmail(
-            $feedback,
-            FeedbackCategory::BUG,
-            '{}',
-        );
-    }
-
-    public function testSendAdminFeedbackEmailSkipsWhenNoRecipients(): void
-    {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
-
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
-        $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
-
-        $mailer = $this->createMock(MailerInterface::class);
-        $mailer->expects(self::never())->method('send');
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())
-            ->method('info')
-            ->with(
-                'feedback.admin_mail_skipped',
-                self::callback(static fn (array $context): bool => 'no_feedback_recipients' === ($context['reason'] ?? null)),
-            );
-
-        $this->createMailer($mailer, $recipientResolver, $logger)->sendAdminFeedbackEmail(
-            $feedback,
-            FeedbackCategory::BUG,
-            '{}',
+            'de',
         );
     }
 
@@ -220,11 +115,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
         new SymfonyTransactionalMailer(
             $mailer,
             $mailConfig,
-            $this->createMock(FeedbackRecipientEmailResolver::class),
             $this->createMock(UrlGeneratorInterface::class),
             $this->createTranslatorMock(),
-            new LocaleResolver(new LocaleCookieManager()),
-            $this->createMock(LoggerInterface::class),
         )->sendVerificationEmail(
             'user@example.test',
             'https://example.test/verify',
@@ -237,11 +129,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
 
     private function createMailer(
         MailerInterface $mailer,
-        ?FeedbackRecipientEmailResolver $recipientResolver = null,
-        ?LoggerInterface $logger = null,
         ?UrlGeneratorInterface $urlGenerator = null,
         ?TranslatorInterface $translator = null,
-        ?LocaleResolver $localeResolver = null,
     ): SymfonyTransactionalMailer {
         return new SymfonyTransactionalMailer(
             $mailer,
@@ -251,11 +140,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
                 appName: 'Test App',
                 replyTo: '',
             ),
-            $recipientResolver ?? $this->createMock(FeedbackRecipientEmailResolver::class),
             $urlGenerator ?? $this->createMock(UrlGeneratorInterface::class),
             $translator ?? $this->createTranslatorMock(),
-            $localeResolver ?? new LocaleResolver(new LocaleCookieManager()),
-            $logger ?? $this->createMock(LoggerInterface::class),
         );
     }
 
@@ -266,22 +152,10 @@ final class SymfonyTransactionalMailerTest extends TestCase
             static fn (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string => match ($id) {
                 'email.verify.title' => 'de' === $locale ? 'E-Mail-Adresse bestätigen' : 'Confirm your email address',
                 'email.reset_password.title' => 'de' === $locale ? 'Passwort zurücksetzen' : 'Reset your password',
-                'feedback.email.title' => 'Feedback',
                 default => $id,
             },
         );
 
         return $translator;
-    }
-
-    private function createAdminUser(string $email, string $locale): User
-    {
-        $user = new User();
-        $user->setUsername(str_replace('@', '-', $email));
-        $user->setEmail($email);
-        $user->setPassword('hashed');
-        $user->setLocale($locale);
-
-        return $user;
     }
 }

--- a/tests/Shared/Unit/Infrastructure/Mail/TransactionalMailWiringTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/TransactionalMailWiringTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Shared\Unit\Infrastructure\Mail;
 
-use App\Feedback\Application\RecordFeedbackHandler;
 use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Infrastructure\Security\EmailVerifier;
 use App\User\UI\Http\Controller\ResetPasswordController;
@@ -41,13 +40,12 @@ final class TransactionalMailWiringTest extends TestCase
     {
         yield EmailVerifier::class => [EmailVerifier::class];
         yield ResetPasswordController::class => [ResetPasswordController::class];
-        yield RecordFeedbackHandler::class => [RecordFeedbackHandler::class];
     }
 
     public function testResetPasswordControllerDoesNotBuildTemplatedEmailDirectly(): void
     {
         $source = (string) file_get_contents(
-            new \ReflectionClass(ResetPasswordController::class)->getFileName(),
+            (string) new \ReflectionClass(ResetPasswordController::class)->getFileName(),
         );
 
         self::assertStringNotContainsString('TemplatedEmail', $source);


### PR DESCRIPTION
## Summary
- add `AdminFeedbackNotifierInterface` and `AdminFeedbackMailer` in Feedback
- remove Feedback domain types from Shared `TransactionalMailer` / `SymfonyTransactionalMailer`
- update `RecordFeedbackHandler` and move feedback mail unit tests into Feedback
- drop Shared→Feedback Deptrac baseline skips

## Test plan
- [x] `vendor/bin/deptrac analyse --no-progress` (0 violations)
- [x] PHPUnit: `tests/Shared/Unit/Infrastructure/Mail/`, `tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php`, `RecordFeedbackHandlerWiringTest.php`
- [x] Smoke: submit feedback widget → admin notification mail still sent