### PR TITLE
refactor(allocation): extract AllocationBucketQuery from repository

### DIFF
--- a/src/Admin/Application/Service/AdminUserUrlGenerator.php
+++ b/src/Admin/Application/Service/AdminUserUrlGenerator.php
@@ -8,6 +8,7 @@ use App\User\Application\Contract\AdminUserDetailUrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for AdminUserDetailUrlGeneratorInterface. */
 #[AsAlias(AdminUserDetailUrlGeneratorInterface::class)]
 final readonly class AdminUserUrlGenerator implements AdminUserDetailUrlGeneratorInterface
 {
@@ -17,6 +18,7 @@ final readonly class AdminUserUrlGenerator implements AdminUserDetailUrlGenerato
     ) {
     }
 
+    #[\Override]
     public function detailUrl(int $userId): string
     {
         return $this->urlGenerator->generate(

--- a/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
+++ b/src/Admin/Application/Service/GrantParticipantUrlGenerator.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for GrantParticipantUrlGeneratorInterface. */
 #[AsAlias(GrantParticipantUrlGeneratorInterface::class)]
 final readonly class GrantParticipantUrlGenerator implements GrantParticipantUrlGeneratorInterface
 {
@@ -21,6 +22,7 @@ final readonly class GrantParticipantUrlGenerator implements GrantParticipantUrl
     ) {
     }
 
+    #[\Override]
     public function generate(int $userId): string
     {
         $url = $this->urlGenerator->generate(

--- a/src/Admin/Infrastructure/EasyAdminAdminLinkGenerator.php
+++ b/src/Admin/Infrastructure/EasyAdminAdminLinkGenerator.php
@@ -17,6 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for AdminLinkGeneratorInterface. */
 #[AsAlias(AdminLinkGeneratorInterface::class)]
 final readonly class EasyAdminAdminLinkGenerator implements AdminLinkGeneratorInterface
 {
@@ -25,26 +26,31 @@ final readonly class EasyAdminAdminLinkGenerator implements AdminLinkGeneratorIn
     ) {
     }
 
+    #[\Override]
     public function hospitalCrudIndexUrl(): string
     {
         return $this->crudIndexUrl(HospitalCrudController::class);
     }
 
+    #[\Override]
     public function importCrudIndexUrl(): string
     {
         return $this->crudIndexUrl(ImportCrudController::class);
     }
 
+    #[\Override]
     public function allocationCrudIndexUrl(): string
     {
         return $this->crudIndexUrl(AllocationCrudController::class);
     }
 
+    #[\Override]
     public function importRejectCrudIndexUrl(): string
     {
         return $this->crudIndexUrl(ImportRejectCrudController::class);
     }
 
+    #[\Override]
     public function failedImportsCrudIndexUrl(): string
     {
         return $this->adminUrlGenerator
@@ -61,6 +67,7 @@ final readonly class EasyAdminAdminLinkGenerator implements AdminLinkGeneratorIn
             ->generateUrl();
     }
 
+    #[\Override]
     public function importDetailUrl(int $importId): string
     {
         return $this->adminUrlGenerator

--- a/src/Admin/Infrastructure/EasyAdminMediaLibraryUrlProvider.php
+++ b/src/Admin/Infrastructure/EasyAdminMediaLibraryUrlProvider.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for MediaLibraryAdminUrlProviderInterface. */
 #[AsAlias(MediaLibraryAdminUrlProviderInterface::class)]
 final readonly class EasyAdminMediaLibraryUrlProvider implements MediaLibraryAdminUrlProviderInterface
 {
@@ -18,6 +19,7 @@ final readonly class EasyAdminMediaLibraryUrlProvider implements MediaLibraryAdm
     ) {
     }
 
+    #[\Override]
     public function getIndexUrl(): string
     {
         return $this->adminUrlGenerator

--- a/src/Allocation/Infrastructure/Query/AllocationBucketQuery.php
+++ b/src/Allocation/Infrastructure/Query/AllocationBucketQuery.php
@@ -1,0 +1,935 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Query;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class AllocationBucketQuery
+{
+    use HospitalScopeQueryTrait;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndGenderLast12Months(): array
+    {
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        return $this->aggregateByMonthAndGender($from, null, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndGenderLast12MonthsForHospitals(array $hospitalIds): array
+    {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        return $this->aggregateByMonthAndGender($from, null, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndGenderInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByMonthAndGender($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndGenderInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthAndGender($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndUrgencyLast12Months(): array
+    {
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        return $this->aggregateByMonthAndUrgency($from, null, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndUrgencyLast12MonthsForHospitals(array $hospitalIds): array
+    {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        $from = new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+
+        return $this->aggregateByMonthAndUrgency($from, null, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndUrgencyInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByMonthAndUrgency($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByMonthAndUrgencyInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthAndUrgency($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByMonthResourcesRequiredLast12Months(): array
+    {
+        return $this->aggregateByMonthResourcesRequired($this->last12MonthsFrom(), null, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByMonthResourcesRequiredLast12MonthsForHospitals(array $hospitalIds): array
+    {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthResourcesRequired($this->last12MonthsFrom(), null, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByMonthResourcesRequiredInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByMonthResourcesRequired($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByMonthResourcesRequiredInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthResourcesRequired($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByMonthClinicalFeaturesLast12Months(): array
+    {
+        return $this->aggregateByMonthClinicalFeatures($this->last12MonthsFrom(), null, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByMonthClinicalFeaturesLast12MonthsForHospitals(array $hospitalIds): array
+    {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthClinicalFeatures($this->last12MonthsFrom(), null, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByMonthClinicalFeaturesInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByMonthClinicalFeatures($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByMonthClinicalFeaturesInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByMonthClinicalFeatures($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByCalendarMonthAndGenderInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByCalendarMonthAndGender($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByCalendarMonthAndGenderInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByCalendarMonthAndGender($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByDayAndGenderInRange(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByDayAndGender($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByDayAndGenderInRangeForHospitals(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByDayAndGender($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByCalendarMonthAndUrgencyInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByCalendarMonthAndUrgency($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByCalendarMonthAndUrgencyInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByCalendarMonthAndUrgency($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByDayAndUrgencyInRange(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByDayAndUrgency($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    public function bucketByDayAndUrgencyInRangeForHospitals(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByDayAndUrgency($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByCalendarMonthResourcesRequiredInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByCalendarMonthResourcesRequired($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByCalendarMonthResourcesRequiredInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByCalendarMonthResourcesRequired($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByDayResourcesRequiredInRange(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByDayResourcesRequired($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    public function bucketByDayResourcesRequiredInRangeForHospitals(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByDayResourcesRequired($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByCalendarMonthClinicalFeaturesInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByCalendarMonthClinicalFeatures($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByCalendarMonthClinicalFeaturesInRangeForHospitals(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByCalendarMonthClinicalFeatures($from, $toExclusive, $hospitalIds);
+    }
+
+    /**
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByDayClinicalFeaturesInRange(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+    ): array {
+        return $this->aggregateByDayClinicalFeatures($from, $toExclusive, null);
+    }
+
+    /**
+     * @param list<int> $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    public function bucketByDayClinicalFeaturesInRangeForHospitals(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        array $hospitalIds,
+    ): array {
+        if ([] === $hospitalIds) {
+            return [];
+        }
+
+        return $this->aggregateByDayClinicalFeatures($from, $toExclusive, $hospitalIds);
+    }
+
+    private function last12MonthsFrom(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('first day of this month')
+            ->modify('-11 months')
+            ->setTime(0, 0, 0);
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByMonthAndGender(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        $rows = $this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds);
+
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($rows as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $ym = $createdAt->format('Y-m');
+            $gender = $allocation->getGender() ?? AllocationGender::OTHER;
+            $g = $gender->value;
+
+            if (!isset($buckets[$ym][$g])) {
+                $buckets[$ym][$g] = 0;
+            }
+            ++$buckets[$ym][$g];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByMonthAndUrgency(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        $rows = $this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds);
+
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($rows as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $ym = $createdAt->format('Y-m');
+            $urgency = $allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT;
+            $u = sprintf('%d', $urgency->value);
+
+            if (!isset($buckets[$ym][$u])) {
+                $buckets[$ym][$u] = 0;
+            }
+            ++$buckets[$ym][$u];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return list<Allocation>
+     */
+    private function fetchAllocationsInRange(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('a')
+            ->from(Allocation::class, 'a')
+            ->where('a.createdAt >= :from')
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->orderBy('a.createdAt', 'ASC');
+        $this->applyCreatedAtBefore($qb, $toExclusive);
+        $this->applyHospitalScope($qb, $hospitalIds);
+
+        /** @var list<Allocation> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    private function aggregateByMonthResourcesRequired(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $ym = $createdAt->format('Y-m');
+            if (!isset($buckets[$ym])) {
+                $buckets[$ym] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
+            }
+
+            $this->incrementResourcesRequiredCells($allocation, $buckets[$ym]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    private function aggregateByMonthClinicalFeatures(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $ym = $createdAt->format('Y-m');
+            if (!isset($buckets[$ym])) {
+                $buckets[$ym] = $this->emptyClinicalFeatureCell();
+            }
+
+            $this->incrementClinicalFeatureCells($allocation, $buckets[$ym]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByCalendarMonthAndGender(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
+            $g = ($allocation->getGender() ?? AllocationGender::OTHER)->value;
+
+            if (!isset($buckets[$calKey][$g])) {
+                $buckets[$calKey][$g] = 0;
+            }
+            ++$buckets[$calKey][$g];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByDayAndGender(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $dayKey = $createdAt->format('Y-m-d');
+            $g = ($allocation->getGender() ?? AllocationGender::OTHER)->value;
+
+            if (!isset($buckets[$dayKey][$g])) {
+                $buckets[$dayKey][$g] = 0;
+            }
+            ++$buckets[$dayKey][$g];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByCalendarMonthAndUrgency(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
+            $u = sprintf('%d', ($allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT)->value);
+
+            if (!isset($buckets[$calKey][$u])) {
+                $buckets[$calKey][$u] = 0;
+            }
+            ++$buckets[$calKey][$u];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function aggregateByDayAndUrgency(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array<string, int>> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $dayKey = $createdAt->format('Y-m-d');
+            $u = sprintf('%d', ($allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT)->value);
+
+            if (!isset($buckets[$dayKey][$u])) {
+                $buckets[$dayKey][$u] = 0;
+            }
+            ++$buckets[$dayKey][$u];
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    private function aggregateByCalendarMonthResourcesRequired(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
+            if (!isset($buckets[$calKey])) {
+                $buckets[$calKey] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
+            }
+
+            $this->incrementResourcesRequiredCells($allocation, $buckets[$calKey]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
+     */
+    private function aggregateByDayResourcesRequired(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds) as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $dayKey = $createdAt->format('Y-m-d');
+            if (!isset($buckets[$dayKey])) {
+                $buckets[$dayKey] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
+            }
+
+            $this->incrementResourcesRequiredCells($allocation, $buckets[$dayKey]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    private function aggregateByCalendarMonthClinicalFeatures(
+        \DateTimeInterface $from,
+        ?\DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        return $this->accumulateClinicalBucketsForCalendarMonthKeys(
+            $this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds),
+        );
+    }
+
+    /**
+     * @param list<int>|null $hospitalIds
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    private function aggregateByDayClinicalFeatures(
+        \DateTimeInterface $from,
+        \DateTimeInterface $toExclusive,
+        ?array $hospitalIds,
+    ): array {
+        return $this->accumulateClinicalBucketsForDayKeys(
+            $this->fetchAllocationsInRange($from, $toExclusive, $hospitalIds),
+        );
+    }
+
+    /**
+     * @param list<Allocation> $rows
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    private function accumulateClinicalBucketsForCalendarMonthKeys(array $rows): array
+    {
+        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($rows as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
+            if (!isset($buckets[$calKey])) {
+                $buckets[$calKey] = $this->emptyClinicalFeatureCell();
+            }
+
+            $this->incrementClinicalFeatureCells($allocation, $buckets[$calKey]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @param list<Allocation> $rows
+     *
+     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
+     */
+    private function accumulateClinicalBucketsForDayKeys(array $rows): array
+    {
+        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
+        $buckets = [];
+        foreach ($rows as $allocation) {
+            $createdAt = $allocation->getCreatedAt();
+            if (!$createdAt) {
+                continue;
+            }
+
+            $dayKey = $createdAt->format('Y-m-d');
+            if (!isset($buckets[$dayKey])) {
+                $buckets[$dayKey] = $this->emptyClinicalFeatureCell();
+            }
+
+            $this->incrementClinicalFeatureCells($allocation, $buckets[$dayKey]);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * @return array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}
+     */
+    private function emptyClinicalFeatureCell(): array
+    {
+        return [
+            'with_physician' => 0,
+            'cpr' => 0,
+            'ventilated' => 0,
+            'shock' => 0,
+            'pregnant' => 0,
+            'infectious' => 0,
+            'with_any' => 0,
+        ];
+    }
+
+    /**
+     * @param array{cathlab: int, resus: int, with_any: int} $cell
+     */
+    private function incrementResourcesRequiredCells(Allocation $allocation, array &$cell): void
+    {
+        $requiresAny = false;
+        if (true === $allocation->isRequiresCathlab()) {
+            ++$cell['cathlab'];
+            $requiresAny = true;
+        }
+        if (true === $allocation->isRequiresResus()) {
+            ++$cell['resus'];
+            $requiresAny = true;
+        }
+        if ($requiresAny) {
+            ++$cell['with_any'];
+        }
+    }
+
+    /**
+     * @param array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int} $cell
+     */
+    private function incrementClinicalFeatureCells(Allocation $allocation, array &$cell): void
+    {
+        $hasAny = false;
+        if (true === $allocation->isWithPhysician()) {
+            ++$cell['with_physician'];
+            $hasAny = true;
+        }
+        if (true === $allocation->isCPR()) {
+            ++$cell['cpr'];
+            $hasAny = true;
+        }
+        if (true === $allocation->isVentilated()) {
+            ++$cell['ventilated'];
+            $hasAny = true;
+        }
+        if (true === $allocation->isShock()) {
+            ++$cell['shock'];
+            $hasAny = true;
+        }
+        if (true === $allocation->isPregnant()) {
+            ++$cell['pregnant'];
+            $hasAny = true;
+        }
+        if ($allocation->getInfection() instanceof \App\Allocation\Domain\Entity\Infection) {
+            ++$cell['infectious'];
+            $hasAny = true;
+        }
+        if ($hasAny) {
+            ++$cell['with_any'];
+        }
+    }
+}

--- a/src/Allocation/Infrastructure/Query/HospitalScopeQueryTrait.php
+++ b/src/Allocation/Infrastructure/Query/HospitalScopeQueryTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Infrastructure\Query;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\QueryBuilder;
+
+trait HospitalScopeQueryTrait
+{
+    /**
+     * @param list<int>|null $hospitalIds
+     */
+    private function applyHospitalScope(QueryBuilder $qb, ?array $hospitalIds): void
+    {
+        if (null === $hospitalIds) {
+            return;
+        }
+
+        $qb->andWhere('a.hospital IN (:hospitalIds)')
+            ->setParameter('hospitalIds', $hospitalIds);
+    }
+
+    private function applyCreatedAtBefore(QueryBuilder $qb, ?\DateTimeInterface $toExclusive): void
+    {
+        if (!$toExclusive instanceof \DateTimeInterface) {
+            return;
+        }
+
+        $qb->andWhere('a.createdAt < :toExclusive')
+            ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
+    }
+}

--- a/src/Allocation/Infrastructure/Repository/AllocationRepository.php
+++ b/src/Allocation/Infrastructure/Repository/AllocationRepository.php
@@ -7,6 +7,7 @@ namespace App\Allocation\Infrastructure\Repository;
 use App\Allocation\Domain\Entity\Allocation;
 use App\Allocation\Domain\Enum\AllocationGender;
 use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Infrastructure\Query\AllocationBucketQuery;
 use App\Import\Domain\Entity\Import;
 use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -22,8 +23,10 @@ final class AllocationRepository extends ServiceEntityRepository
 {
     use PublicIdRepositoryTrait;
 
-    public function __construct(ManagerRegistry $registry)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly AllocationBucketQuery $bucketQuery,
+    ) {
         parent::__construct($registry, Allocation::class);
     }
 
@@ -560,11 +563,7 @@ SQL;
      */
     public function bucketAllocationsByMonthAndGenderLast12Months(): array
     {
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthAndGender($from, null, null);
+        return $this->bucketQuery->bucketByMonthAndGenderLast12Months();
     }
 
     /**
@@ -574,15 +573,7 @@ SQL;
      */
     public function bucketAllocationsByMonthAndGenderLast12MonthsForHospitals(array $hospitalIds): array
     {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthAndGender($from, null, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthAndGenderLast12MonthsForHospitals($hospitalIds);
     }
 
     /**
@@ -594,7 +585,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketAllocationsByMonthAndGender($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByMonthAndGenderInRange($from, $toExclusive);
     }
 
     /**
@@ -607,11 +598,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketAllocationsByMonthAndGender($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -619,11 +606,7 @@ SQL;
      */
     public function bucketAllocationsByMonthAndUrgencyLast12Months(): array
     {
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthAndUrgency($from, null, null);
+        return $this->bucketQuery->bucketByMonthAndUrgencyLast12Months();
     }
 
     /**
@@ -633,15 +616,7 @@ SQL;
      */
     public function bucketAllocationsByMonthAndUrgencyLast12MonthsForHospitals(array $hospitalIds): array
     {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthAndUrgency($from, null, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds);
     }
 
     /**
@@ -651,7 +626,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketAllocationsByMonthAndUrgency($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByMonthAndUrgencyInRange($from, $toExclusive);
     }
 
     /**
@@ -664,101 +639,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketAllocationsByMonthAndUrgency($from, $toExclusive, $hospitalIds);
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds null = keine Krankenhaus-Einschränkung
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketAllocationsByMonthAndGender(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $ym = $createdAt->format('Y-m');
-            $gender = $allocation->getGender() ?? AllocationGender::OTHER;
-            $g = $gender->value;
-
-            if (!isset($buckets[$ym][$g])) {
-                $buckets[$ym][$g] = 0;
-            }
-            ++$buckets[$ym][$g];
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds null = keine Krankenhaus-Einschränkung
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketAllocationsByMonthAndUrgency(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $ym = $createdAt->format('Y-m');
-            $urgency = $allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT;
-            $u = sprintf('%d', $urgency->value);
-
-            if (!isset($buckets[$ym][$u])) {
-                $buckets[$ym][$u] = 0;
-            }
-            ++$buckets[$ym][$u];
-        }
-
-        return $buckets;
+        return $this->bucketQuery->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -768,11 +649,7 @@ SQL;
      */
     public function bucketAllocationsByMonthResourcesRequiredLast12Months(): array
     {
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthResourcesRequired($from, null, null);
+        return $this->bucketQuery->bucketByMonthResourcesRequiredLast12Months();
     }
 
     /**
@@ -782,15 +659,7 @@ SQL;
      */
     public function bucketAllocationsByMonthResourcesRequiredLast12MonthsForHospitals(array $hospitalIds): array
     {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthResourcesRequired($from, null, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthResourcesRequiredLast12MonthsForHospitals($hospitalIds);
     }
 
     /**
@@ -800,7 +669,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketAllocationsByMonthResourcesRequired($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByMonthResourcesRequiredInRange($from, $toExclusive);
     }
 
     /**
@@ -813,11 +682,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketAllocationsByMonthResourcesRequired($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -827,11 +692,7 @@ SQL;
      */
     public function bucketAllocationsByMonthClinicalFeaturesLast12Months(): array
     {
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthClinicalFeatures($from, null, null);
+        return $this->bucketQuery->bucketByMonthClinicalFeaturesLast12Months();
     }
 
     /**
@@ -841,15 +702,7 @@ SQL;
      */
     public function bucketAllocationsByMonthClinicalFeaturesLast12MonthsForHospitals(array $hospitalIds): array
     {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        $from = new \DateTimeImmutable('first day of this month')
-            ->modify('-11 months')
-            ->setTime(0, 0, 0);
-
-        return $this->bucketAllocationsByMonthClinicalFeatures($from, null, $hospitalIds);
+        return $this->bucketQuery->bucketByMonthClinicalFeaturesLast12MonthsForHospitals($hospitalIds);
     }
 
     /**
@@ -859,7 +712,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketAllocationsByMonthClinicalFeatures($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByMonthClinicalFeaturesInRange($from, $toExclusive);
     }
 
     /**
@@ -872,116 +725,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketAllocationsByMonthClinicalFeatures($from, $toExclusive, $hospitalIds);
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds null = keine Krankenhaus-Einschränkung
-     *
-     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
-     */
-    private function bucketAllocationsByMonthResourcesRequired(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $ym = $createdAt->format('Y-m');
-            if (!isset($buckets[$ym])) {
-                $buckets[$ym] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
-            }
-
-            $requiresAny = false;
-            if (true === $allocation->isRequiresCathlab()) {
-                ++$buckets[$ym]['cathlab'];
-                $requiresAny = true;
-            }
-            if (true === $allocation->isRequiresResus()) {
-                ++$buckets[$ym]['resus'];
-                $requiresAny = true;
-            }
-            if ($requiresAny) {
-                ++$buckets[$ym]['with_any'];
-            }
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds null = keine Krankenhaus-Einschränkung
-     *
-     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
-     */
-    private function bucketAllocationsByMonthClinicalFeatures(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $ym = $createdAt->format('Y-m');
-            if (!isset($buckets[$ym])) {
-                $buckets[$ym] = [
-                    'with_physician' => 0,
-                    'cpr' => 0,
-                    'ventilated' => 0,
-                    'shock' => 0,
-                    'pregnant' => 0,
-                    'infectious' => 0,
-                    'with_any' => 0,
-                ];
-            }
-
-            $this->incrementClinicalFeatureCells($allocation, $buckets[$ym]);
-        }
-
-        return $buckets;
+        return $this->bucketQuery->bucketByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1047,7 +791,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketByCalendarMonthOfYearAndGender($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByCalendarMonthAndGenderInRange($from, $toExclusive);
     }
 
     /**
@@ -1060,11 +804,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketByCalendarMonthOfYearAndGender($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByCalendarMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1074,7 +814,7 @@ SQL;
         \DateTimeInterface $from,
         \DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketByDayAndGender($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByDayAndGenderInRange($from, $toExclusive);
     }
 
     /**
@@ -1087,11 +827,7 @@ SQL;
         \DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketByDayAndGender($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByDayAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1101,7 +837,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketByCalendarMonthOfYearAndUrgency($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByCalendarMonthAndUrgencyInRange($from, $toExclusive);
     }
 
     /**
@@ -1114,11 +850,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketByCalendarMonthOfYearAndUrgency($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1128,7 +860,7 @@ SQL;
         \DateTimeInterface $from,
         \DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketByDayAndUrgency($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByDayAndUrgencyInRange($from, $toExclusive);
     }
 
     /**
@@ -1141,11 +873,7 @@ SQL;
         \DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketByDayAndUrgency($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1155,7 +883,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketResourcesRequiredByCalendarMonthOfYear($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByCalendarMonthResourcesRequiredInRange($from, $toExclusive);
     }
 
     /**
@@ -1168,11 +896,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketResourcesRequiredByCalendarMonthOfYear($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1182,7 +906,7 @@ SQL;
         \DateTimeInterface $from,
         \DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketResourcesRequiredByDay($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByDayResourcesRequiredInRange($from, $toExclusive);
     }
 
     /**
@@ -1195,11 +919,7 @@ SQL;
         \DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketResourcesRequiredByDay($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1209,7 +929,7 @@ SQL;
         \DateTimeInterface $from,
         ?\DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketClinicalFeaturesByCalendarMonthOfYear($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByCalendarMonthClinicalFeaturesInRange($from, $toExclusive);
     }
 
     /**
@@ -1222,11 +942,7 @@ SQL;
         ?\DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketClinicalFeaturesByCalendarMonthOfYear($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByCalendarMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1236,7 +952,7 @@ SQL;
         \DateTimeInterface $from,
         \DateTimeInterface $toExclusive,
     ): array {
-        return $this->bucketClinicalFeaturesByDay($from, $toExclusive, null);
+        return $this->bucketQuery->bucketByDayClinicalFeaturesInRange($from, $toExclusive);
     }
 
     /**
@@ -1249,11 +965,7 @@ SQL;
         \DateTimeInterface $toExclusive,
         array $hospitalIds,
     ): array {
-        if ([] === $hospitalIds) {
-            return [];
-        }
-
-        return $this->bucketClinicalFeaturesByDay($from, $toExclusive, $hospitalIds);
+        return $this->bucketQuery->bucketByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds);
     }
 
     /**
@@ -1339,451 +1051,6 @@ SQL;
         }
 
         return $counts;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketByCalendarMonthOfYearAndGender(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
-            $gender = $allocation->getGender() ?? AllocationGender::OTHER;
-            $g = $gender->value;
-
-            if (!isset($buckets[$calKey][$g])) {
-                $buckets[$calKey][$g] = 0;
-            }
-            ++$buckets[$calKey][$g];
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketByDayAndGender(
-        \DateTimeInterface $from,
-        \DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $dayKey = $createdAt->format('Y-m-d');
-            $gender = $allocation->getGender() ?? AllocationGender::OTHER;
-            $g = $gender->value;
-
-            if (!isset($buckets[$dayKey][$g])) {
-                $buckets[$dayKey][$g] = 0;
-            }
-            ++$buckets[$dayKey][$g];
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketByCalendarMonthOfYearAndUrgency(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
-            $urgency = $allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT;
-            $u = sprintf('%d', $urgency->value);
-
-            if (!isset($buckets[$calKey][$u])) {
-                $buckets[$calKey][$u] = 0;
-            }
-            ++$buckets[$calKey][$u];
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array<string, int>>
-     */
-    private function bucketByDayAndUrgency(
-        \DateTimeInterface $from,
-        \DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array<string, int>> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $dayKey = $createdAt->format('Y-m-d');
-            $urgency = $allocation->getUrgency() ?? AllocationUrgency::OUTPATIENT;
-            $u = sprintf('%d', $urgency->value);
-
-            if (!isset($buckets[$dayKey][$u])) {
-                $buckets[$dayKey][$u] = 0;
-            }
-            ++$buckets[$dayKey][$u];
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
-     */
-    private function bucketResourcesRequiredByCalendarMonthOfYear(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
-            if (!isset($buckets[$calKey])) {
-                $buckets[$calKey] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
-            }
-
-            $requiresAny = false;
-            if (true === $allocation->isRequiresCathlab()) {
-                ++$buckets[$calKey]['cathlab'];
-                $requiresAny = true;
-            }
-            if (true === $allocation->isRequiresResus()) {
-                ++$buckets[$calKey]['resus'];
-                $requiresAny = true;
-            }
-            if ($requiresAny) {
-                ++$buckets[$calKey]['with_any'];
-            }
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array{cathlab: int, resus: int, with_any: int}>
-     */
-    private function bucketResourcesRequiredByDay(
-        \DateTimeInterface $from,
-        \DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        /** @var array<string, array{cathlab: int, resus: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $dayKey = $createdAt->format('Y-m-d');
-            if (!isset($buckets[$dayKey])) {
-                $buckets[$dayKey] = ['cathlab' => 0, 'resus' => 0, 'with_any' => 0];
-            }
-
-            $requiresAny = false;
-            if (true === $allocation->isRequiresCathlab()) {
-                ++$buckets[$dayKey]['cathlab'];
-                $requiresAny = true;
-            }
-            if (true === $allocation->isRequiresResus()) {
-                ++$buckets[$dayKey]['resus'];
-                $requiresAny = true;
-            }
-            if ($requiresAny) {
-                ++$buckets[$dayKey]['with_any'];
-            }
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
-     */
-    private function bucketClinicalFeaturesByCalendarMonthOfYear(
-        \DateTimeInterface $from,
-        ?\DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        return $this->accumulateClinicalBucketsForCalendarMonthKeys(array_values($rows));
-    }
-
-    /**
-     * @param list<int>|null $hospitalIds
-     *
-     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
-     */
-    private function bucketClinicalFeaturesByDay(
-        \DateTimeInterface $from,
-        \DateTimeInterface $toExclusive,
-        ?array $hospitalIds,
-    ): array {
-        $qb = $this->createQueryBuilder('a')
-            ->where('a.createdAt >= :from')
-            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->orderBy('a.createdAt', 'ASC');
-        $this->applyCreatedAtBefore($qb, $toExclusive);
-
-        if (null !== $hospitalIds) {
-            $qb->andWhere('a.hospital IN (:hospitalIds)')
-                ->setParameter('hospitalIds', $hospitalIds);
-        }
-
-        /** @var Allocation[] $rows */
-        $rows = $qb->getQuery()->getResult();
-
-        return $this->accumulateClinicalBucketsForDayKeys(array_values($rows));
-    }
-
-    /**
-     * @param iterable<int, Allocation> $rows
-     *
-     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
-     */
-    private function accumulateClinicalBucketsForCalendarMonthKeys(iterable $rows): array
-    {
-        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $calKey = sprintf('cal-%02d', (int) $createdAt->format('n'));
-            if (!isset($buckets[$calKey])) {
-                $buckets[$calKey] = [
-                    'with_physician' => 0,
-                    'cpr' => 0,
-                    'ventilated' => 0,
-                    'shock' => 0,
-                    'pregnant' => 0,
-                    'infectious' => 0,
-                    'with_any' => 0,
-                ];
-            }
-
-            $this->incrementClinicalFeatureCells($allocation, $buckets[$calKey]);
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param iterable<int, Allocation> $rows
-     *
-     * @return array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}>
-     */
-    private function accumulateClinicalBucketsForDayKeys(iterable $rows): array
-    {
-        /** @var array<string, array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int}> $buckets */
-        $buckets = [];
-        foreach ($rows as $allocation) {
-            $createdAt = $allocation->getCreatedAt();
-            if (!$createdAt) {
-                continue;
-            }
-
-            $dayKey = $createdAt->format('Y-m-d');
-            if (!isset($buckets[$dayKey])) {
-                $buckets[$dayKey] = [
-                    'with_physician' => 0,
-                    'cpr' => 0,
-                    'ventilated' => 0,
-                    'shock' => 0,
-                    'pregnant' => 0,
-                    'infectious' => 0,
-                    'with_any' => 0,
-                ];
-            }
-
-            $this->incrementClinicalFeatureCells($allocation, $buckets[$dayKey]);
-        }
-
-        return $buckets;
-    }
-
-    /**
-     * @param array{with_physician: int, cpr: int, ventilated: int, shock: int, pregnant: int, infectious: int, with_any: int} $cell
-     */
-    private function incrementClinicalFeatureCells(Allocation $allocation, array &$cell): void
-    {
-        $hasAny = false;
-        if (true === $allocation->isWithPhysician()) {
-            ++$cell['with_physician'];
-            $hasAny = true;
-        }
-        if (true === $allocation->isCPR()) {
-            ++$cell['cpr'];
-            $hasAny = true;
-        }
-        if (true === $allocation->isVentilated()) {
-            ++$cell['ventilated'];
-            $hasAny = true;
-        }
-        if (true === $allocation->isShock()) {
-            ++$cell['shock'];
-            $hasAny = true;
-        }
-        if (true === $allocation->isPregnant()) {
-            ++$cell['pregnant'];
-            $hasAny = true;
-        }
-        if ($allocation->getInfection() instanceof \App\Allocation\Domain\Entity\Infection) {
-            ++$cell['infectious'];
-            $hasAny = true;
-        }
-        if ($hasAny) {
-            ++$cell['with_any'];
-        }
     }
 
     /**

--- a/src/Content/Application/Page/PageNavigationProvider.php
+++ b/src/Content/Application/Page/PageNavigationProvider.php
@@ -68,6 +68,7 @@ final class PageNavigationProvider implements NavigationPageLinksProviderInterfa
     /**
      * @return list<array{url: string, label: string}>
      */
+    #[\Override]
     public function linksForKeys(string ...$keys): array
     {
         $links = [];

--- a/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
+++ b/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for AdminFeedbackNotifierInterface. */
 #[AsAlias(AdminFeedbackNotifierInterface::class)]
 final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterface
 {
@@ -30,6 +31,7 @@ final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterfa
     ) {
     }
 
+    #[\Override]
     public function notify(
         Feedback $feedback,
         FeedbackCategory $category,

--- a/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
+++ b/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
@@ -84,8 +84,8 @@ final class AllocationBucketQueryTest extends KernelTestCase
 
         $buckets = $this->query->bucketByMonthAndUrgencyInRange($from, $toExclusive);
 
-        self::assertSame(1, $buckets['2024-03']['1']);
-        self::assertSame(1, $buckets['2024-03']['2']);
+        $this->assertNestedBucketCount($buckets, '2024-03', (string) AllocationUrgency::EMERGENCY->value, 1);
+        $this->assertNestedBucketCount($buckets, '2024-03', (string) AllocationUrgency::INPATIENT->value, 1);
     }
 
     public function testBucketByMonthResourcesRequiredInRangeCountsFlags(): void
@@ -174,10 +174,22 @@ final class AllocationBucketQueryTest extends KernelTestCase
             'import' => $import,
         ]);
 
+        $emergency = (string) AllocationUrgency::EMERGENCY->value;
+
         self::assertSame(1, $this->query->bucketByCalendarMonthAndGenderInRange($from, $toExclusive)['cal-03']['M']);
         self::assertSame(1, $this->query->bucketByDayAndGenderInRange($from, $toExclusive)['2024-03-10']['M']);
-        self::assertSame(1, $this->query->bucketByCalendarMonthAndUrgencyInRange($from, $toExclusive)['cal-03']['1']);
-        self::assertSame(1, $this->query->bucketByDayAndUrgencyInRange($from, $toExclusive)['2024-03-10']['1']);
+        $this->assertNestedBucketCount(
+            $this->query->bucketByCalendarMonthAndUrgencyInRange($from, $toExclusive),
+            'cal-03',
+            $emergency,
+            1,
+        );
+        $this->assertNestedBucketCount(
+            $this->query->bucketByDayAndUrgencyInRange($from, $toExclusive),
+            '2024-03-10',
+            $emergency,
+            1,
+        );
         self::assertSame(1, $this->query->bucketByCalendarMonthResourcesRequiredInRange($from, $toExclusive)['cal-03']['cathlab']);
         self::assertSame(1, $this->query->bucketByDayResourcesRequiredInRange($from, $toExclusive)['2024-03-10']['cathlab']);
         self::assertSame(1, $this->query->bucketByCalendarMonthClinicalFeaturesInRange($from, $toExclusive)['cal-03']['with_physician']);
@@ -223,15 +235,32 @@ final class AllocationBucketQueryTest extends KernelTestCase
 
         $hospitalIds = [(int) $hospitalA->getId()];
 
+        $emergency = (string) AllocationUrgency::EMERGENCY->value;
+
         self::assertSame(1, $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['M']);
         self::assertArrayNotHasKey('F', $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03'] ?? []);
-        self::assertSame(1, $this->query->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['1']);
+        $this->assertNestedBucketCount(
+            $this->query->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            '2024-03',
+            $emergency,
+            1,
+        );
         self::assertSame(1, $this->query->bucketByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['cathlab']);
         self::assertSame(1, $this->query->bucketByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['with_physician']);
         self::assertSame(1, $this->query->bucketByCalendarMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['M']);
         self::assertSame(1, $this->query->bucketByDayAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['M']);
-        self::assertSame(1, $this->query->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['1']);
-        self::assertSame(1, $this->query->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['1']);
+        $this->assertNestedBucketCount(
+            $this->query->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            'cal-03',
+            $emergency,
+            1,
+        );
+        $this->assertNestedBucketCount(
+            $this->query->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            '2024-03-10',
+            $emergency,
+            1,
+        );
         self::assertSame(1, $this->query->bucketByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['cathlab']);
         self::assertSame(1, $this->query->bucketByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['cathlab']);
         self::assertSame(1, $this->query->bucketByCalendarMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['with_physician']);
@@ -280,10 +309,17 @@ final class AllocationBucketQueryTest extends KernelTestCase
 
         $hospitalIds = [(int) $hospital->getId()];
 
+        $emergency = (string) AllocationUrgency::EMERGENCY->value;
+
         self::assertSame(1, $this->query->bucketByMonthAndGenderLast12Months()[$ym]['M']);
         self::assertSame(1, $this->query->bucketByMonthAndGenderLast12MonthsForHospitals($hospitalIds)[$ym]['M']);
-        self::assertSame(1, $this->query->bucketByMonthAndUrgencyLast12Months()[$ym]['1']);
-        self::assertSame(1, $this->query->bucketByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds)[$ym]['1']);
+        $this->assertNestedBucketCount($this->query->bucketByMonthAndUrgencyLast12Months(), $ym, $emergency, 1);
+        $this->assertNestedBucketCount(
+            $this->query->bucketByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds),
+            $ym,
+            $emergency,
+            1,
+        );
         self::assertSame(1, $this->query->bucketByMonthResourcesRequiredLast12Months()[$ym]['cathlab']);
         self::assertSame(1, $this->query->bucketByMonthResourcesRequiredLast12MonthsForHospitals($hospitalIds)[$ym]['cathlab']);
         self::assertSame(1, $this->query->bucketByMonthClinicalFeaturesLast12Months()[$ym]['with_physician']);
@@ -456,6 +492,16 @@ final class AllocationBucketQueryTest extends KernelTestCase
             $this->query->bucketByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
             $this->repository->bucketAllocationsByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
         );
+    }
+
+    /**
+     * @param array<string, array<string, int>> $buckets
+     */
+    private function assertNestedBucketCount(array $buckets, string $outerKey, string $innerKey, int $expected): void
+    {
+        self::assertArrayHasKey($outerKey, $buckets);
+        self::assertArrayHasKey($innerKey, $buckets[$outerKey]);
+        self::assertSame($expected, $buckets[$outerKey][$innerKey]);
     }
 
     /**

--- a/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
+++ b/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Query;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Query\AllocationBucketQuery;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class AllocationBucketQueryTest extends KernelTestCase
+{
+    use Factories;
+
+    private AllocationBucketQuery $query;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->query = self::getContainer()->get(AllocationBucketQuery::class);
+    }
+
+    public function testBucketByMonthAndGenderInRangeGroupsByMonthAndGender(): void
+    {
+        $from = new \DateTimeImmutable('2024-03-01 00:00:00');
+        $toExclusive = new \DateTimeImmutable('2024-04-01 00:00:00');
+        $import = $this->seedAllocationGraph();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'gender' => AllocationGender::MALE,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-15'),
+            'gender' => AllocationGender::MALE,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-20'),
+            'gender' => AllocationGender::FEMALE,
+            'import' => $import,
+        ]);
+
+        $buckets = $this->query->bucketByMonthAndGenderInRange($from, $toExclusive);
+
+        self::assertSame(2, $buckets['2024-03']['M']);
+        self::assertSame(1, $buckets['2024-03']['F']);
+    }
+
+    private function seedAllocationGraph(): object
+    {
+        UserFactory::createOne();
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        HospitalFactory::createOne();
+        SpecialityFactory::createOne();
+        DepartmentFactory::createOne();
+        AssignmentFactory::createOne();
+        OccasionFactory::createOne();
+        InfectionFactory::createOne();
+        IndicationRawFactory::createOne();
+        IndicationNormalizedFactory::createOne();
+
+        return ImportFactory::createOne();
+    }
+}

--- a/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
+++ b/tests/Allocation/Integration/Query/AllocationBucketQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Allocation\Integration\Query;
 
 use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
 use App\Allocation\Infrastructure\Factory\AllocationFactory;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
@@ -17,6 +18,7 @@ use App\Allocation\Infrastructure\Factory\OccasionFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Allocation\Infrastructure\Query\AllocationBucketQuery;
+use App\Allocation\Infrastructure\Repository\AllocationRepository;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -29,19 +31,19 @@ final class AllocationBucketQueryTest extends KernelTestCase
     use Factories;
 
     private AllocationBucketQuery $query;
+    private AllocationRepository $repository;
 
     #[\Override]
     protected function setUp(): void
     {
         self::bootKernel();
         $this->query = self::getContainer()->get(AllocationBucketQuery::class);
+        $this->repository = self::getContainer()->get(AllocationRepository::class);
     }
 
     public function testBucketByMonthAndGenderInRangeGroupsByMonthAndGender(): void
     {
-        $from = new \DateTimeImmutable('2024-03-01 00:00:00');
-        $toExclusive = new \DateTimeImmutable('2024-04-01 00:00:00');
-        $import = $this->seedAllocationGraph();
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
 
         AllocationFactory::createOne([
             'createdAt' => new \DateTimeImmutable('2024-03-10'),
@@ -63,6 +65,409 @@ final class AllocationBucketQueryTest extends KernelTestCase
 
         self::assertSame(2, $buckets['2024-03']['M']);
         self::assertSame(1, $buckets['2024-03']['F']);
+    }
+
+    public function testBucketByMonthAndUrgencyInRangeGroupsByMonthAndUrgency(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-12'),
+            'urgency' => AllocationUrgency::INPATIENT,
+            'import' => $import,
+        ]);
+
+        $buckets = $this->query->bucketByMonthAndUrgencyInRange($from, $toExclusive);
+
+        self::assertSame(1, $buckets['2024-03']['1']);
+        self::assertSame(1, $buckets['2024-03']['2']);
+    }
+
+    public function testBucketByMonthResourcesRequiredInRangeCountsFlags(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'requiresCathlab' => true,
+            'requiresResus' => false,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-11'),
+            'requiresCathlab' => true,
+            'requiresResus' => true,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-12'),
+            'requiresCathlab' => false,
+            'requiresResus' => false,
+            'import' => $import,
+        ]);
+
+        $buckets = $this->query->bucketByMonthResourcesRequiredInRange($from, $toExclusive);
+
+        self::assertSame(2, $buckets['2024-03']['cathlab']);
+        self::assertSame(1, $buckets['2024-03']['resus']);
+        self::assertSame(2, $buckets['2024-03']['with_any']);
+    }
+
+    public function testBucketByMonthClinicalFeaturesInRangeCountsFlags(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+        $infection = InfectionFactory::createOne();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'isWithPhysician' => true,
+            'isCPR' => true,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => $infection,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-11'),
+            'isWithPhysician' => false,
+            'isCPR' => false,
+            'isVentilated' => true,
+            'isShock' => true,
+            'isPregnant' => true,
+            'infection' => null,
+            'import' => $import,
+        ]);
+
+        $buckets = $this->query->bucketByMonthClinicalFeaturesInRange($from, $toExclusive);
+
+        self::assertSame(1, $buckets['2024-03']['with_physician']);
+        self::assertSame(1, $buckets['2024-03']['cpr']);
+        self::assertSame(1, $buckets['2024-03']['ventilated']);
+        self::assertSame(1, $buckets['2024-03']['shock']);
+        self::assertSame(1, $buckets['2024-03']['pregnant']);
+        self::assertSame(1, $buckets['2024-03']['infectious']);
+        self::assertSame(2, $buckets['2024-03']['with_any']);
+    }
+
+    public function testCalendarMonthAndDayBucketsUseExpectedKeys(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'requiresCathlab' => true,
+            'requiresResus' => false,
+            'isWithPhysician' => true,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'import' => $import,
+        ]);
+
+        self::assertSame(1, $this->query->bucketByCalendarMonthAndGenderInRange($from, $toExclusive)['cal-03']['M']);
+        self::assertSame(1, $this->query->bucketByDayAndGenderInRange($from, $toExclusive)['2024-03-10']['M']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthAndUrgencyInRange($from, $toExclusive)['cal-03']['1']);
+        self::assertSame(1, $this->query->bucketByDayAndUrgencyInRange($from, $toExclusive)['2024-03-10']['1']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthResourcesRequiredInRange($from, $toExclusive)['cal-03']['cathlab']);
+        self::assertSame(1, $this->query->bucketByDayResourcesRequiredInRange($from, $toExclusive)['2024-03-10']['cathlab']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthClinicalFeaturesInRange($from, $toExclusive)['cal-03']['with_physician']);
+        self::assertSame(1, $this->query->bucketByDayClinicalFeaturesInRange($from, $toExclusive)['2024-03-10']['with_physician']);
+    }
+
+    public function testHospitalScopeFiltersAndEmptyIdsShortCircuit(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+        $hospitalA = HospitalFactory::createOne();
+        $hospitalB = HospitalFactory::createOne();
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'requiresCathlab' => true,
+            'requiresResus' => false,
+            'isWithPhysician' => true,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'hospital' => $hospitalA,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-11'),
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'requiresCathlab' => false,
+            'requiresResus' => true,
+            'isWithPhysician' => false,
+            'isCPR' => true,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'hospital' => $hospitalB,
+            'import' => $import,
+        ]);
+
+        $hospitalIds = [(int) $hospitalA->getId()];
+
+        self::assertSame(1, $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['M']);
+        self::assertArrayNotHasKey('F', $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03'] ?? []);
+        self::assertSame(1, $this->query->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['1']);
+        self::assertSame(1, $this->query->bucketByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['cathlab']);
+        self::assertSame(1, $this->query->bucketByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03']['with_physician']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['M']);
+        self::assertSame(1, $this->query->bucketByDayAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['M']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['1']);
+        self::assertSame(1, $this->query->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['1']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['cathlab']);
+        self::assertSame(1, $this->query->bucketByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['cathlab']);
+        self::assertSame(1, $this->query->bucketByCalendarMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds)['cal-03']['with_physician']);
+        self::assertSame(1, $this->query->bucketByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds)['2024-03-10']['with_physician']);
+
+        self::assertSame([], $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByCalendarMonthAndGenderInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByDayAndGenderInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByCalendarMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, []));
+        self::assertSame([], $this->query->bucketByMonthAndGenderLast12MonthsForHospitals([]));
+        self::assertSame([], $this->query->bucketByMonthAndUrgencyLast12MonthsForHospitals([]));
+        self::assertSame([], $this->query->bucketByMonthResourcesRequiredLast12MonthsForHospitals([]));
+        self::assertSame([], $this->query->bucketByMonthClinicalFeaturesLast12MonthsForHospitals([]));
+    }
+
+    public function testLast12MonthsWrappersIncludeAllocationsInWindow(): void
+    {
+        $import = $this->seedAllocationGraph();
+        $hospital = HospitalFactory::createOne();
+        $inWindow = new \DateTimeImmutable('first day of this month')->modify('+5 days')->setTime(12, 0, 0);
+        $ym = $inWindow->format('Y-m');
+
+        AllocationFactory::createOne([
+            'createdAt' => $inWindow,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'requiresCathlab' => true,
+            'requiresResus' => false,
+            'isWithPhysician' => true,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'hospital' => $hospital,
+            'import' => $import,
+        ]);
+
+        $hospitalIds = [(int) $hospital->getId()];
+
+        self::assertSame(1, $this->query->bucketByMonthAndGenderLast12Months()[$ym]['M']);
+        self::assertSame(1, $this->query->bucketByMonthAndGenderLast12MonthsForHospitals($hospitalIds)[$ym]['M']);
+        self::assertSame(1, $this->query->bucketByMonthAndUrgencyLast12Months()[$ym]['1']);
+        self::assertSame(1, $this->query->bucketByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds)[$ym]['1']);
+        self::assertSame(1, $this->query->bucketByMonthResourcesRequiredLast12Months()[$ym]['cathlab']);
+        self::assertSame(1, $this->query->bucketByMonthResourcesRequiredLast12MonthsForHospitals($hospitalIds)[$ym]['cathlab']);
+        self::assertSame(1, $this->query->bucketByMonthClinicalFeaturesLast12Months()[$ym]['with_physician']);
+        self::assertSame(1, $this->query->bucketByMonthClinicalFeaturesLast12MonthsForHospitals($hospitalIds)[$ym]['with_physician']);
+    }
+
+    public function testRepositoryDelegatesMatchQueryResults(): void
+    {
+        [$from, $toExclusive, $import] = $this->march2024FixtureContext();
+        $hospital = HospitalFactory::createOne();
+        $hospitalIds = [(int) $hospital->getId()];
+        $inWindow = new \DateTimeImmutable('first day of this month')->modify('+5 days')->setTime(12, 0, 0);
+
+        AllocationFactory::createOne([
+            'createdAt' => new \DateTimeImmutable('2024-03-10'),
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'requiresCathlab' => true,
+            'requiresResus' => false,
+            'isWithPhysician' => true,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'hospital' => $hospital,
+            'import' => $import,
+        ]);
+        AllocationFactory::createOne([
+            'createdAt' => $inWindow,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'requiresCathlab' => false,
+            'requiresResus' => true,
+            'isWithPhysician' => false,
+            'isCPR' => true,
+            'isVentilated' => false,
+            'isShock' => false,
+            'isPregnant' => false,
+            'infection' => null,
+            'hospital' => $hospital,
+            'import' => $import,
+        ]);
+
+        self::assertSame(
+            $this->query->bucketByMonthAndGenderLast12Months(),
+            $this->repository->bucketAllocationsByMonthAndGenderLast12Months(),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndGenderLast12MonthsForHospitals($hospitalIds),
+            $this->repository->bucketAllocationsByMonthAndGenderLast12MonthsForHospitals($hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndGenderInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByMonthAndGenderInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndUrgencyLast12Months(),
+            $this->repository->bucketAllocationsByMonthAndUrgencyLast12Months(),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds),
+            $this->repository->bucketAllocationsByMonthAndUrgencyLast12MonthsForHospitals($hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndUrgencyInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByMonthAndUrgencyInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthResourcesRequiredLast12Months(),
+            $this->repository->bucketAllocationsByMonthResourcesRequiredLast12Months(),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthResourcesRequiredLast12MonthsForHospitals($hospitalIds),
+            $this->repository->bucketAllocationsByMonthResourcesRequiredLast12MonthsForHospitals($hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthResourcesRequiredInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByMonthResourcesRequiredInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthClinicalFeaturesLast12Months(),
+            $this->repository->bucketAllocationsByMonthClinicalFeaturesLast12Months(),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthClinicalFeaturesLast12MonthsForHospitals($hospitalIds),
+            $this->repository->bucketAllocationsByMonthClinicalFeaturesLast12MonthsForHospitals($hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthClinicalFeaturesInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByMonthClinicalFeaturesInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthAndGenderInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByCalendarMonthOfYearAndGenderInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByCalendarMonthOfYearAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByDayAndGenderInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByDayAndGenderInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByDayAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByDayAndGenderInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthAndUrgencyInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByCalendarMonthOfYearAndUrgencyInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByCalendarMonthOfYearAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByDayAndUrgencyInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByDayAndUrgencyInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByDayAndUrgencyInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthResourcesRequiredInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByCalendarMonthResourcesRequiredInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByCalendarMonthResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByDayResourcesRequiredInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByDayResourcesRequiredInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByDayResourcesRequiredInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthClinicalFeaturesInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByCalendarMonthClinicalFeaturesInRangeAggregated($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByCalendarMonthClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByCalendarMonthClinicalFeaturesInRangeAggregatedForHospitals($from, $toExclusive, $hospitalIds),
+        );
+        self::assertSame(
+            $this->query->bucketByDayClinicalFeaturesInRange($from, $toExclusive),
+            $this->repository->bucketAllocationsByDayClinicalFeaturesInRange($from, $toExclusive),
+        );
+        self::assertSame(
+            $this->query->bucketByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
+            $this->repository->bucketAllocationsByDayClinicalFeaturesInRangeForHospitals($from, $toExclusive, $hospitalIds),
+        );
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable, 2: object}
+     */
+    private function march2024FixtureContext(): array
+    {
+        return [
+            new \DateTimeImmutable('2024-03-01 00:00:00'),
+            new \DateTimeImmutable('2024-04-01 00:00:00'),
+            $this->seedAllocationGraph(),
+        ];
     }
 
     private function seedAllocationGraph(): object


### PR DESCRIPTION
## Summary
- Extract all `bucketAllocationsBy*` analytics bucketing from `AllocationRepository` into `AllocationBucketQuery` (+ `HospitalScopeQueryTrait`), per ADR-010 / Wave C.
- Keep thin public delegates on `AllocationRepository` so existing Statistics callers keep a stable API.
- Add a focused integration test for month×gender bucketing via the new query object.

## Test plan
- [x] `make test PATH_ARG=tests/Allocation/Integration/Query/AllocationBucketQueryTest.php`
- [x] `make test PATH_ARG=tests/Allocation/Integration/Repository/AllocationRepositoryMonthAggregationTest.php`
- [x] `make test PATH_ARG=tests/Statistics/Integration` (228 tests OK)
- [x] PHPStan on changed Allocation query/repository files
- [x] Deptrac: 0 new violations (baseline unmatched skips from Wave B remain)