### PR TITLE
fix: neutralize CSV formula injection in exports (SEC-003)

### DIFF
--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -17,7 +17,7 @@ Top risks to track:
 
 1. ~~Registration account enumeration via duplicate username/email (error path).~~ **Resolved** (SEC-001 — generic validation).
 2. ~~Blog index preview renders unsanitized HTML (`|raw`) while show uses `PostContentSanitizer`.~~ **Resolved** (SEC-002 — sanitized list preview).
-3. CSV exports without formula neutralization (Excel formula injection).
+3. ~~CSV exports without formula neutralization (Excel formula injection).~~ **Resolved** (SEC-003 — `CsvFormulaEscaper`).
 4. Live Component mount path `/_components` outside `access_control`.
 5. Cross-hospital Explore visibility for all participants (product decision: accept or restrict).
 
@@ -120,7 +120,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`CsvStreamExportResponseFactory::writeRow`](../../src/Shared/Application/Export/CsvStreamExportResponseFactory.php) L44–57; analogous tabular exporter for Analysis Explorer — cells written via `fputcsv` without escaping leading `=`, `+`, `-`, `@`, tab |
 | Risk | Imported free-text fields opened in Excel/LibreOffice can execute formulas (CSV injection) on the analyst’s machine. |
 | Mitigation | Prefix risky cells with `'` (or neutralize) in shared CSV writers before `fputcsv`. |
-| Status | open |
+| Status | resolved (2026-07-28) — `CsvFormulaEscaper` prefixes dangerous string cells in stream/tabular/reject CSV writers; numeric cells unchanged |
 
 ### SEC-004 — Live Component route `/_components` not in `access_control`
 

--- a/src/Import/Infrastructure/Adapter/SplCsvRejectWriter.php
+++ b/src/Import/Infrastructure/Adapter/SplCsvRejectWriter.php
@@ -6,6 +6,7 @@ namespace App\Import\Infrastructure\Adapter;
 
 use App\Import\Application\Contracts\RejectWriterInterface;
 use App\Import\Domain\Entity\Import;
+use App\Shared\Application\Export\CsvFormulaEscaper;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
@@ -59,7 +60,7 @@ final class SplCsvRejectWriter implements RejectWriterInterface
         $this->file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
 
         $this->file->fputcsv(
-            ['line', 'error_messages', 'row_json'],
+            array_map(CsvFormulaEscaper::escape(...), ['line', 'error_messages', 'row_json']),
             $this->delimiter,
             $this->enclosure,
             $this->escape
@@ -75,9 +76,9 @@ final class SplCsvRejectWriter implements RejectWriterInterface
 
         $this->file->fputcsv(
             [
-                $line ?? '',
-                implode(' | ', $messages),
-                json_encode($row, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE),
+                null === $line ? '' : (string) $line,
+                CsvFormulaEscaper::escape(implode(' | ', $messages)),
+                CsvFormulaEscaper::escape(json_encode($row, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE)),
             ],
             $this->delimiter,
             $this->enclosure,

--- a/src/Import/Infrastructure/Analysis/Export/CsvRejectAnalysisExporter.php
+++ b/src/Import/Infrastructure/Analysis/Export/CsvRejectAnalysisExporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Import\Infrastructure\Analysis\Export;
 
 use App\Import\Application\Analysis\DTO\RejectAnalysisResult;
+use App\Shared\Application\Export\CsvFormulaEscaper;
 
 final class CsvRejectAnalysisExporter implements RejectAnalysisExporterInterface
 {
@@ -40,18 +41,24 @@ final class CsvRejectAnalysisExporter implements RejectAnalysisExporterInterface
         }
 
         try {
-            fputcsv($handle, self::HEADERS, self::DELIMITER, self::ENCLOSURE, self::ESCAPE);
+            fputcsv(
+                $handle,
+                array_map(CsvFormulaEscaper::escape(...), self::HEADERS),
+                self::DELIMITER,
+                self::ENCLOSURE,
+                self::ESCAPE,
+            );
 
             foreach ($result->groups as $group) {
                 fputcsv($handle, [
                     $group->count,
-                    $group->field,
-                    $group->rejectedValue,
-                    $group->reason,
-                    $group->exampleFile,
-                    $group->exampleLine,
-                    $group->suggestedTransformerHint,
-                    $group->exampleRawRow,
+                    CsvFormulaEscaper::escape($group->field),
+                    CsvFormulaEscaper::escape($group->rejectedValue),
+                    CsvFormulaEscaper::escape($group->reason),
+                    CsvFormulaEscaper::escape($group->exampleFile),
+                    CsvFormulaEscaper::escape($group->exampleLine),
+                    CsvFormulaEscaper::escape($group->suggestedTransformerHint),
+                    CsvFormulaEscaper::escape($group->exampleRawRow),
                 ], self::DELIMITER, self::ENCLOSURE, self::ESCAPE);
             }
         } finally {

--- a/src/Shared/Application/Export/CsvFormulaEscaper.php
+++ b/src/Shared/Application/Export/CsvFormulaEscaper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Export;
+
+/**
+ * Neutralizes CSV formula injection for spreadsheet clients (Excel, LibreOffice).
+ *
+ * Only string cells should be passed here; numeric types stay unescaped so values
+ * like -42 remain plain numbers rather than formula-like text.
+ */
+final class CsvFormulaEscaper
+{
+    private const array DANGEROUS_PREFIXES = ['=', '+', '-', '@', "\t", "\r"];
+
+    public static function escape(string $value): string
+    {
+        if ('' === $value) {
+            return '';
+        }
+
+        if (\in_array($value[0], self::DANGEROUS_PREFIXES, true)) {
+            return "'".$value;
+        }
+
+        return $value;
+    }
+}

--- a/src/Shared/Application/Export/CsvStreamExportResponseFactory.php
+++ b/src/Shared/Application/Export/CsvStreamExportResponseFactory.php
@@ -49,7 +49,7 @@ final class CsvStreamExportResponseFactory
                 null === $value => '',
                 \is_int($value) => (string) $value,
                 \is_float($value) => rtrim(rtrim(sprintf('%.10F', $value), '0'), '.'),
-                default => $value,
+                default => CsvFormulaEscaper::escape($value),
             }, $cells),
             ',',
             '"',

--- a/src/Statistics/GenericAnalysis/Application/Export/CsvTabularExporter.php
+++ b/src/Statistics/GenericAnalysis/Application/Export/CsvTabularExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\GenericAnalysis\Application\Export;
 
+use App\Shared\Application\Export\CsvFormulaEscaper;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('statistics.tabular_exporter')]
@@ -42,7 +43,10 @@ final class CsvTabularExporter implements TabularExporterInterface
 
         fputcsv(
             $stream,
-            array_map(static fn (TabularExportColumn $column): string => $column->label, $document->headers),
+            array_map(
+                static fn (TabularExportColumn $column): string => CsvFormulaEscaper::escape($column->label),
+                $document->headers,
+            ),
             self::DELIMITER,
             self::ENCLOSURE,
             self::ESCAPE,
@@ -83,6 +87,6 @@ final class CsvTabularExporter implements TabularExporterInterface
             return rtrim(rtrim(sprintf('%.10F', $value), '0'), '.');
         }
 
-        return $value;
+        return CsvFormulaEscaper::escape($value);
     }
 }

--- a/tests/Import/Unit/Infrastructure/Adapter/SplCsvRejectWriterTest.php
+++ b/tests/Import/Unit/Infrastructure/Adapter/SplCsvRejectWriterTest.php
@@ -66,6 +66,16 @@ final class SplCsvRejectWriterTest extends TestCase
         self::assertStringContainsString('boom', $content);
     }
 
+    public function testWriteNeutralizesFormulaInjectionInMessages(): void
+    {
+        $this->writer->start($this->createImportStub());
+        $this->writer->write(['field' => 'value'], ['=CMD|calc'], 3);
+
+        $content = file_get_contents((string) $this->writer->getPath());
+        self::assertNotFalse($content);
+        self::assertStringContainsString("'=CMD|calc", $content);
+    }
+
     public function testWriteBeforeStartThrowsLogicException(): void
     {
         $this->expectException(\LogicException::class);

--- a/tests/Import/Unit/Infrastructure/Analysis/CsvRejectAnalysisExporterTest.php
+++ b/tests/Import/Unit/Infrastructure/Analysis/CsvRejectAnalysisExporterTest.php
@@ -57,4 +57,34 @@ final class CsvRejectAnalysisExporterTest extends TestCase
             @unlink($path);
         }
     }
+
+    public function testExportNeutralizesFormulaInjectionInStringFields(): void
+    {
+        $group = new RejectAnalysisGroup(
+            count: 1,
+            field: 'indication',
+            rejectedValue: '=CMD|"/C calc"!A0',
+            reason: '-bad',
+            exampleFile: '@file.csv',
+            exampleLine: '9',
+            suggestedTransformerHint: '+hint',
+            exampleRawRow: '{"x":1}',
+        );
+
+        $path = sys_get_temp_dir().'/reject-analysis-formula-'.bin2hex(random_bytes(4)).'.csv';
+        $exporter = new CsvRejectAnalysisExporter();
+        $exporter->export(new RejectAnalysisResult(1, [$group]), $path);
+
+        try {
+            $content = file_get_contents($path);
+            self::assertNotFalse($content);
+            self::assertStringContainsString("\"'=CMD|\"\"/C calc\"\"!A0\"", $content);
+            self::assertStringContainsString("'-bad,", $content);
+            self::assertStringContainsString("'@file.csv,", $content);
+            self::assertStringContainsString("'+hint,", $content);
+            self::assertStringContainsString('"{""x"":1}"', $content);
+        } finally {
+            @unlink($path);
+        }
+    }
 }

--- a/tests/Shared/Unit/Export/CsvFormulaEscaperTest.php
+++ b/tests/Shared/Unit/Export/CsvFormulaEscaperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Export;
+
+use App\Shared\Application\Export\CsvFormulaEscaper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CsvFormulaEscaperTest extends TestCase
+{
+    #[DataProvider('provideDangerousValues')]
+    public function testEscapesDangerousPrefixes(string $input, string $expected): void
+    {
+        self::assertSame($expected, CsvFormulaEscaper::escape($input));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function provideDangerousValues(): iterable
+    {
+        yield 'equals' => ['=CMD|"/C calc"!A0', "'=CMD|\"/C calc\"!A0"];
+        yield 'plus' => ['+1+1', "'+1+1"];
+        yield 'minus text' => ['-text', "'-text"];
+        yield 'at' => ['@SUM(A1)', "'@SUM(A1)"];
+        yield 'tab' => ["\tformula", "'\tformula"];
+        yield 'cr' => ["\rformula", "'\rformula"];
+    }
+
+    public function testLeavesSafeValuesUnchanged(): void
+    {
+        self::assertSame('', CsvFormulaEscaper::escape(''));
+        self::assertSame('hello', CsvFormulaEscaper::escape('hello'));
+        self::assertSame('42', CsvFormulaEscaper::escape('42'));
+        self::assertSame('Normal text', CsvFormulaEscaper::escape('Normal text'));
+    }
+}

--- a/tests/Shared/Unit/Export/CsvStreamExportResponseFactoryTest.php
+++ b/tests/Shared/Unit/Export/CsvStreamExportResponseFactoryTest.php
@@ -22,4 +22,18 @@ final class CsvStreamExportResponseFactoryTest extends TestCase
 
         self::assertSame("id,name,,42\n", $line);
     }
+
+    public function testWriteRowNeutralizesFormulaInjectionInStrings(): void
+    {
+        $factory = new CsvStreamExportResponseFactory();
+        $stream = fopen('php://temp', 'w+');
+        self::assertIsResource($stream);
+
+        $factory->writeRow($stream, ['=1+1', -5, 3.5, 'safe']);
+        rewind($stream);
+        $line = stream_get_contents($stream) ?: '';
+        fclose($stream);
+
+        self::assertSame("'=1+1,-5,3.5,safe\n", $line);
+    }
 }

--- a/tests/Statistics/Unit/GenericAnalysis/Export/CsvTabularExporterTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/Export/CsvTabularExporterTest.php
@@ -78,6 +78,23 @@ final class CsvTabularExporterTest extends TestCase
         self::assertStringContainsString("33.3333333333\n", $csv);
     }
 
+    public function testNeutralizesFormulaInjectionInStringCellsAndHeaders(): void
+    {
+        $document = new TabularExportDocument(
+            headers: [new TabularExportColumn('label', '=Danger')],
+            rows: [['=1+2'], ['-text'], [-7]],
+            footerRows: [['+total']],
+        );
+
+        $csv = $this->exportToString($document);
+
+        self::assertStringContainsString("'=Danger\n", $csv);
+        self::assertStringContainsString("'=1+2\n", $csv);
+        self::assertStringContainsString("'-text\n", $csv);
+        self::assertStringContainsString("-7\n", $csv);
+        self::assertStringContainsString("'+total\n", $csv);
+    }
+
     public function testSupportsDynamicColumnCount(): void
     {
         $document = new TabularExportDocument(


### PR DESCRIPTION
## Summary

This pull request mitigates CSV formula injection by ensuring that exported values cannot be interpreted as spreadsheet formulas when opened in applications such as Microsoft Excel or LibreOffice Calc.

### Changes

- Sanitized exported CSV values that could be interpreted as formulas by spreadsheet applications.
- Neutralized cells beginning with formula-triggering characters while preserving their visible content.
- Applied the protection consistently across CSV exports.
- Added or updated automated tests covering common CSV formula injection payloads.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Protect users from CSV formula injection attacks when opening exported files.
- Prevent malicious content from executing through spreadsheet software.
- Align CSV exports with established security best practices for untrusted data.
- Strengthen the application's overall export security without affecting normal data usage.