### PR TITLE
chore: Collect and upload PCOV coverage from unit and database CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,11 +104,14 @@ jobs:
 
             - name: Upload unit test results to Codecov
               if: success()
-              uses: codecov/test-results-action@v1
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
+                  report_type: test_results
                   files: junit-unit.xml
                   flags: unit
+                  name: unit-test-results
+                  disable_search: true
                   fail_ci_if_error: false
 
     database:
@@ -199,9 +202,12 @@ jobs:
 
             - name: Upload integration test results to Codecov
               if: success()
-              uses: codecov/test-results-action@v1
+              uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
+                  report_type: test_results
                   files: junit-integration.xml
                   flags: integration
+                  name: integration-test-results
+                  disable_search: true
                   fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
+                  coverage: pcov
                   extensions: "intl, mbstring, zip"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
@@ -80,7 +81,35 @@ jobs:
               run: composer install --ansi --no-interaction --no-progress
 
             - name: Execute unit tests via ParaTest
-              run: vendor/bin/paratest --testsuite unit --processes=4 --no-coverage --order-by duration --stop-on-failure
+              run: |
+                  mkdir -p var/coverage/logs
+                  vendor/bin/paratest \
+                    --testsuite unit \
+                    --processes=4 \
+                    --coverage-clover=var/coverage/logs/clover-unit.xml \
+                    --log-junit=junit-unit.xml \
+                    --order-by duration \
+                    --stop-on-failure
+
+            - name: Upload unit coverage to Codecov
+              if: success()
+              uses: codecov/codecov-action@v7
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: var/coverage/logs/clover-unit.xml
+                  flags: unit
+                  name: unit
+                  disable_search: true
+                  fail_ci_if_error: true
+
+            - name: Upload unit test results to Codecov
+              if: success()
+              uses: codecov/test-results-action@v1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: junit-unit.xml
+                  flags: unit
+                  fail_ci_if_error: false
 
     database:
         name: Database tests (PHP ${{ matrix.php-version }})
@@ -114,7 +143,7 @@ jobs:
             - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
-                  coverage: xdebug
+                  coverage: pcov
                   extensions: "intl, mbstring, pdo_pgsql, zip"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
@@ -144,20 +173,35 @@ jobs:
 
             - name: Execute database-backed tests via ParaTest
               run: |
-                  vendor/bin/paratest --testsuite all --exclude-testsuite unit --processes=4 --log-junit junit.xml --order-by duration --stop-on-failure
+                  mkdir -p var/coverage/logs
+                  vendor/bin/paratest \
+                    --testsuite all \
+                    --exclude-testsuite unit \
+                    --processes=4 \
+                    --coverage-clover=var/coverage/logs/clover-integration.xml \
+                    --log-junit=junit-integration.xml \
+                    --order-by duration \
+                    --stop-on-failure
                   php bin/report-slowest-tests 10 || true
               env:
                   DATABASE_URL: postgres://app:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/app
-                  XDEBUG_MODE: coverage
 
-            - name: Upload coverage reports to Codecov
+            - name: Upload integration coverage to Codecov
               if: success()
               uses: codecov/codecov-action@v7
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
+                  files: var/coverage/logs/clover-integration.xml
+                  flags: integration
+                  name: integration
+                  disable_search: true
+                  fail_ci_if_error: true
 
-            - name: Upload test results to Codecov
+            - name: Upload integration test results to Codecov
               if: success()
               uses: codecov/test-results-action@v1
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
+                  files: junit-integration.xml
+                  flags: integration
+                  fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,14 @@ coverage:
         # adjust accordingly based on how flaky your tests are
         # this allows a 10% drop from the previous base commit coverage
         threshold: 10%
+
+# CI uploads separate clover reports from the unit and database jobs.
+# Carryforward keeps the other flag's last successful report when only one job re-runs.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit
+      carryforward: true
+    - name: integration
+      carryforward: true

--- a/docs/03-development/testing.md
+++ b/docs/03-development/testing.md
@@ -84,9 +84,11 @@ make lint-trans-de  # lint DE catalogue only
 
 ## CI reference
 
-- **Unit job** (parallel, no database): `vendor/bin/paratest --testsuite unit` — stops on first failure
-- **Database job** (parallel, PostgreSQL, migrations): `bin/phpunit --testsuite all --exclude-testsuite unit` — stops on first failure; either job failing fails the workflow
+- **Unit job** (parallel, no database, PCOV): `paratest --testsuite unit --coverage-clover=…` → Codecov flag `unit`
+- **Database job** (parallel, PostgreSQL, PCOV): `paratest --testsuite all --exclude-testsuite unit --coverage-clover=…` → Codecov flag `integration`
+- Either job failing fails the workflow; Codecov merges both flags for project coverage
 - Workflows: `.github/workflows/tests.yml`
+- Codecov flags: [`codecov.yml`](../../codecov.yml)
 - Linting: `.github/workflows/lint.yml`
 - Security scan: `.github/workflows/security.yml`
 


### PR DESCRIPTION
## Summary
- Enable PCOV coverage in both the unit and database ParaTest jobs
- Upload clover reports to Codecov with explicit `unit` and `integration` flags so project coverage merges both suites
- Document flags/carryforward in `codecov.yml` and refresh the testing CI notes

## Test plan
- [ ] Push branch / open PR and confirm both jobs produce clover files
- [ ] Codecov PR comment shows combined coverage with `unit` + `integration` flags
- [ ] Coverage upload steps fail the job if the clover file is missing (`fail_ci_if_error: true`)