### PR TITLE
test(onboarding): cover complete failure and already-done paths

### DIFF
--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -173,7 +173,8 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] B9 hospital permission / voter edge cases
 - [x] B10 import reject and invalid-input paths
 - [x] B12 explore allocations access and filter edges
-- [ ] B11 / B13 coverage gap PRs (as needed)
+- [x] B13 onboarding failure / already-complete paths
+- [ ] B11 coverage gap PR (as needed)
 - [ ] B14 PR checklist for test doubles (optional; deferred)
 - [x] B16 PHPUnit suite directory drift guard
 - [ ] B15 / B17 / B18 process / automation (optional)

--- a/tests/Onboarding/Functional/Controller/CompleteOnboardingStepControllerTest.php
+++ b/tests/Onboarding/Functional/Controller/CompleteOnboardingStepControllerTest.php
@@ -89,6 +89,69 @@ final class CompleteOnboardingStepControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(404);
     }
 
+    public function testRecompletingAlreadyPersistedStepIsIdempotent(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/');
+
+        $token = $this->csrfToken($client, 'onboarding_complete_'.OnboardingStepKey::RequestClinicAccess->value);
+        $client->request(Request::METHOD_POST, '/onboarding/steps/request_clinic_access/complete', [
+            '_token' => $token,
+        ]);
+        self::assertResponseRedirects('/');
+
+        $client->request(Request::METHOD_GET, '/');
+        $token = $this->csrfToken($client, 'onboarding_complete_'.OnboardingStepKey::RequestClinicAccess->value);
+        $client->request(Request::METHOD_POST, '/onboarding/steps/request_clinic_access/complete', [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseRedirects('/');
+        $repo = $client->getContainer()->get(UserOnboardingStepRepository::class);
+        self::assertCount(1, $repo->findCompletedByUser($user));
+        self::assertNotNull($repo->findForUserAndStep($user, OnboardingStepKey::RequestClinicAccess));
+    }
+
+    public function testAutoCompletedStepIsRejectedWithoutPersisting(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $state = StateFactory::createOne(['createdBy' => $user]);
+        $dispatchArea = DispatchAreaFactory::createOne(['createdBy' => $user, 'state' => $state]);
+        HospitalFactory::createOne([
+            'createdBy' => $user,
+            'dispatchArea' => $dispatchArea,
+            'owner' => $user,
+            'state' => $state,
+        ]);
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/');
+
+        $token = $this->csrfToken($client, 'onboarding_complete_'.OnboardingStepKey::RequestClinicAccess->value);
+        $client->request(Request::METHOD_POST, '/onboarding/steps/request_clinic_access/complete', [
+            '_token' => $token,
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        $repo = $client->getContainer()->get(UserOnboardingStepRepository::class);
+        self::assertNull($repo->findForUserAndStep($user, OnboardingStepKey::RequestClinicAccess));
+    }
+
+    public function testCompleteIsForbiddenWithoutParticipantRole(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+        $client->loginUser($user);
+
+        $client->request(Request::METHOD_POST, '/onboarding/steps/request_clinic_access/complete', [
+            '_token' => 'unused',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
     private function csrfToken(KernelBrowser $client, string $tokenId): string
     {
         $requestStack = $client->getContainer()->get('request_stack');


### PR DESCRIPTION
Close B13 with functional coverage for idempotent re-complete, auto-completed clinic-access rejection, and non-participant deny.