### PR TITLE
fix: Prevent Registration username/email Enumeration (SEC-001)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -57,6 +57,9 @@ services:
 
     Symfony\Component\Lock\LockFactory: '@app.lock.factory'
 
+    App\User\Infrastructure\Registration\RegistrationIdentityGuard:
+        alias: App\User\Infrastructure\Registration\RegistrationIdentityChecker
+
     sentry.callback.before_send:
         class: App\Shared\Infrastructure\Monitoring\Sentry\SentryBeforeSendCallback
         factory: ['@App\Shared\Infrastructure\Monitoring\Sentry\SentryBeforeSendCallback', 'getBeforeSend']

--- a/docs/05-operations/README.md
+++ b/docs/05-operations/README.md
@@ -14,6 +14,7 @@
 | [backup-restore.md](backup-restore.md) | Guide | Database and file backups |
 | [observability-sentry.md](observability-sentry.md) | Guide | Sentry integration and monitoring |
 | [content-security-policy.md](content-security-policy.md) | Guide | CSP report-only, Sentry triage, beta checklist |
+| [security-audit-beta.md](security-audit-beta.md) | Report | Pre-beta security audit (#257): findings and mitigations |
 | [health-check.md](health-check.md) | Reference | `GET /health` endpoint |
 | [troubleshooting.md](troubleshooting.md) | Guide | Symptom → cause → fix |
 | [audit-log-maintenance.md](audit-log-maintenance.md) | Guide | Audit log maintenance; purge import-generated Assessment entries |

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -1,0 +1,409 @@
+# Pre-beta security audit
+
+Related: [Issue #257](https://github.com/nplhse/collaborative-ivena-statistics/issues/257), [permission-model.md](../02-architecture/permission-model.md), [content-security-policy.md](content-security-policy.md), [health-check.md](health-check.md), [audit-log-maintenance.md](audit-log-maintenance.md)
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-07-28 |
+| Scope | Full application (backend + Twig/Stimulus UI), read-only review |
+| Method | Manual code review against issue checklist; existing security tests used as coverage checks, not as substitutes |
+| Out of scope | Code fixes, RateLimiter implementation, CSP enforce, follow-up GitHub issues |
+
+## Verdict
+
+**Conditional go for beta** — no Critical findings. AuthN/AuthZ foundations (firewalls, hospital grants, export scoping, import upload guards, admin impersonation) are solid. Several **Medium** items should be tracked before or early in beta; they do not individually block a limited beta audience if product accepts the collaborative Explore data model and monitors the Medium backlog.
+
+Top risks to track:
+
+1. ~~Registration account enumeration via duplicate username/email (error path).~~ **Resolved** (SEC-001 — generic validation).
+2. Blog index preview renders unsanitized HTML (`|raw`) while show uses `PostContentSanitizer`.
+3. CSV exports without formula neutralization (Excel formula injection).
+4. Live Component mount path `/_components` outside `access_control`.
+5. Cross-hospital Explore visibility for all participants (product decision: accept or restrict).
+
+---
+
+## Inventory
+
+### Firewall and `access_control`
+
+Source: [`config/packages/security.yaml`](../../config/packages/security.yaml)
+
+| Path | Role |
+|------|------|
+| `^/health` | `PUBLIC_ACCESS` |
+| `^/_error_preview`, `^/_error/` | `PUBLIC_ACCESS` |
+| `^/admin` | `ROLE_ADMIN` |
+| `^/hospitals` | `ROLE_PARTICIPANT` |
+| `^/explore/...`, `^/explore` | `ROLE_PARTICIPANT` |
+| `^/statistics` | `ROLE_USER` |
+| `^/login/confirm` | `IS_AUTHENTICATED_REMEMBERED` |
+
+**Not listed** (controller attributes only): `/import`, `/settings`, `/_components`, public content (`/`, `/blog`, `/register`, `/feedback`, …).
+
+Firewall `main`: form login + confirm-password authenticators, `UserAccountStatusChecker`, login throttling **5 / 15 min**, remember-me 7 days, `switch_user` for `ROLE_ADMIN`, `expose_security_errors: none`.
+
+Role hierarchy: `ROLE_ADMIN` → `ROLE_PARTICIPANT`, `ROLE_REVIEW_INDICATIONS`.
+
+### Voters
+
+| Voter | Attributes | Notes |
+|-------|------------|-------|
+| `HospitalVoter` | `ACCESS`, `EDIT`, `MANAGE_ACCESS_GRANTS` | Hospital-scoped |
+| `AllocationVoter` | `VIEW` | Any `ROLE_USER`; **no hospital scope** |
+| `ImportVoter` | `VIEW`, `DELETE`, `DOWNLOAD_SOURCE` | Hospital + creator/admin rules |
+| `ExportVoter` | `EXPORT` | Via `ExportAccessService` |
+| `IndicationRawReviewVoter` | `VIEW`, `EDIT_MATCH`, `REVIEW` | Participant + review roles |
+
+Doc drift: [`permission-model.md`](../02-architecture/permission-model.md) omits `ImportVoter::DOWNLOAD_SOURCE`.
+
+### Rate limiters
+
+Source: [`config/packages/rate_limiter.yaml`](../../config/packages/rate_limiter.yaml)
+
+| Limiter | Policy | Protected surface |
+|---------|--------|-------------------|
+| Firewall `login_throttling` | 5 / 15 min | Login |
+| `verify_email_resend` | 3 / 15 min | Settings resend |
+| `explore_list` | 100 / 10 min | Exact paths: `/explore/allocation`, `/explore/mci_case`, `/explore/hospital`, `/explore/assignment` |
+| `feedback_submit` (+ anon IP/email) | 5 / 1 h (+ 4 / 3) | `POST /feedback` |
+| `transactional_mail` | 1 / 3 s | Messenger mail |
+
+**No app RateLimiter** on: register, reset-password (form IP), import, allocations export, analysis explorer export, remaining explore lists, statistics pages.
+
+### Public / anonymous surfaces
+
+`/`, `/login`, `/register*`, `/verify/email`, `/reset-password*`, `/blog*`, CMS `/{path}`, `/sitemap*`, `/robots.txt`, `POST /feedback`, cookie/locale helpers, `/health`, `/_error*`.
+
+### Security tests (coverage snapshot)
+
+Well covered: admin access, import functional access, explore/statistics access, hospital grants, impersonation guards, login/resend rate limits, CSP headers, voter unit tests for hospital/import/indication.
+
+Gaps: Live Component denial paths, registration enumeration, import source-download audit persistence, explore rate-limit paths beyond `/explore/allocation`, `LoginFailureSubscriber` field mapping.
+
+CI: [`.github/workflows/security.yml`](../../.github/workflows/security.yml) (Psalm security analysis).
+
+---
+
+## Findings
+
+Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status remains `open` until remediated in follow-up work.
+
+### SEC-001 — Registration username/email enumeration
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium |
+| Area | AuthN / User management |
+| Evidence | [`RegistrationController.php`](../../src/User/UI/Http/Controller/RegistrationController.php) (flush on persist); `User` unique constraints without form-level `UniqueEntity`; duplicate → DB exception / error page vs success → check-email |
+| Risk | Attacker can probe whether a username or email is already registered. |
+| Mitigation | Add `UniqueEntity` (or equivalent) with a generic validation message **or** always take the check-email path on collision without leaking existence; add functional tests for response parity. |
+| Status | resolved (2026-07-28) — generic root FormError via `RegistrationIdentityChecker` (no Silent Success; UX); race fallback on `UniqueConstraintViolationException`; field-level leak avoided |
+
+### SEC-002 — Blog index preview uses unsanitized `\|raw`
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium |
+| Area | XSS / Content |
+| Evidence | [`blog/index.html.twig`](../../src/Content/UI/Twig/templates/blog/index.html.twig) L55–56; show path sanitizes via [`PostContentSanitizer`](../../src/Content/Application/Blog/PostContentSanitizer.php) in [`BlogController`](../../src/Content/UI/Http/Controller/BlogController.php) |
+| Risk | Stored XSS on public blog listing if admin-authored HTML bypasses intended sanitizer (or sanitizer config drifts). Show is safe; index is inconsistent. |
+| Mitigation | Sanitize preview in controller (same sanitizer as show) or stop using `\|raw` on index (e.g. `striptags` + truncate only). |
+| Status | open |
+
+### SEC-003 — CSV exports lack formula neutralization
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium |
+| Area | Export |
+| Evidence | [`CsvStreamExportResponseFactory::writeRow`](../../src/Shared/Application/Export/CsvStreamExportResponseFactory.php) L44–57; analogous tabular exporter for Analysis Explorer — cells written via `fputcsv` without escaping leading `=`, `+`, `-`, `@`, tab |
+| Risk | Imported free-text fields opened in Excel/LibreOffice can execute formulas (CSV injection) on the analyst’s machine. |
+| Mitigation | Prefix risky cells with `'` (or neutralize) in shared CSV writers before `fputcsv`. |
+| Status | open |
+
+### SEC-004 — Live Component route `/_components` not in `access_control`
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium |
+| Area | AuthZ / AJAX |
+| Evidence | [`config/routes/ux_live_component.yaml`](../../config/routes/ux_live_component.yaml) prefix `/_components`; not matched by `^/statistics` / `^/explore`; [`AnalysisExplorerShell`](../../src/Statistics/AnalysisExplorer/UI/LiveComponent/AnalysisExplorerShell.php) calls `requireParticipant()` only on `save` / `submitSaveAs` |
+| Risk | Component endpoints are reachable without path-level auth; relies on per-action checks and LiveProp integrity. Persist paths are guarded; preview/rerun actions are weaker. |
+| Mitigation | Add `access_control` for `^/_components` (e.g. `IS_AUTHENTICATED_REMEMBERED` or `ROLE_USER`); require participant (or ownership) on mutating/analysis LiveActions; add denial tests for guest / non-participant. |
+| Status | open |
+
+### SEC-005 — Cross-hospital Explore allocation visibility
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium (or accepted risk — product decision) |
+| Area | AuthZ / Privacy |
+| Evidence | [`AllocationVoter`](../../src/Allocation/Infrastructure/Security/Voter/AllocationVoter.php) L14–15, L36–44 — any `ROLE_USER` may `VIEW`; `/explore` gated to `ROLE_PARTICIPANT` in `security.yaml`; default allocation list is unscoped across hospitals |
+| Risk | Every participant can read allocation detail (incl. hospital identity and clinical fields) for other centers. Fits a collaborative model; conflicts with strict tenant isolation. |
+| Mitigation | **If collaborative-by-design:** document as accepted risk in permission model + onboarding. **If isolation required:** bind `VIEW` to `HospitalPermission::View` and default list scope to accessible hospitals. |
+| Notes | Pure `ROLE_USER` cannot reach `/explore` (403). Firewall is the effective gate; voter alone would be weaker. |
+| Status | open (needs product confirmation) |
+
+### SEC-006 — Incomplete Explore list rate limiting
+
+| Field | Value |
+|-------|-------|
+| Severity | Low–Medium |
+| Area | RateLimit / Scraping |
+| Evidence | [`ExploreListRateLimitSubscriber`](../../src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php) exact match on four paths only; other lists (`indication`, `infection`, `occasion`, `speciality`, `department`, `dispatch_area`, `secondary_transport`, …) unlimited |
+| Risk | Authenticated participants can scrape unbounded Explore lists. |
+| Mitigation | Include all Explore list routes (prefix or explicit allowlist); keep ~100 / 10 min per user+IP as baseline. |
+| Status | open |
+
+### SEC-007 — No RateLimiter on register / reset-password / import / export
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium (register); Low–Medium (others) |
+| Area | RateLimit |
+| Evidence | Limiter config has no register/export/import keys; reset-password has bundle per-user throttle only |
+| Risk | Registration spam / mail flood; export DoS (CPU/IO); reset-password cross-account mail flooding via IP. Login already throttled. |
+| Mitigation | IP (+ optional email) limiters: e.g. register 5/h, reset-password 10/h per IP, allocations export 10/10 min, explorer export 20/10 min, import upload 10/h. |
+| Status | open |
+
+### SEC-008 — Import source download audit intent does not persist
+
+| Field | Value |
+|-------|-------|
+| Severity | Medium |
+| Area | Auditability |
+| Evidence | [`DownloadImportSourceFileController`](../../src/Import/UI/Http/Controller/DownloadImportSourceFileController.php) L37–39 — `beginIntent('import.source_file.downloaded')` with no entity mutation; Doctrine audit subscriber only writes on audited entity changes; unlike [`ExportAuditLogger`](../../src/Shared/Application/Export/ExportAuditLogger.php) / impersonation |
+| Risk | Admin downloads of original import files leave no durable audit row. |
+| Mitigation | Persist an explicit `AuditEntry` (same pattern as export/impersonation) including actor, import id, IP. |
+| Status | open |
+
+### SEC-009 — `ImportFileStorage::resolve` lacks path containment
+
+| Field | Value |
+|-------|-------|
+| Severity | Low–Medium |
+| Area | Import / Files |
+| Evidence | [`ImportFileStorage::resolve`](../../src/Import/Application/Service/ImportFileStorage.php) L23–29 — absolute paths returned as-is; relative paths joined to project dir without asserting prefix under `var/imports` |
+| Risk | If `file_path` in DB is tampered (compromised admin DB write / SQL injection elsewhere), download or worker can read arbitrary files. Normal upload path uses generated relative names only. |
+| Mitigation | After resolve: `realpath` + assert path is under configured imports base dir; reject absolute / `..` paths. |
+| Status | open |
+
+### SEC-010 — Favorite toggle open redirect via Referer
+
+| Field | Value |
+|-------|-------|
+| Severity | Low–Medium |
+| Area | Open redirect |
+| Evidence | [`SavedExplorerViewFavoriteController`](../../src/Statistics/AnalysisExplorer/UI/Http/Controller/SavedExplorerViewFavoriteController.php) L52–54 — `redirect($referer)` without host/path validation; CSRF required |
+| Risk | CSRF-protected but still redirects to attacker-controlled Referer after a valid POST (phishing / token fixation UX). Inconsistent with Feedback/Locale safe-target helpers. |
+| Mitigation | Reuse safe local-path / same-host resolver; fallback to library route. |
+| Status | open |
+
+### SEC-011 — `/import` missing from `access_control`
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | AuthZ / Defense-in-depth |
+| Evidence | `security.yaml` has no `^/import`; all Import controllers use `#[IsGranted('ROLE_PARTICIPANT')]` (+ voters) |
+| Risk | A new import route without attributes would be anonymous by default. |
+| Mitigation | Add `- { path: ^/import, roles: ROLE_PARTICIPANT }` (source download remains `ROLE_ADMIN` via attribute). |
+| Status | open |
+
+### SEC-012 — Public `/health` discloses version and failed-queue count
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | Information disclosure |
+| Evidence | [`HealthCheckReport::toArray`](../../src/Shared/Application/Health/HealthCheckReport.php); public via `access_control` |
+| Risk | Attackers learn app version and whether the failed messenger queue is non-empty. Useful for uptime monitoring by design. |
+| Mitigation | Slim public payload to `status` (+ optional `database`); put detailed checks behind auth or internal network. Document accepted disclosure if kept for Sentry Uptime. |
+| Status | open |
+
+### SEC-013 — Media files publicly served; directory listing not hardened in-app
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | Files / Media |
+| Evidence | `vich_uploader` → `public/uploads/media`; Admin-only upload with MIME allowlist; `.htaccess` disables PHP execution |
+| Risk | Public URLs by design; if server enables directory indexes, filenames may be listable (unique namer mitigates guessing). |
+| Mitigation | Ensure `Options -Indexes` / `autoindex off` in deploy docs; optional signed URLs if media must not be public. |
+| Status | open |
+
+### SEC-014 — CSP remains Report-Only with `unsafe-inline`
+
+| Field | Value |
+|-------|-------|
+| Severity | Low / Info (planned) |
+| Area | Headers |
+| Evidence | [`nelmio_security.yaml`](../../config/packages/nelmio_security.yaml) `when@prod` CSP `report`; [`content-security-policy.md`](content-security-policy.md) P2 enforce roadmap |
+| Risk | CSP does not block XSS; only reports. Inline scripts/styles allowed. |
+| Mitigation | Follow existing CSP beta triage → enforce when violation noise is low; reduce `unsafe-inline`. |
+| Status | open (tracked operationally) |
+
+### SEC-015 — Session cookie settings rely on Symfony defaults
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | Session hardening |
+| Evidence | [`framework.yaml`](../../config/packages/framework.yaml) `session: true` without explicit `cookie_secure` / `cookie_samesite`; Nelmio forced SSL + HSTS in prod |
+| Risk | Defaults (`secure: auto`, `httponly: true`, `samesite: lax`) are acceptable behind HTTPS; not explicitly pinned for ops review. |
+| Mitigation | Set explicit prod values (`cookie_secure: true`, document SameSite choice). |
+| Status | open |
+
+### SEC-016 — Login failure log may miss username hash for form field name
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | Logging |
+| Evidence | [`LoginFailureSubscriber`](../../src/User/Infrastructure/Security/LoginFailureSubscriber.php) reads `_username`; login form uses `login[username]` — Passport UserBadge fallback usually works |
+| Risk | Some failure paths may log `username_hash: null`, reducing forensic value. |
+| Mitigation | Also read `login[username]` from the request. |
+| Status | open |
+
+### SEC-017 — Permission model documentation drift
+
+| Field | Value |
+|-------|-------|
+| Severity | Info |
+| Area | Docs |
+| Evidence | [`permission-model.md`](../02-architecture/permission-model.md) ImportVoter table omits `DOWNLOAD_SOURCE`; AllocationVoter collaborative semantics undocumented |
+| Risk | Maintainers mis-implement access checks. |
+| Mitigation | Update voter table + document Explore collaboration / accepted risk (SEC-005). |
+| Status | open |
+
+### SEC-018 — Messenger import handlers trust queue without permission re-check
+
+| Field | Value |
+|-------|-------|
+| Severity | Info / accepted with hardening notes |
+| Area | Import / Async |
+| Evidence | `ImportAllocationsMessageHandler` loads by `importId` without actor permission re-check |
+| Risk | Compromised DB/queue writer can re-trigger import processing. Not reachable from normal HTTP alone. |
+| Mitigation | Document trust boundary; harden DB/worker credentials; optional status gate (`PENDING` only) and/or actor id on message. |
+| Status | open |
+
+### SEC-019 — Export empty hospital intersect falls back to all allowed hospitals
+
+| Field | Value |
+|-------|-------|
+| Severity | Low |
+| Area | Export |
+| Evidence | `ExportAccessService::resolveEffectiveHospitalIds` — empty intersection → all exportable hospitals (no foreign hospital leak) |
+| Risk | Tampered hospital id list expands scope to all permitted hospitals instead of failing closed. |
+| Mitigation | Prefer empty result / 400 when requested ∩ allowed is empty. |
+| Status | open |
+
+### SEC-020 — AllocationVoter / Live Component test gaps
+
+| Field | Value |
+|-------|-------|
+| Severity | Info |
+| Area | Testing |
+| Evidence | Allocation voter tests cover auth vs anon only; Live Component auth tests do not assert guest denial on `/_components` actions |
+| Risk | Regressions in AuthZ go unnoticed. |
+| Mitigation | Add denial tests for SEC-004/005 decisions; extend Explore rate-limit path coverage. |
+| Status | open |
+
+---
+
+## RateLimiter recommendations (for follow-up)
+
+| Surface | Suggested limiter | Notes |
+|---------|-------------------|-------|
+| `POST /register` | 5 / hour / IP | SEC-007 |
+| `POST /reset-password` | 10 / hour / IP | Complements per-user bundle throttle |
+| Explore list GETs | Extend existing `explore_list` to all list routes | SEC-006 |
+| Allocations export estimate/download | 10 / 10 min / user | SEC-007 |
+| Analysis Explorer CSV export | 20 / 10 min / user | SEC-007 |
+| Import create (`POST /import/new`) | 10 / hour / user | Optional DoS guard |
+
+Do **not** implement in this audit deliverable.
+
+---
+
+## What looks solid (keep)
+
+- Login throttling, `expose_security_errors: none`, hashed login-failure usernames (when resolved).
+- Hospital permission bitmask + owner/admin grant management; no self-escalation to system roles on registration.
+- Statistics filter/scope strips unauthorized hospital IDs (public fallback).
+- Import upload allowlist (csv/txt), size limit, storage under `var/imports`, source download Admin + voter.
+- Export CSRF + hospital intersection via `ExportAccessService`; row cap.
+- Feedback CSRF, multi-layer rate limits, spam heuristics, safe redirect resolver.
+- Admin EasyAdmin double gate (`access_control` + `IsGranted`); impersonation blocks self/admin targets and audits.
+- Reset-password anti-enumeration (uniform check-email flow).
+- Nelmio clickjacking DENY, nosniff, referrer/permissions policy; prod HSTS + CSP report-only readiness.
+- Blog show + page blocks HTML sanitization; comment content escaped.
+
+---
+
+## Accepted / intentional designs (confirm SEC-005)
+
+| Topic | Current behaviour | Recommendation |
+|-------|-------------------|----------------|
+| Collaborative Explore | Participants see cross-hospital allocations | Product: accept (document) **or** restrict (SEC-005) |
+| Public statistics | `ROLE_USER` sees aggregates / public scopes | Keep |
+| Public health endpoint | Uptime-friendly JSON | Keep or slim (SEC-012) |
+| CSP report-only | Beta monitoring before enforce | Follow CSP ops guide |
+| Queue trust for import workers | No HTTP re-auth in handler | Ops hardening (SEC-018) |
+| Admin can assign `ROLE_ADMIN` | ChoiceField whitelist | Accept for small admin set |
+
+---
+
+## Suggested remediation priority (follow-up issues only)
+
+| Priority | Findings | Rationale |
+|----------|----------|-----------|
+| P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
+| P1 early beta | SEC-003, SEC-004, SEC-008 | Export safety, Live Component defense-in-depth, audit gap |
+| P1 product call | SEC-005 | Isolation vs collaboration |
+| P2 hardening | SEC-006, SEC-007, SEC-009–SEC-016, SEC-019 | Rate limits, path containment, redirects, headers, docs |
+| P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
+
+Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.
+
+---
+
+## Appendix A — Review checklist coverage
+
+| Issue #257 area | Covered | Primary findings |
+|-----------------|---------|------------------|
+| Authentication / authorization | Yes | SEC-001, SEC-004, SEC-005, SEC-011 |
+| Voters / permission checks | Yes | SEC-005, SEC-017 |
+| RBAC / privilege boundaries | Yes | Grants, registration, admin roles — solid |
+| Privilege escalation | Yes | No self-escalation found |
+| Ownership / clinic resources | Yes | Import/export/grants solid; Explore collaborative |
+| Public endpoints / anonymous | Yes | SEC-012, content XSS SEC-002 |
+| Scraping / RateLimiter | Yes | SEC-006, SEC-007 |
+| Import / export security | Yes | SEC-003, SEC-008, SEC-009, SEC-019 |
+| Admin / restricted ops | Yes | Solid; SEC-008 audit gap |
+| User management / permissions | Yes | SEC-001 |
+| API / AJAX / Live auth | Yes | SEC-004, SEC-010 |
+| Input validation / common vulns | Yes | SEC-002, SEC-003, SEC-010 |
+| Uploaded files / import processing | Yes | SEC-009, SEC-013, SEC-018 |
+| Error messages / disclosure | Yes | Solid; SEC-012 |
+| Logging / auditability | Yes | SEC-008, SEC-016 |
+
+## Appendix B — Key file index
+
+```
+config/packages/security.yaml
+config/packages/rate_limiter.yaml
+config/packages/nelmio_security.yaml
+config/packages/csrf.yaml
+config/packages/framework.yaml
+config/routes/ux_live_component.yaml
+.github/workflows/security.yml
+src/*/Infrastructure/Security/Voter/*.php
+src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php
+src/Import/Application/Service/ImportFileStorage.php
+src/Shared/Application/Export/CsvStreamExportResponseFactory.php
+src/Statistics/AnalysisExplorer/UI/LiveComponent/AnalysisExplorerShell.php
+docs/02-architecture/permission-model.md
+docs/05-operations/content-security-policy.md
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,3 +54,4 @@ Role-based reading orders live in each section's README:
 - [Explore allocation list](04-features/allocation/explore-allocation-list.md)
 - [Sentry observability](05-operations/observability-sentry.md)
 - [Content Security Policy (report-only)](05-operations/content-security-policy.md)
+- [Pre-beta security audit](05-operations/security-audit-beta.md)

--- a/src/User/Infrastructure/Registration/RegistrationIdentityChecker.php
+++ b/src/User/Infrastructure/Registration/RegistrationIdentityChecker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Registration;
+
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\Form\FormError;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Shared uniqueness check for registration (generic message — no field leak).
+ */
+final readonly class RegistrationIdentityChecker implements RegistrationIdentityGuard
+{
+    public const string MESSAGE_KEY = 'validation.registration.identity_taken';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function __construct(
+        private UserRepository $userRepository,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function isIdentityTaken(string $username, string $email): bool
+    {
+        $normalizedEmail = mb_strtolower(trim($email));
+
+        return null !== $this->userRepository->findOneBy(['username' => $username])
+            || null !== $this->userRepository->findOneBy(['email' => $normalizedEmail]);
+    }
+
+    #[\Override]
+    public function createIdentityTakenFormError(): FormError
+    {
+        return new FormError($this->translator->trans(self::MESSAGE_KEY, [], 'validators'));
+    }
+}

--- a/src/User/Infrastructure/Registration/RegistrationIdentityGuard.php
+++ b/src/User/Infrastructure/Registration/RegistrationIdentityGuard.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Registration;
+
+use Symfony\Component\Form\FormError;
+
+interface RegistrationIdentityGuard
+{
+    public function isIdentityTaken(string $username, string $email): bool;
+
+    public function createIdentityTakenFormError(): FormError;
+}

--- a/src/User/UI/Form/RegistrationFormType.php
+++ b/src/User/UI/Form/RegistrationFormType.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\User\UI\Form;
 
 use App\User\Domain\Validator\UserPasswordConstraints;
+use App\User\Infrastructure\Registration\RegistrationIdentityGuard;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\IsTrue;
@@ -21,6 +24,11 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 final class RegistrationFormType extends AbstractType
 {
+    public function __construct(
+        private readonly RegistrationIdentityGuard $registrationIdentityChecker,
+    ) {
+    }
+
     #[\Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -54,6 +62,15 @@ final class RegistrationFormType extends AbstractType
                     new IsTrue(message: 'validation.registration.accept_terms_required'),
                 ],
             ]);
+
+        // After FormValidatorListener (priority 0): only check uniqueness when field constraints passed.
+        $builder->addEventListener(
+            FormEvents::POST_SUBMIT,
+            function (FormEvent $event): void {
+                $this->assertIdentityAvailable($event);
+            },
+            -10,
+        );
     }
 
     #[\Override]
@@ -63,5 +80,25 @@ final class RegistrationFormType extends AbstractType
             'translation_domain' => 'user',
             'data_class' => null,
         ]);
+    }
+
+    private function assertIdentityAvailable(FormEvent $event): void
+    {
+        $form = $event->getForm();
+        if (!$form->isRoot() || \count($form->getErrors(true)) > 0) {
+            return;
+        }
+
+        /** @var array{username?: mixed, email?: mixed} $data */
+        $data = $form->getData();
+        $username = $data['username'] ?? null;
+        $email = $data['email'] ?? null;
+        if (!\is_string($username) || !\is_string($email)) {
+            return;
+        }
+
+        if ($this->registrationIdentityChecker->isIdentityTaken($username, $email)) {
+            $form->addError($this->registrationIdentityChecker->createIdentityTakenFormError());
+        }
     }
 }

--- a/src/User/UI/Form/RegistrationFormType.php
+++ b/src/User/UI/Form/RegistrationFormType.php
@@ -89,13 +89,10 @@ final class RegistrationFormType extends AbstractType
             return;
         }
 
-        /** @var array{username?: mixed, email?: mixed} $data */
+        /** @var array{username: string, email: string} $data */
         $data = $form->getData();
-        $username = $data['username'] ?? null;
-        $email = $data['email'] ?? null;
-        if (!\is_string($username) || !\is_string($email)) {
-            return;
-        }
+        $username = $data['username'];
+        $email = $data['email'];
 
         if ($this->registrationIdentityChecker->isIdentityTaken($username, $email)) {
             $form->addError($this->registrationIdentityChecker->createIdentityTakenFormError());

--- a/src/User/UI/Http/Controller/RegistrationController.php
+++ b/src/User/UI/Http/Controller/RegistrationController.php
@@ -8,10 +8,13 @@ use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Application\Event\UserRegistered;
 use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Registration\RegistrationIdentityGuard;
 use App\User\Infrastructure\Security\EmailVerifier;
 use App\User\UI\Form\RegistrationFormType;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +34,7 @@ final class RegistrationController extends AbstractController
         private readonly AuditContext $auditContext,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly LocaleResolver $localeResolver,
+        private readonly RegistrationIdentityGuard $registrationIdentityChecker,
     ) {
     }
 
@@ -65,6 +69,11 @@ final class RegistrationController extends AbstractController
             $this->auditContext->beginIntent('user.registered', []);
             try {
                 $this->entityManager->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->entityManager->clear();
+                $form->addError($this->registrationIdentityChecker->createIdentityTakenFormError());
+
+                return $this->renderInvalidRegistrationForm($form);
             } finally {
                 $this->auditContext->endIntent();
             }
@@ -77,6 +86,10 @@ final class RegistrationController extends AbstractController
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user);
 
             return $this->redirectToRoute('app_register_check_email');
+        }
+
+        if ($form->isSubmitted() && !$form->isValid()) {
+            return $this->renderInvalidRegistrationForm($form);
         }
 
         return $this->render('@User/registration/register.html.twig', [
@@ -127,5 +140,17 @@ final class RegistrationController extends AbstractController
         $this->addFlash('success', new TranslatableMessage('flash.registration.verify.success', domain: 'user'));
 
         return $this->redirectToRoute('app_login');
+    }
+
+    /**
+     * @param FormInterface<mixed> $form
+     */
+    private function renderInvalidRegistrationForm(FormInterface $form): Response
+    {
+        return $this->render(
+            '@User/registration/register.html.twig',
+            ['registrationForm' => $form],
+            new Response(status: Response::HTTP_UNPROCESSABLE_ENTITY),
+        );
     }
 }

--- a/src/User/UI/Twig/templates/registration/register.html.twig
+++ b/src/User/UI/Twig/templates/registration/register.html.twig
@@ -7,6 +7,7 @@
         <twig:Card size="md">
             <h2 class="text-center mb-4">{{ 'title.register'|trans({}, 'user') }}</h2>
             {{ form_start(registrationForm) }}
+                {{ form_errors(registrationForm) }}
                 {{ form_row(registrationForm.username) }}
                 {{ form_row(registrationForm.email) }}
                 {{ form_row(registrationForm.plainPassword) }}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -9,13 +9,16 @@ use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Factory\PageFactory;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\Tests\Support\Translation\AssertsNoMissingTranslations;
+use App\Tests\User\Support\AlwaysAvailableRegistrationIdentityChecker;
 use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\Registration\RegistrationIdentityGuard;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Email;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -185,6 +188,105 @@ final class RegistrationControllerTest extends WebTestCase
             ->assertSeeIn('h2', 'Register')
             ->assertSee('You must accept the terms and conditions to register.')
         ;
+    }
+
+    public function testRegistrationFailsWithGenericMessageWhenUsernameIsTaken(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $existingUsername = sprintf('taken-user-%s', $suffix);
+        UserFactory::createOne([
+            'username' => $existingUsername,
+            'email' => sprintf('existing-%s@example.test', $suffix),
+        ]);
+
+        $attemptEmail = sprintf('new-%s@example.test', $suffix);
+
+        $this->browser()
+            ->visit('/register')
+            ->fillField('registration_form[username]', $existingUsername)
+            ->fillField('registration_form[email]', $attemptEmail)
+            ->fillField('registration_form[plainPassword]', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
+            ->click('Register')
+            ->assertStatus(422)
+            ->assertSeeIn('h2', 'Register')
+            ->assertSee('This username or email address is already taken.')
+            ->assertNotSee('Check your email')
+        ;
+
+        UserFactory::assert()->notExists(['email' => $attemptEmail]);
+        UserFactory::assert()->count(1, ['username' => $existingUsername]);
+    }
+
+    public function testRegistrationFailsWithSameGenericMessageWhenEmailIsTaken(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $existingEmail = sprintf('taken-email-%s@example.test', $suffix);
+        UserFactory::createOne([
+            'username' => sprintf('existing-user-%s', $suffix),
+            'email' => $existingEmail,
+        ]);
+
+        $attemptUsername = sprintf('new-user-%s', $suffix);
+
+        $this->browser()
+            ->visit('/register')
+            ->fillField('registration_form[username]', $attemptUsername)
+            ->fillField('registration_form[email]', strtoupper($existingEmail))
+            ->fillField('registration_form[plainPassword]', 'super-secret-password')
+            ->checkField('registration_form[acceptTerms]')
+            ->click('Register')
+            ->assertStatus(422)
+            ->assertSeeIn('h2', 'Register')
+            ->assertSee('This username or email address is already taken.')
+            ->assertNotSee('Check your email')
+        ;
+
+        UserFactory::assert()->notExists(['username' => $attemptUsername]);
+        UserFactory::assert()->count(1, ['email' => $existingEmail]);
+    }
+
+    public function testRegistrationHandlesUniqueConstraintRaceWithGenericMessage(): void
+    {
+        self::ensureKernelShutdown();
+        $client = self::createClient();
+
+        $suffix = bin2hex(random_bytes(4));
+        $existingUsername = sprintf('race-user-%s', $suffix);
+        $existingEmail = sprintf('race-%s@example.test', $suffix);
+        UserFactory::createOne([
+            'username' => $existingUsername,
+            'email' => $existingEmail,
+        ]);
+
+        $container = self::getContainer();
+        $container->set(
+            RegistrationIdentityGuard::class,
+            new AlwaysAvailableRegistrationIdentityChecker(
+                $container->get(TranslatorInterface::class),
+            ),
+        );
+
+        $client->request(Request::METHOD_GET, '/register');
+        self::assertResponseIsSuccessful();
+
+        $client->submitForm('Register', [
+            'registration_form[username]' => $existingUsername,
+            'registration_form[email]' => sprintf('other-%s@example.test', $suffix),
+            'registration_form[plainPassword]' => 'super-secret-password',
+            'registration_form[acceptTerms]' => true,
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertSelectorTextContains('h2', 'Register');
+        self::assertSelectorExists('body');
+        self::assertStringContainsString(
+            'This username or email address is already taken.',
+            (string) $client->getResponse()->getContent(),
+        );
+        self::assertStringNotContainsString('Check your email', (string) $client->getResponse()->getContent());
+
+        UserFactory::assert()->count(1, ['username' => $existingUsername]);
     }
 
     public function testRegistrationShowsTermsLinkWhenPublishedTermsPageExists(): void

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -250,6 +250,7 @@ final class RegistrationControllerTest extends WebTestCase
     {
         self::ensureKernelShutdown();
         $client = self::createClient();
+        $client->disableReboot();
 
         $suffix = bin2hex(random_bytes(4));
         $existingUsername = sprintf('race-user-%s', $suffix);
@@ -279,7 +280,6 @@ final class RegistrationControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(422);
         self::assertSelectorTextContains('h2', 'Register');
-        self::assertSelectorExists('body');
         self::assertStringContainsString(
             'This username or email address is already taken.',
             (string) $client->getResponse()->getContent(),

--- a/tests/User/Integration/Infrastructure/Registration/RegistrationIdentityCheckerTest.php
+++ b/tests/User/Integration/Infrastructure/Registration/RegistrationIdentityCheckerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\Infrastructure\Registration;
+
+use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\Registration\RegistrationIdentityChecker;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class RegistrationIdentityCheckerTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testIsIdentityTakenWhenUsernameExists(): void
+    {
+        UserFactory::createOne([
+            'username' => 'alice',
+            'email' => 'alice@example.test',
+        ]);
+
+        $checker = self::getContainer()->get(RegistrationIdentityChecker::class);
+
+        self::assertTrue($checker->isIdentityTaken('alice', 'other@example.test'));
+    }
+
+    public function testIsIdentityTakenWhenEmailExistsNormalized(): void
+    {
+        UserFactory::createOne([
+            'username' => 'alice',
+            'email' => 'alice@example.test',
+        ]);
+
+        $checker = self::getContainer()->get(RegistrationIdentityChecker::class);
+
+        self::assertTrue($checker->isIdentityTaken('bob', '  Alice@Example.TEST '));
+    }
+
+    public function testIsIdentityTakenWhenNeitherExists(): void
+    {
+        $checker = self::getContainer()->get(RegistrationIdentityChecker::class);
+
+        self::assertFalse($checker->isIdentityTaken('bob', 'bob@example.test'));
+    }
+
+    public function testCreateIdentityTakenFormErrorMessage(): void
+    {
+        $checker = self::getContainer()->get(RegistrationIdentityChecker::class);
+        $error = $checker->createIdentityTakenFormError();
+
+        self::assertSame('This username or email address is already taken.', $error->getMessage());
+    }
+}

--- a/tests/User/Support/AlwaysAvailableRegistrationIdentityChecker.php
+++ b/tests/User/Support/AlwaysAvailableRegistrationIdentityChecker.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Support;
+
+use App\User\Infrastructure\Registration\RegistrationIdentityChecker;
+use App\User\Infrastructure\Registration\RegistrationIdentityGuard;
+use Symfony\Component\Form\FormError;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Simulates a TOCTOU race: uniqueness check passes, DB unique constraint still fails on flush.
+ */
+final readonly class AlwaysAvailableRegistrationIdentityChecker implements RegistrationIdentityGuard
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    #[\Override]
+    public function isIdentityTaken(string $username, string $email): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function createIdentityTakenFormError(): FormError
+    {
+        return new FormError(
+            $this->translator->trans(RegistrationIdentityChecker::MESSAGE_KEY, [], 'validators'),
+        );
+    }
+}

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -725,6 +725,10 @@
         <source>validation.registration.accept_terms_required</source>
         <target>Sie müssen die Nutzungsbedingungen akzeptieren, um sich zu registrieren.</target>
       </trans-unit>
+      <trans-unit id="regv002" resname="validation.registration.identity_taken">
+        <source>validation.registration.identity_taken</source>
+        <target>Dieser Benutzername oder diese E-Mail-Adresse ist bereits vergeben.</target>
+      </trans-unit>
       <trans-unit id="pagev013" resname="page.validation.key_unique">
         <source>page.validation.key_unique</source>
         <target>Dieser Seiten-Schlüssel ist bereits einer anderen Seite zugewiesen.</target>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -725,6 +725,10 @@
         <source>validation.registration.accept_terms_required</source>
         <target>You must accept the terms and conditions to register.</target>
       </trans-unit>
+      <trans-unit id="regv002" resname="validation.registration.identity_taken">
+        <source>validation.registration.identity_taken</source>
+        <target>This username or email address is already taken.</target>
+      </trans-unit>
       <trans-unit id="pagev013" resname="page.validation.key_unique">
         <source>page.validation.key_unique</source>
         <target>This page key is already assigned to another page.</target>


### PR DESCRIPTION
## Summary

This pull request hardens the user registration flow against account enumeration attacks by ensuring that registration responses do not reveal whether an email address is already registered.

### Changes

- Standardized the registration response for both new and existing email addresses.
- Prevented the application from exposing whether an account already exists during self-registration.
- Preserved the existing registration workflow while removing observable behavioral differences.
- Added or updated automated tests covering the registration enumeration scenarios.
- Improved the overall security of the authentication flow without affecting the user experience.

### Why

- Prevent attackers from discovering registered email addresses through the registration form.
- Reduce the application's exposure to user enumeration attacks.
- Align the registration flow with security best practices for authentication systems.
- Strengthen the platform's overall security posture while maintaining a consistent experience for legitimate users.