### PR TITLE
fix: Contain ImportFileStorage Paths under Imports BaseDir

### DIFF
--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -188,7 +188,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`ImportFileStorage::resolve`](../../src/Import/Application/Service/ImportFileStorage.php) L23–29 — absolute paths returned as-is; relative paths joined to project dir without asserting prefix under `var/imports` |
 | Risk | If `file_path` in DB is tampered (compromised admin DB write / SQL injection elsewhere), download or worker can read arbitrary files. Normal upload path uses generated relative names only. |
 | Mitigation | After resolve: `realpath` + assert path is under configured imports base dir; reject absolute / `..` paths. |
-| Status | open |
+| Status | resolved (2026-07-28) — `ImportFileStorage::resolve` asserts canonicalized paths under `%app.imports_base_dir%`; absolute/`..` escapes throw `ImportFilePathOutsideBaseException` (download → 404; worker → failed) |
 
 ### SEC-010 — Favorite toggle open redirect via Referer
 
@@ -362,7 +362,7 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
-| P2 hardening | SEC-009, SEC-011–SEC-016, SEC-019 | Path containment, headers, docs (SEC-010 redirect resolved) |
+| P2 hardening | SEC-011–SEC-016, SEC-019 | Headers, docs (SEC-009 path containment and SEC-010 redirect resolved) |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.

--- a/src/Import/Application/Exception/ImportFilePathOutsideBaseException.php
+++ b/src/Import/Application/Exception/ImportFilePathOutsideBaseException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Exception;
+
+final class ImportFilePathOutsideBaseException extends \RuntimeException
+{
+    public function __construct(string $storedPath = '')
+    {
+        $message = '' === $storedPath
+            ? 'Import file path is empty or invalid'
+            : 'Import file path is outside the configured imports base directory';
+
+        parent::__construct($message);
+    }
+}

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -10,6 +10,7 @@ use App\Import\Application\Contracts\RowReaderInterface;
 use App\Import\Application\DTO\ImportSummary;
 use App\Import\Application\Event\ImportCompleted;
 use App\Import\Application\Event\ImportFailed;
+use App\Import\Application\Exception\ImportFilePathOutsideBaseException;
 use App\Import\Application\Factory\AllocationImporterFactory;
 use App\Import\Application\Factory\RejectWriterFactory;
 use App\Import\Application\Factory\RowReaderFactory;
@@ -65,7 +66,20 @@ final readonly class ImportAllocationsMessageHandler
             return;
         }
 
-        $filePath = $this->fileStorage->resolve($filePath);
+        try {
+            $filePath = $this->fileStorage->resolve($filePath);
+        } catch (ImportFilePathOutsideBaseException $e) {
+            $reason = 'Invalid import file path';
+            $this->importLogger->error('import.file_path.outside_base', [
+                'id' => $message->importId,
+                'msg' => $e->getMessage(),
+            ]);
+            $this->markFailed($import, $reason);
+            $this->dispatchImportOutcome($message->importId, $reason);
+
+            return;
+        }
+
         if (!\is_file($filePath)) {
             $reason = 'CSV not found: '.$filePath;
             $this->markFailed($import, $reason);

--- a/src/Import/Application/Service/ImportFileStorage.php
+++ b/src/Import/Application/Service/ImportFileStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
+use App\Import\Application\Exception\ImportFilePathOutsideBaseException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -15,6 +16,8 @@ final readonly class ImportFileStorage
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
+        #[Autowire('%app.imports_base_dir%')]
+        private string $importsBaseDir,
         private Filesystem $filesystem,
         private LoggerInterface $importLogger,
     ) {
@@ -22,11 +25,23 @@ final readonly class ImportFileStorage
 
     public function resolve(string $storedPath): string
     {
-        if ($this->isAbsolutePath($storedPath)) {
-            return $storedPath;
+        $normalized = str_replace('\\', '/', $storedPath);
+
+        if ('' === $normalized || str_contains($normalized, "\0")) {
+            throw new ImportFilePathOutsideBaseException($storedPath);
         }
 
-        return Path::join($this->projectDir, $storedPath);
+        if ($this->isAbsolutePath($normalized)) {
+            $candidate = Path::canonicalize($normalized);
+        } else {
+            $candidate = Path::canonicalize(Path::join($this->toRealPath($this->projectDir), $normalized));
+        }
+
+        $candidate = $this->toRealPath($candidate);
+        $base = $this->toRealPath($this->importsBaseDir);
+        $this->assertPathIsUnderBase($candidate, $base);
+
+        return $candidate;
     }
 
     public function toRelative(string $absolutePath): string
@@ -42,7 +57,12 @@ final readonly class ImportFileStorage
             return;
         }
 
-        $absPath = $this->resolve($storedPath);
+        try {
+            $absPath = $this->resolve($storedPath);
+        } catch (ImportFilePathOutsideBaseException) {
+            return;
+        }
+
         if (!$this->filesystem->exists($absPath)) {
             return;
         }
@@ -66,13 +86,59 @@ final readonly class ImportFileStorage
         ]);
     }
 
+    /**
+     * Resolve symlinks for existing path prefixes (e.g. /var → /private/var on macOS).
+     */
+    private function toRealPath(string $path): string
+    {
+        $canonical = Path::canonicalize($path);
+        $real = realpath($canonical);
+        if (false !== $real) {
+            return $real;
+        }
+
+        $parts = [];
+        $current = $canonical;
+        while (!\is_dir($current) && !\is_file($current)) {
+            $parent = \dirname($current);
+            if ($parent === $current) {
+                return $canonical;
+            }
+            array_unshift($parts, \basename($current));
+            $current = $parent;
+        }
+
+        $realParent = realpath($current);
+        if (false === $realParent) {
+            return $canonical;
+        }
+
+        return [] === $parts
+            ? $realParent
+            : Path::canonicalize(Path::join($realParent, ...$parts));
+    }
+
+    private function assertPathIsUnderBase(string $path, string $base): void
+    {
+        $normalizedPath = rtrim(str_replace('\\', '/', $path), '/');
+        $normalizedBase = rtrim(str_replace('\\', '/', $base), '/');
+
+        if ($normalizedPath === $normalizedBase) {
+            return;
+        }
+
+        if (!str_starts_with($normalizedPath, $normalizedBase.'/')) {
+            throw new ImportFilePathOutsideBaseException($path);
+        }
+    }
+
     private function isAbsolutePath(string $path): bool
     {
         if ('' === $path) {
             return false;
         }
 
-        if (DIRECTORY_SEPARATOR === $path[0]) {
+        if ('/' === $path[0] || DIRECTORY_SEPARATOR === $path[0]) {
             return true;
         }
 

--- a/src/Import/Application/Service/ImportSourceFileDownloadService.php
+++ b/src/Import/Application/Service/ImportSourceFileDownloadService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
+use App\Import\Application\Exception\ImportFilePathOutsideBaseException;
 use App\Import\Application\Exception\ImportSourceFileNotFoundException;
 use App\Import\Domain\Entity\Import;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -28,7 +29,12 @@ final readonly class ImportSourceFileDownloadService
             throw new ImportSourceFileNotFoundException($importId);
         }
 
-        $absolutePath = $this->fileStorage->resolve($storedPath);
+        try {
+            $absolutePath = $this->fileStorage->resolve($storedPath);
+        } catch (ImportFilePathOutsideBaseException) {
+            throw new ImportSourceFileNotFoundException($importId);
+        }
+
         if (!\is_file($absolutePath)) {
             throw new ImportSourceFileNotFoundException($importId);
         }

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
@@ -40,7 +40,8 @@ final class ImportAllocationsMessageHandlerFailureTest extends ImportAllocations
         $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
         $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
 
-        $missingPath = sys_get_temp_dir().'/ivena-import-missing-'.bin2hex(random_bytes(8)).'.csv';
+        // Path is under imports base but file does not exist on disk.
+        $missingPath = 'var/imports/'.date('Y/m').'/ivena-import-missing-'.bin2hex(random_bytes(8)).'.csv';
 
         $import = new Import()
             ->setName('Missing file IT')

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTestCase.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTestCase.php
@@ -117,11 +117,10 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
         $fixturePath = $projectDir.'/tests/Import/Fixtures/allocation_import_sample.csv';
         self::assertFileExists($fixturePath);
 
-        $targetDir = $projectDir.'/var/tests/imports/'.date('Y/m');
-        @mkdir($targetDir, 0775, true);
-        $csvPath = $targetDir.'/allocation_import_sample_'.bin2hex(random_bytes(4)).'.csv';
-        copy($fixturePath, $csvPath);
-        $relativePath = ltrim(str_replace('\\', '/', (string) preg_replace('#^'.preg_quote($projectDir, '#').'/?#', '', $csvPath)), '/');
+        ['absolutePath' => $csvPath, 'storedPath' => $storedPath] = $this->writeImportCsvUnderBase(
+            'allocation_import_sample_'.bin2hex(random_bytes(4)).'.csv',
+            (string) file_get_contents($fixturePath),
+        );
 
         $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
         $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
@@ -132,7 +131,7 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
             ->setCreatedBy($userRef)
             ->setType(ImportType::ALLOCATION)
             ->setStatus(ImportStatus::PENDING)
-            ->setFilePath($relativePath)
+            ->setFilePath($storedPath)
             ->setFileExtension('csv')
             ->setFileMimeType('text/csv')
             ->setFileSize((int) filesize($csvPath))
@@ -202,17 +201,10 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
 
         $rows = [$row];
 
-        $csvPath = sys_get_temp_dir().'/ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv';
-        $fh = fopen($csvPath, 'wb');
-        self::assertNotFalse($fh);
-        $delimiter = ';';
-        $enclosure = '"';
-        $escape = '\\';
-        fputcsv($fh, $header, $delimiter, $enclosure, $escape);
-        foreach ($rows as $csvRow) {
-            fputcsv($fh, $csvRow, $delimiter, $enclosure, $escape);
-        }
-        fclose($fh);
+        ['absolutePath' => $csvPath, 'storedPath' => $storedPath] = $this->writeImportCsvUnderBase(
+            'ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv',
+            $this->encodeCsvRows($header, $rows),
+        );
 
         $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
         $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
@@ -223,7 +215,7 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
             ->setCreatedBy($userRef)
             ->setType(ImportType::ALLOCATION)
             ->setStatus(ImportStatus::PENDING)
-            ->setFilePath($csvPath)
+            ->setFilePath($storedPath)
             ->setFileExtension('csv')
             ->setFileMimeType('text/csv')
             ->setFileSize((int) filesize($csvPath))
@@ -293,17 +285,10 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
 
         $rows = [$row];
 
-        $csvPath = sys_get_temp_dir().'/ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv';
-        $fh = fopen($csvPath, 'wb');
-        self::assertNotFalse($fh);
-        $delimiter = ';';
-        $enclosure = '"';
-        $escape = '\\';
-        fputcsv($fh, $header, $delimiter, $enclosure, $escape);
-        foreach ($rows as $row) {
-            fputcsv($fh, $row, $delimiter, $enclosure, $escape);
-        }
-        fclose($fh);
+        ['absolutePath' => $csvPath, 'storedPath' => $storedPath] = $this->writeImportCsvUnderBase(
+            'ivena-import-evt-'.bin2hex(random_bytes(8)).'.csv',
+            $this->encodeCsvRows($header, $rows),
+        );
 
         $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $owner->getId());
         $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
@@ -314,7 +299,7 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
             ->setCreatedBy($userRef)
             ->setType(ImportType::ALLOCATION)
             ->setStatus(ImportStatus::PENDING)
-            ->setFilePath($csvPath)
+            ->setFilePath($storedPath)
             ->setFileExtension('csv')
             ->setFileMimeType('text/csv')
             ->setFileSize((int) filesize($csvPath))
@@ -326,6 +311,53 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
         $this->em->flush();
 
         return ['id' => (int) $import->getId(), 'csvPath' => $csvPath];
+    }
+
+    /**
+     * @return array{absolutePath: string, storedPath: string}
+     */
+    protected function writeImportCsvUnderBase(string $basename, string $contents): array
+    {
+        $importsBaseDir = (string) self::getContainer()->getParameter('app.imports_base_dir');
+        $projectDir = (string) self::getContainer()->getParameter('kernel.project_dir');
+        $targetDir = $importsBaseDir.'/'.date('Y/m');
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0775, true) && !is_dir($targetDir)) {
+            self::fail('Unable to create imports test directory: '.$targetDir);
+        }
+
+        $absolutePath = $targetDir.'/'.$basename;
+        file_put_contents($absolutePath, $contents);
+
+        $storedPath = ltrim(str_replace('\\', '/', (string) preg_replace(
+            '#^'.preg_quote($projectDir, '#').'/?#',
+            '',
+            $absolutePath,
+        )), '/');
+
+        return ['absolutePath' => $absolutePath, 'storedPath' => $storedPath];
+    }
+
+    /**
+     * @param list<string>        $header
+     * @param list<list<string>>  $rows
+     */
+    protected function encodeCsvRows(array $header, array $rows): string
+    {
+        $fh = fopen('php://temp', 'r+b');
+        self::assertNotFalse($fh);
+        $delimiter = ';';
+        $enclosure = '"';
+        $escape = '\\';
+        fputcsv($fh, $header, $delimiter, $enclosure, $escape);
+        foreach ($rows as $csvRow) {
+            fputcsv($fh, $csvRow, $delimiter, $enclosure, $escape);
+        }
+        rewind($fh);
+        $contents = stream_get_contents($fh);
+        fclose($fh);
+        self::assertNotFalse($contents);
+
+        return $contents;
     }
 
     protected function countAssessments(): int

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTestCase.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerTestCase.php
@@ -338,8 +338,8 @@ abstract class ImportAllocationsMessageHandlerTestCase extends DatabaseKernelTes
     }
 
     /**
-     * @param list<string>        $header
-     * @param list<list<string>>  $rows
+     * @param list<string>       $header
+     * @param list<list<string>> $rows
      */
     protected function encodeCsvRows(array $header, array $rows): string
     {

--- a/tests/Import/Integration/Service/FileChecksumCalculatorTest.php
+++ b/tests/Import/Integration/Service/FileChecksumCalculatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Import\Integration\Service;
 
+use App\Import\Application\Exception\ImportFilePathOutsideBaseException;
 use App\Import\Application\Service\FileChecksumCalculator;
 use App\Import\Application\Service\ImportFileStorage;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +56,8 @@ final class FileChecksumCalculatorTest extends TestCase
     public function testComputesHashForAbsolutePath(): void
     {
         // Arrange
-        $abs = Path::join($this->projectDir, 'file.csv');
+        $abs = Path::join($this->projectDir, 'var', 'imports', 'file.csv');
+        $this->fs->mkdir(\dirname($abs));
         file_put_contents($abs, 'data');
 
         $calc = new FileChecksumCalculator($this->createFileStorage(), 'sha256');
@@ -65,6 +67,17 @@ final class FileChecksumCalculatorTest extends TestCase
 
         // Assert
         self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $hash);
+    }
+
+    public function testThrowsOnAbsolutePathOutsideImportsBase(): void
+    {
+        $abs = Path::join($this->projectDir, 'outside.csv');
+        file_put_contents($abs, 'data');
+
+        $calc = new FileChecksumCalculator($this->createFileStorage(), 'sha256');
+
+        $this->expectException(ImportFilePathOutsideBaseException::class);
+        $calc->forPath($abs);
     }
 
     public function testThrowsOnMissingFile(): void
@@ -80,6 +93,11 @@ final class FileChecksumCalculatorTest extends TestCase
 
     private function createFileStorage(): ImportFileStorage
     {
-        return new ImportFileStorage($this->projectDir, $this->fs, $this->createMock(LoggerInterface::class));
+        return new ImportFileStorage(
+            $this->projectDir,
+            Path::join($this->projectDir, 'var', 'imports'),
+            $this->fs,
+            $this->createMock(LoggerInterface::class),
+        );
     }
 }

--- a/tests/Import/Integration/Service/FileUploaderTest.php
+++ b/tests/Import/Integration/Service/FileUploaderTest.php
@@ -295,7 +295,12 @@ final class FileUploaderTest extends TestCase
 
     private function createFileStorage(): ImportFileStorage
     {
-        return new ImportFileStorage($this->projectDir, $this->filesystem, $this->logger);
+        return new ImportFileStorage(
+            $this->projectDir,
+            Path::join($this->projectDir, 'var', 'imports'),
+            $this->filesystem,
+            $this->logger,
+        );
     }
 
     /**

--- a/tests/Import/Integration/Service/ImportDeletionServiceTest.php
+++ b/tests/Import/Integration/Service/ImportDeletionServiceTest.php
@@ -119,7 +119,9 @@ final class ImportDeletionServiceTest extends KernelTestCase
     {
         $projectDir = (string) self::getContainer()->getParameter('kernel.project_dir');
         $filesystem = new Filesystem();
-        $sourcePath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
+        $sourceRelativePath = 'var/imports/delete-source-'.bin2hex(random_bytes(8)).'.csv';
+        $sourcePath = Path::join($projectDir, $sourceRelativePath);
+        $filesystem->mkdir(\dirname($sourcePath));
         file_put_contents($sourcePath, "header1;header2\nvalue1;value2\n");
 
         $rejectRelativePath = 'var/imports/rejects/delete-reject-'.bin2hex(random_bytes(4)).'.csv';
@@ -129,7 +131,7 @@ final class ImportDeletionServiceTest extends KernelTestCase
 
         ['import' => $import, 'importId' => $importId] = $this->arrangeImportWithAllocation(
             namePrefix: 'DeleteReject',
-            filePath: $sourcePath,
+            filePath: $sourceRelativePath,
             rejectFilePath: $rejectRelativePath,
         );
 
@@ -139,10 +141,11 @@ final class ImportDeletionServiceTest extends KernelTestCase
             $this->deletionService->delete($import);
 
             self::assertNull($this->imports->find($importId));
+            self::assertFileDoesNotExist($sourcePath);
             self::assertFileDoesNotExist($rejectAbsolutePath);
         } finally {
-            if (\is_file($sourcePath)) {
-                @unlink($sourcePath);
+            if ($filesystem->exists($sourcePath)) {
+                $filesystem->remove($sourcePath);
             }
             if ($filesystem->exists($rejectAbsolutePath)) {
                 $filesystem->remove($rejectAbsolutePath);
@@ -186,9 +189,14 @@ final class ImportDeletionServiceTest extends KernelTestCase
             );
             self::assertNotNull($this->imports->find((int) $secondImport->getId()));
         } finally {
-            $csvPath = $secondImport->getFilePath();
-            if (\is_string($csvPath) && '' !== $csvPath && \is_file($csvPath)) {
-                @unlink($csvPath);
+            $storedPath = $secondImport->getFilePath();
+            if (\is_string($storedPath) && '' !== $storedPath) {
+                $absolute = Path::isAbsolute($storedPath)
+                    ? $storedPath
+                    : Path::join((string) self::getContainer()->getParameter('kernel.project_dir'), $storedPath);
+                if (\is_file($absolute)) {
+                    @unlink($absolute);
+                }
             }
         }
     }
@@ -210,10 +218,14 @@ final class ImportDeletionServiceTest extends KernelTestCase
         ]);
 
         if (null === $filePath) {
-            $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
-            file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+            ['absolutePath' => $csvPath, 'storedPath' => $storedPath] = $this->createImportCsvUnderBase(
+                'ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv',
+            );
         } else {
-            $csvPath = $filePath;
+            $storedPath = $filePath;
+            $csvPath = Path::isAbsolute($filePath)
+                ? $filePath
+                : Path::join((string) self::getContainer()->getParameter('kernel.project_dir'), $filePath);
         }
 
         $importProxy = ImportFactory::createOne([
@@ -221,10 +233,10 @@ final class ImportDeletionServiceTest extends KernelTestCase
             'hospital' => $hospital,
             'type' => ImportType::ALLOCATION,
             'status' => ImportStatus::COMPLETED,
-            'filePath' => $csvPath,
+            'filePath' => $storedPath,
             'fileExtension' => 'csv',
             'fileMimeType' => 'text/csv',
-            'fileSize' => (int) filesize($this->resolveFileSizePath($csvPath, $filePath)),
+            'fileSize' => (int) filesize($csvPath),
             'rowCount' => 1,
             'rowsPassed' => 1,
             'rowsRejected' => null !== $rejectFilePath ? 1 : 0,
@@ -266,15 +278,16 @@ final class ImportDeletionServiceTest extends KernelTestCase
         $hospital = $firstImport->getHospital();
         self::assertNotNull($hospital);
 
-        $csvPath = sys_get_temp_dir().'/ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv';
-        file_put_contents($csvPath, "header1;header2\nvalue1;value2\n");
+        ['absolutePath' => $csvPath, 'storedPath' => $storedPath] = $this->createImportCsvUnderBase(
+            'ivena-import-delete-'.bin2hex(random_bytes(8)).'.csv',
+        );
 
         $importProxy = ImportFactory::createOne([
             'name' => 'DeleteKeepB IT',
             'hospital' => $hospital,
             'type' => ImportType::ALLOCATION,
             'status' => ImportStatus::COMPLETED,
-            'filePath' => $csvPath,
+            'filePath' => $storedPath,
             'fileExtension' => 'csv',
             'fileMimeType' => 'text/csv',
             'fileSize' => (int) filesize($csvPath),
@@ -303,6 +316,24 @@ final class ImportDeletionServiceTest extends KernelTestCase
         return $import;
     }
 
+    /**
+     * @return array{absolutePath: string, storedPath: string}
+     */
+    private function createImportCsvUnderBase(string $basename): array
+    {
+        $projectDir = (string) self::getContainer()->getParameter('kernel.project_dir');
+        $importsBaseDir = (string) self::getContainer()->getParameter('app.imports_base_dir');
+        $targetDir = Path::join($importsBaseDir, date('Y/m'));
+        new Filesystem()->mkdir($targetDir);
+
+        $absolutePath = Path::join($targetDir, $basename);
+        file_put_contents($absolutePath, "header1;header2\nvalue1;value2\n");
+
+        $storedPath = ltrim(str_replace('\\', '/', Path::makeRelative($absolutePath, $projectDir)), '/');
+
+        return ['absolutePath' => $absolutePath, 'storedPath' => $storedPath];
+    }
+
     private function countAllocationsForImport(int $importId): int
     {
         return (int) $this->em->createQueryBuilder()
@@ -328,14 +359,5 @@ final class ImportDeletionServiceTest extends KernelTestCase
             'SELECT COUNT(*) FROM import_batch_run_item WHERE import_id = :importId',
             ['importId' => $importId],
         );
-    }
-
-    private function resolveFileSizePath(string $storedPath, ?string $originalFilePath): string
-    {
-        if (null !== $originalFilePath && !Path::isAbsolute($originalFilePath)) {
-            return Path::join((string) self::getContainer()->getParameter('kernel.project_dir'), $storedPath);
-        }
-
-        return $storedPath;
     }
 }

--- a/tests/Import/Unit/Application/Service/ImportFileStorageTest.php
+++ b/tests/Import/Unit/Application/Service/ImportFileStorageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Import\Unit\Application\Service;
 
+use App\Import\Application\Exception\ImportFilePathOutsideBaseException;
 use App\Import\Application\Service\ImportFileStorage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,7 @@ use Symfony\Component\Filesystem\Path;
 final class ImportFileStorageTest extends TestCase
 {
     private string $projectDir;
+    private string $importsBaseDir;
     private Filesystem $filesystem;
     /** @var MockObject&LoggerInterface */
     private MockObject $logger;
@@ -23,10 +25,16 @@ final class ImportFileStorageTest extends TestCase
     protected function setUp(): void
     {
         $this->projectDir = sys_get_temp_dir().'/import-storage-'.bin2hex(random_bytes(4));
+        $this->importsBaseDir = Path::join($this->projectDir, 'var', 'imports');
         $this->filesystem = new Filesystem();
-        $this->filesystem->mkdir($this->projectDir, 0775);
+        $this->filesystem->mkdir($this->importsBaseDir, 0775);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->storage = new ImportFileStorage($this->projectDir, $this->filesystem, $this->logger);
+        $this->storage = new ImportFileStorage(
+            $this->projectDir,
+            $this->importsBaseDir,
+            $this->filesystem,
+            $this->logger,
+        );
     }
 
     protected function tearDown(): void
@@ -38,18 +46,51 @@ final class ImportFileStorageTest extends TestCase
         parent::tearDown();
     }
 
-    public function testResolveJoinsRelativePathWithProjectDir(): void
+    public function testResolveJoinsRelativePathUnderImportsBase(): void
     {
+        $base = realpath($this->importsBaseDir);
+        self::assertNotFalse($base);
+
         self::assertSame(
-            Path::join($this->projectDir, 'var/imports/file.csv'),
+            Path::canonicalize(Path::join($base, 'file.csv')),
             $this->storage->resolve('var/imports/file.csv'),
         );
     }
 
-    public function testResolveReturnsAbsolutePathUnchanged(): void
+    public function testResolveAcceptsAbsolutePathInsideBase(): void
     {
-        $abs = Path::join($this->projectDir, 'absolute.csv');
-        self::assertSame($abs, $this->storage->resolve($abs));
+        $abs = Path::join($this->importsBaseDir, 'absolute.csv');
+        file_put_contents($abs, 'data');
+
+        self::assertSame(realpath($abs), $this->storage->resolve($abs));
+    }
+
+    public function testResolveRejectsAbsolutePathOutsideBase(): void
+    {
+        $this->expectException(ImportFilePathOutsideBaseException::class);
+
+        $this->storage->resolve('/etc/passwd');
+    }
+
+    public function testResolveRejectsRelativeEscapeViaDotDot(): void
+    {
+        $this->expectException(ImportFilePathOutsideBaseException::class);
+
+        $this->storage->resolve('var/imports/../../.env');
+    }
+
+    public function testResolveRejectsEmptyPath(): void
+    {
+        $this->expectException(ImportFilePathOutsideBaseException::class);
+
+        $this->storage->resolve('');
+    }
+
+    public function testResolveRejectsNullByte(): void
+    {
+        $this->expectException(ImportFilePathOutsideBaseException::class);
+
+        $this->storage->resolve("var/imports/file.csv\0.txt");
     }
 
     public function testToRelativeReturnsForwardSlashes(): void
@@ -64,11 +105,13 @@ final class ImportFileStorageTest extends TestCase
         $abs = Path::join($this->projectDir, $rel);
         $this->filesystem->mkdir(\dirname($abs));
         file_put_contents($abs, 'data');
+        $resolved = realpath($abs);
+        self::assertNotFalse($resolved);
 
         $this->logger
             ->expects($this->once())
             ->method('info')
-            ->with('import.source_file.deleted', $this->callback(static fn (array $context): bool => 42 === $context['import_id'] && $abs === $context['path']));
+            ->with('import.source_file.deleted', $this->callback(static fn (array $context): bool => 42 === $context['import_id'] && $resolved === $context['path']));
 
         $this->storage->delete($rel, 'import.source_file.deleted', 42);
 
@@ -92,6 +135,19 @@ final class ImportFileStorageTest extends TestCase
         $this->storage->delete('', 'import.source_file.deleted', 1);
     }
 
+    public function testDeleteIgnoresPathOutsideBase(): void
+    {
+        $outside = Path::join($this->projectDir, 'outside.csv');
+        file_put_contents($outside, 'secret');
+
+        $this->logger->expects($this->never())->method('info');
+        $this->logger->expects($this->never())->method('warning');
+
+        $this->storage->delete($outside, 'import.source_file.deleted', 1);
+
+        self::assertFileExists($outside);
+    }
+
     public function testDeleteLogsWarningWhenRemovalFails(): void
     {
         $filesystem = $this->createMock(Filesystem::class);
@@ -108,7 +164,7 @@ final class ImportFileStorageTest extends TestCase
                 && 'import.reject_file.deleted' === $context['event']
                 && 'permission denied' === $context['error']));
 
-        $storage = new ImportFileStorage($this->projectDir, $filesystem, $logger);
+        $storage = new ImportFileStorage($this->projectDir, $this->importsBaseDir, $filesystem, $logger);
         $storage->delete('var/imports/locked.csv', 'import.reject_file.deleted', 7);
     }
 }

--- a/tests/Import/Unit/Application/Service/ImportSourceFileDownloadServiceTest.php
+++ b/tests/Import/Unit/Application/Service/ImportSourceFileDownloadServiceTest.php
@@ -24,8 +24,14 @@ final class ImportSourceFileDownloadServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->projectDir = sys_get_temp_dir().'/import-download-'.bin2hex(random_bytes(4));
-        new Filesystem()->mkdir($this->projectDir);
-        $this->service = new ImportSourceFileDownloadService(new ImportFileStorage($this->projectDir, new Filesystem(), new \Psr\Log\NullLogger()));
+        $importsBaseDir = Path::join($this->projectDir, 'var', 'imports');
+        new Filesystem()->mkdir($importsBaseDir);
+        $this->service = new ImportSourceFileDownloadService(new ImportFileStorage(
+            $this->projectDir,
+            $importsBaseDir,
+            new Filesystem(),
+            new \Psr\Log\NullLogger(),
+        ));
     }
 
     #[\Override]
@@ -48,7 +54,16 @@ final class ImportSourceFileDownloadServiceTest extends TestCase
         self::assertStringContainsString('attachment', (string) $response->headers->get('Content-Disposition'));
         self::assertStringContainsString('My Import File.csv', (string) $response->headers->get('Content-Disposition'));
         self::assertSame('text/csv', $response->headers->get('Content-Type'));
-        self::assertSame($absolutePath, $response->getFile()->getPathname());
+        self::assertSame(realpath($absolutePath), $response->getFile()->getPathname());
+    }
+
+    public function testCreateDownloadResponseThrowsWhenPathOutsideImportsBase(): void
+    {
+        $import = $this->createImport('/etc/passwd', 'Escape', 'csv', 'text/csv');
+
+        $this->expectException(ImportSourceFileNotFoundException::class);
+
+        $this->service->createDownloadResponse($import);
     }
 
     public function testCreateDownloadResponseThrowsWhenFileMissingOnDisk(): void


### PR DESCRIPTION
## Summary

This pull request hardens the import subsystem against path traversal attacks by ensuring that all file operations remain confined to the configured import storage directory.

### Changes

- Added path containment validation before accessing import source files.
- Prevented path traversal attempts from escaping the designated import storage location.
- Ensured that file access is restricted to expected and authorized directories.
- Added or updated automated tests covering valid paths, invalid paths, and traversal attempts.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Prevent unauthorized access to files outside the import storage directory.
- Eliminate path traversal as a potential attack vector in the import workflow.
- Enforce strict boundaries around file system operations involving uploaded data.
- Strengthen the application's overall file handling security and defense-in-depth strategy.