### PR TITLE
docs: add PR checklist bullet for test doubles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,11 @@ However, you should follow the following simple guidelines for your contribution
 -   You should make sure to follow the [PHP Standards Recommendations](http://www.php-fig.org/psr/) and the
     [Symfony best practices](http://symfony.com/doc/current/best_practices/index.html).
 -   Also, you must agree to comply to the [Code of Conduct](CODE_OF_CONDUCT.md) of this project.
+
+## Before opening a pull request
+
+-   Run the relevant tests (`make test SUITE=…` / `PATH_ARG=…`) and keep them green.
+-   In unit tests, prefer `createStub()` for return-only collaborators; use a spy for side effects;
+    reserve `expects()` for when call count or `never()` is part of the spec. See
+    [docs/03-development/testing.md](docs/03-development/testing.md#test-doubles).
+-   Do not commit secrets, credentials, or unrelated scope changes.

--- a/docs/03-development/test-architecture-audit.md
+++ b/docs/03-development/test-architecture-audit.md
@@ -175,7 +175,7 @@ Use `make coverage SUITE=unit` for fast loops; full Codecov from CI for trends.
 - [x] B12 explore allocations access and filter edges
 - [x] B13 onboarding failure / already-complete paths
 - [x] B11 projection rebuild invariants
-- [ ] B14 PR checklist for test doubles (optional; deferred)
+- [x] B14 PR checklist for test doubles
 - [x] B16 PHPUnit suite directory drift guard
 - [ ] B15 / B17 / B18 process / automation (optional)
 

--- a/docs/03-development/testing.md
+++ b/docs/03-development/testing.md
@@ -58,6 +58,8 @@ Heuristics:
 
 Do not introduce Mockery or Prophecy for application tests. Full taxonomy, findings, and follow-up backlog: [test-architecture-audit.md](test-architecture-audit.md).
 
+PR checklist: see [CONTRIBUTING.md](../../CONTRIBUTING.md) — stub by default, spy for side effects.
+
 ## Static analysis and linting
 
 ```bash


### PR DESCRIPTION
## Summary

This pull request adds concise pull request guidance for choosing appropriate PHPUnit test doubles and links it to the existing testing documentation.

### Changes

- Added a new “Before opening a pull request” section to `CONTRIBUTING.md`.
- Added reminders to run the relevant test suites and avoid committing secrets or unrelated changes.
- Documented the preferred use of `createStub()` for return-only collaborators.
- Clarified that spies should be used for verifying side effects.
- Reserved `expects()` for cases where invocation counts or `never()` are part of the required behavior.
- Added reciprocal links between the contribution and testing documentation.
- Marked the B14 test-architecture follow-up as completed.

### Why

- Give contributors and reviewers a clear, easily discoverable rule for selecting test doubles.
- Encourage simpler and less brittle unit tests.
- Reduce unnecessary interaction-based mocking.
- Keep pull request expectations aligned with the project’s broader testing guidelines.