### PR TITLE
test(import): cover reject and invalid-input paths

### DIFF
--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -171,7 +171,8 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] B1–B5 double hygiene PRs
 - [x] B6–B8 large-class splits
 - [x] B9 hospital permission / voter edge cases
-- [ ] B10–B13 coverage gap PRs (as needed)
+- [x] B10 import reject and invalid-input paths
+- [ ] B11–B13 coverage gap PRs (as needed)
 - [ ] B14–B18 process / automation (optional)
 
 When opening GitHub issues, link back to this file and to #324.

--- a/tests/Import/Integration/Infrastructure/Adapter/DoctrineRejectWriterTest.php
+++ b/tests/Import/Integration/Infrastructure/Adapter/DoctrineRejectWriterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Integration\Infrastructure\Adapter;
+
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Entity\ImportReject;
+use App\Import\Infrastructure\Adapter\DoctrineRejectWriter;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class DoctrineRejectWriterTest extends DatabaseKernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->em = self::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testStartWriteCloseCreatesOneImportReject(): void
+    {
+        $hospital = HospitalFactory::createOne();
+        $import = ImportFactory::createOne(['hospital' => $hospital]);
+
+        $writer = new DoctrineRejectWriter($this->em);
+
+        $writer->start($import);
+        $writer->write(['age' => 'not-a-number'], ['age: Invalid age'], 3);
+        $writer->close();
+
+        self::assertSame(1, $writer->getCount());
+        self::assertNull($writer->getPath());
+        self::assertSame('db', $writer->getType());
+
+        $reject = $this->em->getRepository(ImportReject::class)->findOneBy([]);
+        self::assertInstanceOf(ImportReject::class, $reject);
+        self::assertSame(3, $reject->getLineNumber());
+        self::assertSame(['age: Invalid age'], $reject->getMessages());
+        self::assertSame(['age' => 'not-a-number'], $reject->getRow());
+        self::assertSame($import->getId(), $reject->getImport()?->getId());
+    }
+
+    public function testWriteBeforeStartThrowsLogicException(): void
+    {
+        $writer = new DoctrineRejectWriter($this->em);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Reject writer not started. Call start() before write().');
+
+        $writer->write(['age' => 'not-a-number'], ['age: Invalid age'], 1);
+    }
+
+    public function testStartWithUnpersistedImportThrowsLogicException(): void
+    {
+        $writer = new DoctrineRejectWriter($this->em);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Import has no id assigned yet.');
+
+        $writer->start(new Import());
+    }
+}

--- a/tests/Import/Unit/Application/Exception/ImportExceptionTest.php
+++ b/tests/Import/Unit/Application/Exception/ImportExceptionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Exception;
+
+use App\Import\Application\Exception\ImportException;
+use PHPUnit\Framework\TestCase;
+
+final class ImportExceptionTest extends TestCase
+{
+    public function testSummarizeWithMessageOnly(): void
+    {
+        $exception = new ImportException('Something went wrong.');
+
+        self::assertSame('Something went wrong.', $exception->summarize());
+    }
+
+    public function testSummarizeWithCodeStrFieldAndValue(): void
+    {
+        $exception = new ImportException(
+            'Invalid value.',
+            field: 'age',
+            value: '-1',
+            codeStr: 'INVALID_VALUE',
+        );
+
+        self::assertSame(
+            'INVALID_VALUE | Invalid value. | field=age | value="-1"',
+            $exception->summarize(),
+        );
+    }
+
+    public function testContextFiltersEmptyAndNullValues(): void
+    {
+        $exception = new ImportException(
+            'Invalid value.',
+            field: null,
+            value: '',
+            codeStr: null,
+        );
+
+        self::assertSame([
+            'exception' => ImportException::class,
+            'message' => 'Invalid value.',
+        ], $exception->context());
+    }
+
+    public function testContextIncludesAllProvidedValues(): void
+    {
+        $exception = new ImportException(
+            'Invalid value.',
+            field: 'age',
+            value: '-1',
+            codeStr: 'INVALID_VALUE',
+        );
+
+        self::assertSame([
+            'error_code' => 'INVALID_VALUE',
+            'field' => 'age',
+            'value' => '-1',
+            'exception' => ImportException::class,
+            'message' => 'Invalid value.',
+        ], $exception->context());
+    }
+}

--- a/tests/Import/Unit/Application/Factory/RejectWriterFactoryTest.php
+++ b/tests/Import/Unit/Application/Factory/RejectWriterFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Factory;
+
+use App\Import\Application\Contracts\RejectWriterInterface;
+use App\Import\Application\Factory\RejectWriterFactory;
+use PHPUnit\Framework\TestCase;
+
+final class RejectWriterFactoryTest extends TestCase
+{
+    private RejectWriterInterface $dbWriter;
+    private RejectWriterInterface $csvWriter;
+
+    protected function setUp(): void
+    {
+        $this->dbWriter = $this->createStub(RejectWriterInterface::class);
+        $this->dbWriter->method('getType')->willReturn('db');
+
+        $this->csvWriter = $this->createStub(RejectWriterInterface::class);
+        $this->csvWriter->method('getType')->willReturn('csv');
+    }
+
+    public function testCreateWithoutArgumentReturnsDefaultTypeWriter(): void
+    {
+        $factory = new RejectWriterFactory([$this->dbWriter, $this->csvWriter], 'db');
+
+        self::assertSame($this->dbWriter, $factory->create());
+    }
+
+    public function testCreateWithExplicitTypeReturnsMatchingWriter(): void
+    {
+        $factory = new RejectWriterFactory([$this->dbWriter, $this->csvWriter], 'db');
+
+        self::assertSame($this->csvWriter, $factory->create('csv'));
+    }
+
+    public function testCreateWithUnknownTypeThrowsInvalidArgumentException(): void
+    {
+        $factory = new RejectWriterFactory([$this->dbWriter, $this->csvWriter], 'db');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Available/');
+
+        $factory->create('unknown');
+    }
+}

--- a/tests/Import/Unit/Application/Service/AllocationImporterTest.php
+++ b/tests/Import/Unit/Application/Service/AllocationImporterTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Import\Application\Contracts\AllocationPersisterInterface;
+use App\Import\Application\Contracts\AllocationRowProcessorInterface;
+use App\Import\Application\Contracts\RejectWriterInterface;
+use App\Import\Application\Contracts\RowTypeDetectorInterface;
+use App\Import\Application\Exception\RowRejectException;
+use App\Import\Application\Service\AllocationImporter;
+use App\Import\Application\Service\AllocationRowProcessorRegistry;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\AllocationRowType;
+use App\Tests\Import\Doubles\Service\Adapter\InMemoryRejectWriter;
+use App\Tests\Import\Doubles\Service\Adapter\InMemoryRowReader;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class AllocationImporterTest extends TestCase
+{
+    private function createNoopProcessor(AllocationRowType $type): AllocationRowProcessorInterface
+    {
+        return new readonly class($type) implements AllocationRowProcessorInterface {
+            public function __construct(private AllocationRowType $type)
+            {
+            }
+
+            public function type(): AllocationRowType
+            {
+                return $this->type;
+            }
+
+            public function warm(): void
+            {
+            }
+
+            public function process(array $row, Import $import, int $lineNo): void
+            {
+            }
+        };
+    }
+
+    private function createThrowingProcessor(AllocationRowType $type, \Throwable $exception): AllocationRowProcessorInterface
+    {
+        return new readonly class($type, $exception) implements AllocationRowProcessorInterface {
+            public function __construct(
+                private AllocationRowType $type,
+                private \Throwable $exception,
+            ) {
+            }
+
+            public function type(): AllocationRowType
+            {
+                return $this->type;
+            }
+
+            public function warm(): void
+            {
+            }
+
+            public function process(array $row, Import $import, int $lineNo): void
+            {
+                throw $this->exception;
+            }
+        };
+    }
+
+    public function testUnknownRowTypeIsRejectedAndSummarized(): void
+    {
+        $reader = InMemoryRowReader::fromAssocRows([
+            ['foo' => 'bar'],
+        ]);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $detector = $this->createStub(RowTypeDetectorInterface::class);
+        $detector->method('detect')->willReturn(null);
+
+        $persister = $this->createStub(AllocationPersisterInterface::class);
+
+        $registry = new AllocationRowProcessorRegistry([]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with('reject.row_type_unknown', $this->callback(
+                static fn (array $context): bool => ['Unable to detect a supported row type.'] === $context['messages'],
+            ));
+
+        $importer = new AllocationImporter($reader, $detector, $registry, $persister, $rejectWriter, $logger);
+
+        $summary = $importer->import(new Import());
+
+        self::assertSame(1, $summary->total);
+        self::assertSame(0, $summary->ok);
+        self::assertSame(1, $summary->rejected);
+
+        $records = $rejectWriter->all();
+        self::assertCount(1, $records);
+        self::assertSame(['Unable to detect a supported row type.'], $records[0]['messages']);
+    }
+
+    public function testRowRejectExceptionFromProcessorIsWrittenAndSummarized(): void
+    {
+        $reader = InMemoryRowReader::fromAssocRows([
+            ['pzc' => 'A1', 'age' => 'not-a-number'],
+        ]);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $detector = $this->createStub(RowTypeDetectorInterface::class);
+        $detector->method('detect')->willReturn(AllocationRowType::ALLOCATION);
+
+        $persister = $this->createStub(AllocationPersisterInterface::class);
+
+        $processor = $this->createThrowingProcessor(
+            AllocationRowType::ALLOCATION,
+            new RowRejectException(['age: invalid']),
+        );
+        $registry = new AllocationRowProcessorRegistry([$processor]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with('reject.row_rejected', $this->callback(
+                static fn (array $context): bool => ['age: invalid'] === $context['messages'],
+            ));
+
+        $importer = new AllocationImporter($reader, $detector, $registry, $persister, $rejectWriter, $logger);
+
+        $summary = $importer->import(new Import());
+
+        self::assertSame(1, $summary->total);
+        self::assertSame(0, $summary->ok);
+        self::assertSame(1, $summary->rejected);
+
+        $records = $rejectWriter->all();
+        self::assertCount(1, $records);
+        self::assertSame(['age: invalid'], $records[0]['messages']);
+    }
+
+    public function testOkAndRejectedRowsAreCountedAndPersisterFlushesOnce(): void
+    {
+        $reader = InMemoryRowReader::fromAssocRows([
+            ['pzc' => 'A1'],
+            ['foo' => 'bar'],
+        ]);
+        $rejectWriter = new InMemoryRejectWriter();
+
+        $detector = $this->createStub(RowTypeDetectorInterface::class);
+        $detector->method('detect')->willReturnOnConsecutiveCalls(AllocationRowType::ALLOCATION, null);
+
+        $persister = $this->createMock(AllocationPersisterInterface::class);
+        $persister->expects($this->once())->method('flush');
+
+        $processor = $this->createNoopProcessor(AllocationRowType::ALLOCATION);
+        $registry = new AllocationRowProcessorRegistry([$processor]);
+
+        $logger = $this->createStub(LoggerInterface::class);
+
+        $importer = new AllocationImporter($reader, $detector, $registry, $persister, $rejectWriter, $logger);
+
+        $summary = $importer->import(new Import());
+
+        self::assertSame(2, $summary->total);
+        self::assertSame(1, $summary->ok);
+        self::assertSame(1, $summary->rejected);
+    }
+
+    public function testUnexpectedExceptionFromProcessorIsRethrownAndRejectWriterIsClosed(): void
+    {
+        $reader = InMemoryRowReader::fromAssocRows([
+            ['pzc' => 'A1'],
+        ]);
+
+        $closeTrackingRejectWriter = new class(new InMemoryRejectWriter()) implements RejectWriterInterface {
+            public bool $closed = false;
+
+            public function __construct(private readonly InMemoryRejectWriter $inner)
+            {
+            }
+
+            public function start(Import $import): void
+            {
+                $this->inner->start($import);
+            }
+
+            public function write(array $row, array $messages, ?int $line = null): void
+            {
+                $this->inner->write($row, $messages, $line);
+            }
+
+            public function close(): void
+            {
+                $this->closed = true;
+                $this->inner->close();
+            }
+
+            public function getCount(): int
+            {
+                return $this->inner->getCount();
+            }
+
+            public function getPath(): ?string
+            {
+                return $this->inner->getPath();
+            }
+
+            public function getType(): string
+            {
+                return $this->inner->getType();
+            }
+        };
+
+        $detector = $this->createStub(RowTypeDetectorInterface::class);
+        $detector->method('detect')->willReturn(AllocationRowType::ALLOCATION);
+
+        $persister = $this->createStub(AllocationPersisterInterface::class);
+
+        $processor = $this->createThrowingProcessor(
+            AllocationRowType::ALLOCATION,
+            new \RuntimeException('boom'),
+        );
+        $registry = new AllocationRowProcessorRegistry([$processor]);
+
+        $logger = $this->createStub(LoggerInterface::class);
+
+        $importer = new AllocationImporter($reader, $detector, $registry, $persister, $closeTrackingRejectWriter, $logger);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        try {
+            $importer->import(new Import());
+        } finally {
+            self::assertTrue($closeTrackingRejectWriter->closed);
+        }
+    }
+}

--- a/tests/Import/Unit/Application/Service/AllocationRowProcessorTest.php
+++ b/tests/Import/Unit/Application/Service/AllocationRowProcessorTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Hospital;
+use App\Import\Application\Contracts\AllocationEntityResolverInterface;
+use App\Import\Application\Contracts\AllocationPersisterInterface;
+use App\Import\Application\Contracts\RowToDtoMapperInterface;
+use App\Import\Application\DTO\AllocationRowDTO;
+use App\Import\Application\Exception\ReferenceNotFoundException;
+use App\Import\Application\Exception\RowRejectException;
+use App\Import\Application\Service\AllocationRowProcessor;
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\AllocationRowType;
+use App\Import\Infrastructure\Mapping\AllocationImportFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class AllocationRowProcessorTest extends TestCase
+{
+    /**
+     * @param iterable<AllocationEntityResolverInterface> $resolvers
+     */
+    private function createFactory(EntityManagerInterface $em, iterable $resolvers = []): AllocationImportFactory
+    {
+        return new AllocationImportFactory($em, $resolvers);
+    }
+
+    private function createEmStub(): EntityManagerInterface
+    {
+        return $this->createStub(EntityManagerInterface::class);
+    }
+
+    public function testTypeReturnsAllocation(): void
+    {
+        $validator = $this->createStub(ValidatorInterface::class);
+        $mapper = $this->createStub(RowToDtoMapperInterface::class);
+        $mapper->method('mapAssoc')->willReturn(new AllocationRowDTO());
+        $factory = $this->createFactory($this->createEmStub());
+        $persister = $this->createStub(AllocationPersisterInterface::class);
+
+        $processor = new AllocationRowProcessor($validator, $mapper, $factory, $persister);
+
+        self::assertSame(AllocationRowType::ALLOCATION, $processor->type());
+    }
+
+    public function testWarmDelegatesToFactoryWithoutThrowing(): void
+    {
+        $warmed = new class implements AllocationEntityResolverInterface {
+            public bool $warmed = false;
+
+            #[\Override]
+            public function warm(): void
+            {
+                $this->warmed = true;
+            }
+
+            #[\Override]
+            public function supports(Allocation $entity, AllocationRowDTO $dto): bool
+            {
+                return false;
+            }
+
+            #[\Override]
+            public function apply(Allocation $entity, AllocationRowDTO $dto): void
+            {
+            }
+        };
+
+        $validator = $this->createStub(ValidatorInterface::class);
+        $mapper = $this->createStub(RowToDtoMapperInterface::class);
+        $mapper->method('mapAssoc')->willReturn(new AllocationRowDTO());
+        $factory = $this->createFactory($this->createEmStub(), [$warmed]);
+        $persister = $this->createStub(AllocationPersisterInterface::class);
+
+        $processor = new AllocationRowProcessor($validator, $mapper, $factory, $persister);
+
+        $processor->warm();
+
+        self::assertTrue($warmed->warmed);
+    }
+
+    public function testValidationFailureThrowsRowRejectExceptionAndNeverPersists(): void
+    {
+        $violation = new ConstraintViolation(
+            message: 'Invalid age',
+            messageTemplate: null,
+            parameters: [],
+            root: new AllocationRowDTO(),
+            propertyPath: 'age',
+            invalidValue: -1,
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturn($violations);
+
+        $mapper = $this->createStub(RowToDtoMapperInterface::class);
+        $mapper->method('mapAssoc')->willReturn(new AllocationRowDTO());
+
+        $factory = $this->createFactory($this->createEmStub());
+
+        $persister = $this->createMock(AllocationPersisterInterface::class);
+        $persister->expects($this->never())->method('persist');
+        $persister->expects($this->never())->method('flush');
+
+        $processor = new AllocationRowProcessor($validator, $mapper, $factory, $persister);
+
+        try {
+            $processor->process(['age' => '-1'], new Import(), 1);
+            self::fail('Expected RowRejectException to be thrown.');
+        } catch (RowRejectException $e) {
+            self::assertSame(['age: Invalid age'], $e->messages());
+        }
+    }
+
+    public function testImportExceptionFromFactoryIsMappedToRowRejectException(): void
+    {
+        $hospital = new Hospital();
+        $import = new Import();
+        $import->setHospital($hospital);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getReference')->willReturnCallback(
+            static fn (string $class, mixed $id): object => match ($class) {
+                Hospital::class => $hospital,
+                Import::class => $import,
+                default => throw new \LogicException("Unexpected reference class: {$class}"),
+            },
+        );
+
+        $throwingResolver = new class implements AllocationEntityResolverInterface {
+            #[\Override]
+            public function warm(): void
+            {
+            }
+
+            #[\Override]
+            public function supports(Allocation $entity, AllocationRowDTO $dto): bool
+            {
+                return true;
+            }
+
+            #[\Override]
+            public function apply(Allocation $entity, AllocationRowDTO $dto): void
+            {
+                throw ReferenceNotFoundException::forField('dispatchArea', 'XYZ');
+            }
+        };
+
+        $factory = $this->createFactory($em, [$throwingResolver]);
+
+        $validator = $this->createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList());
+
+        $mapper = $this->createStub(RowToDtoMapperInterface::class);
+        $mapper->method('mapAssoc')->willReturn(new AllocationRowDTO());
+
+        $persister = $this->createMock(AllocationPersisterInterface::class);
+        $persister->expects($this->never())->method('persist');
+        $persister->expects($this->never())->method('flush');
+
+        $processor = new AllocationRowProcessor($validator, $mapper, $factory, $persister);
+
+        try {
+            $processor->process(['dispatchArea' => 'XYZ'], $import, 1);
+            self::fail('Expected RowRejectException to be thrown.');
+        } catch (RowRejectException $e) {
+            self::assertSame(
+                ['REF_NOT_FOUND | Reference not found for "dispatchArea" | field=dispatchArea | value="XYZ"'],
+                $e->messages(),
+            );
+            self::assertSame([
+                'error_code' => 'REF_NOT_FOUND',
+                'field' => 'dispatchArea',
+                'value' => 'XYZ',
+                'exception' => ReferenceNotFoundException::class,
+                'message' => 'Reference not found for "dispatchArea"',
+            ], $e->context());
+        }
+    }
+}

--- a/tests/Import/Unit/Infrastructure/Adapter/RuleBasedRowTypeDetectorTest.php
+++ b/tests/Import/Unit/Infrastructure/Adapter/RuleBasedRowTypeDetectorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Infrastructure\Adapter;
+
+use App\Import\Domain\Enum\AllocationRowType;
+use App\Import\Infrastructure\Adapter\RuleBasedRowTypeDetector;
+use PHPUnit\Framework\TestCase;
+
+final class RuleBasedRowTypeDetectorTest extends TestCase
+{
+    private RuleBasedRowTypeDetector $detector;
+
+    protected function setUp(): void
+    {
+        $this->detector = new RuleBasedRowTypeDetector();
+    }
+
+    public function testDetectReturnsMciCaseWhenManvIsSet(): void
+    {
+        self::assertSame(AllocationRowType::MCI_CASE, $this->detector->detect(['manv' => 'yes']));
+    }
+
+    public function testDetectReturnsMciCaseWhenManvIdIsSet(): void
+    {
+        self::assertSame(AllocationRowType::MCI_CASE, $this->detector->detect(['manv_id' => '123']));
+    }
+
+    public function testDetectReturnsAllocationWhenPzcIsSet(): void
+    {
+        self::assertSame(AllocationRowType::ALLOCATION, $this->detector->detect(['pzc' => 'A1']));
+    }
+
+    public function testDetectReturnsNullForEmptyRow(): void
+    {
+        self::assertNull($this->detector->detect([]));
+    }
+
+    public function testDetectReturnsNullWhenManvIsWhitespaceOnly(): void
+    {
+        self::assertNull($this->detector->detect(['manv' => '   ']));
+    }
+
+    public function testDetectReturnsNullWhenPzcIsWhitespaceOnly(): void
+    {
+        self::assertNull($this->detector->detect(['pzc' => "  \t "]));
+    }
+}

--- a/tests/Import/Unit/Infrastructure/Adapter/SplCsvRejectWriterTest.php
+++ b/tests/Import/Unit/Infrastructure/Adapter/SplCsvRejectWriterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Infrastructure\Adapter;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Infrastructure\Adapter\SplCsvRejectWriter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class SplCsvRejectWriterTest extends TestCase
+{
+    private string $rejectsBaseDir;
+    private Filesystem $filesystem;
+    private SplCsvRejectWriter $writer;
+
+    protected function setUp(): void
+    {
+        $this->rejectsBaseDir = sys_get_temp_dir().'/'.uniqid('spl-csv-reject-writer-', true);
+        $this->filesystem = new Filesystem();
+        $this->writer = new SplCsvRejectWriter($this->filesystem, $this->rejectsBaseDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->filesystem->exists($this->rejectsBaseDir)) {
+            $this->filesystem->remove($this->rejectsBaseDir);
+        }
+
+        parent::tearDown();
+    }
+
+    private function createImportStub(): Import
+    {
+        $import = $this->createStub(Import::class);
+        $import->method('getId')->willReturn(42);
+
+        return $import;
+    }
+
+    public function testStartCreatesFileWithHeaderAndResetsCount(): void
+    {
+        $this->writer->start($this->createImportStub());
+
+        self::assertNotNull($this->writer->getPath());
+        self::assertFileExists($this->writer->getPath());
+        self::assertSame(0, $this->writer->getCount());
+
+        $content = file_get_contents((string) $this->writer->getPath());
+        self::assertNotFalse($content);
+        self::assertStringContainsString('line;error_messages;row_json', $content);
+    }
+
+    public function testWriteAfterStartIncrementsCountAndAppendsLine(): void
+    {
+        $this->writer->start($this->createImportStub());
+
+        $this->writer->write(['field' => 'value'], ['boom'], 7);
+
+        self::assertSame(1, $this->writer->getCount());
+
+        $content = file_get_contents((string) $this->writer->getPath());
+        self::assertNotFalse($content);
+        self::assertStringContainsString('7', $content);
+        self::assertStringContainsString('boom', $content);
+    }
+
+    public function testWriteBeforeStartThrowsLogicException(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        $this->writer->write(['field' => 'value'], ['boom'], 1);
+    }
+
+    public function testGetTypeReturnsCsv(): void
+    {
+        self::assertSame('csv', $this->writer->getType());
+    }
+
+    public function testCloseAfterStartDoesNotThrow(): void
+    {
+        $this->writer->start($this->createImportStub());
+
+        $this->writer->close();
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Add unit coverage for reject writers, row-type detection, `ImportException` helpers, and importer/processor reject paths (unknown type, validation, mapping failures, `close()` on abort).
- Add integration coverage for `DoctrineRejectWriter` persistence and lifecycle guards.
- Mark backlog item B10 done in the test-architecture audit.

## Test plan
- [x] `make ci`
- [ ] CI unit + database jobs green on the PR