### PR TITLE
Fix: Admin CSP Inline Violations

### DIFF
--- a/assets/admin-kpi.js
+++ b/assets/admin-kpi.js
@@ -1,5 +1,9 @@
 import { Application } from '@hotwired/stimulus';
 import AdminKpiChartController from './controllers/admin-kpi-chart_controller.js';
+import CheckboxSelectAllController from './controllers/checkbox-select-all_controller.js';
+import ConfirmSubmitController from './controllers/confirm-submit_controller.js';
 
 const application = Application.start();
 application.register('admin-kpi-chart', AdminKpiChartController);
+application.register('checkbox-select-all', CheckboxSelectAllController);
+application.register('confirm-submit', ConfirmSubmitController);

--- a/assets/controllers/admin-kpi-chart_controller.js
+++ b/assets/controllers/admin-kpi-chart_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus';
-import { loadApexCharts } from '../lib/load-apexcharts.js';
+import { applyChartNonce, loadApexCharts } from '../lib/load-apexcharts.js';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
@@ -41,7 +41,7 @@ export default class extends Controller {
         const maxRecords = records.length ? Math.max(...records) : 0;
         const maxRate = rejectionRates.length ? Math.max(...rejectionRates) : 0;
 
-        const options = {
+        const options = applyChartNonce({
             chart: {
                 type: 'line',
                 height: 280,
@@ -120,7 +120,7 @@ export default class extends Controller {
                         seriesIndex === 1 ? `${value.toFixed(2)}%` : Math.round(value).toString(),
                 },
             },
-        };
+        });
 
         if (generation !== this._renderGeneration || !this.hasChartTarget) {
             return;

--- a/assets/controllers/checkbox-select-all_controller.js
+++ b/assets/controllers/checkbox-select-all_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['toggle', 'item'];
+
+    toggleAll() {
+        if (!this.hasToggleTarget) {
+            return;
+        }
+
+        const checked = this.toggleTarget.checked;
+        this.itemTargets.forEach((checkbox) => {
+            checkbox.checked = checked;
+        });
+    }
+}

--- a/assets/controllers/confirm-submit_controller.js
+++ b/assets/controllers/confirm-submit_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static values = {
+        message: String,
+    };
+
+    confirm(event) {
+        if (!window.confirm(this.messageValue)) {
+            event.preventDefault();
+        }
+    }
+}

--- a/assets/lib/load-apexcharts.js
+++ b/assets/lib/load-apexcharts.js
@@ -6,3 +6,32 @@ export function loadApexCharts() {
     }
     return apexChartsPromise;
 }
+
+/**
+ * CSP style nonce from EasyAdmin's <meta name="csp-nonce"> when present.
+ * Without a meta tag (normal app pages), ApexCharts relies on style-src 'unsafe-inline'.
+ */
+export function getCspNonce() {
+    return document.querySelector('meta[name="csp-nonce"]')?.content || undefined;
+}
+
+/**
+ * Merge chart.nonce into ApexCharts options when a CSP nonce is available.
+ *
+ * @param {Record<string, unknown>} options
+ * @returns {Record<string, unknown>}
+ */
+export function applyChartNonce(options) {
+    const nonce = getCspNonce();
+    if (!nonce) {
+        return options;
+    }
+
+    return {
+        ...options,
+        chart: {
+            ...(options.chart ?? {}),
+            nonce,
+        },
+    };
+}

--- a/assets/styles/admin-kpi.css
+++ b/assets/styles/admin-kpi.css
@@ -61,3 +61,15 @@
 .ea-failed-messages-row-actions {
     gap: 0.5rem;
 }
+
+.ea-failed-messages-select-col {
+    width: 2.5rem;
+}
+
+.ea-failed-messages-pre-headers {
+    max-height: 16rem;
+}
+
+.ea-failed-messages-pre-body {
+    max-height: 28rem;
+}

--- a/docs/05-operations/content-security-policy.md
+++ b/docs/05-operations/content-security-policy.md
@@ -136,6 +136,18 @@ Multiple users / many events / unknown domain?
 
 **Action:** Resolve the issue; comment with the reason.
 
+### EasyAdmin and nonces
+
+EasyAdmin calls Nelmio’s `csp_nonce()` and adds `'nonce-…'` to `script-src` / `style-src` on `/admin` responses. Under **CSP Level 3**, that **disables `'unsafe-inline'`** for those directives — even though the YAML policy still lists it. Inline event handlers (`onsubmit`), bare `<script>` / `style=""` attributes, and vendor-injected `<style>` without a matching nonce therefore show up as Report-Only violations on admin pages only.
+
+Mitigations already in place for the known Failed Messages / dashboard KPI noise:
+
+- Confirm dialogs and select-all → Stimulus (`confirm-submit`, `checkbox-select-all`)
+- Inline layout styles → CSS classes in `admin-kpi.css`
+- ApexCharts injected styles → `chart.nonce` from `<meta name="csp-nonce">` via `applyChartNonce()` in `assets/lib/load-apexcharts.js`
+
+Resolve matching Sentry CSP issues as `policy-gap` after deploy if they stop recurring.
+
 ### Policy gap (fix later, not an attack)
 
 | Pattern | Example | Action |
@@ -143,6 +155,7 @@ Multiple users / many events / unknown domain?
 | Known CDN you plan to allow | New analytics or font host | Add to CSP in P2 or refactor to `'self'` |
 | Same route after a feature deploy | New external asset on one page | Extend policy or self-host |
 | OpenStreetMap variant | Unexpected tile subdomain | Adjust `img-src` / `connect-src` if legitimate |
+| EasyAdmin + nonce (see above) | `script-src-attr` / `style-src-elem` on `/admin/…` with `blocked_uri: inline` | Prefer Stimulus / CSS / vendor nonce; do not “fix” by removing EasyAdmin nonces |
 
 **Action:** Open a P2 ticket; resolve the issue if it is understood backlog.
 

--- a/src/Admin/UI/Twig/templates/operations/failed_messages_detail.html.twig
+++ b/src/Admin/UI/Twig/templates/operations/failed_messages_detail.html.twig
@@ -13,7 +13,9 @@
         <form method="post"
               action="{{ delete_url }}"
               class="m-0"
-              onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin')|e('js') }}');">
+              data-controller="confirm-submit"
+              data-action="submit->confirm-submit#confirm"
+              data-confirm-submit-message-value="{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin') }}">
             <input type="hidden" name="_token" value="{{ csrf_token('failed_message_delete_' ~ message.id) }}">
             <button type="submit" class="btn btn-outline-secondary ea-admin-action-btn">
                 {{ 'ops.failed_messages.delete'|trans({}, 'admin') }}
@@ -29,10 +31,10 @@
     </dl>
 
     <h3 class="h5 mt-4">{{ 'ops.failed_messages.headers'|trans({}, 'admin') }}</h3>
-    <pre class="rounded border bg-white p-3 overflow-auto small" style="max-height: 16rem;">{{ message.headers }}</pre>
+    <pre class="rounded border bg-white p-3 overflow-auto small ea-failed-messages-pre-headers">{{ message.headers }}</pre>
 
     <h3 class="h5 mt-4">{{ 'ops.failed_messages.body'|trans({}, 'admin') }}</h3>
-    <pre class="rounded border bg-white p-3 overflow-auto small" style="max-height: 28rem;">{{ message.body }}</pre>
+    <pre class="rounded border bg-white p-3 overflow-auto small ea-failed-messages-pre-body">{{ message.body }}</pre>
 
     <p class="text-muted small mt-3">{{ 'ops.failed_messages.cli_hint'|trans({}, 'admin') }}</p>
 {% endblock %}

--- a/src/Admin/UI/Twig/templates/operations/failed_messages_index.html.twig
+++ b/src/Admin/UI/Twig/templates/operations/failed_messages_index.html.twig
@@ -15,7 +15,9 @@
             <form method="post"
                   action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete_all') }}"
                   class="m-0"
-                  onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_all'|trans({}, 'admin')|e('js') }}');">
+                  data-controller="confirm-submit"
+                  data-action="submit->confirm-submit#confirm"
+                  data-confirm-submit-message-value="{{ 'ops.failed_messages.confirm_delete_all'|trans({}, 'admin') }}">
                 <input type="hidden" name="_token" value="{{ csrf_token('failed_messages_delete_all') }}">
                 <button type="submit" class="btn btn-primary ea-admin-primary-badge-btn d-inline-flex align-items-center">
                     {{ 'ops.failed_messages.delete_all'|trans({}, 'admin') }}
@@ -27,7 +29,9 @@
                   action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete_selected') }}"
                   id="failed-messages-batch-form"
                   class="m-0"
-                  onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_selected'|trans({}, 'admin')|e('js') }}');">
+                  data-controller="confirm-submit"
+                  data-action="submit->confirm-submit#confirm"
+                  data-confirm-submit-message-value="{{ 'ops.failed_messages.confirm_delete_selected'|trans({}, 'admin') }}">
                 <input type="hidden" name="_token" value="{{ csrf_token('failed_messages_delete_batch') }}">
                 <button type="submit" class="btn btn-outline-primary ea-admin-action-btn">
                     {{ 'ops.failed_messages.delete_selected'|trans({}, 'admin') }}
@@ -35,15 +39,17 @@
             </form>
         </div>
 
-        <div class="card">
+        <div class="card" data-controller="checkbox-select-all">
             <div class="table-responsive">
                 <table class="table table-striped table-hover mb-0 align-middle">
                     <thead>
                         <tr>
-                            <th scope="col" style="width: 2.5rem;">
+                            <th scope="col" class="ea-failed-messages-select-col">
                                 <input type="checkbox"
                                        class="form-check-input"
                                        id="failed-messages-select-all"
+                                       data-checkbox-select-all-target="toggle"
+                                       data-action="change->checkbox-select-all#toggleAll"
                                        aria-label="{{ 'ops.failed_messages.select_all'|trans({}, 'admin') }}">
                             </th>
                             <th scope="col">ID</th>
@@ -62,6 +68,7 @@
                                            name="ids[]"
                                            value="{{ message.id }}"
                                            form="failed-messages-batch-form"
+                                           data-checkbox-select-all-target="item"
                                            aria-label="{{ 'ops.failed_messages.select_item'|trans({'%id%': message.id}, 'admin') }}">
                                 </td>
                                 <td>{{ message.id }}</td>
@@ -76,7 +83,9 @@
                                         <form method="post"
                                               action="{{ ea_url().setRoute('app_admin_dashboard_operations_failed_messages_delete', {id: message.id}) }}"
                                               class="m-0"
-                                              onsubmit="return confirm('{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin')|e('js') }}');">
+                                              data-controller="confirm-submit"
+                                              data-action="submit->confirm-submit#confirm"
+                                              data-confirm-submit-message-value="{{ 'ops.failed_messages.confirm_delete_one'|trans({}, 'admin') }}">
                                             <input type="hidden" name="_token" value="{{ csrf_token('failed_message_delete_' ~ message.id) }}">
                                             <button type="submit" class="btn btn-sm btn-outline-secondary">
                                                 {{ 'ops.failed_messages.delete'|trans({}, 'admin') }}
@@ -90,15 +99,6 @@
                 </table>
             </div>
         </div>
-
-        <script>
-            document.getElementById('failed-messages-select-all')?.addEventListener('change', (event) => {
-                const checked = event.target.checked;
-                document.querySelectorAll('.failed-message-select').forEach((checkbox) => {
-                    checkbox.checked = checked;
-                });
-            });
-        </script>
     {% else %}
         <div class="card">
             <div class="table-responsive">

--- a/tests/Admin/Functional/Controller/FailedMessengerControllerTest.php
+++ b/tests/Admin/Functional/Controller/FailedMessengerControllerTest.php
@@ -30,11 +30,21 @@ final class FailedMessengerControllerTest extends WebTestCase
         $client->loginUser($admin);
         $client->request(Request::METHOD_GET, '/admin/operations/failed-messages');
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('ImportAllocationsMessage', $client->getResponse()->getContent());
+        $indexHtml = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('ImportAllocationsMessage', $indexHtml);
+        self::assertStringContainsString('data-controller="confirm-submit"', $indexHtml);
+        self::assertStringContainsString('data-controller="checkbox-select-all"', $indexHtml);
+        self::assertStringNotContainsString('onsubmit=', $indexHtml);
+        self::assertStringNotContainsString("document.getElementById('failed-messages-select-all')", $indexHtml);
 
         $client->request(Request::METHOD_GET, '/admin/operations/failed-messages/'.$messageId);
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('test-body-content', $client->getResponse()->getContent());
+        $detailHtml = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('test-body-content', $detailHtml);
+        self::assertStringContainsString('data-controller="confirm-submit"', $detailHtml);
+        self::assertStringNotContainsString('onsubmit=', $detailHtml);
+        self::assertStringContainsString('ea-failed-messages-pre-headers', $detailHtml);
+        self::assertStringContainsString('ea-failed-messages-pre-body', $detailHtml);
     }
 
     public function testAdminCanDeleteSingleFailedMessage(): void


### PR DESCRIPTION
## Summary

- Fix CSP Report-Only noise on EasyAdmin admin pages caused by CSP Level 3 ignoring `'unsafe-inline'` once EasyAdmin injects a nonce into the policy.
- Remove inline `onsubmit` handlers, an inline select-all `<script>`, and `style=""` attributes from the Failed Messages UI; replace them with Stimulus controllers and CSS classes.
- Pass EasyAdmin’s `csp-nonce` meta value into ApexCharts via `chart.nonce` so vendor-injected `<style>` tags are allowed under `style-src-elem`.

## Context

Sentry CSP reports on `/admin` and `/admin/operations/failed-messages` showed:

| Directive | Cause |
|-----------|--------|
| `script-src-attr` | `onsubmit="return confirm(...)"` |
| `script-src-elem` | Inline select-all `<script>` |
| `style-src-attr` | `style="width/max-height…"` |
| `style-src-elem` | ApexCharts creating `<style>` without a nonce |

These are policy gaps, not attacks. EasyAdmin calls `csp_nonce()`, so browsers drop `'unsafe-inline'` even though Nelmio still lists it in report-only mode.

## Changes

- New Stimulus controllers: `confirm-submit`, `checkbox-select-all` (registered in the admin `admin-kpi` entry)
- Failed Messages templates use data attributes + CSS classes instead of inline JS/CSS
- `applyChartNonce()` helper reads `<meta name="csp-nonce">` for ApexCharts
- CSP ops docs updated; functional tests assert the new markup

Report-Only / enforce policy is unchanged.

## Test plan

- [ ] `./vendor/bin/phpunit --testsuite functional --filter FailedMessenger`
- [ ] Manually open `/admin` — KPI chart renders; no new ApexCharts `style-src-elem` report-only violations
- [ ] Manually open `/admin/operations/failed-messages` — confirm dialogs and select-all still work; no `onsubmit` / inline select-all script in page source
- [ ] After deploy, resolve matching Sentry CSP issues as `policy-gap` if they stop recurring