### PR TITLE
test(content): split PageImageContentAnalyzerTest by content type

### DIFF
--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -46,7 +46,7 @@ Infrastructure already in good shape:
 | ~~973~~ split | `AnalysisExplorerShell*Test.php` (HappyPath / Filter / Auth / EdgeCases) | Done |
 | ~~950~~ split | `ImportAllocationsMessageHandler*Test.php` (Run / Reimport / Failure / MessageBus) | Done |
 | ~~925~~ split | `ExplorerResultsTablePresenter*Test.php` (Columns / Matrix / BoxPlot / HospitalMetrics) | Done |
-| ~717 | `tests/Content/Integration/Page/PageImageContentAnalyzerTest.php` | Analyzer scenarios by content type |
+| ~~717~~ split | `PageImageContentAnalyzer*Test.php` (ImageBlock / HtmlSnippet) | Done |
 | ~611 | `tests/Statistics/Functional/Controller/DashboardControllerTest.php` | Auth / widgets / empty states |
 | ~577 | `tests/Content/Unit/Page/PageContentValidatorTest.php` | Rule groups |
 | ~535 | `tests/Allocation/Integration/Query/AllocationBucketQueryTest.php` | Query variants |

--- a/tests/Content/Integration/Page/PageImageContentAnalyzerHtmlSnippetTest.php
+++ b/tests/Content/Integration/Page/PageImageContentAnalyzerHtmlSnippetTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Infrastructure\Factory\MediaFactory;
+use App\Content\Infrastructure\Factory\PageFactory;
+
+final class PageImageContentAnalyzerHtmlSnippetTest extends PageImageContentAnalyzerTestCase
+{
+    public function testDetectsRichtextSnippetWithLegacyLargeSizeClass(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-richtext-snippet',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/snippet.png" alt="Snippet"></figure>',
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('richtext', $findings[0]->blockType);
+        self::assertSame('lg', $findings[0]->currentSize);
+    }
+
+    public function testDetectsHighlightBlockWithFloatedSnippet(): void
+    {
+        $media = MediaFactory::createOne(['filename' => 'highlight-float.png']);
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-highlight',
+            'content' => [
+                [
+                    'type' => 'highlight',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<figure class="page-content-image page-content-image--size-md page-content-image--float-right"><img src="/uploads/media/%s" alt="Highlight"></figure>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('highlight', $findings[0]->blockType);
+        self::assertSame('right', $findings[0]->float);
+        self::assertSame('md', $findings[0]->currentSize);
+        self::assertSame('No change', $findings[0]->recommendation);
+    }
+
+    public function testDetectsAccordionItemWithImageSnippet(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-accordion',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            [
+                                'title' => 'FAQ',
+                                'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/accordion.png" alt="Accordion"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('accordion item 1', $findings[0]->blockType);
+    }
+
+    public function testDetectsInlineImageWithoutFigureClasses(): void
+    {
+        $media = MediaFactory::createOne(['filename' => 'inline-only.png']);
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-inline-img',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<p>Text <img src="/uploads/media/%s" alt="Inline"></p>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('inline img', $findings[0]->blockType);
+        self::assertSame('auto', $findings[0]->currentSize);
+    }
+
+    public function testUnknownSnippetSizeRecommendsReviewLayout(): void
+    {
+        $media = MediaFactory::createOne(['filename' => 'xl-snippet.png']);
+
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-unknown-snippet-size',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => sprintf(
+                            '<figure class="page-content-image page-content-image--size-xl"><img src="/uploads/media/%s" alt="XL"></figure>',
+                            $media->getFilename(),
+                        ),
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('xl', $findings[0]->currentSize);
+        self::assertSame('Review layout', $findings[0]->recommendation);
+    }
+
+    public function testSnippetWithoutSrcReportsMissingSrc(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-snippet-no-src',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('missing_src', $findings[0]->status);
+    }
+
+    public function testDetectsFloatedLeftSnippetInHtml(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-float-left-snippet',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => [
+                        'html' => '<figure class="page-content-image page-content-image--size-sm page-content-image--float-left"><img src="/uploads/media/float-left.png" alt="Left"></figure>',
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertSame('left', $findings[0]->float);
+    }
+
+    public function testSkipsAccordionItemsWithoutHtml(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-accordion-invalid-item',
+            'content' => [
+                [
+                    'type' => 'accordion',
+                    'enabled' => true,
+                    'data' => [
+                        'items' => [
+                            ['title' => 'No html'],
+                            [
+                                'title' => 'With snippet',
+                                'html' => '<figure class="page-content-image page-content-image--size-md"><img src="/uploads/media/acc-valid.png" alt="Valid"></figure>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $findings = $this->analyzer()->analyze($page->getId());
+
+        self::assertCount(1, $findings);
+        self::assertStringContainsString('accordion item 2', $findings[0]->blockType);
+    }
+
+    public function testSkipsHtmlBlocksWithEmptyContent(): void
+    {
+        $page = PageFactory::createOne([
+            'slug' => 'analyzer-empty-html',
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => ''],
+                ],
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'Title only'],
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $this->analyzer()->analyze($page->getId()));
+    }
+}

--- a/tests/Content/Integration/Page/PageImageContentAnalyzerImageBlockTest.php
+++ b/tests/Content/Integration/Page/PageImageContentAnalyzerImageBlockTest.php
@@ -4,24 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Content\Integration\Page;
 
-use App\Content\Application\Page\PageImageContentAnalyzer;
 use App\Content\Infrastructure\Factory\MediaFactory;
 use App\Content\Infrastructure\Factory\PageFactory;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Filesystem\Path;
-use Zenstruck\Foundry\Attribute\ResetDatabase;
-use Zenstruck\Foundry\Test\Factories;
 
-#[ResetDatabase]
-final class PageImageContentAnalyzerTest extends KernelTestCase
+final class PageImageContentAnalyzerImageBlockTest extends PageImageContentAnalyzerTestCase
 {
-    use Factories;
-
-    protected function setUp(): void
-    {
-        self::bootKernel();
-    }
-
     public function testRecommendsMigratingSmallFullWidthImageToAuto(): void
     {
         $media = MediaFactory::createOne([
@@ -124,28 +112,6 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
         self::assertSame('Sync media files locally', $findings[0]->recommendation);
     }
 
-    public function testDetectsRichtextSnippetWithLegacyLargeSizeClass(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-richtext-snippet',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/snippet.png" alt="Snippet"></figure>',
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertStringContainsString('richtext', $findings[0]->blockType);
-        self::assertSame('lg', $findings[0]->currentSize);
-    }
-
     public function testAnalyzeAllPagesWhenNoPageIdFilter(): void
     {
         $this->createImagePage('analyzer-all-1');
@@ -159,88 +125,6 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
     public function testReturnsEmptyFindingsForUnknownPageId(): void
     {
         self::assertSame([], $this->analyzer()->analyze(999_999));
-    }
-
-    public function testDetectsHighlightBlockWithFloatedSnippet(): void
-    {
-        $media = MediaFactory::createOne(['filename' => 'highlight-float.png']);
-
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-highlight',
-            'content' => [
-                [
-                    'type' => 'highlight',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => sprintf(
-                            '<figure class="page-content-image page-content-image--size-md page-content-image--float-right"><img src="/uploads/media/%s" alt="Highlight"></figure>',
-                            $media->getFilename(),
-                        ),
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertStringContainsString('highlight', $findings[0]->blockType);
-        self::assertSame('right', $findings[0]->float);
-        self::assertSame('md', $findings[0]->currentSize);
-        self::assertSame('No change', $findings[0]->recommendation);
-    }
-
-    public function testDetectsAccordionItemWithImageSnippet(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-accordion',
-            'content' => [
-                [
-                    'type' => 'accordion',
-                    'enabled' => true,
-                    'data' => [
-                        'items' => [
-                            [
-                                'title' => 'FAQ',
-                                'html' => '<figure class="page-content-image page-content-image--size-lg"><img src="/uploads/media/accordion.png" alt="Accordion"></figure>',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertStringContainsString('accordion item 1', $findings[0]->blockType);
-    }
-
-    public function testDetectsInlineImageWithoutFigureClasses(): void
-    {
-        $media = MediaFactory::createOne(['filename' => 'inline-only.png']);
-
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-inline-img',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => sprintf(
-                            '<p>Text <img src="/uploads/media/%s" alt="Inline"></p>',
-                            $media->getFilename(),
-                        ),
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertStringContainsString('inline img', $findings[0]->blockType);
-        self::assertSame('auto', $findings[0]->currentSize);
     }
 
     public function testReportsDimensionsUnknownWhenDatabaseMetadataMissing(): void
@@ -467,75 +351,6 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
         self::assertSame('Review layout', $findings[0]->recommendation);
     }
 
-    public function testUnknownSnippetSizeRecommendsReviewLayout(): void
-    {
-        $media = MediaFactory::createOne(['filename' => 'xl-snippet.png']);
-
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-unknown-snippet-size',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => sprintf(
-                            '<figure class="page-content-image page-content-image--size-xl"><img src="/uploads/media/%s" alt="XL"></figure>',
-                            $media->getFilename(),
-                        ),
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertSame('xl', $findings[0]->currentSize);
-        self::assertSame('Review layout', $findings[0]->recommendation);
-    }
-
-    public function testSnippetWithoutSrcReportsMissingSrc(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-snippet-no-src',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => '<figure class="page-content-image page-content-image--size-lg"></figure>',
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertSame('missing_src', $findings[0]->status);
-    }
-
-    public function testDetectsFloatedLeftSnippetInHtml(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-float-left-snippet',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => [
-                        'html' => '<figure class="page-content-image page-content-image--size-sm page-content-image--float-left"><img src="/uploads/media/float-left.png" alt="Left"></figure>',
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertSame('left', $findings[0]->float);
-    }
-
     public function testResolvesMediaBySrcFilenameWhenMediaIdMissing(): void
     {
         $media = MediaFactory::createOne([
@@ -600,54 +415,6 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
         self::assertSame(1, $findings[0]->imageWidth);
     }
 
-    public function testSkipsAccordionItemsWithoutHtml(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-accordion-invalid-item',
-            'content' => [
-                [
-                    'type' => 'accordion',
-                    'enabled' => true,
-                    'data' => [
-                        'items' => [
-                            ['title' => 'No html'],
-                            [
-                                'title' => 'With snippet',
-                                'html' => '<figure class="page-content-image page-content-image--size-md"><img src="/uploads/media/acc-valid.png" alt="Valid"></figure>',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $findings = $this->analyzer()->analyze($page->getId());
-
-        self::assertCount(1, $findings);
-        self::assertStringContainsString('accordion item 2', $findings[0]->blockType);
-    }
-
-    public function testSkipsHtmlBlocksWithEmptyContent(): void
-    {
-        $page = PageFactory::createOne([
-            'slug' => 'analyzer-empty-html',
-            'content' => [
-                [
-                    'type' => 'richtext',
-                    'enabled' => true,
-                    'data' => ['html' => ''],
-                ],
-                [
-                    'type' => 'headline',
-                    'enabled' => true,
-                    'data' => ['text' => 'Title only'],
-                ],
-            ],
-        ]);
-
-        self::assertSame([], $this->analyzer()->analyze($page->getId()));
-    }
-
     public function testUnreadableLocalFileReportsDimensionsUnknown(): void
     {
         $media = MediaFactory::createOne([
@@ -708,10 +475,5 @@ final class PageImageContentAnalyzerTest extends KernelTestCase
                 ],
             ],
         ]);
-    }
-
-    private function analyzer(): PageImageContentAnalyzer
-    {
-        return self::getContainer()->get(PageImageContentAnalyzer::class);
     }
 }

--- a/tests/Content/Integration/Page/PageImageContentAnalyzerTestCase.php
+++ b/tests/Content/Integration/Page/PageImageContentAnalyzerTestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Page;
+
+use App\Content\Application\Page\PageImageContentAnalyzer;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+abstract class PageImageContentAnalyzerTestCase extends KernelTestCase
+{
+    use Factories;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    protected function analyzer(): PageImageContentAnalyzer
+    {
+        return self::getContainer()->get(PageImageContentAnalyzer::class);
+    }
+}


### PR DESCRIPTION
## Summary

This pull request restructures the integration tests for the PageImageContentAnalyzer by splitting the oversized test suite into smaller, content-specific test classes.

## Changes

* Split the existing analyzer test suite into separate tests for image blocks and HTML-based image snippets.
* Introduced a shared abstract test case for common setup and analyzer access.
* Preserved the existing test scenarios while organizing them by content type.
* Retained coverage for image sizing, alignment, missing sources, legacy markup, inline images, accordion content, and invalid or empty content.
* Updated the test architecture audit to mark this test-suite hotspot as resolved.

## Why

* Reduce the size and complexity of a single oversized test class.
* Make individual test scenarios easier to locate, understand, and maintain.
* Improve test isolation and provide a clearer structure for future analyzer scenarios.
* Align the test suite with the project’s broader strategy for splitting identified test architecture hotspots.