### PR TITLE
fix: persist audit entry for import source downloads

### DIFF
--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -177,7 +177,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`DownloadImportSourceFileController`](../../src/Import/UI/Http/Controller/DownloadImportSourceFileController.php) L37–39 — `beginIntent('import.source_file.downloaded')` with no entity mutation; Doctrine audit subscriber only writes on audited entity changes; unlike [`ExportAuditLogger`](../../src/Shared/Application/Export/ExportAuditLogger.php) / impersonation |
 | Risk | Admin downloads of original import files leave no durable audit row. |
 | Mitigation | Persist an explicit `AuditEntry` (same pattern as export/impersonation) including actor, import id, IP. |
-| Status | open |
+| Status | resolved (2026-07-28) — `ImportSourceDownloadAuditLogger` persists `download` AuditEntry after successful source-file delivery; 404 does not audit |
 
 ### SEC-009 — `ImportFileStorage::resolve` lacks path containment
 
@@ -361,7 +361,7 @@ Do **not** implement in this audit deliverable.
 | Priority | Findings | Rationale |
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
-| P1 early beta | SEC-003, SEC-004, SEC-008 | Export safety, Live Component defense-in-depth, audit gap |
+| P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
 | P2 hardening | SEC-009–SEC-016, SEC-019 | Path containment, redirects, headers, docs |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 

--- a/src/Import/Application/Service/ImportSourceDownloadAuditLogger.php
+++ b/src/Import/Application/Service/ImportSourceDownloadAuditLogger.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Entity\Import;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Persists an explicit audit row for successful import source-file downloads (SEC-008).
+ *
+ * Doctrine's AuditingDoctrineSubscriber only writes on audited entity mutations;
+ * beginIntent alone does not create a durable entry.
+ */
+final readonly class ImportSourceDownloadAuditLogger
+{
+    public const string INTENT = 'import.source_file.downloaded';
+
+    public const string ACTION = 'download';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private AuditContext $auditContext,
+    ) {
+    }
+
+    public function log(User $actor, Import $import): void
+    {
+        $importId = $import->getId();
+        if (null === $importId) {
+            throw new \InvalidArgumentException('Cannot audit download for an Import without an ID.');
+        }
+
+        $requestId = $this->auditContext->ensureRequestId(static fn (): string => bin2hex(random_bytes(16)));
+        $origin = $this->auditContext->getOrigin() ?? AuditContext::ORIGIN_HTTP;
+
+        $metadata = [
+            'intent' => self::INTENT,
+            'import_id' => $importId,
+        ];
+
+        $clientIp = $this->auditContext->getClientIp();
+        if (null !== $clientIp && '' !== $clientIp) {
+            $metadata['clientIp'] = $clientIp;
+        }
+
+        $userAgent = $this->auditContext->getUserAgent();
+        if (null !== $userAgent && '' !== $userAgent) {
+            $metadata['userAgent'] = $userAgent;
+        }
+
+        $this->entityManager->persist(new AuditEntry(
+            new \DateTimeImmutable('now'),
+            $requestId,
+            $actor,
+            $origin,
+            self::ACTION,
+            Import::class,
+            (string) $importId,
+            [],
+            $metadata,
+        ));
+        $this->entityManager->flush();
+    }
+}

--- a/src/Import/UI/Http/Controller/DownloadImportSourceFileController.php
+++ b/src/Import/UI/Http/Controller/DownloadImportSourceFileController.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Import\UI\Http\Controller;
 
 use App\Import\Application\Exception\ImportSourceFileNotFoundException;
+use App\Import\Application\Service\ImportSourceDownloadAuditLogger;
 use App\Import\Application\Service\ImportSourceFileDownloadService;
 use App\Import\Domain\Entity\Import;
 use App\Import\Infrastructure\Security\Voter\ImportVoter;
-use App\Shared\Infrastructure\Audit\AuditContext;
+use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -20,7 +21,7 @@ final class DownloadImportSourceFileController extends AbstractController
 {
     public function __construct(
         private readonly ImportSourceFileDownloadService $downloadService,
-        private readonly AuditContext $auditContext,
+        private readonly ImportSourceDownloadAuditLogger $auditLogger,
     ) {
     }
 
@@ -34,13 +35,18 @@ final class DownloadImportSourceFileController extends AbstractController
         }
 
         try {
-            $this->auditContext->beginIntent('import.source_file.downloaded', [
-                'import_id' => $importId,
-            ]);
-
-            return $this->downloadService->createDownloadResponse($import);
+            $response = $this->downloadService->createDownloadResponse($import);
         } catch (ImportSourceFileNotFoundException) {
             throw new NotFoundHttpException();
         }
+
+        $actor = $this->getUser();
+        if (!$actor instanceof User) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $this->auditLogger->log($actor, $import);
+
+        return $response;
     }
 }

--- a/tests/Import/Functional/Controller/DownloadImportSourceFileControllerTest.php
+++ b/tests/Import/Functional/Controller/DownloadImportSourceFileControllerTest.php
@@ -7,11 +7,15 @@ namespace App\Tests\Import\Functional\Controller;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Application\Service\ImportSourceDownloadAuditLogger;
+use App\Import\Domain\Entity\Import;
 use App\Import\Domain\Enum\ImportStatus;
 use App\Import\Domain\Enum\ImportType;
 use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -39,6 +43,14 @@ final class DownloadImportSourceFileControllerTest extends WebTestCase
 
         $projectDir = self::getContainer()->getParameter('kernel.project_dir');
         self::assertSame($content, file_get_contents(Path::join((string) $projectDir, $relativePath)));
+
+        $auditEntry = $this->findLatestDownloadAudit((string) $importId);
+        self::assertNotNull($auditEntry);
+        self::assertSame($admin->getId(), $auditEntry->getActor()?->getId());
+        self::assertSame(ImportSourceDownloadAuditLogger::ACTION, $auditEntry->getAction());
+        self::assertSame(Import::class, $auditEntry->getEntityClass());
+        self::assertSame(ImportSourceDownloadAuditLogger::INTENT, $auditEntry->getMetadata()['intent'] ?? null);
+        self::assertSame($importId, $auditEntry->getMetadata()['import_id'] ?? null);
     }
 
     public function testHospitalOwnerWithoutAdminRoleCannotDownloadSourceFile(): void
@@ -61,6 +73,7 @@ final class DownloadImportSourceFileControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, '/import/'.$importId.'/source-file');
 
         self::assertResponseStatusCodeSame(404);
+        self::assertNull($this->findLatestDownloadAudit((string) $importId));
     }
 
     public function testShowPageDisplaysDownloadLinkForAdmin(): void
@@ -136,5 +149,24 @@ final class DownloadImportSourceFileControllerTest extends WebTestCase
         ]);
 
         return [$admin, (int) $import->getId(), $relativePath, $content];
+    }
+
+    private function findLatestDownloadAudit(string $importId): ?AuditEntry
+    {
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var list<AuditEntry> $entries */
+        $entries = $em->getRepository(AuditEntry::class)->findBy(
+            [
+                'action' => ImportSourceDownloadAuditLogger::ACTION,
+                'entityClass' => Import::class,
+                'entityId' => $importId,
+            ],
+            ['id' => 'DESC'],
+            1,
+        );
+
+        return $entries[0] ?? null;
     }
 }

--- a/tests/Import/Unit/Application/Service/ImportSourceDownloadAuditLoggerTest.php
+++ b/tests/Import/Unit/Application/Service/ImportSourceDownloadAuditLoggerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Import\Unit\Application\Service;
+
+use App\Import\Application\Service\ImportSourceDownloadAuditLogger;
+use App\Import\Domain\Entity\Import;
+use App\Shared\Infrastructure\Audit\AuditContext;
+use App\Shared\Infrastructure\Audit\Entity\AuditEntry;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ImportSourceDownloadAuditLoggerTest extends TestCase
+{
+    public function testLogPersistsAuditEntryWithIntentMetadata(): void
+    {
+        $import = $this->createStub(Import::class);
+        $import->method('getId')->willReturn(42);
+
+        $actor = $this->createStub(User::class);
+
+        $auditContext = new AuditContext();
+        $auditContext->setRequestId('req-123');
+        $auditContext->setOrigin(AuditContext::ORIGIN_HTTP);
+        $auditContext->setClientIp('203.0.113.50');
+        $auditContext->setUserAgent('PHPUnit');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (object $entry) use ($actor): bool {
+                self::assertInstanceOf(AuditEntry::class, $entry);
+                self::assertSame($actor, $entry->getActor());
+                self::assertSame(ImportSourceDownloadAuditLogger::ACTION, $entry->getAction());
+                self::assertSame(Import::class, $entry->getEntityClass());
+                self::assertSame('42', $entry->getEntityId());
+                self::assertSame(ImportSourceDownloadAuditLogger::INTENT, $entry->getMetadata()['intent'] ?? null);
+                self::assertSame(42, $entry->getMetadata()['import_id'] ?? null);
+                self::assertSame('203.0.113.50', $entry->getMetadata()['clientIp'] ?? null);
+                self::assertSame('PHPUnit', $entry->getMetadata()['userAgent'] ?? null);
+
+                return true;
+            }));
+        $entityManager->expects(self::once())->method('flush');
+
+        $logger = new ImportSourceDownloadAuditLogger($entityManager, $auditContext);
+        $logger->log($actor, $import);
+    }
+
+    public function testLogThrowsWhenImportHasNoId(): void
+    {
+        $import = $this->createStub(Import::class);
+        $import->method('getId')->willReturn(null);
+
+        $logger = new ImportSourceDownloadAuditLogger(
+            $this->createStub(EntityManagerInterface::class),
+            new AuditContext(),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $logger->log($this->createStub(User::class), $import);
+    }
+}


### PR DESCRIPTION
## Summary

This pull request improves the auditability of sensitive import source file access by recording successful administrative downloads in the persistent audit log.

### Changes

- Added an explicit audit entry when an administrator successfully downloads an import source file.
- Recorded the security-relevant download action independently of transient request or application logs.
- Ensured that only successful downloads create a corresponding audit record.
- Added or updated automated tests covering the audit behavior.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Provide a durable record of access to potentially sensitive source files.
- Improve traceability and accountability for administrative download actions.
- Support later security reviews, incident investigations, and compliance checks.
- Strengthen the application's audit trail around privileged data access.