### PR TITLE
fix: Add rate limiters for Register, Reset, Import, and Exports

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -34,7 +34,7 @@ framework:
             interval: '1 hour'
         import_create:
             policy: fixed_window
-            limit: 10
+            limit: 30
             interval: '1 hour'
         allocations_export:
             policy: fixed_window

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -24,6 +24,26 @@ framework:
             policy: sliding_window
             limit: 1
             interval: '3 seconds'
+        register:
+            policy: fixed_window
+            limit: 5
+            interval: '1 hour'
+        reset_password_request:
+            policy: fixed_window
+            limit: 10
+            interval: '1 hour'
+        import_create:
+            policy: fixed_window
+            limit: 10
+            interval: '1 hour'
+        allocations_export:
+            policy: fixed_window
+            limit: 10
+            interval: '10 minutes'
+        analysis_explorer_export:
+            policy: fixed_window
+            limit: 20
+            interval: '10 minutes'
 
 when@test:
     framework:
@@ -47,4 +67,24 @@ when@test:
             transactional_mail:
                 policy: sliding_window
                 limit: 1000
+                interval: '1 second'
+            register:
+                policy: fixed_window
+                limit: 10000
+                interval: '1 second'
+            reset_password_request:
+                policy: fixed_window
+                limit: 10000
+                interval: '1 second'
+            import_create:
+                policy: fixed_window
+                limit: 10000
+                interval: '1 second'
+            allocations_export:
+                policy: fixed_window
+                limit: 10000
+                interval: '1 second'
+            analysis_explorer_export:
+                policy: fixed_window
+                limit: 10000
                 interval: '1 second'

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -166,7 +166,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | Limiter config has no register/export/import keys; reset-password has bundle per-user throttle only |
 | Risk | Registration spam / mail flood; export DoS (CPU/IO); reset-password cross-account mail flooding via IP. Login already throttled. |
 | Mitigation | IP (+ optional email) limiters: e.g. register 5/h, reset-password 10/h per IP, allocations export 10/10 min, explorer export 20/10 min, import upload 10/h. |
-| Status | open |
+| Status | resolved (2026-07-28) — `register`, `reset_password_request`, `import_create`, `allocations_export`, `analysis_explorer_export` limiters via `ClientRateLimit`; reset reject keeps check-email UX |
 
 ### SEC-008 — Import source download audit intent does not persist
 
@@ -317,12 +317,12 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 
 | Surface | Suggested limiter | Notes |
 |---------|-------------------|-------|
-| `POST /register` | 5 / hour / IP | SEC-007 |
-| `POST /reset-password` | 10 / hour / IP | Complements per-user bundle throttle |
+| `POST /register` | 5 / hour / IP | SEC-007 **resolved** |
+| `POST /reset-password` | 10 / hour / IP | SEC-007 **resolved** (silent check-email) |
 | Explore list GETs | All GET `/explore` via `explore_list` | SEC-006 **resolved** |
-| Allocations export estimate/download | 10 / 10 min / user | SEC-007 |
-| Analysis Explorer CSV export | 20 / 10 min / user | SEC-007 |
-| Import create (`POST /import/new`) | 10 / hour / user | Optional DoS guard |
+| Allocations export estimate/download | 10 / 10 min / user+IP | SEC-007 **resolved** |
+| Analysis Explorer CSV export | 20 / 10 min / user+IP | SEC-007 **resolved** |
+| Import create (`POST /import/new`) | 10 / hour / user+IP | SEC-007 **resolved** |
 
 Do **not** implement in this audit deliverable.
 
@@ -362,7 +362,7 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004, SEC-008 | Export safety, Live Component defense-in-depth, audit gap |
-| P2 hardening | SEC-007, SEC-009–SEC-016, SEC-019 | Rate limits, path containment, redirects, headers, docs |
+| P2 hardening | SEC-009–SEC-016, SEC-019 | Path containment, redirects, headers, docs |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -165,8 +165,8 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Area | RateLimit |
 | Evidence | Limiter config has no register/export/import keys; reset-password has bundle per-user throttle only |
 | Risk | Registration spam / mail flood; export DoS (CPU/IO); reset-password cross-account mail flooding via IP. Login already throttled. |
-| Mitigation | IP (+ optional email) limiters: e.g. register 5/h, reset-password 10/h per IP, allocations export 10/10 min, explorer export 20/10 min, import upload 10/h. |
-| Status | resolved (2026-07-28) — `register`, `reset_password_request`, `import_create`, `allocations_export`, `analysis_explorer_export` limiters via `ClientRateLimit`; reset reject keeps check-email UX |
+| Mitigation | IP (+ optional email) limiters: e.g. register 5/h, reset-password 10/h per IP, allocations export 10/10 min, explorer export 20/10 min, import upload 30/h. |
+| Status | resolved (2026-07-28) — `register`, `reset_password_request`, `import_create` (30/h), `allocations_export`, `analysis_explorer_export` limiters via `ClientRateLimit`; reset reject keeps check-email UX |
 
 ### SEC-008 — Import source download audit intent does not persist
 
@@ -322,7 +322,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Explore list GETs | All GET `/explore` via `explore_list` | SEC-006 **resolved** |
 | Allocations export estimate/download | 10 / 10 min / user+IP | SEC-007 **resolved** |
 | Analysis Explorer CSV export | 20 / 10 min / user+IP | SEC-007 **resolved** |
-| Import create (`POST /import/new`) | 10 / hour / user+IP | SEC-007 **resolved** |
+| Import create (`POST /import/new`) | 30 / hour / user+IP | SEC-007 **resolved** |
 
 Do **not** implement in this audit deliverable.
 

--- a/src/Allocation/UI/Http/Controller/Export/DownloadAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/DownloadAllocationsExportController.php
@@ -11,10 +11,15 @@ use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
 use App\Allocation\UI\Form\OwnHospitalAllocationsExportType;
 use App\Shared\Application\Export\ExportBlockedException;
 use App\Shared\Application\Export\ExportOrchestrator;
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,8 +38,21 @@ final class DownloadAllocationsExportController extends AbstractController
     }
 
     #[Route('/hospitals/export/allocations/download', name: 'app_hospitals_export_allocations_download', methods: ['POST'])]
-    public function __invoke(Request $request, #[CurrentUser] User $user): \Symfony\Component\HttpFoundation\StreamedResponse
-    {
+    public function __invoke(
+        Request $request,
+        #[CurrentUser] User $user,
+        #[Autowire(service: 'limiter.allocations_export')]
+        RateLimiterFactory $allocationsExportLimiter,
+    ): StreamedResponse {
+        $userId = $user->getId();
+        if (null === $userId) {
+            throw new \LogicException('Authenticated user has no ID.');
+        }
+
+        if (!ClientRateLimit::acceptUserAndIp($allocationsExportLimiter, 'allocations_export', (string) $userId, $request)) {
+            throw new TooManyRequestsHttpException(message: 'Too many export requests. Please try again later.');
+        }
+
         if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $request->request->getString('_token'))) {
             throw new BadRequestHttpException('Invalid CSRF token.');
         }

--- a/src/Allocation/UI/Http/Controller/Export/EstimateAllocationsExportController.php
+++ b/src/Allocation/UI/Http/Controller/Export/EstimateAllocationsExportController.php
@@ -10,10 +10,14 @@ use App\Allocation\Application\Export\OwnHospitalAllocationsExportFilterMapper;
 use App\Allocation\Infrastructure\Security\Voter\ExportVoter;
 use App\Allocation\UI\Form\OwnHospitalAllocationsExportType;
 use App\Shared\Application\Export\ExportOrchestrator;
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -30,8 +34,21 @@ final class EstimateAllocationsExportController extends AbstractController
     }
 
     #[Route('/hospitals/export/allocations/estimate', name: 'app_hospitals_export_allocations_estimate', methods: ['POST'])]
-    public function __invoke(Request $request, #[CurrentUser] User $user): Response
-    {
+    public function __invoke(
+        Request $request,
+        #[CurrentUser] User $user,
+        #[Autowire(service: 'limiter.allocations_export')]
+        RateLimiterFactory $allocationsExportLimiter,
+    ): Response {
+        $userId = $user->getId();
+        if (null === $userId) {
+            throw new \LogicException('Authenticated user has no ID.');
+        }
+
+        if (!ClientRateLimit::acceptUserAndIp($allocationsExportLimiter, 'allocations_export', (string) $userId, $request)) {
+            throw new TooManyRequestsHttpException(message: 'Too many export requests. Please try again later.');
+        }
+
         $form = $this->createForm(
             OwnHospitalAllocationsExportType::class,
             null,

--- a/src/Import/UI/Http/Controller/NewImportController.php
+++ b/src/Import/UI/Http/Controller/NewImportController.php
@@ -15,10 +15,12 @@ use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
 use App\Import\UI\Form\ImportCreateType;
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
@@ -26,6 +28,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -47,8 +50,11 @@ final class NewImportController extends AbstractController
     ) {
     }
 
-    public function __invoke(Request $request): Response
-    {
+    public function __invoke(
+        Request $request,
+        #[Autowire(service: 'limiter.import_create')]
+        RateLimiterFactory $importCreateLimiter,
+    ): Response {
         $form = $this->createForm(ImportCreateType::class);
         $form->handleRequest($request);
 
@@ -77,6 +83,12 @@ final class NewImportController extends AbstractController
         $userId = $user->getId();
         if (null === $userId) {
             throw new \LogicException('Authenticated user has no ID.');
+        }
+
+        if (!ClientRateLimit::acceptUserAndIp($importCreateLimiter, 'import_create', (string) $userId, $request)) {
+            $this->addFlash('warning', new TranslatableMessage('flash.import.rate_limited', domain: 'import'));
+
+            return $this->redirectToRoute('app_import_new');
         }
 
         /** @var Hospital $managedHospital */

--- a/src/Shared/Application/RateLimit/ClientRateLimit.php
+++ b/src/Shared/Application/RateLimit/ClientRateLimit.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\RateLimit;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Shared consume helpers for HTTP rate limiters (SEC-007).
+ */
+final class ClientRateLimit
+{
+    public static function acceptIp(RateLimiterFactory $factory, string $bucket, Request $request): bool
+    {
+        $key = sprintf('%s_%s', $bucket, sha1($request->getClientIp() ?? 'unknown'));
+
+        return $factory->create($key)->consume(1)->isAccepted();
+    }
+
+    public static function acceptUserAndIp(
+        RateLimiterFactory $factory,
+        string $bucket,
+        string $userIdentifier,
+        Request $request,
+    ): bool {
+        $key = sprintf(
+            '%s_%s_%s',
+            $bucket,
+            sha1($userIdentifier),
+            sha1($request->getClientIp() ?? 'unknown'),
+        );
+
+        return $factory->create($key)->consume(1)->isAccepted();
+    }
+}

--- a/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerExportController.php
+++ b/src/Statistics/AnalysisExplorer/UI/Http/Controller/AnalysisExplorerExportController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\AnalysisExplorer\UI\Http\Controller;
 
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\Statistics\AnalysisExplorer\Application\AnalysisRunnerRegistry;
 use App\Statistics\AnalysisExplorer\Application\AnalysisViewConfigNormalizer;
 use App\Statistics\AnalysisExplorer\Application\ExplorerAnalysisQueryFactory;
@@ -17,10 +18,13 @@ use App\Statistics\UI\Http\Controller\StatisticsFilterValueResolver;
 use App\User\Domain\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -50,9 +54,18 @@ final class AnalysisExplorerExportController extends AbstractController
         Request $request,
         #[CurrentUser] ?User $user,
         #[ValueResolver(StatisticsFilterValueResolver::class)] StatisticsFilter $filter,
+        #[Autowire(service: 'limiter.analysis_explorer_export')]
+        RateLimiterFactory $analysisExplorerExportLimiter,
     ): Response {
         if (!$this->isCsrfTokenValid(self::CSRF_TOKEN_ID, $request->request->getString('_token'))) {
             throw new BadRequestHttpException('Invalid CSRF token.');
+        }
+
+        $userKey = $user instanceof User && null !== $user->getId()
+            ? (string) $user->getId()
+            : 'anon';
+        if (!ClientRateLimit::acceptUserAndIp($analysisExplorerExportLimiter, 'analysis_explorer_export', $userKey, $request)) {
+            throw new TooManyRequestsHttpException(message: 'Too many export requests. Please try again later.');
         }
 
         $appliedConfigState = $request->request->getString('appliedConfigState');

--- a/src/User/UI/Http/Controller/RegistrationController.php
+++ b/src/User/UI/Http/Controller/RegistrationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Application\Locale\LocaleResolver;
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Application\Event\UserRegistered;
 use App\User\Domain\Entity\User;
@@ -14,11 +15,13 @@ use App\User\UI\Form\RegistrationFormType;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -41,6 +44,8 @@ final class RegistrationController extends AbstractController
     #[Route('/register', name: 'app_register')]
     public function register(
         Request $request,
+        #[Autowire(service: 'limiter.register')]
+        RateLimiterFactory $registerLimiter,
     ): Response {
         if ($this->getUser() instanceof UserInterface) {
             return $this->redirectToRoute('app_default');
@@ -50,6 +55,14 @@ final class RegistrationController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            if (!ClientRateLimit::acceptIp($registerLimiter, 'register', $request)) {
+                $this->addFlash('warning', new TranslatableMessage('flash.registration.rate_limited', domain: 'user'));
+
+                return $this->render('@User/registration/register.html.twig', [
+                    'registrationForm' => $form,
+                ]);
+            }
+
             /** @var array{username: string, email: string} $data */
             $data = $form->getData();
             $plainPassword = $form->get('plainPassword')->getData();

--- a/src/User/UI/Http/Controller/ResetPasswordController.php
+++ b/src/User/UI/Http/Controller/ResetPasswordController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\UI\Http\Controller;
 
 use App\Shared\Application\Locale\LocaleResolver;
+use App\Shared\Application\RateLimit\ClientRateLimit;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\Shared\Infrastructure\Mail\TransactionalMailer;
 use App\User\Domain\Entity\User;
@@ -12,10 +13,12 @@ use App\User\UI\Form\ResetPasswordFormType;
 use App\User\UI\Form\ResetPasswordRequestFormType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Translation\TranslatableMessage;
 use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
@@ -38,12 +41,20 @@ final class ResetPasswordController extends AbstractController
     }
 
     #[Route('/reset-password', name: 'app_forgot_password_request')]
-    public function request(Request $request): Response
-    {
+    public function request(
+        Request $request,
+        #[Autowire(service: 'limiter.reset_password_request')]
+        RateLimiterFactory $resetPasswordRequestLimiter,
+    ): Response {
         $form = $this->createForm(ResetPasswordRequestFormType::class);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            if (!ClientRateLimit::acceptIp($resetPasswordRequestLimiter, 'reset_password_request', $request)) {
+                // Same UX as success — avoid account/IP enumeration via distinct responses.
+                return $this->redirectToRoute('app_check_email');
+            }
+
             /** @var array{email: string} $data */
             $data = $form->getData();
             $this->processSendingPasswordResetEmail($data['email']);

--- a/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
@@ -25,6 +25,7 @@ use App\Shared\Application\Export\ExportBlockedException;
 use App\Shared\Application\Export\ExportEstimate;
 use App\Shared\Application\Export\ExportLimits;
 use App\Shared\Application\Export\ExportOrchestrator;
+use App\Tests\Support\RateLimit\DeniesRateLimiter;
 use App\Tests\Support\Translation\AssertsNoMissingTranslations;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Factory\UserFactory;
@@ -39,6 +40,7 @@ use Zenstruck\Foundry\Test\Factories;
 final class AllocationsExportControllerTest extends WebTestCase
 {
     use AssertsNoMissingTranslations;
+    use DeniesRateLimiter;
     use Factories;
 
     public function testNonParticipantCannotAccessExportPage(): void
@@ -101,6 +103,46 @@ final class AllocationsExportControllerTest extends WebTestCase
         self::assertSelectorExists('[data-testid="export-allocations-download"]');
         self::assertSelectorNotExists('#export-estimate select[name*="[urgency]"]');
         self::assertSelectorNotExists('#export-estimate #export-allocations-download-form');
+    }
+
+    public function testExportEstimateIsRateLimited(): void
+    {
+        [$client, $owner] = $this->createOwnerClient();
+        $client->disableReboot();
+        $ownerId = $owner->getId();
+        self::assertNotNull($ownerId);
+
+        $this->denyRateLimiter(
+            'limiter.allocations_export',
+            $this->userAndIpRateLimitKey('allocations_export', $ownerId),
+        );
+
+        $client->request(
+            Request::METHOD_POST,
+            '/hospitals/export/allocations/estimate',
+            [],
+            [],
+            ['HTTP_TURBO_FRAME' => 'export-estimate'],
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_TOO_MANY_REQUESTS);
+    }
+
+    public function testExportDownloadIsRateLimited(): void
+    {
+        [$client, $owner] = $this->createOwnerClient();
+        $client->disableReboot();
+        $ownerId = $owner->getId();
+        self::assertNotNull($ownerId);
+
+        $this->denyRateLimiter(
+            'limiter.allocations_export',
+            $this->userAndIpRateLimitKey('allocations_export', $ownerId),
+        );
+
+        $client->request(Request::METHOD_POST, '/hospitals/export/allocations/download');
+
+        self::assertResponseStatusCodeSame(Response::HTTP_TOO_MANY_REQUESTS);
     }
 
     public function testParticipantWithoutHospitalDoesNotSeeNavLink(): void

--- a/tests/Import/Functional/Controller/NewImportControllerTest.php
+++ b/tests/Import/Functional/Controller/NewImportControllerTest.php
@@ -15,10 +15,13 @@ use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Domain\Entity\Import;
+use App\Tests\Support\RateLimit\DeniesRateLimiter;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Factory\UserFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
@@ -26,6 +29,7 @@ use Zenstruck\Foundry\Test\Factories;
 #[ResetDatabase]
 final class NewImportControllerTest extends WebTestCase
 {
+    use DeniesRateLimiter;
     use HasBrowser;
     use Factories;
 
@@ -95,6 +99,55 @@ final class NewImportControllerTest extends WebTestCase
             })
             ->assertSee('View import details')
             ->assertSeeElement('[data-import-status-target="detailLink"]:not(.d-none)');
+    }
+
+    public function testSubmitIsRateLimited(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+
+        [$owner, $hospitalId] = $this->createOwnerWithHospital();
+        $ownerId = $owner->getId();
+        self::assertNotNull($ownerId);
+
+        $csvPath = $this->fixturesDir.'/allocation_import_sample.csv';
+        self::assertFileExists($csvPath);
+
+        $client->loginUser($owner);
+
+        $this->denyRateLimiter(
+            'limiter.import_create',
+            $this->userAndIpRateLimitKey('import_create', $ownerId),
+        );
+
+        $crawler = $client->request(Request::METHOD_GET, '/import/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->form();
+        $client->request(
+            Request::METHOD_POST,
+            '/import/new',
+            [
+                'import_create' => [
+                    'name' => 'Rate Limited Import',
+                    'hospital' => (string) $hospitalId,
+                    '_token' => $form['import_create[_token]']->getValue(),
+                ],
+            ],
+            [
+                'import_create' => [
+                    'file' => new UploadedFile($csvPath, 'allocation_import_sample.csv', 'text/csv', null, true),
+                ],
+            ],
+        );
+
+        self::assertResponseRedirects('/import/new');
+        $client->followRedirect();
+        self::assertSelectorTextContains('body', 'Too many import attempts');
+
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        self::assertNull($em->getRepository(Import::class)->findOneBy(['name' => 'Rate Limited Import']));
     }
 
     public function testSubmitWithXlsxShowsValidationErrorAndDoesNotPersist(): void

--- a/tests/Shared/Unit/RateLimit/ClientRateLimitTest.php
+++ b/tests/Shared/Unit/RateLimit/ClientRateLimitTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\RateLimit;
+
+use App\Shared\Application\RateLimit\ClientRateLimit;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+final class ClientRateLimitTest extends TestCase
+{
+    public function testAcceptIpAllowsUntilLimitThenRejects(): void
+    {
+        $factory = $this->createFactory(limit: 3);
+        $request = Request::create('/register', Request::METHOD_POST, server: ['REMOTE_ADDR' => '203.0.113.10']);
+
+        self::assertTrue(ClientRateLimit::acceptIp($factory, 'register', $request));
+        self::assertTrue(ClientRateLimit::acceptIp($factory, 'register', $request));
+        self::assertTrue(ClientRateLimit::acceptIp($factory, 'register', $request));
+        self::assertFalse(ClientRateLimit::acceptIp($factory, 'register', $request));
+    }
+
+    public function testAcceptUserAndIpUsesSeparateBucketsPerUser(): void
+    {
+        $factory = $this->createFactory(limit: 1);
+        $request = Request::create('/import/new', Request::METHOD_POST, server: ['REMOTE_ADDR' => '203.0.113.20']);
+
+        self::assertTrue(ClientRateLimit::acceptUserAndIp($factory, 'import_create', '1', $request));
+        self::assertFalse(ClientRateLimit::acceptUserAndIp($factory, 'import_create', '1', $request));
+        self::assertTrue(ClientRateLimit::acceptUserAndIp($factory, 'import_create', '2', $request));
+    }
+
+    private function createFactory(int $limit): RateLimiterFactory
+    {
+        return new RateLimiterFactory([
+            'id' => 'sec007_test',
+            'policy' => 'fixed_window',
+            'limit' => $limit,
+            'interval' => '1 hour',
+        ], new InMemoryStorage());
+    }
+}

--- a/tests/Statistics/Functional/Controller/AnalysisExplorerExportControllerTest.php
+++ b/tests/Statistics/Functional/Controller/AnalysisExplorerExportControllerTest.php
@@ -21,18 +21,21 @@ use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
 use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\DTO\StatisticsFilterPeriod;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Tests\Support\RateLimit\DeniesRateLimiter;
 use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
 use App\Tests\Support\Statistics\RefreshesStatisticsFunctionalDataTrait;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
 
 #[ResetDatabase]
 final class AnalysisExplorerExportControllerTest extends WebTestCase
 {
+    use DeniesRateLimiter;
     use Factories;
     use InteractsWithAuthenticatedUser;
     use RefreshesStatisticsFunctionalDataTrait;
@@ -94,6 +97,35 @@ final class AnalysisExplorerExportControllerTest extends WebTestCase
         );
 
         self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testExportIsRateLimited(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+        $user = $this->loginAsRoleUser($client);
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $client->request(Request::METHOD_GET, '/statistics/analysis/explorer?scope=public&period=all');
+        self::assertResponseIsSuccessful();
+        $token = $this->csrfToken($client, 'explorer_export_csv');
+
+        $this->denyRateLimiter(
+            'limiter.analysis_explorer_export',
+            $this->userAndIpRateLimitKey('analysis_explorer_export', $userId),
+        );
+
+        $client->request(
+            Request::METHOD_POST,
+            '/statistics/analysis/explorer/export/table.csv?scope=public&period=all',
+            [
+                '_token' => $token,
+                'appliedConfigState' => '{}',
+            ],
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_TOO_MANY_REQUESTS);
     }
 
     private function csrfToken(KernelBrowser $client, string $tokenId): string

--- a/tests/Support/RateLimit/DeniesRateLimiter.php
+++ b/tests/Support/RateLimit/DeniesRateLimiter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\RateLimit;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+/**
+ * Installs a pre-exhausted limiter service so Functional tests can hit reject paths
+ * without relying on low when@test limits (which poison suites).
+ *
+ * @mixin KernelTestCase
+ */
+trait DeniesRateLimiter
+{
+    private function denyRateLimiter(string $serviceId, string $bucketKey): void
+    {
+        $factory = new RateLimiterFactory([
+            'id' => $serviceId.'_deny',
+            'policy' => 'fixed_window',
+            'limit' => 1,
+            'interval' => '1 hour',
+        ], new InMemoryStorage());
+
+        self::getContainer()->set($serviceId, $factory);
+        $factory->create($bucketKey)->consume(1);
+    }
+
+    private function ipRateLimitKey(string $bucket, string $ip = '127.0.0.1'): string
+    {
+        return sprintf('%s_%s', $bucket, sha1($ip));
+    }
+
+    private function userAndIpRateLimitKey(string $bucket, string|int $userId, string $ip = '127.0.0.1'): string
+    {
+        return sprintf('%s_%s_%s', $bucket, sha1((string) $userId), sha1($ip));
+    }
+}

--- a/tests/User/Functional/Controller/RegistrationControllerTest.php
+++ b/tests/User/Functional/Controller/RegistrationControllerTest.php
@@ -8,6 +8,7 @@ use App\Content\Domain\Entity\Page;
 use App\Content\Domain\Enum\PageKey;
 use App\Content\Infrastructure\Factory\PageFactory;
 use App\Tests\Support\Browser\CookieConsentTestHelper;
+use App\Tests\Support\RateLimit\DeniesRateLimiter;
 use App\Tests\Support\Translation\AssertsNoMissingTranslations;
 use App\Tests\User\Support\AlwaysAvailableRegistrationIdentityChecker;
 use App\User\Domain\Factory\UserFactory;
@@ -29,6 +30,7 @@ final class RegistrationControllerTest extends WebTestCase
 {
     use AssertsNoMissingTranslations;
     use CookieConsentTestHelper;
+    use DeniesRateLimiter;
     use Factories;
     use HasBrowser;
     use MailerAssertionsTrait;
@@ -93,6 +95,31 @@ final class RegistrationControllerTest extends WebTestCase
             'username' => $username,
             'locale' => 'en',
         ]);
+    }
+
+    public function testRegistrationIsRateLimited(): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $username = sprintf('register-rate-limit-%s', $suffix);
+        $email = sprintf('register-rate-limit-%s@example.test', $suffix);
+
+        $client = self::createClient();
+        $client->disableReboot();
+        $this->denyRateLimiter('limiter.register', $this->ipRateLimitKey('register'));
+
+        $client->request(Request::METHOD_GET, '/register');
+        self::assertResponseIsSuccessful();
+
+        $client->submitForm('Register', [
+            'registration_form[username]' => $username,
+            'registration_form[email]' => $email,
+            'registration_form[plainPassword]' => 'super-secret-password',
+            'registration_form[acceptTerms]' => true,
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('body', 'Too many registration attempts');
+        UserFactory::assert()->notExists(['email' => $email]);
     }
 
     public function testRegistrationSendsAdminNotificationToNotificationRecipients(): void

--- a/tests/User/Functional/Controller/ResetPasswordControllerTest.php
+++ b/tests/User/Functional/Controller/ResetPasswordControllerTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Tests\User\Functional\Controller;
 
+use App\Tests\Support\RateLimit\DeniesRateLimiter;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Factory\UserFactory;
 use App\User\Infrastructure\Repository\ResetPasswordRequestRepository;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -18,6 +20,7 @@ use Zenstruck\Foundry\Test\Factories;
 #[ResetDatabase]
 final class ResetPasswordControllerTest extends WebTestCase
 {
+    use DeniesRateLimiter;
     use Factories;
     use HasBrowser;
 
@@ -61,6 +64,37 @@ final class ResetPasswordControllerTest extends WebTestCase
         $user = $this->getUserRepository()->findOneBy(['email' => 'verified@example.test']);
         self::assertInstanceOf(User::class, $user);
         self::assertSame(1, $this->getResetPasswordRequestRepository()->count(['user' => $user]));
+    }
+
+    public function testResetRequestIsRateLimitedSilently(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+
+        UserFactory::new([
+            'email' => 'rate-limited-reset@example.test',
+            'isVerified' => true,
+            'username' => 'rate-limited-reset',
+        ])->create();
+
+        $this->denyRateLimiter(
+            'limiter.reset_password_request',
+            $this->ipRateLimitKey('reset_password_request'),
+        );
+
+        $crawler = $client->request(Request::METHOD_GET, '/reset-password');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Send reset email')->form([
+            'reset_password_request_form[email]' => 'rate-limited-reset@example.test',
+        ]);
+        $client->submit($form);
+
+        self::assertResponseRedirects('/reset-password/check-email');
+
+        $user = $this->getUserRepository()->findOneBy(['email' => 'rate-limited-reset@example.test']);
+        self::assertInstanceOf(User::class, $user);
+        self::assertSame(0, $this->getResetPasswordRequestRepository()->count(['user' => $user]));
     }
 
     public function testResetRequestIsBlockedForDisabledEmail(): void

--- a/translations/import+intl-icu.de.xlf
+++ b/translations/import+intl-icu.de.xlf
@@ -9,6 +9,10 @@
         <source>flash.import.created</source>
         <target>Neuer Import wurde erfolgreich erstellt!</target>
       </trans-unit>
+      <trans-unit id="FlsImpRlDe" resname="flash.import.rate_limited">
+        <source>flash.import.rate_limited</source>
+        <target>Zu viele Importversuche. Bitte versuche es später erneut.</target>
+      </trans-unit>
       <trans-unit id="FlsImpRunDe" resname="flash.import.delete_running_blocked">
         <source>flash.import.delete_running_blocked</source>
         <target>Dieser Import wird gerade ausgeführt und kann deshalb nicht gelöscht werden.</target>

--- a/translations/import+intl-icu.en.xlf
+++ b/translations/import+intl-icu.en.xlf
@@ -9,6 +9,10 @@
         <source>flash.import.created</source>
         <target>New Import has been created successfully!</target>
       </trans-unit>
+      <trans-unit id="FlsImpRlEn" resname="flash.import.rate_limited">
+        <source>flash.import.rate_limited</source>
+        <target>Too many import attempts. Please try again later.</target>
+      </trans-unit>
       <trans-unit id="impFlDelOk" resname="flash.import.deleted">
         <source>flash.import.deleted</source>
         <target>Import has been deleted successfully.</target>

--- a/translations/user+intl-icu.de.xlf
+++ b/translations/user+intl-icu.de.xlf
@@ -117,6 +117,10 @@
         <source>flash.settings.email.resend_rate_limited</source>
         <target>Bitte warten Sie, bevor Sie erneut eine Verifizierungs-E-Mail anfordern.</target>
       </trans-unit>
+      <trans-unit id="FlsRegRlDe" resname="flash.registration.rate_limited">
+        <source>flash.registration.rate_limited</source>
+        <target>Zu viele Registrierungsversuche. Bitte versuchen Sie es später erneut.</target>
+      </trans-unit>
       <trans-unit id="FlsSetEmUpDe" resname="flash.settings.email.updated_verify_required">
         <source>flash.settings.email.updated_verify_required</source>
         <target>E-Mail-Adresse aktualisiert. Bitte verifizieren Sie Ihre neue E-Mail-Adresse.</target>

--- a/translations/user+intl-icu.en.xlf
+++ b/translations/user+intl-icu.en.xlf
@@ -41,6 +41,10 @@
         <source>flash.settings.email.resend_rate_limited</source>
         <target>Please wait before requesting another verification email.</target>
       </trans-unit>
+      <trans-unit id="FlsRegRlEn" resname="flash.registration.rate_limited">
+        <source>flash.registration.rate_limited</source>
+        <target>Too many registration attempts. Please try again later.</target>
+      </trans-unit>
       <trans-unit id="FHE32nf" resname="flash.settings.email.updated_verify_required">
         <source>flash.settings.email.updated_verify_required</source>
         <target>Email address updated. Please verify your new email.</target>


### PR DESCRIPTION
## Summary

This pull request strengthens the application's rate-limiting strategy by introducing and consolidating dedicated limiters for security-sensitive and resource-intensive endpoints.

### Changes

- Added dedicated rate limiters for endpoints that require additional protection against excessive requests.
- Centralized limiter configuration to provide consistent throttling behavior across the application.
- Applied appropriate limits to relevant authentication, Explore, and other sensitive workflows.
- Standardized the handling of exhausted rate limits and corresponding HTTP responses.
- Added or updated automated tests covering normal usage, limit exhaustion, and limiter isolation.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Reduce the risk of brute-force attempts, automated scraping, and denial-of-service attacks.
- Protect expensive application operations from excessive or abusive traffic.
- Make rate-limit policies easier to understand, maintain, and adjust.
- Strengthen the application's defense-in-depth strategy through consistent request throttling.