### PR TITLE
docs: Accept collaborative Explore, require PARTICIPANT for allocation detail view

### DIFF
--- a/docs/02-architecture/decisions/011-collaborative-explore-allocation-visibility.md
+++ b/docs/02-architecture/decisions/011-collaborative-explore-allocation-visibility.md
@@ -1,0 +1,39 @@
+# ADR 011: Collaborative Explore allocation visibility
+
+**Status:** accepted
+
+## Context
+
+Explore (`/explore`) lists and shows allocation records that may belong to any participating hospital. The security audit (SEC-005) asked whether this cross-hospital visibility is intentional collaboration or a missing tenant boundary. Hospital grants (`HospitalPermission::View`) already gate clinic management, import, export, and scoped statistics filters — but not Explore allocation `VIEW`.
+
+Separately, path-level `access_control` already requires `ROLE_PARTICIPANT` for `/explore`, while `AllocationVoter` historically granted `VIEW` to any `ROLE_USER`. That mismatch left the voter weaker than the firewall if it were ever reused outside Explore.
+
+## Decision
+
+1. **Collaborative by design:** Participants may view allocation list and detail records for **all** hospitals. Explore hospital filters (including “My hospitals”) are UX convenience, not an authorization boundary. Allocation `VIEW` is **not** bound to `HospitalPermission::View`.
+2. **Participant required:** Viewing allocations requires `ROLE_PARTICIPANT`. `ROLE_USER` alone is insufficient. Enforce this both via `access_control` on `/explore` and in `AllocationVoter` (defense in depth).
+
+## Consequences
+
+**Positive:**
+
+- Matches the product goal of a shared, collaborative allocation overview
+- Clear docs reduce mis-implementation of hospital-scoped Explore checks
+- Voter and path gate agree on `ROLE_PARTICIPANT`
+
+**Negative:**
+
+- Clinical free-text and hospital identity are visible across centers to every participant
+- Must be communicated in onboarding / beta expectations
+
+## Alternatives
+
+- **Tenant isolation** — bind `AllocationVoter::VIEW` to `HospitalPermission::View` and default list scope to accessible hospitals — rejected; conflicts with collaborative Explore
+- **Leave voter on `ROLE_USER`** — rejected; weaker than the `/explore` path gate and invites drift
+
+## References
+
+- [../permission-model.md](../permission-model.md)
+- [../../04-features/allocation/explore-allocation-list.md](../../04-features/allocation/explore-allocation-list.md)
+- [../../05-operations/security-audit-beta.md](../../05-operations/security-audit-beta.md) (SEC-005)
+- `src/Allocation/Infrastructure/Security/Voter/AllocationVoter.php`

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -26,6 +26,7 @@ Each ADR includes:
 | [008](008-shared-platform-and-domain-framework-coupling.md) | Shared platform role and domain framework coupling | accepted |
 | [009](009-ports-repositories-query-objects-and-naming.md) | Ports, repositories, query objects, and naming | accepted |
 | [010](010-architecture-guardrails-and-beta-scope.md) | Architecture guardrails and beta complexity scope | accepted |
+| [011](011-collaborative-explore-allocation-visibility.md) | Collaborative Explore allocation visibility | accepted |
 
 ## Template
 

--- a/docs/02-architecture/permission-model.md
+++ b/docs/02-architecture/permission-model.md
@@ -2,7 +2,7 @@
 
 The application uses Symfony roles for global access and hospital-scoped permission grants for participants.
 
-Related: [decisions/002-hospital-permission-bitmask.md](decisions/002-hospital-permission-bitmask.md)
+Related: [decisions/002-hospital-permission-bitmask.md](decisions/002-hospital-permission-bitmask.md), [decisions/011-collaborative-explore-allocation-visibility.md](decisions/011-collaborative-explore-allocation-visibility.md)
 
 ## Global roles
 
@@ -11,7 +11,7 @@ Defined in `src/User/Domain/Security/UserRole.php`:
 | Role | Purpose |
 |------|---------|
 | `ROLE_USER` | Base access; public statistics (`/statistics`) |
-| `ROLE_PARTICIPANT` | Hospital participant; `/hospitals`, `/explore` |
+| `ROLE_PARTICIPANT` | Hospital participant; `/hospitals`, `/explore` (allocation list/detail) |
 | `ROLE_ADMIN` | EasyAdmin back office, impersonation |
 | `ROLE_REVIEW_INDICATIONS` | Indication raw review worklist |
 | `ROLE_FEEDBACK_RECIPIENT` | Receives feedback admin notifications (with `ROLE_ADMIN`) |
@@ -49,7 +49,15 @@ Grants are stored in `HospitalAccessGrant` as an integer mask and validated via 
 | `ExportVoter` | `EXPORT` | (none) |
 | `IndicationRawReviewVoter` | `VIEW`, `EDIT_MATCH`, `REVIEW` | `IndicationRaw` |
 
+`AllocationVoter::VIEW` requires `ROLE_PARTICIPANT` (not merely `ROLE_USER`) and applies to **any** allocation — it does **not** check `HospitalPermission::View`. Path `access_control` on `/explore` also requires `ROLE_PARTICIPANT`.
+
 Use `$this->denyAccessUnlessGranted()` in controllers and `#[IsGranted]` attributes where appropriate.
+
+## Explore collaboration
+
+Explore is a **collaborative** overview: participants may list and open allocations from other hospitals. Hospital filters (including “My hospitals”) are optional UX, not an authz boundary. See [ADR 011](decisions/011-collaborative-explore-allocation-visibility.md).
+
+Import, export, clinic management, and hospital-scoped statistics filters remain grant-based via `HospitalPermissionAccess`.
 
 ## Benchmarking vs. statistics
 

--- a/docs/04-features/allocation/explore-allocation-list.md
+++ b/docs/04-features/allocation/explore-allocation-list.md
@@ -2,7 +2,9 @@
 
 Route: `/explore/allocation` (`app_explore_allocation_list`)
 
-Cursor-paginated list of allocation records with a filter drawer (hospital attributes, geography, clinical flags, and more).
+Requires `ROLE_PARTICIPANT` (`access_control` on `/explore`). Cursor-paginated list of allocation records with a filter drawer (hospital attributes, geography, clinical flags, and more).
+
+**Collaborative by design** ([ADR 011](../../02-architecture/decisions/011-collaborative-explore-allocation-visibility.md)): the default “All hospitals” scope shows allocations across centers. That is intentional; hospital filters are UX, not an authorization boundary. `ROLE_USER` alone cannot access Explore.
 
 ## My hospitals filter
 

--- a/docs/04-features/onboarding/participant-onboarding.md
+++ b/docs/04-features/onboarding/participant-onboarding.md
@@ -10,6 +10,8 @@ Alpha onboarding for users with `ROLE_PARTICIPANT`: a dashboard card guides new 
 4. Browse imported allocations in Explore (links to `/explore/allocation?hospitalFilter=my_hospitals`)
 5. Open statistics overview
 
+Explore requires `ROLE_PARTICIPANT`. By design, participants can also see allocations from other clinics (collaborative overview — see [ADR 011](../../02-architecture/decisions/011-collaborative-explore-allocation-visibility.md)); the onboarding link prefers “My hospitals” as a starting filter only.
+
 Step availability is **strictly sequential**: a step becomes actionable only after all previous steps are completed (step 1 is auto-completed when the user already has clinic view access). Users unlock the next step by marking the current one complete on the dashboard card; there is no automatic check yet for whether an import actually exists.
 
 Step-specific permissions still apply (for example, import or statistics rights on at least one hospital). Completed steps are stored in `user_onboarding_step`.

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -19,7 +19,7 @@ Top risks to track:
 2. ~~Blog index preview renders unsanitized HTML (`|raw`) while show uses `PostContentSanitizer`.~~ **Resolved** (SEC-002 — sanitized list preview).
 3. ~~CSV exports without formula neutralization (Excel formula injection).~~ **Resolved** (SEC-003 — `CsvFormulaEscaper`).
 4. ~~Live Component mount path `/_components` outside `access_control`.~~ **Resolved** (SEC-004 — `ROLE_USER` path gate).
-5. Cross-hospital Explore visibility for all participants (product decision: accept or restrict).
+5. ~~Cross-hospital Explore visibility for all participants.~~ **Accepted** (SEC-005 — collaborative by design; `ROLE_PARTICIPANT` required).
 
 ---
 
@@ -144,7 +144,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Risk | Every participant can read allocation detail (incl. hospital identity and clinical fields) for other centers. Fits a collaborative model; conflicts with strict tenant isolation. |
 | Mitigation | **If collaborative-by-design:** document as accepted risk in permission model + onboarding. **If isolation required:** bind `VIEW` to `HospitalPermission::View` and default list scope to accessible hospitals. |
 | Notes | Pure `ROLE_USER` cannot reach `/explore` (403). Firewall is the effective gate; voter alone would be weaker. |
-| Status | open (needs product confirmation) |
+| Status | accepted (2026-07-28) — collaborative by design ([ADR 011](../02-architecture/decisions/011-collaborative-explore-allocation-visibility.md)); `AllocationVoter` requires `ROLE_PARTICIPANT` (hierarchy-aware); not hospital-grant-scoped |
 
 ### SEC-006 — Incomplete Explore list rate limiting
 
@@ -276,7 +276,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`permission-model.md`](../02-architecture/permission-model.md) ImportVoter table omits `DOWNLOAD_SOURCE`; AllocationVoter collaborative semantics undocumented |
 | Risk | Maintainers mis-implement access checks. |
 | Mitigation | Update voter table + document Explore collaboration / accepted risk (SEC-005). |
-| Status | open |
+| Status | open — AllocationVoter / Explore collaboration documented with SEC-005 (ADR 011); `ImportVoter::DOWNLOAD_SOURCE` still missing from voter table |
 
 ### SEC-018 — Messenger import handlers trust queue without permission re-check
 
@@ -343,11 +343,11 @@ Do **not** implement in this audit deliverable.
 
 ---
 
-## Accepted / intentional designs (confirm SEC-005)
+## Accepted / intentional designs
 
 | Topic | Current behaviour | Recommendation |
 |-------|-------------------|----------------|
-| Collaborative Explore | Participants see cross-hospital allocations | Product: accept (document) **or** restrict (SEC-005) |
+| Collaborative Explore | Participants see cross-hospital allocations; `ROLE_PARTICIPANT` required | **Accepted** (SEC-005 / ADR 011) |
 | Public statistics | `ROLE_USER` sees aggregates / public scopes | Keep |
 | Public health endpoint | Uptime-friendly JSON | Keep or slim (SEC-012) |
 | CSP report-only | Beta monitoring before enforce | Follow CSP ops guide |
@@ -362,7 +362,6 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004, SEC-008 | Export safety, Live Component defense-in-depth, audit gap |
-| P1 product call | SEC-005 | Isolation vs collaboration |
 | P2 hardening | SEC-006, SEC-007, SEC-009–SEC-016, SEC-019 | Rate limits, path containment, redirects, headers, docs |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 

--- a/src/Allocation/Infrastructure/Security/Voter/AllocationVoter.php
+++ b/src/Allocation/Infrastructure/Security/Voter/AllocationVoter.php
@@ -10,15 +10,25 @@ use App\User\Domain\Security\UserRole;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 /**
- * Explore allocation detail: any authenticated user with ROLE_USER may VIEW (no per-hospital restriction).
+ * Explore allocation detail: any ROLE_PARTICIPANT may VIEW any allocation (collaborative by design).
+ *
+ * Not scoped to HospitalPermission::View. ROLE_USER alone is insufficient.
+ * Role hierarchy is respected (e.g. ROLE_ADMIN implies ROLE_PARTICIPANT).
+ * See docs/02-architecture/decisions/011-collaborative-explore-allocation-visibility.md.
  *
  * @extends Voter<string, Allocation>
  */
 final class AllocationVoter extends Voter
 {
     public const string VIEW = 'VIEW';
+
+    public function __construct(
+        private readonly RoleHierarchyInterface $roleHierarchy,
+    ) {
+    }
 
     #[\Override]
     public function supportsType(string $subjectType): bool
@@ -40,6 +50,8 @@ final class AllocationVoter extends Voter
             return false;
         }
 
-        return \in_array(UserRole::USER, $user->getRoles(), true);
+        $reachableRoles = $this->roleHierarchy->getReachableRoleNames($token->getRoleNames());
+
+        return \in_array(UserRole::PARTICIPANT, $reachableRoles, true);
     }
 }

--- a/tests/Allocation/Unit/Infrastructure/Security/AllocationVoterTest.php
+++ b/tests/Allocation/Unit/Infrastructure/Security/AllocationVoterTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
 
 final class AllocationVoterTest extends TestCase
 {
@@ -20,17 +21,43 @@ final class AllocationVoterTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
-        $this->voter = new AllocationVoter();
+        $this->voter = new AllocationVoter(new RoleHierarchy([
+            UserRole::ADMIN => [UserRole::PARTICIPANT, UserRole::REVIEW_INDICATIONS],
+        ]));
     }
 
-    public function testViewGrantedForAuthenticatedUser(): void
+    public function testViewGrantedForParticipant(): void
     {
-        $user = $this->createUser([UserRole::USER]);
+        $user = $this->createUser([UserRole::USER, UserRole::PARTICIPANT]);
         $allocation = $this->createMock(Allocation::class);
-        $token = $this->createToken($user);
+        $token = $this->createToken($user, [UserRole::USER, UserRole::PARTICIPANT]);
 
         self::assertSame(
             Voter::ACCESS_GRANTED,
+            $this->voter->vote($token, $allocation, [AllocationVoter::VIEW]),
+        );
+    }
+
+    public function testViewGrantedForAdminViaRoleHierarchy(): void
+    {
+        $user = $this->createUser([UserRole::USER, UserRole::ADMIN]);
+        $allocation = $this->createMock(Allocation::class);
+        $token = $this->createToken($user, [UserRole::USER, UserRole::ADMIN]);
+
+        self::assertSame(
+            Voter::ACCESS_GRANTED,
+            $this->voter->vote($token, $allocation, [AllocationVoter::VIEW]),
+        );
+    }
+
+    public function testViewDeniedForUserWithoutParticipantRole(): void
+    {
+        $user = $this->createUser([UserRole::USER]);
+        $allocation = $this->createMock(Allocation::class);
+        $token = $this->createToken($user, [UserRole::USER]);
+
+        self::assertSame(
+            Voter::ACCESS_DENIED,
             $this->voter->vote($token, $allocation, [AllocationVoter::VIEW]),
         );
     }
@@ -40,6 +67,7 @@ final class AllocationVoterTest extends TestCase
         $allocation = $this->createMock(Allocation::class);
         $token = $this->createMock(TokenInterface::class);
         $token->method('getUser')->willReturn(null);
+        $token->method('getRoleNames')->willReturn([]);
 
         self::assertSame(
             Voter::ACCESS_DENIED,
@@ -58,10 +86,14 @@ final class AllocationVoterTest extends TestCase
         return $user;
     }
 
-    private function createToken(User $user): TokenInterface&MockObject
+    /**
+     * @param list<string> $roleNames
+     */
+    private function createToken(User $user, array $roleNames): TokenInterface&MockObject
     {
         $token = $this->createMock(TokenInterface::class);
         $token->method('getUser')->willReturn($user);
+        $token->method('getRoleNames')->willReturn($roleNames);
 
         return $token;
     }


### PR DESCRIPTION
## Summary

This pull request documents the security review and acceptance of the collaborative Explore functionality, including the rationale for the remaining risk and the safeguards that are already in place.

### Changes

- Added security documentation for the collaborative Explore feature.
- Documented the threat assessment and the corresponding mitigation measures.
- Explained why the remaining residual risk is considered acceptable.
- Recorded the security review outcome as part of the project's security documentation.
- Linked the decision to the broader security hardening and review process.

### Why

- Provide a transparent record of the security assessment and its outcome.
- Document the reasoning behind accepting the remaining risk.
- Help future contributors understand the security assumptions of the collaborative Explore feature.
- Improve the project's long-term security governance and auditability.