### PR TITLE
test: Cover hospital permission mask and voter deny paths

### DIFF
--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -170,7 +170,8 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] Backlog formulated (B1–B18)
 - [x] B1–B5 double hygiene PRs
 - [x] B6–B8 large-class splits
-- [ ] B9–B13 coverage gap PRs (as needed)
+- [x] B9 hospital permission / voter edge cases
+- [ ] B10–B13 coverage gap PRs (as needed)
 - [ ] B14–B18 process / automation (optional)
 
 When opening GitHub issues, link back to this file and to #324.

--- a/tests/Allocation/Integration/Application/Service/HospitalPermissionAccessTest.php
+++ b/tests/Allocation/Integration/Application/Service/HospitalPermissionAccessTest.php
@@ -94,6 +94,67 @@ final class HospitalPermissionAccessTest extends KernelTestCase
         self::assertTrue($this->access->canManageAccessGrants($admin, $hospital));
     }
 
+    public function testAdminHasPermissionOnForeignHospitalWithoutGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $admin = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        self::assertTrue($this->access->hasPermission($admin, (int) $hospital->getId(), HospitalPermission::Import));
+        self::assertTrue($this->access->hasPermission($admin, (int) $hospital->getId(), HospitalPermission::Benchmarking));
+    }
+
+    public function testHasPermissionFalseWhenNoGrantAndNotOwner(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        self::assertFalse($this->access->hasPermission($intruder, (int) $hospital->getId(), HospitalPermission::View));
+    }
+
+    public function testHasPermissionFalseForUnknownHospitalId(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        self::assertFalse($this->access->hasPermission($user, 999_999_999, HospitalPermission::View));
+    }
+
+    public function testHasPermissionFalseForWrongHospital(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospitalA = $this->createHospitalForOwner($owner);
+        $hospitalB = $this->createHospitalForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospitalA,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertTrue($this->access->hasPermission($grantee, (int) $hospitalA->getId(), HospitalPermission::View));
+        self::assertFalse($this->access->hasPermission($grantee, (int) $hospitalB->getId(), HospitalPermission::View));
+    }
+
+    public function testCanEditHospitalDeniedForGranteeWithViewGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertFalse($this->access->canEditHospital($grantee, $hospital));
+        self::assertFalse($this->access->canManageAccessGrants($grantee, $hospital));
+    }
+
     private function createHospitalForOwner(object $owner): object
     {
         StateFactory::createOne();

--- a/tests/Allocation/Integration/Infrastructure/Security/HospitalVoterTest.php
+++ b/tests/Allocation/Integration/Infrastructure/Security/HospitalVoterTest.php
@@ -166,6 +166,40 @@ final class HospitalVoterTest extends KernelTestCase
         );
     }
 
+    public function testEditDeniedForGranteeWithViewGrant(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $grantee = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $hospital = $this->createHospitalForOwner($owner);
+
+        HospitalAccessGrantFactory::createOne([
+            'hospital' => $hospital,
+            'user' => $grantee,
+            'permissions' => HospitalPermissionMask::fromPermissions([HospitalPermission::View]),
+            'createdBy' => $owner,
+        ]);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($grantee), $hospital, [HospitalVoter::EDIT]),
+        );
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($grantee), $hospital, [HospitalVoter::MANAGE_ACCESS_GRANTS]),
+        );
+    }
+
+    public function testEditDeniedForForeignParticipant(): void
+    {
+        [, $hospital] = $this->createOwnedHospital();
+        $intruder = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
+            $this->voter->vote($this->createToken($intruder), $hospital, [HospitalVoter::EDIT]),
+        );
+    }
+
     public function testSupportsTypeForHospitalOnly(): void
     {
         self::assertTrue($this->voter->supportsType(Hospital::class));

--- a/tests/Allocation/Unit/Domain/HospitalPermissionMaskTest.php
+++ b/tests/Allocation/Unit/Domain/HospitalPermissionMaskTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Allocation\Unit\Domain;
 
 use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Allocation\Domain\HospitalPermissionMask;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HospitalPermissionMaskTest extends TestCase
@@ -25,6 +26,7 @@ final class HospitalPermissionMaskTest extends TestCase
         $mask = HospitalPermissionMask::fromPermissions([HospitalPermission::Statistics]);
 
         self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Statistics));
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::View));
         self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Benchmarking));
     }
 
@@ -33,5 +35,80 @@ final class HospitalPermissionMaskTest extends TestCase
         $raw = HospitalPermission::Benchmarking->value;
 
         self::assertFalse(HospitalPermissionMask::isValid($raw));
+    }
+
+    public function testImportImpliesViewButNotBenchmarking(): void
+    {
+        $mask = HospitalPermissionMask::fromPermissions([HospitalPermission::Import]);
+
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Import));
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::View));
+        self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Statistics));
+        self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Benchmarking));
+    }
+
+    public function testExportImpliesViewButNotImport(): void
+    {
+        $mask = HospitalPermissionMask::fromPermissions([HospitalPermission::Export]);
+
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::Export));
+        self::assertTrue(HospitalPermissionMask::has($mask, HospitalPermission::View));
+        self::assertFalse(HospitalPermissionMask::has($mask, HospitalPermission::Import));
+    }
+
+    public function testEmptyPermissionsYieldZeroMask(): void
+    {
+        self::assertSame(0, HospitalPermissionMask::fromPermissions([]));
+        self::assertTrue(HospitalPermissionMask::isValid(0));
+    }
+
+    public function testFullAssignableMaskIsValid(): void
+    {
+        $mask = HospitalPermissionMask::fromPermissions(HospitalPermission::assignableCases());
+
+        self::assertSame(31, $mask);
+        self::assertTrue(HospitalPermissionMask::isValid($mask));
+    }
+
+    #[DataProvider('provideRequiredBits')]
+    public function testRequiredBits(HospitalPermission $permission, int $expected): void
+    {
+        self::assertSame($expected, HospitalPermissionMask::requiredBits($permission));
+    }
+
+    /**
+     * @return iterable<string, array{HospitalPermission, int}>
+     */
+    public static function provideRequiredBits(): iterable
+    {
+        yield 'view' => [HospitalPermission::View, 1];
+        yield 'statistics' => [HospitalPermission::Statistics, 3];
+        yield 'import' => [HospitalPermission::Import, 5];
+        yield 'export' => [HospitalPermission::Export, 9];
+        yield 'benchmarking' => [HospitalPermission::Benchmarking, 19];
+    }
+
+    public function testHasRequiresAllImpliedBits(): void
+    {
+        self::assertFalse(HospitalPermissionMask::has(HospitalPermission::Statistics->value, HospitalPermission::Statistics));
+        self::assertFalse(HospitalPermissionMask::has(HospitalPermission::Import->value, HospitalPermission::Import));
+        self::assertTrue(HospitalPermissionMask::has(5, HospitalPermission::Import));
+        self::assertFalse(HospitalPermissionMask::has(5, HospitalPermission::Statistics));
+    }
+
+    public function testIsValidRejectsUnknownBitsAndIncompleteMasks(): void
+    {
+        self::assertFalse(HospitalPermissionMask::isValid(32));
+        self::assertFalse(HospitalPermissionMask::isValid(2));
+        self::assertTrue(HospitalPermissionMask::isValid(3));
+        self::assertTrue(HospitalPermissionMask::isValid(31));
+    }
+
+    public function testNormalizeFillsImpliedBitsAndStripsUnknownBits(): void
+    {
+        self::assertSame(3, HospitalPermissionMask::normalize(2));
+        self::assertSame(19, HospitalPermissionMask::normalize(16));
+        self::assertSame(0, HospitalPermissionMask::normalize(32));
+        self::assertSame(5, HospitalPermissionMask::normalize(4));
     }
 }

--- a/tests/Allocation/Unit/Entity/HospitalAccessGrantTest.php
+++ b/tests/Allocation/Unit/Entity/HospitalAccessGrantTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Entity;
+
+use App\Allocation\Domain\Entity\HospitalAccessGrant;
+use App\Allocation\Domain\Enum\HospitalPermission;
+use App\Allocation\Domain\HospitalPermissionMask;
+use PHPUnit\Framework\TestCase;
+
+final class HospitalAccessGrantTest extends TestCase
+{
+    public function testSetPermissionsStoresNormalizedMaskFromPermissionList(): void
+    {
+        $grant = new HospitalAccessGrant();
+        $mask = HospitalPermissionMask::fromPermissions([
+            HospitalPermission::View,
+            HospitalPermission::Statistics,
+        ]);
+
+        $grant->setPermissions($mask);
+
+        self::assertSame($mask, $grant->getPermissions());
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::View));
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::Statistics));
+    }
+
+    public function testSetPermissionsNormalizesIncompleteRawMaskBeforeStore(): void
+    {
+        $grant = new HospitalAccessGrant();
+
+        // Raw Statistics bit alone is invalid for has()/isValid(), but setPermissions normalizes first.
+        $grant->setPermissions(HospitalPermission::Statistics->value);
+
+        self::assertSame(3, $grant->getPermissions());
+        self::assertTrue(HospitalPermissionMask::isValid($grant->getPermissions()));
+    }
+
+    public function testSetPermissionsStripsUnknownBitsViaNormalize(): void
+    {
+        $grant = new HospitalAccessGrant();
+
+        $grant->setPermissions(32);
+
+        self::assertSame(0, $grant->getPermissions());
+    }
+
+    public function testSetPermissionsNormalizesBenchmarkingToIncludeDependencies(): void
+    {
+        $grant = new HospitalAccessGrant();
+
+        $grant->setPermissions(HospitalPermission::Benchmarking->value);
+
+        self::assertSame(19, $grant->getPermissions());
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::Benchmarking));
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::Statistics));
+        self::assertTrue(HospitalPermissionMask::has($grant->getPermissions(), HospitalPermission::View));
+    }
+}


### PR DESCRIPTION
## Summary
- Expand unit coverage for `HospitalPermissionMask` (implied bits, normalize/isValid edges) and `HospitalAccessGrant` permission storage
- Add Integration deny/edge cases for `HospitalPermissionAccess` and `HospitalVoter` (admin without grant, missing/wrong hospital, grantee cannot EDIT/MANAGE)
- Pure domain logic stays in Unit; Access/Voter deny paths use Integration because final collaborators cannot be PHPUnit-mocked
- No production code changes; advances test-architecture backlog item for hospital permissions (#324)

## Test plan
- [x] `HospitalPermissionMaskTest` + `HospitalAccessGrantTest`
- [x] Extended `HospitalPermissionAccessTest` + `HospitalVoterTest` (Integration)
- [x] `make ci`
- [ ] CI unit + database jobs on the PR