### PR TITLE
fix: sanitize blog index preview HTML (SEC-002)

### DIFF
--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -16,7 +16,7 @@ Related: [Issue #257](https://github.com/nplhse/collaborative-ivena-statistics/i
 Top risks to track:
 
 1. ~~Registration account enumeration via duplicate username/email (error path).~~ **Resolved** (SEC-001 — generic validation).
-2. Blog index preview renders unsanitized HTML (`|raw`) while show uses `PostContentSanitizer`.
+2. ~~Blog index preview renders unsanitized HTML (`|raw`) while show uses `PostContentSanitizer`.~~ **Resolved** (SEC-002 — sanitized list preview).
 3. CSV exports without formula neutralization (Excel formula injection).
 4. Live Component mount path `/_components` outside `access_control`.
 5. Cross-hospital Explore visibility for all participants (product decision: accept or restrict).
@@ -109,7 +109,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`blog/index.html.twig`](../../src/Content/UI/Twig/templates/blog/index.html.twig) L55–56; show path sanitizes via [`PostContentSanitizer`](../../src/Content/Application/Blog/PostContentSanitizer.php) in [`BlogController`](../../src/Content/UI/Http/Controller/BlogController.php) |
 | Risk | Stored XSS on public blog listing if admin-authored HTML bypasses intended sanitizer (or sanitizer config drifts). Show is safe; index is inconsistent. |
 | Mitigation | Sanitize preview in controller (same sanitizer as show) or stop using `\|raw` on index (e.g. `striptags` + truncate only). |
-| Status | open |
+| Status | resolved (2026-07-28) — `PostContentSanitizer::preview()` builds list snippets; index/category/tag pass `previews` map (no unsanitized Twig `|raw` on `post.content`) |
 
 ### SEC-003 — CSV exports lack formula neutralization
 

--- a/src/Content/Application/Blog/PostContentSanitizer.php
+++ b/src/Content/Application/Blog/PostContentSanitizer.php
@@ -9,6 +9,8 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 final readonly class PostContentSanitizer
 {
+    public const int PLAIN_PREVIEW_MAX_LENGTH = 260;
+
     /** @psalm-suppress PossiblyUnusedMethod */
     public function __construct(
         #[Autowire(service: 'html_sanitizer.sanitizer.page_richtext')]
@@ -25,5 +27,27 @@ final readonly class PostContentSanitizer
         $decoded = html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
         return $this->pageRichtextSanitizer->sanitize($decoded);
+    }
+
+    /**
+     * Safe HTML snippet for blog list cards (first paragraph or truncated plain text).
+     */
+    public function preview(string $content, int $plainMaxLength = self::PLAIN_PREVIEW_MAX_LENGTH): string
+    {
+        $safe = $this->sanitize($content);
+        if ('' === $safe) {
+            return '';
+        }
+
+        if (str_contains($safe, '</p>')) {
+            return explode('</p>', $safe, 2)[0].'</p>';
+        }
+
+        $text = strip_tags($safe);
+        if (mb_strlen($text) > $plainMaxLength) {
+            $text = mb_substr($text, 0, $plainMaxLength).'...';
+        }
+
+        return htmlspecialchars($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 }

--- a/src/Content/UI/Http/Controller/BlogController.php
+++ b/src/Content/UI/Http/Controller/BlogController.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Content\UI\Http\Controller;
 
 use App\Content\Application\Blog\PostContentSanitizer;
+use App\Content\Domain\Entity\Post;
 use App\Content\Domain\Entity\PostComment;
 use App\Content\Infrastructure\Repository\PostCategoryRepository;
 use App\Content\Infrastructure\Repository\PostCommentRepository;
 use App\Content\Infrastructure\Repository\PostRepository;
 use App\Content\Infrastructure\Repository\PostTagRepository;
 use App\Content\UI\Http\DTO\BlogListQueryParametersDTO;
+use App\Shared\Infrastructure\Pagination\Paginator;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -38,8 +40,11 @@ final class BlogController extends AbstractController
     #[Route('/blog', name: 'app_blog_index', methods: ['GET'])]
     public function index(#[MapQueryString] BlogListQueryParametersDTO $query): Response
     {
+        $paginator = $this->postRepository->getPublishedPaginator($query);
+
         return $this->render('@Content/blog/index.html.twig', [
-            'paginator' => $this->postRepository->getPublishedPaginator($query),
+            'paginator' => $paginator,
+            'previews' => $this->buildPreviews($paginator),
             'pagination_route' => 'app_blog_index',
             'pagination_route_params' => [],
             'list_title' => 'blog.list.all_posts',
@@ -56,8 +61,11 @@ final class BlogController extends AbstractController
             throw $this->createNotFoundException($this->translator->trans('error.blog.category_not_found', [], 'content'));
         }
 
+        $paginator = $this->postRepository->getPublishedByCategorySlugPaginator($slug, $query);
+
         return $this->render('@Content/blog/index.html.twig', [
-            'paginator' => $this->postRepository->getPublishedByCategorySlugPaginator($slug, $query),
+            'paginator' => $paginator,
+            'previews' => $this->buildPreviews($paginator),
             'pagination_route' => 'app_blog_category',
             'pagination_route_params' => ['slug' => $slug],
             'activeCategory' => $category,
@@ -75,8 +83,11 @@ final class BlogController extends AbstractController
             throw $this->createNotFoundException($this->translator->trans('error.blog.tag_not_found', [], 'content'));
         }
 
+        $paginator = $this->postRepository->getPublishedByTagSlugPaginator($slug, $query);
+
         return $this->render('@Content/blog/index.html.twig', [
-            'paginator' => $this->postRepository->getPublishedByTagSlugPaginator($slug, $query),
+            'paginator' => $paginator,
+            'previews' => $this->buildPreviews($paginator),
             'pagination_route' => 'app_blog_tag',
             'pagination_route_params' => ['slug' => $slug],
             'activeTag' => $tag,
@@ -101,7 +112,7 @@ final class BlogController extends AbstractController
     public function show(string $slug): Response
     {
         $post = $this->postRepository->findPublishedBySlug($slug);
-        if (!$post instanceof \App\Content\Domain\Entity\Post) {
+        if (!$post instanceof Post) {
             throw $this->createNotFoundException($this->translator->trans('error.blog.post_not_found', [], 'content'));
         }
 
@@ -120,7 +131,7 @@ final class BlogController extends AbstractController
     public function createComment(string $slug, Request $request): RedirectResponse
     {
         $post = $this->postRepository->findPublishedBySlug($slug);
-        if (!$post instanceof \App\Content\Domain\Entity\Post) {
+        if (!$post instanceof Post) {
             throw $this->createNotFoundException($this->translator->trans('error.blog.post_not_found', [], 'content'));
         }
 
@@ -167,8 +178,22 @@ final class BlogController extends AbstractController
     }
 
     /**
+     * @return array<int, string>
+     */
+    private function buildPreviews(Paginator $paginator): array
+    {
+        $previews = [];
+        foreach ($paginator->getResults() as $post) {
+            /* @var Post $post */
+            $previews[(int) $post->getId()] = $this->postContentSanitizer->preview((string) $post->getContent());
+        }
+
+        return $previews;
+    }
+
+    /**
      * @return array{
-     *   latest_posts: list<\App\Content\Domain\Entity\Post>,
+     *   latest_posts: list<Post>,
      *   sidebar_categories: list<array{category: \App\Content\Domain\Entity\PostCategory, postCount: int}>,
      *   sidebar_tags: list<array{tag: \App\Content\Domain\Entity\PostTag, postCount: int}>
      * }

--- a/src/Content/UI/Twig/templates/blog/index.html.twig
+++ b/src/Content/UI/Twig/templates/blog/index.html.twig
@@ -52,12 +52,7 @@
                                             <span>| {{ 'blog.comments.count'|trans(({count: post.comments|length}), 'content') }}</span>
                                         </div>
                                         <div>
-                                            {% if '</p>' in post.content %}
-                                                {{ (post.content|split('</p>')|first ~ '</p>')|raw }}
-                                            {% else %}
-                                                {% set preview = post.content|striptags %}
-                                                {{ preview|length > 260 ? preview|slice(0, 260) ~ '...' : preview }}
-                                            {% endif %}
+                                            {{ previews[post.id]|default('')|raw }}
                                         </div>
                                         <div class="mt-3 d-flex align-items-center justify-content-between gap-2 flex-wrap">
                                             <a class="btn btn-outline-primary btn-sm" href="{{ path('app_blog_show', {slug: post.slug}) }}">

--- a/tests/Content/Functional/Controller/BlogControllerTest.php
+++ b/tests/Content/Functional/Controller/BlogControllerTest.php
@@ -103,6 +103,31 @@ final class BlogControllerTest extends WebTestCase
         self::assertSelectorExists('.pagination');
     }
 
+    public function testIndexPreviewSanitizesScriptTagsFromPostContent(): void
+    {
+        $client = self::createClient();
+        $category = PostCategoryFactory::createOne(['name' => 'Security', 'slug' => 'security']);
+
+        PostFactory::createOne([
+            'title' => 'XSS Preview Post',
+            'slug' => 'xss-preview-post',
+            'content' => '<p>Hello preview</p><script>alert(1)</script><p>Hidden second</p>',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-1 hour'),
+            'category' => $category,
+        ]);
+
+        $client->request(Request::METHOD_GET, '/blog');
+        self::assertResponseIsSuccessful();
+
+        $html = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('Hello preview', $html);
+        self::assertStringContainsString('<p>Hello preview</p>', $html);
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringNotContainsString('alert(1)', $html);
+        self::assertStringNotContainsString('Hidden second', $html);
+    }
+
     public function testCategoryAndTagFiltersUsePublishedDuePosts(): void
     {
         $client = self::createClient();

--- a/tests/Content/Integration/Blog/PostContentSanitizerTest.php
+++ b/tests/Content/Integration/Blog/PostContentSanitizerTest.php
@@ -61,4 +61,41 @@ final class PostContentSanitizerTest extends KernelTestCase
         self::assertStringContainsString('page-content-image--float-left', $html);
         self::assertStringContainsString('float-start', $html);
     }
+
+    public function testPreviewKeepsFirstParagraphAndStripsScript(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+        $preview = $sut->preview('<p>Safe intro</p><script>alert(1)</script><p>More</p>');
+
+        self::assertStringContainsString('<p>Safe intro</p>', $preview);
+        self::assertStringNotContainsString('<script>', $preview);
+        self::assertStringNotContainsString('More', $preview);
+    }
+
+    public function testPreviewTruncatesPlainTextWithoutParagraph(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+        $long = str_repeat('a', PostContentSanitizer::PLAIN_PREVIEW_MAX_LENGTH + 40);
+        $preview = $sut->preview($long);
+
+        self::assertStringNotContainsString('<', $preview);
+        self::assertStringEndsWith('...', $preview);
+        self::assertSame(
+            PostContentSanitizer::PLAIN_PREVIEW_MAX_LENGTH + 3,
+            mb_strlen(html_entity_decode($preview, ENT_QUOTES | ENT_HTML5, 'UTF-8')),
+        );
+    }
+
+    public function testPreviewReturnsEmptyStringForEmptyContent(): void
+    {
+        self::bootKernel();
+
+        $sut = self::getContainer()->get(PostContentSanitizer::class);
+
+        self::assertSame('', $sut->preview(''));
+    }
 }


### PR DESCRIPTION
## Summary

This pull request fixes a cross-site scripting (XSS) vulnerability in the blog index by ensuring that post previews are rendered safely and cannot execute untrusted HTML or JavaScript.

### Changes

- Sanitized blog preview content before rendering it on the blog index.
- Prevented untrusted HTML from being interpreted as executable markup.
- Preserved the intended preview experience while eliminating the XSS attack vector.
- Added or updated automated tests covering malicious preview content.
- Documented the completed security fix as part of the project's security hardening efforts.

### Why

- Protect users from stored cross-site scripting attacks originating from blog content.
- Ensure that user-controlled content is rendered as safe preview text.
- Align the blog rendering pipeline with secure output-encoding best practices.
- Strengthen the application's overall defense against client-side injection vulnerabilities.