### PR TITLE
fix: Validate favorite Toggle referer redirect

### DIFF
--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -199,7 +199,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`SavedExplorerViewFavoriteController`](../../src/Statistics/AnalysisExplorer/UI/Http/Controller/SavedExplorerViewFavoriteController.php) L52–54 — `redirect($referer)` without host/path validation; CSRF required |
 | Risk | CSRF-protected but still redirects to attacker-controlled Referer after a valid POST (phishing / token fixation UX). Inconsistent with Feedback/Locale safe-target helpers. |
 | Mitigation | Reuse safe local-path / same-host resolver; fallback to library route. |
-| Status | open |
+| Status | resolved (2026-07-28) — Favorite toggle uses shared `SafeRedirectTargetResolver` (local path or same-host); unsafe/empty Referer falls back to `app_stats_analysis_library` |
 
 ### SEC-011 — `/import` missing from `access_control`
 
@@ -362,7 +362,7 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
-| P2 hardening | SEC-009–SEC-016, SEC-019 | Path containment, redirects, headers, docs |
+| P2 hardening | SEC-009, SEC-011–SEC-016, SEC-019 | Path containment, headers, docs (SEC-010 redirect resolved) |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.

--- a/src/Shared/UI/Http/Controller/LocaleSwitchController.php
+++ b/src/Shared/UI/Http/Controller/LocaleSwitchController.php
@@ -7,6 +7,7 @@ namespace App\Shared\UI\Http\Controller;
 use App\Shared\Application\Locale\SupportedLocales;
 use App\Shared\Application\Locale\UserLocalePreferenceUpdater;
 use App\Shared\Infrastructure\Locale\LocaleCookieManager;
+use App\Shared\UI\Http\SafeRedirectTargetResolver;
 use App\User\Domain\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +20,7 @@ final class LocaleSwitchController extends AbstractController
         private readonly UserLocalePreferenceUpdater $userLocalePreferenceUpdater,
         private readonly LocaleCookieManager $localeCookieManager,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly SafeRedirectTargetResolver $safeRedirectTargetResolver,
     ) {
     }
 
@@ -44,12 +46,12 @@ final class LocaleSwitchController extends AbstractController
     private function resolveRedirectTarget(Request $request): string
     {
         $targetPath = $request->query->getString('_target_path');
-        if ('' !== $targetPath && $this->isSafeRedirectTarget($request, $targetPath)) {
+        if ('' !== $targetPath && $this->safeRedirectTargetResolver->isSafe($request, $targetPath)) {
             return $targetPath;
         }
 
-        $referer = $request->headers->get('Referer', '');
-        if ('' !== $referer && $this->isSafeRedirectTarget($request, $referer)) {
+        $referer = $request->headers->get('Referer');
+        if (\is_string($referer) && $this->safeRedirectTargetResolver->isSafe($request, $referer)) {
             return $referer;
         }
 
@@ -59,16 +61,5 @@ final class LocaleSwitchController extends AbstractController
         }
 
         return $this->urlGenerator->generate('app_default');
-    }
-
-    private function isSafeRedirectTarget(Request $request, string $target): bool
-    {
-        if (str_starts_with($target, '/')) {
-            return !str_starts_with($target, '//');
-        }
-
-        $host = $request->getSchemeAndHttpHost();
-
-        return str_starts_with($target, $host.'/') || $target === $host;
     }
 }

--- a/src/Shared/UI/Http/SafeRedirectTargetResolver.php
+++ b/src/Shared/UI/Http/SafeRedirectTargetResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class SafeRedirectTargetResolver
+{
+    public function isSafe(Request $request, string $target): bool
+    {
+        if ('' === $target) {
+            return false;
+        }
+
+        if (str_starts_with($target, '/')) {
+            return !str_starts_with($target, '//');
+        }
+
+        $host = $request->getSchemeAndHttpHost();
+
+        return str_starts_with($target, $host.'/') || $target === $host;
+    }
+
+    public function resolve(?string $candidate, Request $request, string $fallback): string
+    {
+        if (null !== $candidate && $this->isSafe($request, $candidate)) {
+            return $candidate;
+        }
+
+        return $fallback;
+    }
+}

--- a/src/Statistics/AnalysisExplorer/UI/Http/Controller/SavedExplorerViewFavoriteController.php
+++ b/src/Statistics/AnalysisExplorer/UI/Http/Controller/SavedExplorerViewFavoriteController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\AnalysisExplorer\UI\Http\Controller;
 
+use App\Shared\UI\Http\SafeRedirectTargetResolver;
 use App\Statistics\AnalysisExplorer\Application\SavedExplorerViewFavoriteService;
 use App\Statistics\Infrastructure\Repository\SavedExplorerViewRepository;
 use App\User\Domain\Entity\User;
@@ -19,6 +20,7 @@ final class SavedExplorerViewFavoriteController extends AbstractController
     public function __construct(
         private readonly SavedExplorerViewRepository $viewRepository,
         private readonly SavedExplorerViewFavoriteService $favoriteService,
+        private readonly SafeRedirectTargetResolver $safeRedirectTargetResolver,
     ) {
     }
 
@@ -49,11 +51,14 @@ final class SavedExplorerViewFavoriteController extends AbstractController
 
         $this->favoriteService->toggle($user, $view);
 
-        $referer = $request->headers->get('referer');
-        if (\is_string($referer) && '' !== $referer) {
-            return $this->redirect($referer);
-        }
+        $fallback = $this->generateUrl('app_stats_analysis_library');
 
-        return $this->redirectToRoute('app_stats_analysis_library');
+        return $this->redirect(
+            $this->safeRedirectTargetResolver->resolve(
+                $request->headers->get('referer'),
+                $request,
+                $fallback,
+            ),
+        );
     }
 }

--- a/tests/Shared/Unit/UI/Http/SafeRedirectTargetResolverTest.php
+++ b/tests/Shared/Unit/UI/Http/SafeRedirectTargetResolverTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\UI\Http;
+
+use App\Shared\UI\Http\SafeRedirectTargetResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class SafeRedirectTargetResolverTest extends TestCase
+{
+    private SafeRedirectTargetResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new SafeRedirectTargetResolver();
+    }
+
+    #[DataProvider('isSafeProvider')]
+    public function testIsSafe(string $target, bool $expected): void
+    {
+        $request = Request::create('https://app.example/current');
+
+        self::assertSame($expected, $this->resolver->isSafe($request, $target));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function isSafeProvider(): iterable
+    {
+        yield 'local path' => ['/statistics/analysis/library', true];
+        yield 'local path with query' => ['/explore?x=1', true];
+        yield 'protocol relative' => ['//evil.example/phish', false];
+        yield 'external absolute' => ['https://evil.example/phish', false];
+        yield 'same host absolute' => ['https://app.example/statistics/analysis/library', true];
+        yield 'same host root' => ['https://app.example', true];
+        yield 'empty' => ['', false];
+    }
+
+    public function testResolveReturnsCandidateWhenSafe(): void
+    {
+        $request = Request::create('https://app.example/current');
+
+        self::assertSame(
+            '/statistics/analysis/library',
+            $this->resolver->resolve('/statistics/analysis/library', $request, '/fallback'),
+        );
+    }
+
+    public function testResolveReturnsFallbackWhenUnsafeOrEmpty(): void
+    {
+        $request = Request::create('https://app.example/current');
+
+        self::assertSame('/fallback', $this->resolver->resolve('https://evil.example/x', $request, '/fallback'));
+        self::assertSame('/fallback', $this->resolver->resolve(null, $request, '/fallback'));
+        self::assertSame('/fallback', $this->resolver->resolve('', $request, '/fallback'));
+        self::assertSame('/fallback', $this->resolver->resolve('//evil.example', $request, '/fallback'));
+    }
+}

--- a/tests/Statistics/Functional/Controller/SavedExplorerViewFavoriteControllerTest.php
+++ b/tests/Statistics/Functional/Controller/SavedExplorerViewFavoriteControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Functional\Controller;
+
+use App\Statistics\Infrastructure\Repository\SavedExplorerViewRepository;
+use App\Tests\Statistics\Support\SeedsExplorerSystemViewsTrait;
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class SavedExplorerViewFavoriteControllerTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+    use SeedsExplorerSystemViewsTrait;
+
+    public function testToggleWithSafeRefererRedirectsBack(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedExplorerSystemViews();
+        $viewId = $this->systemViewId();
+        $token = $this->csrfTokenAfterVisit($client, 'explorer_favorite_'.$viewId);
+
+        $client->request(
+            Request::METHOD_POST,
+            '/statistics/analysis/explorer/views/'.$viewId.'/favorite/toggle',
+            ['_token' => $token],
+            server: ['HTTP_REFERER' => 'http://localhost/statistics/analysis/library'],
+        );
+
+        self::assertResponseRedirects('/statistics/analysis/library');
+    }
+
+    public function testToggleWithExternalRefererFallsBackToLibrary(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedExplorerSystemViews();
+        $viewId = $this->systemViewId();
+        $token = $this->csrfTokenAfterVisit($client, 'explorer_favorite_'.$viewId);
+
+        $client->request(
+            Request::METHOD_POST,
+            '/statistics/analysis/explorer/views/'.$viewId.'/favorite/toggle',
+            ['_token' => $token],
+            server: ['HTTP_REFERER' => 'https://evil.example/phish'],
+        );
+
+        self::assertResponseRedirects('/statistics/analysis/library');
+    }
+
+    public function testToggleWithoutRefererFallsBackToLibrary(): void
+    {
+        $client = $this->createClientAsParticipant();
+        $this->seedExplorerSystemViews();
+        $viewId = $this->systemViewId();
+        $token = $this->csrfTokenAfterVisit($client, 'explorer_favorite_'.$viewId);
+
+        $client->request(
+            Request::METHOD_POST,
+            '/statistics/analysis/explorer/views/'.$viewId.'/favorite/toggle',
+            ['_token' => $token],
+        );
+
+        self::assertResponseRedirects('/statistics/analysis/library');
+    }
+
+    private function systemViewId(): int
+    {
+        $view = self::getContainer()->get(SavedExplorerViewRepository::class)->findBySlug('allocations-over-time');
+        $id = $view?->getId();
+        self::assertNotNull($id);
+
+        return $id;
+    }
+
+    private function csrfTokenAfterVisit(KernelBrowser $client, string $tokenId): string
+    {
+        $client->request(Request::METHOD_GET, '/statistics/analysis/library');
+        self::assertResponseIsSuccessful();
+
+        $requestStack = $client->getContainer()->get('request_stack');
+        $request = $client->getRequest();
+        $requestStack->push($request);
+        try {
+            $token = $client->getContainer()->get('security.csrf.token_manager')->getToken($tokenId);
+        } finally {
+            $requestStack->pop();
+        }
+
+        return (string) $token->getValue();
+    }
+}


### PR DESCRIPTION
## Summary

This pull request secures the redirect behavior of the favorite action by ensuring that users can only be redirected to trusted internal application URLs.

### Changes

- Added validation for redirect targets used after adding or removing a favorite.
- Prevented external or otherwise unsafe URLs from being accepted as return destinations.
- Added a safe internal fallback when the provided redirect target is missing or invalid.
- Preserved the existing navigation flow for legitimate application URLs.
- Added or updated automated tests covering valid redirects, malicious targets, and fallback behavior.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Prevent open redirect attacks through user-controlled return URLs.
- Ensure that favorite actions cannot redirect users to untrusted external websites.
- Reduce the risk of phishing and other redirect-based attacks.
- Strengthen the application's URL-handling security while preserving the intended user experience.