### PR TITLE
security: Slim public /health JSON payload

### DIFF
--- a/docs/05-operations/health-check.md
+++ b/docs/05-operations/health-check.md
@@ -1,6 +1,6 @@
 # Health check
 
-`GET /health` is a public endpoint (no login) that returns JSON with runtime status.
+`GET /health` is a public endpoint (no login) that returns slim JSON for uptime monitoring.
 
 Related: [observability-sentry.md](observability-sentry.md), [deployment.md](deployment.md), [troubleshooting.md](troubleshooting.md)
 
@@ -9,13 +9,16 @@ Related: [observability-sentry.md](observability-sentry.md), [deployment.md](dep
 | `status` | HTTP | Meaning |
 |--------|------|---------|
 | `healthy` | 200 | Database reachable, no failed Messenger messages |
-| `degraded` | 200 | Database OK, failed queue has messages — check `messenger:failed:show` |
+| `degraded` | 200 | Database OK, failed queue has messages — check `messenger:failed:show` or Admin ops dashboard |
 | `unhealthy` | 503 | Database unreachable |
+
+Public JSON includes only `status` and `checks.database` (no app `version`, no `messenger_failed` count). Full details remain available in the Admin ops dashboard.
 
 Example:
 
 ```bash
 curl -sS https://<host>/health | jq
+# { "status": "healthy", "checks": { "database": "ok" } }
 ```
 
 ## Uptime monitoring
@@ -28,7 +31,7 @@ For external uptime monitoring (Sentry Uptime or similar), point the monitor at 
 | HTTP **503** (`unhealthy`, database down) | yes |
 | HTTP **200** with `"status": "degraded"` | no (by design) |
 
-`degraded` means the app is up but the failed queue has messages. Investigate with `php bin/console messenger:failed:show`. Sentry Uptime does not parse JSON response bodies.
+`degraded` means the app is up but the failed queue has messages. Investigate with `php bin/console messenger:failed:show` or the Admin ops panel. Sentry Uptime does not parse JSON response bodies.
 
 ### Sentry Uptime setup
 

--- a/docs/05-operations/observability-sentry.md
+++ b/docs/05-operations/observability-sentry.md
@@ -84,6 +84,6 @@ The Symfony SDK (`sentry/sentry-symfony`) sends errors, logs, and traces **from 
 | HTTP **503** (`unhealthy`, database down) | yes |
 | HTTP **200** with `"status": "degraded"` (failed Messenger messages) | no (by design) |
 
-`degraded` means the app is up but the failed queue has messages. Use `php bin/console messenger:failed:show` and [health-check.md](health-check.md) — Sentry Uptime does not parse JSON response bodies.
+`degraded` means the app is up but the failed queue has messages. Use `php bin/console messenger:failed:show`, the Admin ops dashboard, or [health-check.md](health-check.md) — Sentry Uptime does not parse JSON response bodies (public `/health` also omits version and messenger details).
 
 Related: [health-check.md](health-check.md) (`GET /health` response format).

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -221,7 +221,7 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 | Evidence | [`HealthCheckReport::toArray`](../../src/Shared/Application/Health/HealthCheckReport.php); public via `access_control` |
 | Risk | Attackers learn app version and whether the failed messenger queue is non-empty. Useful for uptime monitoring by design. |
 | Mitigation | Slim public payload to `status` (+ optional `database`); put detailed checks behind auth or internal network. Document accepted disclosure if kept for Sentry Uptime. |
-| Status | open |
+| Status | resolved (2026-07-29) — public `GET /health` uses `toPublicArray()` (`status` + `checks.database` only); version/messenger details remain on full report for Admin ops |
 
 ### SEC-013 — Media files publicly served; directory listing not hardened in-app
 
@@ -362,7 +362,7 @@ Do **not** implement in this audit deliverable.
 |----------|----------|-----------|
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
-| P2 hardening | SEC-012–SEC-016, SEC-019 | Headers, docs (SEC-011 `/import` access_control resolved) |
+| P2 hardening | SEC-013–SEC-016, SEC-019 | Headers, docs (SEC-012 public `/health` payload slimmed) |
 | P3 backlog | SEC-014, SEC-017, SEC-018, SEC-020 | CSP enforce, docs, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.

--- a/src/Shared/Application/Health/HealthCheckReport.php
+++ b/src/Shared/Application/Health/HealthCheckReport.php
@@ -26,6 +26,8 @@ final readonly class HealthCheckReport
     }
 
     /**
+     * Full report for authenticated ops surfaces (e.g. admin dashboard).
+     *
      * @return array{status: string, version: string, checks: array<string, string>}
      */
     public function toArray(): array
@@ -34,6 +36,24 @@ final readonly class HealthCheckReport
             'status' => $this->status->value,
             'version' => $this->version,
             'checks' => $this->checks,
+        ];
+    }
+
+    /**
+     * Slim public payload for GET /health (no version, no messenger details).
+     *
+     * @return array{status: string, checks: array<string, string>}
+     */
+    public function toPublicArray(): array
+    {
+        $checks = [];
+        if (isset($this->checks['database'])) {
+            $checks['database'] = $this->checks['database'];
+        }
+
+        return [
+            'status' => $this->status->value,
+            'checks' => $checks,
         ];
     }
 }

--- a/src/Shared/UI/Http/Controller/HealthCheckController.php
+++ b/src/Shared/UI/Http/Controller/HealthCheckController.php
@@ -22,7 +22,7 @@ final readonly class HealthCheckController
         $report = $this->healthCheckService->check();
 
         return new JsonResponse(
-            $report->toArray(),
+            $report->toPublicArray(),
             $report->httpStatusCode(),
         );
     }

--- a/tests/Shared/Functional/Controller/HealthCheckControllerTest.php
+++ b/tests/Shared/Functional/Controller/HealthCheckControllerTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Shared\Functional\Controller;
 
-use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 final class HealthCheckControllerTest extends WebTestCase
 {
-    public function testHealthEndpointIsPublicAndReturnsJson(): void
+    public function testHealthEndpointIsPublicAndReturnsSlimJson(): void
     {
         $client = self::createClient();
         $client->request(Request::METHOD_GET, '/health');
@@ -21,10 +20,11 @@ final class HealthCheckControllerTest extends WebTestCase
 
         self::assertIsArray($payload);
         self::assertArrayHasKey('status', $payload);
-        self::assertArrayHasKey('version', $payload);
         self::assertArrayHasKey('checks', $payload);
-        self::assertSame(Kernel::APP_VERSION, $payload['version']);
+        self::assertArrayNotHasKey('version', $payload);
+        self::assertSame(['database'], array_keys($payload['checks']));
         self::assertSame('ok', $payload['checks']['database']);
+        self::assertArrayNotHasKey('messenger_failed', $payload['checks']);
         self::assertContains($payload['status'], ['healthy', 'degraded']);
     }
 }

--- a/tests/Shared/Unit/Health/HealthCheckServiceTest.php
+++ b/tests/Shared/Unit/Health/HealthCheckServiceTest.php
@@ -27,6 +27,15 @@ final class HealthCheckServiceTest extends TestCase
         self::assertSame('ok', $report->checks['database']);
         self::assertSame('ok', $report->checks['messenger_failed']);
         self::assertSame(200, $report->httpStatusCode());
+        self::assertSame(
+            [
+                'status' => 'healthy',
+                'checks' => ['database' => 'ok'],
+            ],
+            $report->toPublicArray(),
+        );
+        self::assertArrayHasKey('version', $report->toArray());
+        self::assertArrayHasKey('messenger_failed', $report->toArray()['checks']);
     }
 
     public function testReturnsDegradedWhenFailedMessagesExist(): void
@@ -40,6 +49,13 @@ final class HealthCheckServiceTest extends TestCase
         self::assertSame('ok', $report->checks['database']);
         self::assertSame('3 failed message(s)', $report->checks['messenger_failed']);
         self::assertSame(200, $report->httpStatusCode());
+        self::assertSame(
+            [
+                'status' => 'degraded',
+                'checks' => ['database' => 'ok'],
+            ],
+            $report->toPublicArray(),
+        );
     }
 
     public function testReturnsUnhealthyWhenDatabaseUnreachable(): void
@@ -58,6 +74,13 @@ final class HealthCheckServiceTest extends TestCase
         self::assertSame('unreachable', $report->checks['database']);
         self::assertSame('skipped', $report->checks['messenger_failed']);
         self::assertSame(503, $report->httpStatusCode());
+        self::assertSame(
+            [
+                'status' => 'unhealthy',
+                'checks' => ['database' => 'unreachable'],
+            ],
+            $report->toPublicArray(),
+        );
     }
 
     private function createConnectionMock(int $failedCount): Connection


### PR DESCRIPTION
## Summary

This pull request hardens the public health endpoint by limiting its response to essential health information, preventing the disclosure of unnecessary operational or infrastructure details.

### Changes

- Reduced the public health endpoint payload to the minimum information required for health checks.
- Removed implementation and environment details that are not needed by external consumers.
- Preserved compatibility with monitoring systems expecting a successful health response.
- Ensured that internal application state and diagnostic information remain unavailable through the public endpoint.
- Added or updated automated tests verifying the public response contract.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Minimize information disclosure through publicly accessible endpoints.
- Reduce the amount of infrastructure and application metadata exposed to unauthenticated users.
- Follow the principle of least information for health and monitoring endpoints.
- Strengthen the application's security posture while maintaining operational observability.