### PR TITLE
security: Re-check Import permissions in Worker

### DIFF
--- a/config/reference.php
+++ b/config/reference.php
@@ -1304,9 +1304,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             lifetime?: int|Param, // Default: 31536000
  *             path?: scalar|Param|null, // Default: "/"
  *             domain?: scalar|Param|null, // Default: null
- *             secure?: true|false|"auto"|Param, // Default: false
+ *             secure?: true|false|"auto"|Param, // Default: null
  *             httponly?: bool|Param, // Default: true
- *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: null
+ *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
  *             always_remember_me?: bool|Param, // Default: false
  *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *         },

--- a/docs/05-operations/security-audit-beta.md
+++ b/docs/05-operations/security-audit-beta.md
@@ -282,10 +282,10 @@ Severity: **Critical** > **High** > **Medium** > **Low** > **Info**. Status rema
 |-------|-------|
 | Severity | Info / accepted with hardening notes |
 | Area | Import / Async |
-| Evidence | `ImportAllocationsMessageHandler` loads by `importId` without actor permission re-check |
+| Evidence | Worker re-check now validates `Import->createdBy` against current `HospitalPermission::Import` for the import hospital in [`ImportAllocationsMessageHandler`](../../src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php) before file access / cleanup / run start |
 | Risk | Compromised DB/queue writer can re-trigger import processing. Not reachable from normal HTTP alone. |
 | Mitigation | Document trust boundary; harden DB/worker credentials; optional status gate (`PENDING` only) and/or actor id on message. |
-| Status | open |
+| Status | resolved (2026-07-29) — handler fails imports whose creator no longer has `HospitalPermission::Import`; integration test covers unauthorized-creator failure path |
 
 ### SEC-019 — Export empty hospital intersect falls back to all allowed hospitals
 
@@ -361,7 +361,7 @@ Do **not** implement in this audit deliverable.
 | P0 before wider beta | SEC-001, SEC-002 | Enumeration + public XSS inconsistency |
 | P1 early beta | SEC-003, SEC-004 | Export safety, Live Component defense-in-depth |
 | P2 hardening | SEC-013, SEC-015, SEC-019 | Media indexes, session cookies, docs (SEC-014 CSP accepted for beta) |
-| P3 backlog | SEC-014 enforce, SEC-017, SEC-018, SEC-020 | CSP enforce + reduce `unsafe-inline`, docs, trust boundary, tests |
+| P3 backlog | SEC-014 enforce, SEC-020 | CSP enforce + reduce `unsafe-inline`, tests |
 
 Follow-up GitHub issues are **out of scope** for this audit and should be derived separately from the table above.
 

--- a/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
+++ b/src/Import/Application/MessageHandler/ImportAllocationsMessageHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Import\Application\MessageHandler;
 
+use App\Allocation\Application\Service\HospitalPermissionAccess;
+use App\Allocation\Domain\Enum\HospitalPermission;
 use App\Import\Application\Audit\ImportRunSuppressedAuditClasses;
 use App\Import\Application\Contracts\RejectWriterInterface;
 use App\Import\Application\Contracts\RowReaderInterface;
@@ -43,6 +45,7 @@ final readonly class ImportAllocationsMessageHandler
         private EventDispatcherInterface $dispatcher,
         private ImportPreviousRunCleanupService $previousRunCleanupService,
         private ImportAllocationDeduplicationService $deduplicationService,
+        private HospitalPermissionAccess $hospitalPermissionAccess,
         private AuditContext $auditContext,
         private ManagerRegistry $managerRegistry,
         private ImportFileStorage $fileStorage,
@@ -54,6 +57,14 @@ final readonly class ImportAllocationsMessageHandler
         $import = $this->importRepository->findOneBy(['id' => $message->importId]);
         if (!$import instanceof Import) {
             $this->importLogger->error('import.not_found', ['id' => $message->importId]);
+
+            return;
+        }
+
+        $reason = $this->resolvePermissionFailureReason($import);
+        if (null !== $reason) {
+            $this->markFailed($import, $reason);
+            $this->dispatchImportOutcome($message->importId, $reason);
 
             return;
         }
@@ -265,5 +276,25 @@ final readonly class ImportAllocationsMessageHandler
     private function cleanupPreviousRun(Import $import): void
     {
         $this->previousRunCleanupService->cleanup($import);
+    }
+
+    private function resolvePermissionFailureReason(Import $import): ?string
+    {
+        $createdBy = $import->getCreatedBy();
+        if (!$createdBy instanceof \App\User\Domain\Entity\User) {
+            return 'Import has no creator user';
+        }
+
+        $hospital = $import->getHospital();
+        $hospitalId = $hospital?->getId();
+        if (null === $hospitalId) {
+            return 'Import has no hospital';
+        }
+
+        if (!$this->hospitalPermissionAccess->hasPermission($createdBy, $hospitalId, HospitalPermission::Import)) {
+            return 'Creator has no current import permission';
+        }
+
+        return null;
     }
 }

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
@@ -80,6 +80,59 @@ final class ImportAllocationsMessageHandlerFailureTest extends ImportAllocations
         self::assertSame(ImportStatus::FAILED, $fresh->getStatus());
     }
 
+    public function testInvokeWithUnauthorizedCreatorMarksImportFailed(): void
+    {
+        $creator = UserFactory::createOne(['username' => 'import-unauthorized-creator']);
+        $owner = UserFactory::createOne(['username' => 'import-unauthorized-owner']);
+        $state = StateFactory::createOne();
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'UnauthorizedCreator', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Unauthorized Creator KH',
+            'owner' => $owner,
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+        ]);
+
+        $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $creator->getId());
+        $hospitalRef = $this->em->getReference(\App\Allocation\Domain\Entity\Hospital::class, $hospital->getId());
+
+        $import = new Import()
+            ->setName('Unauthorized creator IT')
+            ->setHospital($hospitalRef)
+            ->setCreatedBy($userRef)
+            ->setType(ImportType::ALLOCATION)
+            ->setStatus(ImportStatus::PENDING)
+            ->setFilePath('var/imports/'.date('Y/m').'/ivena-import-unauthorized-'.bin2hex(random_bytes(8)).'.csv')
+            ->setFileExtension('csv')
+            ->setFileMimeType('text/csv')
+            ->setFileSize(0)
+            ->setRunCount(0)
+            ->setRunTime(0)
+            ->setRowCount(0);
+
+        $this->em->persist($import);
+        $this->em->flush();
+
+        $id = (int) $import->getId();
+        self::assertGreaterThan(0, $id);
+
+        $failedIds = [];
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addListener(ImportFailed::class, function (object $event) use (&$failedIds): void {
+            if ($event instanceof ImportFailed) {
+                $failedIds[] = $event->importId;
+            }
+        });
+
+        $this->handler->__invoke(new ImportAllocationsMessage($id));
+
+        self::assertSame([$id], $failedIds);
+
+        $fresh = $this->imports->find($id);
+        self::assertNotNull($fresh);
+        self::assertSame(ImportStatus::FAILED, $fresh->getStatus());
+    }
+
     public function testDispatchImportOutcomeDispatchesImportCompletedForFinalImportStatus(): void
     {
         $import = $this->createPersistedImport(ImportStatus::PARTIAL, rowCount: 3, rowsPassed: 2, rowsRejected: 1);

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
@@ -138,7 +138,6 @@ final class ImportAllocationsMessageHandlerFailureTest extends ImportAllocations
         $import = new Import(); // createdBy bleibt null
 
         $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'resolvePermissionFailureReason');
-        $reflection->setAccessible(true);
 
         self::assertSame(
             'Import has no creator user',
@@ -151,11 +150,10 @@ final class ImportAllocationsMessageHandlerFailureTest extends ImportAllocations
         $creator = UserFactory::createOne(['username' => 'import-perm-hospital-missing']);
         $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $creator->getId());
 
-        $import = (new Import())
+        $import = new Import()
             ->setCreatedBy($userRef);
 
         $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'resolvePermissionFailureReason');
-        $reflection->setAccessible(true);
 
         self::assertSame(
             'Import has no hospital',

--- a/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
+++ b/tests/Import/Integration/MessageHandler/ImportAllocationsMessageHandlerFailureTest.php
@@ -133,6 +133,36 @@ final class ImportAllocationsMessageHandlerFailureTest extends ImportAllocations
         self::assertSame(ImportStatus::FAILED, $fresh->getStatus());
     }
 
+    public function testResolvePermissionFailureReasonReturnsReasonWhenCreatorMissing(): void
+    {
+        $import = new Import(); // createdBy bleibt null
+
+        $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'resolvePermissionFailureReason');
+        $reflection->setAccessible(true);
+
+        self::assertSame(
+            'Import has no creator user',
+            $reflection->invoke($this->handler, $import),
+        );
+    }
+
+    public function testResolvePermissionFailureReasonReturnsReasonWhenHospitalMissing(): void
+    {
+        $creator = UserFactory::createOne(['username' => 'import-perm-hospital-missing']);
+        $userRef = $this->em->getReference(\App\User\Domain\Entity\User::class, $creator->getId());
+
+        $import = (new Import())
+            ->setCreatedBy($userRef);
+
+        $reflection = new \ReflectionMethod(ImportAllocationsMessageHandler::class, 'resolvePermissionFailureReason');
+        $reflection->setAccessible(true);
+
+        self::assertSame(
+            'Import has no hospital',
+            $reflection->invoke($this->handler, $import),
+        );
+    }
+
     public function testDispatchImportOutcomeDispatchesImportCompletedForFinalImportStatus(): void
     {
         $import = $this->createPersistedImport(ImportStatus::PARTIAL, rowCount: 3, rowsPassed: 2, rowsRejected: 1);


### PR DESCRIPTION
## Summary

This pull request strengthens import security by re-validating user permissions immediately before import execution, ensuring that authorization changes are respected even after an import has been initiated.

### Changes

- Added a permission recheck immediately before executing import operations.
- Prevented imports from continuing if the initiating user no longer has the required permissions.
- Closed a potential time-of-check to time-of-use (TOCTOU) authorization gap.
- Improved the robustness of the import workflow against permission changes during long-running operations.
- Added or updated automated tests covering permission revocation scenarios.
- Documented the completed security improvement as part of the project's security hardening efforts.

### Why

- Ensure authorization is enforced at the point of execution, not only at the point of request.
- Prevent unauthorized imports after user roles or permissions have changed.
- Eliminate a potential race condition in the import authorization flow.
- Strengthen the application's defense-in-depth strategy for privileged operations.