### PR TITLE
chore: upload unit and integration coverage in one Codecov step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,16 +91,13 @@ jobs:
                     --order-by duration \
                     --stop-on-failure
 
-            - name: Upload unit coverage to Codecov
+            - name: Upload unit coverage artifact
               if: success()
-              uses: codecov/codecov-action@v7
+              uses: actions/upload-artifact@v4
               with:
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  files: var/coverage/logs/clover-unit.xml
-                  flags: unit
-                  name: unit
-                  disable_search: true
-                  fail_ci_if_error: true
+                  name: coverage-unit
+                  path: var/coverage/logs/clover-unit.xml
+                  if-no-files-found: error
 
             - name: Upload unit test results to Codecov
               if: success()
@@ -109,7 +106,6 @@ jobs:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   report_type: test_results
                   files: junit-unit.xml
-                  flags: unit
                   name: unit-test-results
                   disable_search: true
                   fail_ci_if_error: false
@@ -189,16 +185,13 @@ jobs:
               env:
                   DATABASE_URL: postgres://app:password@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/app
 
-            - name: Upload integration coverage to Codecov
+            - name: Upload integration coverage artifact
               if: success()
-              uses: codecov/codecov-action@v7
+              uses: actions/upload-artifact@v4
               with:
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  files: var/coverage/logs/clover-integration.xml
-                  flags: integration
-                  name: integration
-                  disable_search: true
-                  fail_ci_if_error: true
+                  name: coverage-integration
+                  path: var/coverage/logs/clover-integration.xml
+                  if-no-files-found: error
 
             - name: Upload integration test results to Codecov
               if: success()
@@ -207,7 +200,39 @@ jobs:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   report_type: test_results
                   files: junit-integration.xml
-                  flags: integration
                   name: integration-test-results
                   disable_search: true
                   fail_ci_if_error: false
+
+    # Single unflagged coverage upload (unit + integration clovers).
+    # Dual per-job flagged uploads since #346 stayed stuck in Codecov "started".
+    coverage:
+        name: Upload coverage to Codecov
+        needs: [unit, database]
+        runs-on: ubuntu-latest
+        if: success()
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v7
+
+            - name: Download unit coverage
+              uses: actions/download-artifact@v4
+              with:
+                  name: coverage-unit
+                  path: var/coverage/logs
+
+            - name: Download integration coverage
+              uses: actions/download-artifact@v4
+              with:
+                  name: coverage-integration
+                  path: var/coverage/logs
+
+            - name: Upload combined coverage to Codecov
+              uses: codecov/codecov-action@v7
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: var/coverage/logs/clover-unit.xml,var/coverage/logs/clover-integration.xml
+                  name: unit-and-integration
+                  disable_search: true
+                  fail_ci_if_error: true
+                  verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,13 +12,6 @@ coverage:
         # this allows a 10% drop from the previous base commit coverage
         threshold: 10%
 
-# CI uploads separate clover reports from the unit and database jobs.
-# Carryforward keeps the other flag's last successful report when only one job re-runs.
-flag_management:
-  default_rules:
-    carryforward: true
-  individual_flags:
-    - name: unit
-      carryforward: true
-    - name: integration
-      carryforward: true
+# CI uploads unit + integration clovers in one unflagged Codecov step
+# (.github/workflows/tests.yml → job "coverage"). Per-flag uploads were
+# deferred after dual flagged reports stayed stuck in processing (#346).

--- a/docs/03-development/testing.md
+++ b/docs/03-development/testing.md
@@ -86,11 +86,12 @@ make lint-trans-de  # lint DE catalogue only
 
 ## CI reference
 
-- **Unit job** (parallel, no database, PCOV): `paratest --testsuite unit --coverage-clover=…` → Codecov flag `unit`
-- **Database job** (parallel, PostgreSQL, PCOV): `paratest --testsuite all --exclude-testsuite unit --coverage-clover=…` → Codecov flag `integration`
-- Either job failing fails the workflow; Codecov merges both flags for project coverage
+- **Unit job** (parallel, no database, PCOV): clover artifact `coverage-unit`
+- **Database job** (parallel, PostgreSQL, PCOV): clover artifact `coverage-integration`
+- **Coverage job** (after both succeed): one Codecov upload with both clovers, no flags (full project coverage)
+- Either test job failing fails the workflow; the coverage job does not run unless both succeed
 - Workflows: `.github/workflows/tests.yml`
-- Codecov flags: [`codecov.yml`](../../codecov.yml)
+- Codecov: [`codecov.yml`](../../codecov.yml)
 - Linting: `.github/workflows/lint.yml`
 - Security scan: `.github/workflows/security.yml`
 


### PR DESCRIPTION
## Summary
- Collect unit and integration clover reports as CI artifacts, then upload both in a single unflagged Codecov step (full project coverage).
- Drop per-job Codecov flags that stayed stuck in `started` since #346; keep JUnit test-result uploads without flags.
- Document the new coverage job and simplify `codecov.yml` accordingly.

## Why
Dual flagged coverage uploads from #346 were accepted by Codecov but never processed (`state: started`). The last working pattern (#345) was a single unflagged coverage upload. This restores that processing shape while still including **both** suites.

## Test plan
- [x] CI: unit + database jobs produce clover artifacts
- [x] CI: `Upload coverage to Codecov` job succeeds with both files
- [ ] Codecov commit API: coverage upload reaches `merged`/`processed` with non-null `totals`
- [ ] Codecov PR/commit UI shows coverage again (no Missing Head Report after processing)
