### PR TITLE
test: Prefer stubs over mocks for return-only collaborators in unit tests

### DIFF
--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -168,7 +168,7 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] Suite gaps fixed; empty Seed removed
 - [x] Test-double section in testing docs
 - [x] Backlog formulated (B1–B18)
-- [ ] B1–B5 double hygiene PRs
+- [x] B1–B5 double hygiene PRs
 - [ ] B6–B8 large-class splits
 - [ ] B9–B13 coverage gap PRs (as needed)
 - [ ] B14–B18 process / automation (optional)

--- a/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
+++ b/tests/Engagement/Unit/Application/MonthlyReminderMailerTest.php
@@ -24,7 +24,7 @@ final class MonthlyReminderMailerTest extends TestCase
         $content = $this->content();
         $capturedLocale = null;
 
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static function (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null) use (&$capturedLocale): string {
                 if ('monthly_reminder.subject' === $id) {
@@ -80,7 +80,7 @@ final class MonthlyReminderMailerTest extends TestCase
 
     public function testReplyToIsAppliedWhenConfigured(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('subject');
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -97,7 +97,7 @@ final class MonthlyReminderMailerTest extends TestCase
 
         new MonthlyReminderMailer(
             $mailer,
-            $this->createMock(MessageBusInterface::class),
+            $this->createStub(MessageBusInterface::class),
             new MailConfig(
                 fromEmail: 'no-reply@example.test',
                 fromName: 'IVENA Stats',
@@ -105,14 +105,14 @@ final class MonthlyReminderMailerTest extends TestCase
                 replyTo: 'support@example.test',
             ),
             $translator,
-            $this->createMock(LoggerInterface::class),
+            $this->createStub(LoggerInterface::class),
             bulkDelayMs: 0,
         )->send('owner@example.test', $this->content(), 'en');
     }
 
     public function testBulkIndexDispatchesDelayedSendEmailMessage(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('subject');
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -143,14 +143,14 @@ final class MonthlyReminderMailerTest extends TestCase
                 replyTo: '',
             ),
             $translator,
-            $this->createMock(LoggerInterface::class),
+            $this->createStub(LoggerInterface::class),
             bulkDelayMs: 3000,
         )->send('owner@example.test', $this->content(), 'en', bulkIndex: 2);
     }
 
     public function testDispatchIdHeaderIsAddedWhenProvided(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('subject');
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -167,7 +167,7 @@ final class MonthlyReminderMailerTest extends TestCase
 
         new MonthlyReminderMailer(
             $mailer,
-            $this->createMock(MessageBusInterface::class),
+            $this->createStub(MessageBusInterface::class),
             new MailConfig(
                 fromEmail: 'no-reply@example.test',
                 fromName: 'IVENA Stats',
@@ -175,7 +175,7 @@ final class MonthlyReminderMailerTest extends TestCase
                 replyTo: '',
             ),
             $translator,
-            $this->createMock(LoggerInterface::class),
+            $this->createStub(LoggerInterface::class),
             bulkDelayMs: 0,
         )->send('owner@example.test', $this->content(), 'en', dispatchId: 42);
     }

--- a/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
+++ b/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
@@ -27,13 +27,13 @@ final class AdminFeedbackMailerTest extends TestCase
             ->setMessage('Broken filter')
             ->setPageUrl('https://example.test/page');
 
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([
             $this->createAdminUser('admin-a@example.test', 'de'),
             $this->createAdminUser('admin-b@example.test', 'de'),
         ]);
 
-        $translator = $this->createTranslatorMock();
+        $translator = $this->createTranslatorStub();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -63,7 +63,7 @@ final class AdminFeedbackMailerTest extends TestCase
             ->setMessage('Broken filter')
             ->setPageUrl('https://example.test/page');
 
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([
             $this->createAdminUser('de-admin@example.test', 'de'),
             $this->createAdminUser('en-admin@example.test', 'en'),
@@ -71,7 +71,7 @@ final class AdminFeedbackMailerTest extends TestCase
 
         $localeResolver = new LocaleResolver(new LocaleCookieManager());
 
-        $translator = $this->createTranslatorMock();
+        $translator = $this->createTranslatorStub();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::exactly(2))
             ->method('send')
@@ -96,7 +96,7 @@ final class AdminFeedbackMailerTest extends TestCase
             ->setMessage('Broken filter')
             ->setPageUrl('https://example.test/page');
 
-        $recipientResolver = $this->createMock(FeedbackRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -132,16 +132,16 @@ final class AdminFeedbackMailerTest extends TestCase
                 appName: 'Test App',
                 replyTo: '',
             ),
-            $recipientResolver ?? $this->createMock(FeedbackRecipientEmailResolver::class),
-            $translator ?? $this->createTranslatorMock(),
+            $recipientResolver ?? $this->createStub(FeedbackRecipientEmailResolver::class),
+            $translator ?? $this->createTranslatorStub(),
             $localeResolver ?? new LocaleResolver(new LocaleCookieManager()),
-            $logger ?? $this->createMock(LoggerInterface::class),
+            $logger ?? $this->createStub(LoggerInterface::class),
         );
     }
 
-    private function createTranslatorMock(): TranslatorInterface
+    private function createTranslatorStub(): TranslatorInterface
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id): string => match ($id) {
                 'feedback.email.title' => 'Feedback',

--- a/tests/Import/Unit/Service/Resolver/IndicationCreationStrategyTest.php
+++ b/tests/Import/Unit/Service/Resolver/IndicationCreationStrategyTest.php
@@ -28,9 +28,8 @@ final class IndicationCreationStrategyTest extends TestCase
         $text = 'Brustschmerz';
         $hash = IndicationKey::hashFrom($code, $text);
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash, 'id' => 10, 'normalized_id' => 5],
             ]);
@@ -103,9 +102,8 @@ final class IndicationCreationStrategyTest extends TestCase
         $hash1 = IndicationKey::hashFrom('123', 'Brustschmerz');
         IndicationKey::hashFrom('456', 'Covid');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash1, 'id' => 10, 'normalized_id' => 5],
             ]);
@@ -140,10 +138,10 @@ final class IndicationCreationStrategyTest extends TestCase
                 }
             );
 
-        $import = $this->createMock(Import::class);
-        $createdBy = $this->createMock(User::class);
-        $createdBy->expects(self::atLeastOnce())->method('getId')->willReturn(99);
-        $import->expects(self::atLeastOnce())->method('getCreatedBy')->willReturn($createdBy);
+        $createdBy = $this->createStub(User::class);
+        $createdBy->method('getId')->willReturn(99);
+        $import = $this->createStub(Import::class);
+        $import->method('getCreatedBy')->willReturn($createdBy);
 
         $strategy = new IndicationCreationStrategy($repo, new IndicationCache(), $em);
         $strategy->warm();
@@ -169,9 +167,8 @@ final class IndicationCreationStrategyTest extends TestCase
     {
         $hash1 = IndicationKey::hashFrom('123', 'Brustschmerz');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash1, 'id' => 10, 'normalized_id' => null],
             ]);
@@ -189,8 +186,8 @@ final class IndicationCreationStrategyTest extends TestCase
                     : $this->fail("Unexpected getReference: {$class}#{$id}")
             );
 
-        $import = $this->createMock(Import::class);
-        $import->expects(self::atLeastOnce())->method('getCreatedBy')->willReturn(null);
+        $import = $this->createStub(Import::class);
+        $import->method('getCreatedBy')->willReturn(null);
 
         $strategy = new IndicationCreationStrategy($repo, new IndicationCache(), $em);
         $strategy->warm();
@@ -213,9 +210,8 @@ final class IndicationCreationStrategyTest extends TestCase
         $hash1 = IndicationKey::hashFrom('123', 'Brustschmerz');
         $hash2 = IndicationKey::hashFrom('456', 'Covid');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash1, 'id' => 10, 'normalized_id' => 5],
                 ['hash' => $hash2, 'id' => 11, 'normalized_id' => 6],
@@ -265,9 +261,8 @@ final class IndicationCreationStrategyTest extends TestCase
         $hash1 = IndicationKey::hashFrom('123', 'Brustschmerz');
         $hash2 = IndicationKey::hashFrom('456', 'Covid');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash1, 'id' => 10, 'normalized_id' => 5],
                 ['hash' => $hash2, 'id' => 11, 'normalized_id' => 6],
@@ -315,9 +310,8 @@ final class IndicationCreationStrategyTest extends TestCase
     {
         $hash = IndicationKey::hashFrom('123', 'Brustschmerz');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash, 'id' => 10, 'normalized_id' => 5],
             ]);
@@ -357,9 +351,8 @@ final class IndicationCreationStrategyTest extends TestCase
     {
         $hash1 = IndicationKey::hashFrom('123', 'Brustschmerz');
 
-        $repo = $this->createMock(IndicationRawRepository::class);
-        $repo->expects(self::once())
-            ->method('preloadAllLight')
+        $repo = $this->createStub(IndicationRawRepository::class);
+        $repo->method('preloadAllLight')
             ->willReturn([
                 ['hash' => $hash1, 'id' => 10, 'normalized_id' => 5],
             ]);

--- a/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/AdminNotificationSenderTest.php
@@ -25,10 +25,10 @@ final class AdminNotificationSenderTest extends TestCase
         $adminA = $this->createAdminUser('admin-a@example.test', 'de');
         $adminB = $this->createAdminUser('admin-b@example.test', 'de');
 
-        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(NotificationRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([$adminA, $adminB]);
 
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Neue Benutzerregistrierung');
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -55,12 +55,12 @@ final class AdminNotificationSenderTest extends TestCase
 
     public function testSendUsesImportFailedTemplate(): void
     {
-        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(NotificationRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([
             $this->createAdminUser('admin@example.test', 'en'),
         ]);
 
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Import failed');
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -92,7 +92,7 @@ final class AdminNotificationSenderTest extends TestCase
 
     public function testSendSkipsWhenNoRecipients(): void
     {
-        $recipientResolver = $this->createMock(NotificationRecipientEmailResolver::class);
+        $recipientResolver = $this->createStub(NotificationRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
 
         $mailer = $this->createMock(MailerInterface::class);
@@ -128,9 +128,9 @@ final class AdminNotificationSenderTest extends TestCase
                 replyTo: '',
             ),
             $recipientResolver,
-            $translator ?? $this->createMock(TranslatorInterface::class),
+            $translator ?? $this->createStub(TranslatorInterface::class),
             new LocaleResolver(new LocaleCookieManager()),
-            $logger ?? $this->createMock(LoggerInterface::class),
+            $logger ?? $this->createStub(LoggerInterface::class),
         );
     }
 

--- a/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/SymfonyTransactionalMailerTest.php
@@ -17,7 +17,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
 {
     public function testSendVerificationEmailUsesConfiguredSenderRecipientAndLocale(): void
     {
-        $translator = $this->createTranslatorMock();
+        $translator = $this->createTranslatorStub();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -63,7 +63,7 @@ final class SymfonyTransactionalMailerTest extends TestCase
             )
             ->willReturn('https://example.test/reset-password/reset/selector_verifier');
 
-        $translator = $this->createTranslatorMock();
+        $translator = $this->createTranslatorStub();
         $mailer = $this->createMock(MailerInterface::class);
         $mailer->expects(self::once())
             ->method('send')
@@ -115,8 +115,8 @@ final class SymfonyTransactionalMailerTest extends TestCase
         new SymfonyTransactionalMailer(
             $mailer,
             $mailConfig,
-            $this->createMock(UrlGeneratorInterface::class),
-            $this->createTranslatorMock(),
+            $this->createStub(UrlGeneratorInterface::class),
+            $this->createTranslatorStub(),
         )->sendVerificationEmail(
             'user@example.test',
             'https://example.test/verify',
@@ -140,14 +140,14 @@ final class SymfonyTransactionalMailerTest extends TestCase
                 appName: 'Test App',
                 replyTo: '',
             ),
-            $urlGenerator ?? $this->createMock(UrlGeneratorInterface::class),
-            $translator ?? $this->createTranslatorMock(),
+            $urlGenerator ?? $this->createStub(UrlGeneratorInterface::class),
+            $translator ?? $this->createTranslatorStub(),
         );
     }
 
-    private function createTranslatorMock(): TranslatorInterface
+    private function createTranslatorStub(): TranslatorInterface
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string => match ($id) {
                 'email.verify.title' => 'de' === $locale ? 'E-Mail-Adresse bestätigen' : 'Confirm your email address',

--- a/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionLabelResolverTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionLabelResolverTest.php
@@ -18,7 +18,7 @@ final class AnalysisDimensionLabelResolverTest extends TestCase
 {
     public function testTranslatesGenderBucketViaTranslationKey(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id, array $parameters = [], ?string $domain = null): string => match ($id) {
                 AllocationStatsGenderProjectionCode::Male->labelTranslationKey() => 'Male',
@@ -34,7 +34,7 @@ final class AnalysisDimensionLabelResolverTest extends TestCase
 
     public function testBooleanDimensionUsesYesNoTranslations(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id, array $parameters = [], ?string $domain = null): string => match ($id) {
                 'action.yes' => 'Yes',
@@ -57,7 +57,7 @@ final class AnalysisDimensionLabelResolverTest extends TestCase
 
     private function resolver(TranslatorInterface $translator): AnalysisDimensionLabelResolver
     {
-        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver = $this->createStub(GenericAnalysisEntityLabelResolverInterface::class);
         $entityLabelResolver->method('supports')->willReturn(false);
 
         return new AnalysisDimensionLabelResolver(

--- a/tests/Statistics/Unit/AnalysisExplorer/AnalysisViewConfigNormalizerTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/AnalysisViewConfigNormalizerTest.php
@@ -31,7 +31,7 @@ final class AnalysisViewConfigNormalizerTest extends TestCase
 
     public function testNormalizesTimeRowsWithGenderColumnsBarToGroupedBar(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Title');
 
         $normalizer = new AnalysisViewConfigNormalizer(
@@ -70,7 +70,7 @@ final class AnalysisViewConfigNormalizerTest extends TestCase
 
     public function testNormalizesGenderRowsWithoutGrainToTotal(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Title');
 
         $normalizer = new AnalysisViewConfigNormalizer(
@@ -107,7 +107,7 @@ final class AnalysisViewConfigNormalizerTest extends TestCase
 
     public function testForcesBoxPlotForDistributionProfile(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Title');
 
         $normalizer = new AnalysisViewConfigNormalizer(

--- a/tests/Statistics/Unit/AnalysisExplorer/DefaultAnalysisViewFactoryTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/DefaultAnalysisViewFactoryTest.php
@@ -20,7 +20,7 @@ final class DefaultAnalysisViewFactoryTest extends TestCase
 {
     public function testCreateDefaultReturnsAllocationsOverTimeConfig(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->with('stats.analysis_explorer.allocations_over_time')->willReturn('Allocations over time');
 
         $filter = new StatisticsFilter(

--- a/tests/Statistics/Unit/AnalysisExplorer/DefaultHospitalsAnalysisViewFactoryTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/DefaultHospitalsAnalysisViewFactoryTest.php
@@ -21,7 +21,7 @@ final class DefaultHospitalsAnalysisViewFactoryTest extends TestCase
 {
     public function testCreateDefaultReturnsParticipatingCohortByHospitalCount(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Hospitals by master cohort');
 
         $filter = new StatisticsFilter(

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerChoiceGrouperTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerChoiceGrouperTest.php
@@ -74,7 +74,7 @@ final class ExplorerChoiceGrouperTest extends TestCase
 
     private function translator(): TranslatorInterface
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id): string => match ($id) {
                 'stats.analysis_explorer.metric_group.counts' => 'Counts',

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerDescriptionFactoryTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerDescriptionFactoryTest.php
@@ -75,7 +75,7 @@ final class ExplorerDescriptionFactoryTest extends TestCase
      */
     private function factory(array $map): ExplorerDescriptionFactory
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static function (string $id, array $parameters = []) use ($map): string {
                 $template = $map[$id] ?? $id;

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditChoicePresenterTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerEditChoicePresenterTest.php
@@ -84,7 +84,7 @@ final class ExplorerEditChoicePresenterTest extends TestCase
 
     private function presenter(): ExplorerEditChoicePresenter
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id): string => match ($id) {
                 'stats.analysis_explorer.dimension_group.time_and_calendar' => 'Time and calendar',

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerResultsTableExportBuilderTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerResultsTableExportBuilderTest.php
@@ -393,7 +393,7 @@ final class ExplorerResultsTableExportBuilderTest extends TestCase
 
     private function createBuilder(): ExplorerResultsTableExportBuilder
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnMap([
             ['stats.analysis_explorer.dimension.month', [], 'statistics', null, 'Month'],
             ['stats.analysis_explorer.dimension.gender', [], 'statistics', null, 'Gender'],

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerTitleFactoryTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerTitleFactoryTest.php
@@ -64,7 +64,7 @@ final class ExplorerTitleFactoryTest extends TestCase
      */
     private function translator(array $map): TranslatorInterface
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static function (string $id, array $parameters = []) use ($map): string {
                 $template = $map[$id] ?? $id;

--- a/tests/Statistics/Unit/AnalysisExplorer/HospitalsDistributionResultMapperTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/HospitalsDistributionResultMapperTest.php
@@ -26,10 +26,10 @@ final class HospitalsDistributionResultMapperTest extends TestCase
 {
     public function testMapsRawHospitalValuesIntoBoxPlotRowsPerBucket(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
 
-        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver = $this->createStub(GenericAnalysisEntityLabelResolverInterface::class);
         $entityLabelResolver->method('supports')->willReturn(false);
 
         $mapper = new HospitalsDistributionResultMapper(
@@ -75,10 +75,10 @@ final class HospitalsDistributionResultMapperTest extends TestCase
 
     public function testCastsNumericBucketKeysToString(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
 
-        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver = $this->createStub(GenericAnalysisEntityLabelResolverInterface::class);
         $entityLabelResolver->method('supports')->willReturn(false);
 
         $mapper = new HospitalsDistributionResultMapper(
@@ -120,10 +120,10 @@ final class HospitalsDistributionResultMapperTest extends TestCase
 
     public function testMapsRawValuesIntoBoxPlotRowsPerBucketAndSeries(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(static fn (string $id): string => $id);
 
-        $entityLabelResolver = $this->createMock(GenericAnalysisEntityLabelResolverInterface::class);
+        $entityLabelResolver = $this->createStub(GenericAnalysisEntityLabelResolverInterface::class);
         $entityLabelResolver->method('supports')->willReturn(false);
 
         $mapper = new HospitalsDistributionResultMapper(

--- a/tests/Statistics/Unit/Application/Insights/HospitalInsightSelectorTest.php
+++ b/tests/Statistics/Unit/Application/Insights/HospitalInsightSelectorTest.php
@@ -194,7 +194,7 @@ final class HospitalInsightSelectorTest extends TestCase
     public function testSelectPassesExplicitLocaleToTranslator(): void
     {
         $capturedLocale = null;
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static function (
                 string $id,
@@ -225,7 +225,7 @@ final class HospitalInsightSelectorTest extends TestCase
 
     private function translator(): TranslatorInterface
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static function (string $id, array $parameters = []): string {
                 if ([] === $parameters) {

--- a/tests/Statistics/Unit/Application/Overview/OverviewBenchmarkSummaryFactoryTest.php
+++ b/tests/Statistics/Unit/Application/Overview/OverviewBenchmarkSummaryFactoryTest.php
@@ -165,7 +165,7 @@ final class OverviewBenchmarkSummaryFactoryTest extends TestCase
 
     private function factory(): OverviewBenchmarkSummaryFactory
     {
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $routeName, array $parameters = []): string => sprintf(
                 'https://example.test/indication/%s',

--- a/tests/Statistics/Unit/Application/Overview/OverviewPortalNavigationFactoryTest.php
+++ b/tests/Statistics/Unit/Application/Overview/OverviewPortalNavigationFactoryTest.php
@@ -19,7 +19,7 @@ final class OverviewPortalNavigationFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static function (string $name, array $params = []): string {
                 if ('app_stats_analysis_explorer_view' === $name) {

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkDefaultResolverTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkDefaultResolverTest.php
@@ -15,11 +15,11 @@ final class BenchmarkDefaultResolverTest extends TestCase
 {
     public function testRedirectsToPublicScopesForUserWithoutHospitalAccess(): void
     {
-        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess = $this->createStub(HospitalAccessInterface::class);
         $hospitalAccess->method('canUseBenchmarkingScope')->willReturn(false);
 
         $resolver = new BenchmarkDefaultResolver($hospitalAccess);
-        $payload = $resolver->maybeRedirectPayload(new Request(), $this->createMock(User::class));
+        $payload = $resolver->maybeRedirectPayload(new Request(), $this->createStub(User::class));
 
         self::assertNotNull($payload);
         self::assertSame('public', $payload['query']['scope']);
@@ -30,13 +30,13 @@ final class BenchmarkDefaultResolverTest extends TestCase
 
     public function testRedirectsToMyHospitalsAndHospitalCohortForParticipant(): void
     {
-        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess = $this->createStub(HospitalAccessInterface::class);
         $hospitalAccess->method('canUseBenchmarkingScope')->willReturn(true);
 
         $resolver = new BenchmarkDefaultResolver($hospitalAccess);
         $payload = $resolver->maybeRedirectPayload(
             new Request(),
-            $this->createMock(User::class),
+            $this->createStub(User::class),
         );
 
         self::assertNotNull($payload);
@@ -48,7 +48,7 @@ final class BenchmarkDefaultResolverTest extends TestCase
 
     public function testDoesNotRedirectWhenComparisonScopePresent(): void
     {
-        $hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $hospitalAccess = $this->createStub(HospitalAccessInterface::class);
 
         $resolver = new BenchmarkDefaultResolver($hospitalAccess);
         $request = new Request([StatisticsQueryKeys::COMPARISON_SCOPE => 'public']);

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkHeatmapBuilderTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkHeatmapBuilderTest.php
@@ -19,7 +19,7 @@ final class BenchmarkHeatmapBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
             static fn (string $id): string => str_contains($id, 'weekday.') ? substr($id, strrpos($id, '.') + 1) : $id,
         );

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkReportServiceTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkReportServiceTest.php
@@ -45,7 +45,7 @@ final class BenchmarkReportServiceTest extends TestCase
 
         $aggregationProvider = new FixedBenchmarkAggregationProvider($aggregation);
 
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnArgument(0);
 
         $this->service = new BenchmarkReportService(
@@ -109,7 +109,7 @@ final class BenchmarkReportServiceTest extends TestCase
             [],
         );
 
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnArgument(0);
 
         $service = new BenchmarkReportService(

--- a/tests/Statistics/Unit/Controller/ReportsPagePresenterTest.php
+++ b/tests/Statistics/Unit/Controller/ReportsPagePresenterTest.php
@@ -18,7 +18,7 @@ final class ReportsPagePresenterTest extends TestCase
 {
     public function testAddsLimitFooterAndSelectUrls(): void
     {
-        $router = $this->createMock(UrlGeneratorInterface::class);
+        $router = $this->createStub(UrlGeneratorInterface::class);
         $router->method('generate')->willReturnCallback(
             static fn (string $routeName, array $params): string => sprintf('%s?%s', $routeName, http_build_query($params)),
         );
@@ -39,7 +39,7 @@ final class ReportsPagePresenterTest extends TestCase
 
     private function definition(string $key): ReportDefinitionInterface
     {
-        $definition = $this->createMock(ReportDefinitionInterface::class);
+        $definition = $this->createStub(ReportDefinitionInterface::class);
         $definition->method('key')->willReturn($key);
         $definition->method('labelTranslationKey')->willReturn('label.'.$key);
         $definition->method('descriptionTranslationKey')->willReturn('description.'.$key);

--- a/tests/Statistics/Unit/GenericAnalysis/ChartPrimaryBucketLimiterTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/ChartPrimaryBucketLimiterTest.php
@@ -14,7 +14,7 @@ final class ChartPrimaryBucketLimiterTest extends TestCase
 
     protected function setUp(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Other');
 
         $this->limiter = new ChartPrimaryBucketLimiter($translator);

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisDimensionPolicyTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAnalysisDimensionPolicyTest.php
@@ -18,17 +18,17 @@ final class GenericAnalysisDimensionPolicyTest extends TestCase
 {
     private GenericAnalysisDimensionPolicy $policy;
 
-    private \PHPUnit\Framework\MockObject\MockObject $hospitalAccess;
+    private HospitalAccessInterface&\PHPUnit\Framework\MockObject\Stub $hospitalAccess;
 
     protected function setUp(): void
     {
-        $this->hospitalAccess = $this->createMock(HospitalAccessInterface::class);
+        $this->hospitalAccess = $this->createStub(HospitalAccessInterface::class);
         $this->policy = new GenericAnalysisDimensionPolicy($this->hospitalAccess, new DimensionRegistry());
     }
 
     public function testPublicScopeDisallowsHospitalForParticipant(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
 
         self::assertFalse($this->policy->isAllowed(
@@ -40,7 +40,7 @@ final class GenericAnalysisDimensionPolicyTest extends TestCase
 
     public function testCohortScopeAllowsHospitalForParticipant(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
 
         self::assertTrue($this->policy->isAllowed(
@@ -52,7 +52,7 @@ final class GenericAnalysisDimensionPolicyTest extends TestCase
 
     public function testAdminAllowsHospitalOnPublicScope(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(true);
 
         self::assertTrue($this->policy->isAllowed(
@@ -64,7 +64,7 @@ final class GenericAnalysisDimensionPolicyTest extends TestCase
 
     public function testStateDimensionRequiresStateScope(): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createStub(User::class);
         $this->hospitalAccess->method('isAdminHospitalScopeUser')->willReturn(false);
 
         self::assertFalse($this->policy->isAllowed(

--- a/tests/Statistics/Unit/UI/Http/Controller/StatisticsDrawerFilterBadgePresenterTest.php
+++ b/tests/Statistics/Unit/UI/Http/Controller/StatisticsDrawerFilterBadgePresenterTest.php
@@ -12,7 +12,7 @@ final class StatisticsDrawerFilterBadgePresenterTest extends TestCase
 {
     public function testPresentsReadableBadgesSortedByLabel(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(static fn (string $key): string => match ($key) {
             'label.gender' => 'Gender',
             'label.urgency' => 'Urgency',
@@ -45,7 +45,7 @@ final class StatisticsDrawerFilterBadgePresenterTest extends TestCase
 
     public function testPresentsAgeGroupInfectionAndBooleanNo(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(static fn (string $key): string => match ($key) {
             'label.age_group' => 'Age group',
             'label.infection' => 'Infection',


### PR DESCRIPTION
## Summary
- Align Feedback, Engagement, Import, Shared mail, and Statistics unit tests with the stub/spy/mock policy from the test-architecture audit (#324)
- Use `createStub()` for input-only collaborators; keep `createMock()` + `expects()` only where call count / `never` is the behaviour under test
- No production code changes

## Test plan
- [x] `make ci`
- [x] Targeted PHPUnit for touched mail/import tests
- [x] `vendor/bin/phpunit tests/Statistics/Unit`
- [x] CI unit + database jobs on the PR