### PR TITLE
chore: Removed some obsolete Deptrac baseline rules

### DIFF
--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -4,6 +4,8 @@ deptrac:
       - App\Allocation\UI\Http\DTO\AllocationQueryParametersDTO
     App\Allocation\Application\Allocations\AllocationListHospitalScopeOptionsProvider:
       - App\Allocation\Infrastructure\Repository\HospitalRepository
+    App\Allocation\Application\Audit\ImportAssessmentAuditPurgeService:
+      - App\Allocation\Infrastructure\Query\ImportAssessmentAuditPurgeQuery
     App\Allocation\Application\Explore\ExploreFilterOptionsProvider:
       - App\Allocation\Infrastructure\Repository\AssignmentRepository
       - App\Allocation\Infrastructure\Repository\DepartmentRepository
@@ -21,8 +23,6 @@ deptrac:
       - App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData
     App\Allocation\Application\Export\OwnHospitalAllocationsExporter:
       - App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery
-    App\Allocation\Application\Audit\ImportAssessmentAuditPurgeService:
-      - App\Allocation\Infrastructure\Query\ImportAssessmentAuditPurgeQuery
     App\Allocation\Application\Indication\IndicationMatchSuggestionService:
       - App\Allocation\Infrastructure\Repository\IndicationNormalizedRepository
       - App\Import\Infrastructure\Indication\IndicationKey
@@ -308,23 +308,6 @@ deptrac:
       - App\Import\Application\Service\ImportListAccess
     App\Onboarding\Domain\Entity\UserOnboardingStep:
       - App\Onboarding\Infrastructure\Repository\UserOnboardingStepRepository
-    App\Shared\Infrastructure\Mail\SymfonyTransactionalMailer:
-      - App\Feedback\Domain\Entity\Feedback
-      - App\Feedback\Domain\Enum\FeedbackCategory
-    App\Shared\Infrastructure\Mail\TransactionalMailer:
-      - App\Feedback\Domain\Entity\Feedback
-      - App\Feedback\Domain\Enum\FeedbackCategory
-    App\Shared\Application\Navigation\FooterNavigationProvider:
-      - App\Content\Application\Page\PageNavigationProvider
-      - App\Content\Domain\Entity\Page
-      - App\Content\Domain\Enum\PageKey
-    App\Shared\Application\Navigation\SitemapProvider:
-      - App\Allocation\Infrastructure\Security\Voter\ExportVoter
-      - App\Content\Application\Page\PageNavigationProvider
-    App\Shared\Infrastructure\Audit\AuditValueNormalizer:
-      - App\Allocation\Domain\Entity\Address
-    App\Shared\Infrastructure\Audit\Query\ImportAssessmentAuditPurgeQuery:
-      - App\Allocation\Domain\Entity\Assessment
     App\Statistics\Application\ClinicalFeaturesProvider:
       - App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult
     App\Statistics\Application\ClinicalFeaturesQuery:


### PR DESCRIPTION
## Summary
- Remove obsolete Deptrac baseline skips left over from Wave B (Shared mail, navigation, audit/purge edges that no longer exist).
- Baseline is clean again: unmatched skip errors go to zero; real skipped violations stay unchanged.

## Test plan
- [ ] `make deptrac` → 0 violations, 0 errors