### PR TITLE
refactor(shared): remove Content and Allocation feature leaks from Shared

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -21,6 +21,8 @@ deptrac:
       - App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData
     App\Allocation\Application\Export\OwnHospitalAllocationsExporter:
       - App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery
+    App\Allocation\Application\Audit\ImportAssessmentAuditPurgeService:
+      - App\Allocation\Infrastructure\Query\ImportAssessmentAuditPurgeQuery
     App\Allocation\Application\Indication\IndicationMatchSuggestionService:
       - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
       - App\Import\Infrastructure\Indication\IndicationKey
@@ -313,17 +315,6 @@ deptrac:
       - App\Import\Application\Service\ImportListAccess
     App\Onboarding\Domain\Entity\UserOnboardingStep:
       - App\Onboarding\Infrastructure\Repository\UserOnboardingStepRepository
-    App\Shared\Application\Navigation\FooterNavigationProvider:
-      - App\Content\Application\Page\PageNavigationProvider
-      - App\Content\Domain\Entity\Page
-      - App\Content\Domain\Enum\PageKey
-    App\Shared\Application\Navigation\SitemapProvider:
-      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
-      - App\Content\Application\Page\PageNavigationProvider
-    App\Shared\Infrastructure\Audit\AuditValueNormalizer:
-      - App\Allocation\Domain\Entity\Address
-    App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery:
-      - App\Allocation\Domain\Entity\Assessment
     App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer:
       - App\Feedback\Domain\Entity\Feedback
       - App\Feedback\Domain\Enum\FeedbackCategory

--- a/src/Allocation/Application/Audit/ImportAssessmentAuditPurgeService.php
+++ b/src/Allocation/Application/Audit/ImportAssessmentAuditPurgeService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Audit;
+
+use App\Allocation\Infrastructure\Query\ImportAssessmentAuditPurgeQuery;
+
+final readonly class ImportAssessmentAuditPurgeService
+{
+    public function __construct(
+        private ImportAssessmentAuditPurgeQuery $purgeQuery,
+    ) {
+    }
+
+    public function countCandidates(): int
+    {
+        return $this->purgeQuery->countCandidates();
+    }
+
+    /**
+     * @return array{min: \DateTimeImmutable, max: \DateTimeImmutable}|null
+     */
+    public function fetchOccurredAtRange(): ?array
+    {
+        return $this->purgeQuery->fetchOccurredAtRange();
+    }
+
+    public function deleteCandidates(): int
+    {
+        return $this->purgeQuery->deleteCandidates();
+    }
+}

--- a/src/Allocation/Infrastructure/Query/ImportAssessmentAuditPurgeQuery.php
+++ b/src/Allocation/Infrastructure/Query/ImportAssessmentAuditPurgeQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Shared\Infrastructure\Audit\Query;
+namespace App\Allocation\Infrastructure\Query;
 
 use App\Allocation\Domain\Entity\Assessment;
 use Doctrine\DBAL\Connection;

--- a/src/Allocation/UI/Console/Command/PurgeImportAssessmentAuditCommand.php
+++ b/src/Allocation/UI/Console/Command/PurgeImportAssessmentAuditCommand.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace App\Shared\UI\Console\Command;
+namespace App\Allocation\UI\Console\Command;
 
-use App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery;
-use App\Shared\UI\Console\Input\PurgeImportAssessmentAuditInput;
+use App\Allocation\Application\Audit\ImportAssessmentAuditPurgeService;
+use App\Allocation\UI\Console\Input\PurgeImportAssessmentAuditInput;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Command\Command;
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final readonly class PurgeImportAssessmentAuditCommand
 {
     public function __construct(
-        private ImportAssessmentAuditPurgeQuery $purgeQuery,
+        private ImportAssessmentAuditPurgeService $purgeService,
     ) {
     }
 
@@ -34,8 +34,8 @@ final readonly class PurgeImportAssessmentAuditCommand
             $dryRun = false;
         }
 
-        $count = $this->purgeQuery->countCandidates();
-        $range = $this->purgeQuery->fetchOccurredAtRange();
+        $count = $this->purgeService->countCandidates();
+        $range = $this->purgeService->fetchOccurredAtRange();
 
         $io->section('Candidates');
         $io->writeln(sprintf('Matching audit entries: <info>%d</info>', $count));
@@ -61,7 +61,7 @@ final readonly class PurgeImportAssessmentAuditCommand
             return Command::SUCCESS;
         }
 
-        $deleted = $this->purgeQuery->deleteCandidates();
+        $deleted = $this->purgeService->deleteCandidates();
         $io->success(sprintf('Deleted %d import-generated Assessment create audit entr%s.', $deleted, 1 === $deleted ? 'y' : 'ies'));
 
         return Command::SUCCESS;

--- a/src/Allocation/UI/Console/Input/PurgeImportAssessmentAuditInput.php
+++ b/src/Allocation/UI/Console/Input/PurgeImportAssessmentAuditInput.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Shared\UI\Console\Input;
+namespace App\Allocation\UI\Console\Input;
 
 use Symfony\Component\Console\Attribute\Option;
 

--- a/src/Content/Application/Page/PageNavigationProvider.php
+++ b/src/Content/Application/Page/PageNavigationProvider.php
@@ -9,11 +9,14 @@ use App\Content\Application\Page\DTO\PublishedPageLink;
 use App\Content\Domain\Entity\Page;
 use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Repository\PageRepository;
+use App\Shared\Application\Navigation\Contract\NavigationPageLinksProviderInterface;
 use App\Shared\Application\Navigation\DTO\SitemapPageNode;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
-final class PageNavigationProvider
+#[AsAlias(NavigationPageLinksProviderInterface::class)]
+final class PageNavigationProvider implements NavigationPageLinksProviderInterface
 {
     /** @var list<PageKey> */
     private const array GUEST_ONLY_HEADER_KEYS = [
@@ -63,6 +66,34 @@ final class PageNavigationProvider
     }
 
     /**
+     * @return list<array{url: string, label: string}>
+     */
+    public function linksForKeys(string ...$keys): array
+    {
+        $links = [];
+
+        foreach ($keys as $keyValue) {
+            $pageKey = PageKey::tryFrom($keyValue);
+            if (!$pageKey instanceof PageKey) {
+                continue;
+            }
+
+            $page = $this->getPageByKey($pageKey);
+            $url = $this->getUrlByKey($pageKey);
+            if (!$page instanceof Page || null === $url) {
+                continue;
+            }
+
+            $links[] = [
+                'url' => $url,
+                'label' => (string) $page->getTitle(),
+            ];
+        }
+
+        return $links;
+    }
+
+    /**
      * @return list<PageNavigationLink>
      */
     public function getHeaderPages(): array
@@ -85,6 +116,15 @@ final class PageNavigationProvider
             PageKey::Privacy,
             PageKey::Terms,
         );
+    }
+
+    /**
+     * @return list<SitemapPageNode>
+     */
+    #[\Override]
+    public function visiblePublishedPageTree(): array
+    {
+        return $this->getVisiblePublishedPageTree();
     }
 
     /**

--- a/src/Shared/Application/Navigation/Contract/NavigationPageLinksProviderInterface.php
+++ b/src/Shared/Application/Navigation/Contract/NavigationPageLinksProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Navigation\Contract;
+
+use App\Shared\Application\Navigation\DTO\SitemapPageNode;
+
+interface NavigationPageLinksProviderInterface
+{
+    /**
+     * @return list<array{url: string, label: string}>
+     */
+    public function linksForKeys(string ...$keys): array;
+
+    /**
+     * @return list<SitemapPageNode>
+     */
+    public function visiblePublishedPageTree(): array;
+}

--- a/src/Shared/Application/Navigation/FooterNavigationProvider.php
+++ b/src/Shared/Application/Navigation/FooterNavigationProvider.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Navigation;
 
-use App\Content\Application\Page\PageNavigationProvider;
-use App\Content\Domain\Enum\PageKey;
+use App\Shared\Application\Navigation\Contract\NavigationPageLinksProviderInterface;
 use App\Shared\Application\Navigation\DTO\FooterNavigationColumn;
 use App\Shared\Application\Navigation\DTO\FooterNavigationLink;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -24,7 +23,7 @@ final readonly class FooterNavigationProvider
      * @var list<array{
      *   key: string,
      *   labelKey: string,
-     *   pageKeys: list<PageKey>,
+     *   pageKeys: list<string>,
      *   routes: list<string>
      * }>
      */
@@ -32,19 +31,19 @@ final readonly class FooterNavigationProvider
         [
             'key' => 'project',
             'labelKey' => 'footer.column.project',
-            'pageKeys' => [PageKey::About, PageKey::Features],
+            'pageKeys' => ['about', 'features'],
             'routes' => ['app_blog_index'],
         ],
         [
             'key' => 'help',
             'labelKey' => 'footer.column.help',
-            'pageKeys' => [PageKey::Faq],
+            'pageKeys' => ['faq'],
             'routes' => [],
         ],
         [
             'key' => 'legal',
             'labelKey' => 'footer.column.legal',
-            'pageKeys' => [PageKey::Imprint, PageKey::Privacy, PageKey::Terms],
+            'pageKeys' => ['imprint', 'privacy', 'terms'],
             'routes' => [],
         ],
         [
@@ -56,7 +55,7 @@ final readonly class FooterNavigationProvider
     ];
 
     public function __construct(
-        private PageNavigationProvider $pageNavigationProvider,
+        private NavigationPageLinksProviderInterface $pageLinksProvider,
         private UrlGeneratorInterface $urlGenerator,
         private TranslatorInterface $translator,
     ) {
@@ -90,20 +89,14 @@ final readonly class FooterNavigationProvider
     /**
      * @return list<FooterNavigationLink>
      */
-    private function buildPageLinks(PageKey ...$pageKeys): array
+    private function buildPageLinks(string ...$pageKeys): array
     {
         $links = [];
 
-        foreach ($pageKeys as $pageKey) {
-            $page = $this->pageNavigationProvider->getPageByKey($pageKey);
-            $url = $this->pageNavigationProvider->getUrlByKey($pageKey);
-            if (!$page instanceof \App\Content\Domain\Entity\Page || null === $url) {
-                continue;
-            }
-
+        foreach ($this->pageLinksProvider->linksForKeys(...$pageKeys) as $pageLink) {
             $links[] = new FooterNavigationLink(
-                url: $url,
-                label: (string) $page->getTitle(),
+                url: $pageLink['url'],
+                label: $pageLink['label'],
             );
         }
 

--- a/src/Shared/Application/Navigation/SitemapProvider.php
+++ b/src/Shared/Application/Navigation/SitemapProvider.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Application\Navigation;
 
-use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
-use App\Content\Application\Page\PageNavigationProvider;
+use App\Shared\Application\Navigation\Contract\NavigationPageLinksProviderInterface;
 use App\Shared\Application\Navigation\DTO\SitemapLink;
 use App\Shared\Application\Navigation\DTO\SitemapSection;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -140,7 +139,7 @@ final readonly class SitemapProvider
     ];
 
     public function __construct(
-        private PageNavigationProvider $pageNavigationProvider,
+        private NavigationPageLinksProviderInterface $pageLinksProvider,
         private UrlGeneratorInterface $urlGenerator,
         private TranslatorInterface $translator,
         private AuthorizationCheckerInterface $authorizationChecker,
@@ -162,7 +161,7 @@ final readonly class SitemapProvider
             );
 
             if ('content' === $sectionDefinition['key']) {
-                $pageTree = $this->pageNavigationProvider->getVisiblePublishedPageTree();
+                $pageTree = $this->pageLinksProvider->visiblePublishedPageTree();
             }
 
             if ([] === $links && [] === $pageTree) {
@@ -269,7 +268,7 @@ final readonly class SitemapProvider
             self::VISIBILITY_GUEST => !$this->authorizationChecker->isGranted('ROLE_USER'),
             self::VISIBILITY_AUTHENTICATED => $this->authorizationChecker->isGranted('ROLE_USER'),
             self::VISIBILITY_PARTICIPANT => $this->authorizationChecker->isGranted('ROLE_PARTICIPANT'),
-            self::VISIBILITY_EXPORT => $this->authorizationChecker->isGranted(ExportVoter::EXPORT),
+            self::VISIBILITY_EXPORT => $this->authorizationChecker->isGranted('EXPORT'),
             default => false,
         };
     }

--- a/src/Shared/Infrastructure/Audit/AuditValueNormalizer.php
+++ b/src/Shared/Infrastructure/Audit/AuditValueNormalizer.php
@@ -36,14 +36,11 @@ final readonly class AuditValueNormalizer
             return $value->format(\DateTimeInterface::ATOM);
         }
 
-        if ($this->isAddressLike($value)) {
-            return [
-                'street' => $value->getStreet(),
-                'postalCode' => $value->getPostalCode(),
-                'city' => $value->getCity(),
-                'state' => $value->getState(),
-                'country' => $value->getCountry(),
-            ];
+        if (\is_object($value)) {
+            $address = $this->normalizeAddressLike($value);
+            if (null !== $address) {
+                return $address;
+            }
         }
 
         if ($value instanceof Collection) {
@@ -67,16 +64,27 @@ final readonly class AuditValueNormalizer
     }
 
     /**
-     * @phpstan-assert-if-true object{getStreet(): string, getPostalCode(): string, getCity(): string, getState(): string, getCountry(): string} $value
+     * @return array{street: string, postalCode: string, city: string, state: string, country: string}|null
      */
-    private function isAddressLike(mixed $value): bool
+    private function normalizeAddressLike(object $value): ?array
     {
-        return \is_object($value)
-            && method_exists($value, 'getStreet')
-            && method_exists($value, 'getPostalCode')
-            && method_exists($value, 'getCity')
-            && method_exists($value, 'getState')
-            && method_exists($value, 'getCountry');
+        if (
+            !method_exists($value, 'getStreet')
+            || !method_exists($value, 'getPostalCode')
+            || !method_exists($value, 'getCity')
+            || !method_exists($value, 'getState')
+            || !method_exists($value, 'getCountry')
+        ) {
+            return null;
+        }
+
+        return [
+            'street' => (string) $value->getStreet(),
+            'postalCode' => (string) $value->getPostalCode(),
+            'city' => (string) $value->getCity(),
+            'state' => (string) $value->getState(),
+            'country' => (string) $value->getCountry(),
+        ];
     }
 
     /**

--- a/src/Shared/Infrastructure/Audit/AuditValueNormalizer.php
+++ b/src/Shared/Infrastructure/Audit/AuditValueNormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Audit;
 
-use App\Allocation\Domain\Entity\Address;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\MappingException;
@@ -37,7 +36,7 @@ final readonly class AuditValueNormalizer
             return $value->format(\DateTimeInterface::ATOM);
         }
 
-        if ($value instanceof Address) {
+        if ($this->isAddressLike($value)) {
             return [
                 'street' => $value->getStreet(),
                 'postalCode' => $value->getPostalCode(),
@@ -65,6 +64,19 @@ final readonly class AuditValueNormalizer
         }
 
         return null;
+    }
+
+    /**
+     * @phpstan-assert-if-true object{getStreet(): string, getPostalCode(): string, getCity(): string, getState(): string, getCountry(): string} $value
+     */
+    private function isAddressLike(mixed $value): bool
+    {
+        return \is_object($value)
+            && method_exists($value, 'getStreet')
+            && method_exists($value, 'getPostalCode')
+            && method_exists($value, 'getCity')
+            && method_exists($value, 'getState')
+            && method_exists($value, 'getCountry');
     }
 
     /**

--- a/tests/Allocation/Functional/Command/PurgeImportAssessmentAuditCommandTest.php
+++ b/tests/Allocation/Functional/Command/PurgeImportAssessmentAuditCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Shared\Functional\Command;
+namespace App\Tests\Allocation\Functional\Command;
 
 use App\Allocation\Domain\Entity\Allocation;
 use App\Allocation\Domain\Entity\Assessment;
@@ -20,11 +20,11 @@ use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
 use App\Allocation\Infrastructure\Factory\OccasionFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Query\ImportAssessmentAuditPurgeQuery;
+use App\Allocation\UI\Console\Command\PurgeImportAssessmentAuditCommand;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
-use App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery;
-use App\Shared\UI\Console\Command\PurgeImportAssessmentAuditCommand;
 use App\User\Domain\Factory\UserFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;


### PR DESCRIPTION
## Summary
- introduce `NavigationPageLinksProviderInterface` (Shared) implemented by Content `PageNavigationProvider`
- decouple sitemap EXPORT visibility from `ExportVoter` (`isGranted('EXPORT')`)
- normalize address-like values in audit without importing Allocation `Address`
- move import Assessment audit purge query/command into Allocation (plus Application facade)
- update Deptrac baseline accordingly

## Test plan
- [x] `vendor/bin/deptrac analyse --no-progress` (0 violations)
- [x] PHPUnit: `tests/Shared/Integration/Navigation/`, `tests/Content/Integration/Page/PageNavigationProviderTest.php`, `tests/Allocation/Functional/Command/PurgeImportAssessmentAuditCommandTest.php`
- [x] Smoke: footer/sitemap CMS links, export-visible sitemap entries, `app:audit:purge-import-assessments --dry-run`