### PR TITLE
chore: fail CI when PHPUnit suite directories drift

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,9 @@ jobs:
             - name: Check Symfony deprecations
               run: ./bin/check-deprecations
 
+            - name: Check PHPUnit suite directories
+              run: ./bin/check-phpunit-suite-dirs
+
             - name: Lint Composer config
               run: composer validate --strict
 

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ lint: lint-container lint-php lint-twig lint-trans lint-js static-analysis ## Ru
 
 cs: rector fix-php ## Run all coding standards checks
 
-ci: swiss-knife rector fix-php fix-twig fix-js static-analysis
+ci: check-phpunit-suite-dirs swiss-knife rector fix-php fix-twig fix-js static-analysis
 
 static-analysis: phpstan psalm ## Run the static analysis
 
@@ -215,6 +215,9 @@ swiss-knife: ## Apply Swiss Knife fixes (conflicts, commented code, finalize)
 
 check-deprecations: ## Run deprecation checks (console + phpunit)
 	@./bin/check-deprecations
+
+check-phpunit-suite-dirs: ## Fail if tests/{Context}/{Unit|Integration|Functional} drift from phpunit.dist.xml suites
+	@./bin/check-phpunit-suite-dirs
 
 ## —— Tests ✅ —————————————————————————————————————————————————————————————————
 SUITE ?= all

--- a/bin/check-phpunit-suite-dirs
+++ b/bin/check-phpunit-suite-dirs
@@ -1,0 +1,115 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fail when bounded-context test layer directories drift from named PHPUnit suites.
+ *
+ * Prevents F1-style regressions: tests under tests/{Context}/{Unit|Integration|Functional}
+ * that are never picked up by `make test SUITE=…` / CI because they were not registered
+ * in phpunit.dist.xml.
+ *
+ * Usage: make check-phpunit-suite-dirs  or  composer check-phpunit-suite-dirs
+ */
+
+$root = dirname(__DIR__);
+$configPath = $root.'/phpunit.dist.xml';
+
+if (!is_file($configPath)) {
+    fwrite(STDERR, "phpunit.dist.xml not found at {$configPath}\n");
+    exit(1);
+}
+
+$layers = [
+    'Unit' => 'unit',
+    'Integration' => 'integration',
+    'Functional' => 'functional',
+];
+
+$dom = new DOMDocument();
+$dom->preserveWhiteSpace = false;
+if (!$dom->load($configPath)) {
+    fwrite(STDERR, "Failed to parse {$configPath}\n");
+    exit(1);
+}
+
+$xpath = new DOMXPath($dom);
+$errors = [];
+
+foreach ($layers as $layerDir => $suiteName) {
+    $nodes = $xpath->query(sprintf('/phpunit/testsuites/testsuite[@name="%s"]/directory', $suiteName));
+    if (false === $nodes) {
+        $errors[] = sprintf('Could not query suite "%s" in phpunit.dist.xml', $suiteName);
+        continue;
+    }
+
+    /** @var list<string> $configured */
+    $configured = [];
+    foreach ($nodes as $node) {
+        $path = trim($node->textContent ?? '');
+        if ('' === $path) {
+            continue;
+        }
+        $configured[] = str_replace('\\', '/', $path);
+    }
+    $configuredSet = array_fill_keys($configured, true);
+
+    $pattern = $root.'/tests/*/'.$layerDir;
+    $found = glob($pattern, GLOB_ONLYDIR) ?: [];
+
+    foreach ($found as $absoluteDir) {
+        $context = basename(dirname($absoluteDir));
+        $relative = 'tests/'.$context.'/'.$layerDir;
+
+        if (!directoryContainsTestPhp($absoluteDir)) {
+            continue;
+        }
+
+        if (!isset($configuredSet[$relative])) {
+            $errors[] = sprintf(
+                '%s contains *Test.php files but is not listed in the "%s" suite in phpunit.dist.xml',
+                $relative,
+                $suiteName,
+            );
+        }
+    }
+
+    foreach ($configured as $relative) {
+        if (!is_dir($root.'/'.$relative)) {
+            $errors[] = sprintf(
+                'suite "%s" lists %s but that directory does not exist',
+                $suiteName,
+                $relative,
+            );
+        }
+    }
+}
+
+if ([] !== $errors) {
+    fwrite(STDERR, "PHPUnit suite directory check failed:\n");
+    foreach ($errors as $error) {
+        fwrite(STDERR, '  - '.$error."\n");
+    }
+    fwrite(STDERR, "\nRegister every tests/{Context}/{Unit|Integration|Functional} directory that holds tests in the matching named suite.\n");
+    exit(1);
+}
+
+fwrite(STDOUT, "PHPUnit suite directories are in sync with phpunit.dist.xml.\n");
+exit(0);
+
+function directoryContainsTestPhp(string $directory): bool
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+    );
+
+    /** @var SplFileInfo $file */
+    foreach ($iterator as $file) {
+        if ($file->isFile() && str_ends_with($file->getFilename(), 'Test.php')) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/composer.json
+++ b/composer.json
@@ -144,6 +144,9 @@
         "check-deprecations": [
             "@php bin/check-deprecations"
         ],
+        "check-phpunit-suite-dirs": [
+            "@php bin/check-phpunit-suite-dirs"
+        ],
         "architecture:analyse": [
             "deptrac analyse --no-progress"
         ],

--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -151,7 +151,7 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 
 | ID | Suggested issue title | Scope | Notes |
 |----|----------------------|-------|-------|
-| B16 | `ci: fail if tests/*/Unit dirs missing from phpunit unit suite` | Small script or workflow check | Prevents F1 regression |
+| B16 | `ci: fail if tests/*/Unit dirs missing from phpunit unit suite` | Small script + `make ci` / lint workflow | Covers Unit, Integration, and Functional layer dirs; prevents F1 regression |
 | B17 | `spike: Infection on one domain package` | e.g. Allocation permission or Import reject rules | Spike only; not a beta blocker |
 | B18 | `chore: slow-test budget from report-slowest-tests` | Track outliers after splits | Soft budget first |
 
@@ -173,6 +173,8 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] B9 hospital permission / voter edge cases
 - [x] B10 import reject and invalid-input paths
 - [ ] B11–B13 coverage gap PRs (as needed)
-- [ ] B14–B18 process / automation (optional)
+- [ ] B14 PR checklist for test doubles (optional; deferred)
+- [x] B16 PHPUnit suite directory drift guard
+- [ ] B15 / B17 / B18 process / automation (optional)
 
 When opening GitHub issues, link back to this file and to #324.

--- a/docs/03-development/testing.md
+++ b/docs/03-development/testing.md
@@ -36,6 +36,8 @@ Cross-cutting groups: `browser` (Zenstruck browser tests), `materialized-view` (
 
 When adding a new bounded context under `tests/`, register its `Unit` / `Integration` / `Functional` directories in the matching named suites in `phpunit.dist.xml`. The CI unit job only runs the `unit` suite.
 
+`make check-phpunit-suite-dirs` (also part of `make ci` and the lint workflow) fails if a layer directory that contains `*Test.php` files is missing from its named suite, or if a suite lists a directory that does not exist.
+
 ## Test doubles
 
 Prefer the lightest double that matches what the test asserts. PHPUnit’s `createMock()` can act as stub, spy, or mock depending on usage — choose the API that communicates intent.


### PR DESCRIPTION
## Summary
- Add `bin/check-phpunit-suite-dirs` so context `Unit` / `Integration` / `Functional` dirs with tests cannot silently fall out of named PHPUnit suites (F1 regression).
- Wire the check into `make ci`, Composer, and the lint workflow; document it and mark backlog B16 done.

## Test plan
- [x] `make check-phpunit-suite-dirs`
- [x] `make ci`
- [x] Lint workflow step green on the PR