### PR TITLE
fix: Explore list rate limit

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -30,8 +30,8 @@ when@test:
         rate_limiter:
             explore_list:
                 policy: fixed_window
-                limit: 3
-                interval: '15 minutes'
+                limit: 10000
+                interval: '1 second'
             feedback_submit:
                 policy: fixed_window
                 limit: 10000

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -155,7 +155,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`ExploreListRateLimitSubscriber`](../../src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php) exact match on four paths only; other lists (`indication`, `infection`, `occasion`, `speciality`, `department`, `dispatch_area`, `secondary_transport`, …) unlimited |
 | Risk | Authenticated participants can scrape unbounded Explore lists. |
 | Mitigation | Include all Explore list routes (prefix or explicit allowlist); keep ~100 / 10 min per user+IP as baseline. |
-| Status | open |
+| Status | resolved (2026-07-28) — all GET under `/explore` share `explore_list` (100 / 10 min per user+IP); previously unlimited lists included |
 
 ### SEC-007 — No RateLimiter on register / reset-password / import / export
 
@@ -362,7 +362,7 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004, SEC-008 | Export safety, Live Component defense-in-depth, audit gap |
-| P2 hardening | SEC-006, SEC-007, SEC-009–SEC-016, SEC-019 | Rate limits, path containment, redirects, headers, docs |
+| P2 hardening | SEC-007, SEC-009–SEC-016, SEC-019 | Rate limits, path containment, redirects, headers, docs |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -155,7 +155,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`ExploreListRateLimitSubscriber`](../../src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php) exact match on four paths only; other lists (`indication`, `infection`, `occasion`, `speciality`, `department`, `dispatch_area`, `secondary_transport`, …) unlimited |
 | Risk | Authenticated participants can scrape unbounded Explore lists. |
 | Mitigation | Include all Explore list routes (prefix or explicit allowlist); keep ~100 / 10 min per user+IP as baseline. |
-| Status | resolved (2026-07-28) — all GET under `/explore` share `explore_list` (100 / 10 min per user+IP); previously unlimited lists included |
+| Status | resolved (2026-07-28) — all GET under `/explore` share `explore_list` (100 / 10 min per user+IP); subscriber runs after firewall; test env uses a high limit so suites are not poisoned |
 
 ### SEC-007 — No RateLimiter on register / reset-password / import / export
 

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -319,7 +319,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 |---------|-------------------|-------|
 | `POST /register` | 5 / hour / IP | SEC-007 |
 | `POST /reset-password` | 10 / hour / IP | Complements per-user bundle throttle |
-| Explore list GETs | Extend existing `explore_list` to all list routes | SEC-006 |
+| Explore list GETs | All GET `/explore` via `explore_list` | SEC-006 **resolved** |
 | Allocations export estimate/download | 10 / 10 min / user | SEC-007 |
 | Analysis Explorer CSV export | 20 / 10 min / user | SEC-007 |
 | Import create (`POST /import/new`) | 10 / hour / user | Optional DoS guard |

--- a/src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php
+++ b/src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php
@@ -17,6 +17,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * Shared rate limit for Explore GET scraping protection (lists, details, worklists).
  *
+ * Runs after the security firewall (priority 8) so the user identity is available
+ * for the limiter key instead of collapsing every request into "anon".
+ *
  * @psalm-suppress UnusedClass
  */
 final readonly class ExploreListRateLimitSubscriber
@@ -30,7 +33,7 @@ final readonly class ExploreListRateLimitSubscriber
     ) {
     }
 
-    #[AsEventListener(event: KernelEvents::REQUEST, priority: 8)]
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 7)]
     public function onKernelRequest(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {

--- a/src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php
+++ b/src/Allocation/Infrastructure/Http/ExploreListRateLimitSubscriber.php
@@ -14,16 +14,14 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/** @psalm-suppress UnusedClass */
+/**
+ * Shared rate limit for Explore GET scraping protection (lists, details, worklists).
+ *
+ * @psalm-suppress UnusedClass
+ */
 final readonly class ExploreListRateLimitSubscriber
 {
-    /** @var list<string> */
-    private const array LIMITED_PATH_PREFIXES = [
-        '/explore/allocation',
-        '/explore/mci_case',
-        '/explore/hospital',
-        '/explore/assignment',
-    ];
+    private const string EXPLORE_PATH_PREFIX = '/explore';
 
     public function __construct(
         #[Autowire(service: 'limiter.explore_list')]
@@ -40,7 +38,7 @@ final readonly class ExploreListRateLimitSubscriber
         }
 
         $request = $event->getRequest();
-        if (Request::METHOD_GET !== $request->getMethod() || !$this->isLimitedExploreListPath($request->getPathInfo())) {
+        if (Request::METHOD_GET !== $request->getMethod() || !$this->isLimitedExplorePath($request->getPathInfo())) {
             return;
         }
 
@@ -56,8 +54,8 @@ final readonly class ExploreListRateLimitSubscriber
         $event->setResponse(new Response('Too many requests. Please try again later.', Response::HTTP_TOO_MANY_REQUESTS));
     }
 
-    private function isLimitedExploreListPath(string $path): bool
+    private function isLimitedExplorePath(string $path): bool
     {
-        return \in_array($path, self::LIMITED_PATH_PREFIXES, true);
+        return self::EXPLORE_PATH_PREFIX === $path || str_starts_with($path, self::EXPLORE_PATH_PREFIX.'/');
     }
 }

--- a/tests/Allocation/Functional/Security/ExploreListRateLimitTest.php
+++ b/tests/Allocation/Functional/Security/ExploreListRateLimitTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Allocation\Functional\Security;
 
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -19,22 +20,7 @@ final class ExploreListRateLimitTest extends WebTestCase
 
     public function testExploreAllocationListIsRateLimited(): void
     {
-        $client = self::createClient();
-
-        UserFactory::new(['username' => 'explore-rate-limit', 'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']])->create();
-        $this->acceptEssentialCookiesOnly($client);
-
-        $crawler = $client->request(Request::METHOD_GET, '/login');
-        $form = $crawler->selectButton('Sign in')->form([
-            'login[username]' => 'explore-rate-limit',
-            'login[password]' => 'password',
-        ]);
-        $client->submit($form);
-
-        if ($client->getResponse()->isRedirect()) {
-            $client->followRedirect();
-        }
-
+        $client = $this->createLoggedInParticipantClient('explore-rate-limit');
         $client->getContainer()->get('cache.rate_limiter')->clear();
 
         for ($i = 0; $i < 3; ++$i) {
@@ -44,5 +30,58 @@ final class ExploreListRateLimitTest extends WebTestCase
 
         $client->request(Request::METHOD_GET, '/explore/allocation');
         self::assertResponseStatusCodeSame(429);
+    }
+
+    public function testPreviouslyUnlimitedExploreListsShareTheSameBucket(): void
+    {
+        $client = $this->createLoggedInParticipantClient('explore-rate-limit-mixed');
+        $client->getContainer()->get('cache.rate_limiter')->clear();
+
+        $client->request(Request::METHOD_GET, '/explore/allocation');
+        self::assertResponseIsSuccessful();
+
+        $client->request(Request::METHOD_GET, '/explore/indication');
+        self::assertResponseIsSuccessful();
+
+        $client->request(Request::METHOD_GET, '/explore/infection');
+        self::assertResponseIsSuccessful();
+
+        $client->request(Request::METHOD_GET, '/explore/speciality');
+        self::assertResponseStatusCodeSame(429);
+    }
+
+    public function testNonExplorePathsAreNotAffectedByExploreListLimiter(): void
+    {
+        $client = $this->createLoggedInParticipantClient('explore-rate-limit-other');
+        $client->getContainer()->get('cache.rate_limiter')->clear();
+
+        for ($i = 0; $i < 3; ++$i) {
+            $client->request(Request::METHOD_GET, '/explore/allocation');
+            self::assertResponseIsSuccessful();
+        }
+
+        $client->request(Request::METHOD_GET, '/statistics/');
+        self::assertResponseIsSuccessful();
+    }
+
+    private function createLoggedInParticipantClient(string $username): KernelBrowser
+    {
+        $client = self::createClient();
+
+        UserFactory::new(['username' => $username, 'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']])->create();
+        $this->acceptEssentialCookiesOnly($client);
+
+        $crawler = $client->request(Request::METHOD_GET, '/login');
+        $form = $crawler->selectButton('Sign in')->form([
+            'login[username]' => $username,
+            'login[password]' => 'password',
+        ]);
+        $client->submit($form);
+
+        if ($client->getResponse()->isRedirect()) {
+            $client->followRedirect();
+        }
+
+        return $client;
     }
 }

--- a/tests/Allocation/Functional/Security/ExploreListRateLimitTest.php
+++ b/tests/Allocation/Functional/Security/ExploreListRateLimitTest.php
@@ -6,74 +6,31 @@ namespace App\Tests\Allocation\Functional\Security;
 
 use App\Tests\Support\Browser\CookieConsentTestHelper;
 use App\User\Domain\Factory\UserFactory;
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
 
+/**
+ * Smoke: Explore GETs remain reachable under the generous when@test explore_list limit.
+ * Enforcement behaviour is covered by ExploreListRateLimitSubscriberTest (unit).
+ */
 #[ResetDatabase]
 final class ExploreListRateLimitTest extends WebTestCase
 {
     use CookieConsentTestHelper;
     use Factories;
 
-    public function testExploreAllocationListIsRateLimited(): void
-    {
-        $client = $this->createLoggedInParticipantClient('explore-rate-limit');
-        $client->getContainer()->get('cache.rate_limiter')->clear();
-
-        for ($i = 0; $i < 3; ++$i) {
-            $client->request(Request::METHOD_GET, '/explore/allocation');
-            self::assertResponseIsSuccessful();
-        }
-
-        $client->request(Request::METHOD_GET, '/explore/allocation');
-        self::assertResponseStatusCodeSame(429);
-    }
-
-    public function testPreviouslyUnlimitedExploreListsShareTheSameBucket(): void
-    {
-        $client = $this->createLoggedInParticipantClient('explore-rate-limit-mixed');
-        $client->getContainer()->get('cache.rate_limiter')->clear();
-
-        $client->request(Request::METHOD_GET, '/explore/allocation');
-        self::assertResponseIsSuccessful();
-
-        $client->request(Request::METHOD_GET, '/explore/indication');
-        self::assertResponseIsSuccessful();
-
-        $client->request(Request::METHOD_GET, '/explore/infection');
-        self::assertResponseIsSuccessful();
-
-        $client->request(Request::METHOD_GET, '/explore/speciality');
-        self::assertResponseStatusCodeSame(429);
-    }
-
-    public function testNonExplorePathsAreNotAffectedByExploreListLimiter(): void
-    {
-        $client = $this->createLoggedInParticipantClient('explore-rate-limit-other');
-        $client->getContainer()->get('cache.rate_limiter')->clear();
-
-        for ($i = 0; $i < 3; ++$i) {
-            $client->request(Request::METHOD_GET, '/explore/allocation');
-            self::assertResponseIsSuccessful();
-        }
-
-        $client->request(Request::METHOD_GET, '/statistics/');
-        self::assertResponseIsSuccessful();
-    }
-
-    private function createLoggedInParticipantClient(string $username): KernelBrowser
+    public function testPreviouslyUnlimitedExploreListRemainsReachableForParticipant(): void
     {
         $client = self::createClient();
 
-        UserFactory::new(['username' => $username, 'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']])->create();
+        UserFactory::new(['username' => 'explore-rate-limit-smoke', 'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']])->create();
         $this->acceptEssentialCookiesOnly($client);
 
         $crawler = $client->request(Request::METHOD_GET, '/login');
         $form = $crawler->selectButton('Sign in')->form([
-            'login[username]' => $username,
+            'login[username]' => 'explore-rate-limit-smoke',
             'login[password]' => 'password',
         ]);
         $client->submit($form);
@@ -82,6 +39,11 @@ final class ExploreListRateLimitTest extends WebTestCase
             $client->followRedirect();
         }
 
-        return $client;
+        $client->getContainer()->get('cache.rate_limiter')->clear();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $client->request(Request::METHOD_GET, '/explore/indication');
+            self::assertResponseIsSuccessful();
+        }
     }
 }

--- a/tests/Allocation/Unit/Infrastructure/Http/ExploreListRateLimitSubscriberTest.php
+++ b/tests/Allocation/Unit/Infrastructure/Http/ExploreListRateLimitSubscriberTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Infrastructure\Http;
+
+use App\Allocation\Infrastructure\Http\ExploreListRateLimitSubscriber;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class ExploreListRateLimitSubscriberTest extends TestCase
+{
+    public function testIgnoresNonExplorePaths(): void
+    {
+        $subscriber = new ExploreListRateLimitSubscriber($this->createFactory(), $this->createStub(TokenStorageInterface::class));
+        $event = $this->createGetRequestEvent('/statistics/');
+
+        $subscriber->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testIgnoresNonGetMethods(): void
+    {
+        $subscriber = new ExploreListRateLimitSubscriber($this->createFactory(), $this->createStub(TokenStorageInterface::class));
+        $event = $this->createRequestEvent(Request::create('/explore/allocation', Request::METHOD_POST));
+
+        $subscriber->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testReturnsTooManyRequestsWhenLimitExceeded(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $user->method('getUserIdentifier')->willReturn('participant-1');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        $tokenStorage = $this->createStub(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        $factory = $this->createFactory(limit: 3);
+        $subscriber = new ExploreListRateLimitSubscriber($factory, $tokenStorage);
+
+        for ($i = 0; $i < 3; ++$i) {
+            $event = $this->createGetRequestEvent('/explore/indication');
+            $subscriber->onKernelRequest($event);
+            self::assertNull($event->getResponse());
+        }
+
+        $event = $this->createGetRequestEvent('/explore/indication');
+        $subscriber->onKernelRequest($event);
+
+        $response = $event->getResponse();
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $response->getStatusCode());
+    }
+
+    public function testAllowsRequestWhenLimitAccepted(): void
+    {
+        $tokenStorage = $this->createStub(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn(null);
+
+        $subscriber = new ExploreListRateLimitSubscriber($this->createFactory(limit: 3), $tokenStorage);
+        $event = $this->createGetRequestEvent('/explore/allocation/019fa883-a780-7929-bf8b-2392e0ae1565');
+
+        $subscriber->onKernelRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    private function createFactory(int $limit = 3): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            [
+                'id' => 'explore_list_test',
+                'policy' => 'fixed_window',
+                'limit' => $limit,
+                'interval' => '1 hour',
+            ],
+            new InMemoryStorage(),
+        );
+    }
+
+    private function createGetRequestEvent(string $path): RequestEvent
+    {
+        return $this->createRequestEvent(Request::create($path, Request::METHOD_GET));
+    }
+
+    private function createRequestEvent(Request $request): RequestEvent
+    {
+        /** @var HttpKernelInterface&MockObject $kernel */
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+    }
+}


### PR DESCRIPTION
## Summary

This pull request introduces rate limiting for the Explore list endpoint to protect the application against excessive request rates while preserving normal interactive usage.

### Changes

- Added rate limiting to the Explore list endpoint.
- Applied request throttling to reduce the impact of abusive or automated traffic.
- Preserved the normal user experience for legitimate interactive requests.
- Added or updated automated tests covering rate-limit behavior and edge cases.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Reduce the risk of automated scraping and denial-of-service attempts.
- Protect backend resources from excessive request volumes.
- Improve the resilience of the Explore functionality without affecting normal usage.
- Strengthen the application's defense-in-depth strategy by introducing endpoint-level request throttling.