### PR TITLE
docs(security): align permission model with ImportVoter (SEC-017)

### DIFF
--- a/docs/02-architecture/permission-model.md
+++ b/docs/02-architecture/permission-model.md
@@ -45,7 +45,7 @@ Grants are stored in `HospitalAccessGrant` as an integer mask and validated via 
 |-------|------------|---------|
 | `HospitalVoter` | `ACCESS`, `EDIT`, `MANAGE_ACCESS_GRANTS` | `Hospital` |
 | `AllocationVoter` | `VIEW` | `Allocation` |
-| `ImportVoter` | `VIEW`, `DELETE` | `Import` |
+| `ImportVoter` | `VIEW`, `DELETE`, `DOWNLOAD_SOURCE` | `Import` |
 | `ExportVoter` | `EXPORT` | (none) |
 | `IndicationRawReviewVoter` | `VIEW`, `EDIT_MATCH`, `REVIEW` | `IndicationRaw` |
 

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -51,12 +51,10 @@ Role hierarchy: `ROLE_ADMIN` → `ROLE_PARTICIPANT`, `ROLE_REVIEW_INDICATIONS`.
 | Voter | Attributes | Notes |
 |-------|------------|-------|
 | `HospitalVoter` | `ACCESS`, `EDIT`, `MANAGE_ACCESS_GRANTS` | Hospital-scoped |
-| `AllocationVoter` | `VIEW` | Any `ROLE_USER`; **no hospital scope** |
+| `AllocationVoter` | `VIEW` | Any `ROLE_PARTICIPANT`; **no hospital scope** |
 | `ImportVoter` | `VIEW`, `DELETE`, `DOWNLOAD_SOURCE` | Hospital + creator/admin rules |
 | `ExportVoter` | `EXPORT` | Via `ExportAccessService` |
 | `IndicationRawReviewVoter` | `VIEW`, `EDIT_MATCH`, `REVIEW` | Participant + review roles |
-
-Doc drift: [`permission-model.md`](../02-architecture/permission-model.md) omits `ImportVoter::DOWNLOAD_SOURCE`.
 
 ### Rate limiters
 
@@ -273,10 +271,10 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 |-------|-------|
 | Severity | Info |
 | Area | Docs |
-| Evidence | [`permission-model.md`](../02-architecture/permission-model.md) ImportVoter table omits `DOWNLOAD_SOURCE`; AllocationVoter collaborative semantics undocumented |
+| Evidence | [`permission-model.md`](../02-architecture/permission-model.md) ImportVoter table omitted `DOWNLOAD_SOURCE` while code already enforced it in [`ImportVoter`](../../src/Import/Infrastructure/Security/Voter/ImportVoter.php) |
 | Risk | Maintainers mis-implement access checks. |
 | Mitigation | Update voter table + document Explore collaboration / accepted risk (SEC-005). |
-| Status | open — AllocationVoter / Explore collaboration documented with SEC-005 (ADR 011); `ImportVoter::DOWNLOAD_SOURCE` still missing from voter table |
+| Status | resolved (2026-07-29) — `permission-model.md` voter table now includes `ImportVoter::DOWNLOAD_SOURCE`; Explore collaboration remains documented via SEC-005 / ADR 011 |
 
 ### SEC-018 — Messenger import handlers trust queue without permission re-check
 
@@ -363,7 +361,7 @@ Do **not** implement in this audit deliverable.
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
 | P2 hardening | SEC-013, SEC-016, SEC-019 | Media indexes, login logs, docs (SEC-014 CSP accepted for beta) |
-| P3 backlog | SEC-014 enforce, SEC-017, SEC-018, SEC-020 | CSP enforce + reduce `unsafe-inline`, docs, trust boundary, tests |
+| P3 backlog | SEC-014 enforce, SEC-018, SEC-020 | CSP enforce + reduce `unsafe-inline`, trust boundary, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.
 


### PR DESCRIPTION
## Summary

This pull request resolves documentation drift by aligning the project's permission model documentation with the application's actual authorization behavior, ensuring that the documented security model accurately reflects the implemented access controls.

### Changes

- Updated the permission model documentation to match the current implementation.
- Removed outdated or inaccurate descriptions of authorization rules.
- Clarified user roles, permissions, and access boundaries where necessary.
- Ensured consistency between the documented security model and the application's authorization logic.
- Reviewed related documentation for terminology and structural consistency.
- Documented the completed security documentation improvement as part of the project's security hardening efforts.

### Why

- Keep security documentation synchronized with the implemented authorization model.
- Reduce the risk of misunderstandings caused by outdated documentation.
- Provide developers and reviewers with an accurate reference for access control decisions.
- Support future maintenance and security audits through reliable documentation.