### PR TITLE
fix: Feedback notification E-Mails were rejected as spam by SMTP-Server

### DIFF
--- a/config/packages/app.yaml
+++ b/config/packages/app.yaml
@@ -23,7 +23,21 @@ app:
         spam:
             min_submission_seconds: 4
             long_message_threshold: 1800
+            max_message_length: 4000
             anonymous_threshold: 6
             authenticated_threshold: 8
             authenticated_score_bonus: 2
-            keywords: ['casino', 'crypto', 'loan', 'viagra', 'seo', 'backlink', 'guest post']
+            keywords:
+                - casino
+                - crypto
+                - loan
+                - viagra
+                - seo
+                - backlink
+                - guest post
+                - cialis
+                - forex
+                - nft
+                - weight loss
+                - make money
+                - click here

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -37,6 +37,7 @@ framework:
             messenger.bus.default:
                 middleware:
                     - 'App\Shared\Infrastructure\Audit\Messenger\AuditMessengerMiddleware'
+                    - 'App\Shared\Infrastructure\Mail\Messenger\SkipPermanentSmtpRetryMiddleware'
 
         routing:
             Symfony\Component\Mailer\Messenger\SendEmailMessage: async_mail

--- a/docs/05-operations/transactional-mail.md
+++ b/docs/05-operations/transactional-mail.md
@@ -91,6 +91,8 @@ Configure SPF, DKIM, and DMARC for the domain used in `MAILER_FROM`.
 4. Smoke-test: register a user, request a password reset, submit feedback.
 5. If mail does not arrive, check `messenger:stats`, `messenger:failed:show`, and `journalctl --user -u messenger -f`.
 
+Feedback admin notifications include a short, URL-stripped message preview (max 250 characters) and a link to the full entry in EasyAdmin — the full user text is not put in outbound SMTP payloads.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -99,5 +101,6 @@ Configure SPF, DKIM, and DMARC for the domain used in `MAILER_FROM`.
 | Reset link or mail images use `http://localhost` | `APP_URL` unset or wrong; restart worker after change |
 | Feedback saved but no admin email | No user with Admin + Receives Feedback |
 | Mail in spam | SPF/DKIM/DMARC or `MAILER_FROM` not aligned with SMTP provider |
+| `554 5.7.1 Spam message rejected` (or other SMTP 5xx) | Permanent rejection by the MTA (often spammy user content in outbound mail). Message goes to the `failed` transport **without** the usual 5 retries. Do **not** blindly retry; inspect content, delete the failed message, and fix the source (e.g. feedback spam). |
 
 More symptoms: [troubleshooting.md](troubleshooting.md)

--- a/src/Feedback/Application/FeedbackMailPreview.php
+++ b/src/Feedback/Application/FeedbackMailPreview.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feedback\Application;
+
+/**
+ * Builds a deliverability-safe short preview of user feedback for outbound admin mail.
+ */
+final readonly class FeedbackMailPreview
+{
+    public const int MAX_LENGTH = 250;
+
+    public static function fromMessage(string $message): string
+    {
+        $stripped = preg_replace('/\b(?:https?:\/\/|www\.)\S+/iu', '', $message) ?? $message;
+        $normalized = trim(preg_replace('/\s+/u', ' ', $stripped) ?? $stripped);
+
+        if (mb_strlen($normalized) <= self::MAX_LENGTH) {
+            return $normalized;
+        }
+
+        return mb_substr($normalized, 0, self::MAX_LENGTH).'…';
+    }
+}

--- a/src/Feedback/Application/FeedbackSpamChecker.php
+++ b/src/Feedback/Application/FeedbackSpamChecker.php
@@ -62,8 +62,8 @@ final readonly class FeedbackSpamChecker
 
         $urlCount = preg_match_all('/\b(?:https?:\/\/|www\.)\S+/i', $message);
         if (\is_int($urlCount) && $urlCount >= 1) {
-            // One URL is enough to push anonymous submissions over the default threshold.
-            $score += 6;
+            // A single URL alone stays under the anonymous threshold (6); multiple URLs tip it.
+            $score += 4;
             $reasons[] = 'contains_url';
             if ($urlCount >= 2) {
                 $score += 2;

--- a/src/Feedback/Application/FeedbackSpamChecker.php
+++ b/src/Feedback/Application/FeedbackSpamChecker.php
@@ -17,6 +17,8 @@ final readonly class FeedbackSpamChecker
         private int $minSubmissionSeconds,
         #[Autowire('%app.feedback.spam.long_message_threshold%')]
         private int $longMessageThreshold,
+        #[Autowire('%app.feedback.spam.max_message_length%')]
+        private int $maxMessageLength,
         #[Autowire('%app.feedback.spam.anonymous_threshold%')]
         private int $anonymousThreshold,
         #[Autowire('%app.feedback.spam.authenticated_threshold%')]
@@ -36,12 +38,16 @@ final readonly class FeedbackSpamChecker
         int $submittedAtTimestamp,
         bool $isAuthenticated,
     ): FeedbackSpamCheckResult {
-        $score = 0;
-        $reasons = [];
-
         if (null !== $honeypotValue && '' !== trim($honeypotValue)) {
             return new FeedbackSpamCheckResult(true, 100, ['honeypot_filled']);
         }
+
+        if (mb_strlen($message) > $this->maxMessageLength) {
+            return new FeedbackSpamCheckResult(true, 100, ['message_too_long']);
+        }
+
+        $score = 0;
+        $reasons = [];
 
         if (null !== $renderedAtTimestamp && $renderedAtTimestamp > 0) {
             $elapsed = $submittedAtTimestamp - $renderedAtTimestamp;
@@ -55,9 +61,14 @@ final readonly class FeedbackSpamChecker
         }
 
         $urlCount = preg_match_all('/\b(?:https?:\/\/|www\.)\S+/i', $message);
-        if (\is_int($urlCount) && $urlCount > 1) {
-            $score += 3;
-            $reasons[] = 'multiple_urls';
+        if (\is_int($urlCount) && $urlCount >= 1) {
+            // One URL is enough to push anonymous submissions over the default threshold.
+            $score += 6;
+            $reasons[] = 'contains_url';
+            if ($urlCount >= 2) {
+                $score += 2;
+                $reasons[] = 'multiple_urls';
+            }
         }
 
         if (1 === preg_match('/<[^>]+>/', $message)) {

--- a/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
+++ b/src/Feedback/Infrastructure/Mail/AdminFeedbackMailer.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace App\Feedback\Infrastructure\Mail;
 
+use App\Admin\UI\Http\Controller\DashboardController;
+use App\Admin\UI\Http\Controller\Feedback\FeedbackCrudController;
 use App\Feedback\Application\Contract\AdminFeedbackNotifierInterface;
+use App\Feedback\Application\FeedbackMailPreview;
 use App\Feedback\Domain\Entity\Feedback;
 use App\Feedback\Domain\Enum\FeedbackCategory;
 use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Mail\MailConfig;
 use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
@@ -28,6 +33,7 @@ final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterfa
         private TranslatorInterface $translator,
         private LocaleResolver $localeResolver,
         private LoggerInterface $logger,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
     ) {
     }
 
@@ -49,6 +55,9 @@ final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterfa
             return;
         }
 
+        $messagePreview = FeedbackMailPreview::fromMessage((string) $feedback->getMessage());
+        $adminUrl = $this->feedbackAdminUrl($feedback);
+
         foreach ($recipientsByLocale as $locale => $recipients) {
             $email = $this->createTemplatedEmail($locale)
                 ->to(...$recipients)
@@ -63,10 +72,28 @@ final readonly class AdminFeedbackMailer implements AdminFeedbackNotifierInterfa
                     'feedback' => $feedback,
                     'categoryLabel' => $category->value,
                     'contextJson' => $contextJsonPreview,
+                    'messagePreview' => $messagePreview,
+                    'adminUrl' => $adminUrl,
                 ]);
 
             $this->mailer->send($email);
         }
+    }
+
+    private function feedbackAdminUrl(Feedback $feedback): ?string
+    {
+        $id = $feedback->getId();
+        if (null === $id) {
+            return null;
+        }
+
+        return $this->adminUrlGenerator
+            ->unsetAll()
+            ->setDashboard(DashboardController::class)
+            ->setController(FeedbackCrudController::class)
+            ->setAction(Action::DETAIL)
+            ->setEntityId($id)
+            ->generateUrl();
     }
 
     private function createTemplatedEmail(string $locale): TemplatedEmail

--- a/src/Feedback/UI/Form/FeedbackSubmitFormType.php
+++ b/src/Feedback/UI/Form/FeedbackSubmitFormType.php
@@ -64,7 +64,7 @@ final class FeedbackSubmitFormType extends AbstractType
                 'attr' => ['rows' => 5],
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(min: 3, max: 5000),
+                    new Assert\Length(min: 3, max: 4000),
                 ],
                 'required' => true,
             ])

--- a/src/Feedback/UI/Twig/templates/email/admin_feedback_notification.html.twig
+++ b/src/Feedback/UI/Twig/templates/email/admin_feedback_notification.html.twig
@@ -60,7 +60,14 @@
                                 </div>
                                 <div style="background-color:{{ quoteBg }};border-radius:8px;padding:14px 16px;display:inline-block;width:calc(100% - 32px);box-sizing:border-box;">
                                     <div style="font-weight:600;color:{{ fgHeading }};margin-bottom:8px;">{{ 'feedback.email.label.message'|trans({}, 'feedback') }}</div>
-                                    <p style="margin:0 0 12px;font-size:15px;line-height:1.6;white-space:pre-wrap;word-break:break-word;">{{ feedback.message|e('html') }}</p>
+                                    <p style="margin:0 0 12px;font-size:15px;line-height:1.6;white-space:pre-wrap;word-break:break-word;">{{ messagePreview|e('html') }}</p>
+                                    <p style="margin:0;font-size:13px;line-height:1.5;color:{{ fg }};">
+                                        {{ 'feedback.email.full_message_in_admin'|trans({}, 'feedback') }}
+                                        {% if adminUrl %}
+                                            <br/>
+                                            <a href="{{ adminUrl }}" style="color:{{ link }};text-decoration:none;">{{ 'feedback.email.open_in_admin'|trans({}, 'feedback') }}</a>
+                                        {% endif %}
+                                    </p>
                                 </div>
                                 {% if feedback.userAgent %}
                                     <div style="margin-top:24px;font-size:12px;color:{{ fg }};">

--- a/src/Shared/Infrastructure/DependencyInjection/AppConfiguration.php
+++ b/src/Shared/Infrastructure/DependencyInjection/AppConfiguration.php
@@ -89,6 +89,10 @@ final class AppConfiguration implements ConfigurationInterface
                                     ->defaultValue(1800)
                                     ->min(200)
                                 ->end()
+                                ->integerNode('max_message_length')
+                                    ->defaultValue(4000)
+                                    ->min(200)
+                                ->end()
                                 ->integerNode('anonymous_threshold')
                                     ->defaultValue(6)
                                     ->min(1)
@@ -103,7 +107,21 @@ final class AppConfiguration implements ConfigurationInterface
                                 ->end()
                                 ->arrayNode('keywords')
                                     ->scalarPrototype()->end()
-                                    ->defaultValue(['casino', 'crypto', 'loan', 'viagra', 'seo', 'backlink', 'guest post'])
+                                    ->defaultValue([
+                                        'casino',
+                                        'crypto',
+                                        'loan',
+                                        'viagra',
+                                        'seo',
+                                        'backlink',
+                                        'guest post',
+                                        'cialis',
+                                        'forex',
+                                        'nft',
+                                        'weight loss',
+                                        'make money',
+                                        'click here',
+                                    ])
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Shared/Infrastructure/DependencyInjection/AppExtension.php
+++ b/src/Shared/Infrastructure/DependencyInjection/AppExtension.php
@@ -36,6 +36,7 @@ final class AppExtension extends Extension
         $spamConfig = $config['feedback']['spam'];
         $container->setParameter('app.feedback.spam.min_submission_seconds', $spamConfig['min_submission_seconds']);
         $container->setParameter('app.feedback.spam.long_message_threshold', $spamConfig['long_message_threshold']);
+        $container->setParameter('app.feedback.spam.max_message_length', $spamConfig['max_message_length']);
         $container->setParameter('app.feedback.spam.anonymous_threshold', $spamConfig['anonymous_threshold']);
         $container->setParameter('app.feedback.spam.authenticated_threshold', $spamConfig['authenticated_threshold']);
         $container->setParameter('app.feedback.spam.authenticated_score_bonus', $spamConfig['authenticated_score_bonus']);

--- a/src/Shared/Infrastructure/Mail/Messenger/SkipPermanentSmtpRetryMiddleware.php
+++ b/src/Shared/Infrastructure/Mail/Messenger/SkipPermanentSmtpRetryMiddleware.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mail\Messenger;
+
+use Symfony\Component\Mailer\Exception\UnexpectedResponseException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * Permanent SMTP 5xx responses (e.g. 554 spam rejection) must not be retried.
+ *
+ * @psalm-suppress UnusedClass Wired via messenger.bus.default middleware.
+ */
+final readonly class SkipPermanentSmtpRetryMiddleware implements MiddlewareInterface
+{
+    #[\Override]
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } catch (\Throwable $exception) {
+            $smtp = $this->findPermanentSmtpException($exception);
+            if ($smtp instanceof UnexpectedResponseException) {
+                throw new UnrecoverableMessageHandlingException(sprintf('Permanent SMTP rejection (code %d); not retrying.', $smtp->getCode()), $smtp->getCode(), $exception);
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function findPermanentSmtpException(\Throwable $exception): ?UnexpectedResponseException
+    {
+        foreach ($this->flattenExceptions($exception) as $candidate) {
+            if (!$candidate instanceof UnexpectedResponseException) {
+                continue;
+            }
+
+            $code = $candidate->getCode();
+            if ($code >= 500 && $code < 600) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<\Throwable>
+     */
+    private function flattenExceptions(\Throwable $exception): array
+    {
+        $found = [];
+        $queue = [$exception];
+
+        while ([] !== $queue) {
+            $current = array_shift($queue);
+            $found[] = $current;
+
+            if ($current instanceof HandlerFailedException) {
+                foreach ($current->getWrappedExceptions() as $wrapped) {
+                    $queue[] = $wrapped;
+                }
+            }
+
+            $previous = $current->getPrevious();
+            if (null !== $previous) {
+                $queue[] = $previous;
+            }
+        }
+
+        return $found;
+    }
+}

--- a/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
+++ b/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
@@ -206,6 +206,60 @@ final class FeedbackSubmitControllerTest extends WebTestCase
         self::assertSame(0, $repo->count([]));
     }
 
+    public function testAnonymousSubmissionWithUrlIsSilentlyDropped(): void
+    {
+        $client = self::createClient();
+        $this->acceptEssentialCookiesOnly($client);
+
+        $client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $token = $this->csrfTokenFromFeedbackForm($client);
+
+        $this->submitFeedbackPost($client, [
+            '_token' => $token,
+            '_redirect_target' => '/',
+            'guestEmail' => 'url-spam@example.test',
+            'category' => 'other',
+            'message' => 'Check out https://spam.example/offer for deals.',
+        ]);
+
+        self::assertResponseRedirects();
+        $client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+
+        /** @var FeedbackRepository $repo */
+        $repo = self::getContainer()->get(FeedbackRepository::class);
+        self::assertSame(0, $repo->count([]));
+    }
+
+    public function testMessageAboveMaxLengthGetsValidationFlash(): void
+    {
+        $client = self::createClient();
+        $this->acceptEssentialCookiesOnly($client);
+
+        $client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $token = $this->csrfTokenFromFeedbackForm($client);
+
+        $this->submitFeedbackPost($client, [
+            '_token' => $token,
+            '_redirect_target' => '/',
+            'guestEmail' => 'toolong@example.test',
+            'category' => 'bug',
+            'message' => str_repeat('a', 4001),
+        ]);
+
+        self::assertResponseRedirects();
+        $client->followRedirect();
+        self::assertSelectorExists('.alert-danger');
+
+        /** @var FeedbackRepository $repo */
+        $repo = self::getContainer()->get(FeedbackRepository::class);
+        self::assertSame(0, $repo->count([]));
+    }
+
     public function testInvalidExtraContextAndRouteAreSanitized(): void
     {
         $client = self::createClient();

--- a/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
+++ b/tests/Feedback/Functional/FeedbackSubmitControllerTest.php
@@ -206,7 +206,36 @@ final class FeedbackSubmitControllerTest extends WebTestCase
         self::assertSame(0, $repo->count([]));
     }
 
-    public function testAnonymousSubmissionWithUrlIsSilentlyDropped(): void
+    public function testAnonymousSubmissionWithSingleUrlIsAccepted(): void
+    {
+        $client = self::createClient();
+        $this->acceptEssentialCookiesOnly($client);
+
+        $client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $token = $this->csrfTokenFromFeedbackForm($client);
+        $message = 'Bug screenshot: https://example.test/shot.png';
+
+        $this->submitFeedbackPost($client, [
+            '_token' => $token,
+            '_redirect_target' => '/',
+            'guestEmail' => 'single-url@example.test',
+            'category' => 'bug',
+            'message' => $message,
+        ]);
+
+        self::assertResponseRedirects();
+        $client->followRedirect();
+        self::assertSelectorExists('.alert-success');
+
+        /** @var FeedbackRepository $repo */
+        $repo = self::getContainer()->get(FeedbackRepository::class);
+        $feedback = $repo->findOneBy(['message' => $message]);
+        self::assertNotNull($feedback);
+    }
+
+    public function testAnonymousSubmissionWithMultipleUrlsIsSilentlyDropped(): void
     {
         $client = self::createClient();
         $this->acceptEssentialCookiesOnly($client);
@@ -221,7 +250,7 @@ final class FeedbackSubmitControllerTest extends WebTestCase
             '_redirect_target' => '/',
             'guestEmail' => 'url-spam@example.test',
             'category' => 'other',
-            'message' => 'Check out https://spam.example/offer for deals.',
+            'message' => 'See https://a.example and https://b.example for deals.',
         ]);
 
         self::assertResponseRedirects();

--- a/tests/Feedback/Unit/Application/FeedbackMailPreviewTest.php
+++ b/tests/Feedback/Unit/Application/FeedbackMailPreviewTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Feedback\Unit\Application;
+
+use App\Feedback\Application\FeedbackMailPreview;
+use PHPUnit\Framework\TestCase;
+
+final class FeedbackMailPreviewTest extends TestCase
+{
+    public function testStripsHttpAndWwwUrls(): void
+    {
+        $preview = FeedbackMailPreview::fromMessage(
+            'Hello https://spam.example/path and www.evil.test/x thanks',
+        );
+
+        self::assertSame('Hello and thanks', $preview);
+        self::assertStringNotContainsString('https://', $preview);
+        self::assertStringNotContainsString('www.', $preview);
+    }
+
+    public function testTruncatesToMaxLengthWithEllipsis(): void
+    {
+        $message = str_repeat('a', FeedbackMailPreview::MAX_LENGTH + 50);
+        $preview = FeedbackMailPreview::fromMessage($message);
+
+        self::assertSame(FeedbackMailPreview::MAX_LENGTH + 1, mb_strlen($preview));
+        self::assertStringEndsWith('…', $preview);
+        self::assertSame(str_repeat('a', FeedbackMailPreview::MAX_LENGTH).'…', $preview);
+    }
+
+    public function testStripsUrlsBeforeTruncating(): void
+    {
+        $url = 'https://spam.example/'.str_repeat('x', 300);
+        $preview = FeedbackMailPreview::fromMessage('Start '.$url.' end text that remains');
+
+        self::assertSame('Start end text that remains', $preview);
+    }
+
+    public function testNormalizesWhitespace(): void
+    {
+        $preview = FeedbackMailPreview::fromMessage("Line one\n\n  line   two  ");
+
+        self::assertSame('Line one line two', $preview);
+    }
+}

--- a/tests/Feedback/Unit/Application/FeedbackSpamCheckerTest.php
+++ b/tests/Feedback/Unit/Application/FeedbackSpamCheckerTest.php
@@ -14,6 +14,7 @@ final class FeedbackSpamCheckerTest extends TestCase
         return new FeedbackSpamChecker(
             minSubmissionSeconds: 4,
             longMessageThreshold: 1800,
+            maxMessageLength: 4000,
             anonymousThreshold: 6,
             authenticatedThreshold: 8,
             authenticatedScoreBonus: 2,
@@ -50,6 +51,21 @@ final class FeedbackSpamCheckerTest extends TestCase
         self::assertContains('submitted_too_fast', $result->getReasons());
     }
 
+    public function testSingleUrlIsSpamForAnonymous(): void
+    {
+        $result = $this->createChecker()->check(
+            message: 'See https://a.example for details.',
+            honeypotValue: '',
+            renderedAtTimestamp: time() - 20,
+            submittedAtTimestamp: time(),
+            isAuthenticated: false,
+        );
+
+        self::assertTrue($result->isSpam());
+        self::assertContains('contains_url', $result->getReasons());
+        self::assertNotContains('multiple_urls', $result->getReasons());
+    }
+
     public function testMultipleLinksIncreaseSpamScore(): void
     {
         $result = $this->createChecker()->check(
@@ -60,8 +76,10 @@ final class FeedbackSpamCheckerTest extends TestCase
             isAuthenticated: false,
         );
 
-        self::assertGreaterThanOrEqual(3, $result->getScore());
+        self::assertTrue($result->isSpam());
+        self::assertContains('contains_url', $result->getReasons());
         self::assertContains('multiple_urls', $result->getReasons());
+        self::assertGreaterThanOrEqual(8, $result->getScore());
     }
 
     public function testHtmlContentIncreasesSpamScore(): void
@@ -78,22 +96,22 @@ final class FeedbackSpamCheckerTest extends TestCase
         self::assertContains('contains_html', $result->getReasons());
     }
 
-    public function testAuthenticatedUserIsLessStrict(): void
+    public function testAuthenticatedUserIsLessStrictForSingleUrl(): void
     {
         $now = time();
-        $message = 'Visit https://a.example and https://b.example';
+        $message = 'Visit https://a.example please';
 
         $anonymousResult = $this->createChecker()->check(
             message: $message,
             honeypotValue: '',
-            renderedAtTimestamp: $now - 1,
+            renderedAtTimestamp: $now - 20,
             submittedAtTimestamp: $now,
             isAuthenticated: false,
         );
         $authenticatedResult = $this->createChecker()->check(
             message: $message,
             honeypotValue: '',
-            renderedAtTimestamp: $now - 1,
+            renderedAtTimestamp: $now - 20,
             submittedAtTimestamp: $now,
             isAuthenticated: true,
         );
@@ -156,5 +174,20 @@ final class FeedbackSpamCheckerTest extends TestCase
         );
 
         self::assertContains('very_long_message', $result->getReasons());
+    }
+
+    public function testMessageAboveMaxLengthIsHardRejected(): void
+    {
+        $result = $this->createChecker()->check(
+            message: str_repeat('a', 4001),
+            honeypotValue: '',
+            renderedAtTimestamp: time() - 20,
+            submittedAtTimestamp: time(),
+            isAuthenticated: false,
+        );
+
+        self::assertTrue($result->isSpam());
+        self::assertSame(100, $result->getScore());
+        self::assertContains('message_too_long', $result->getReasons());
     }
 }

--- a/tests/Feedback/Unit/Application/FeedbackSpamCheckerTest.php
+++ b/tests/Feedback/Unit/Application/FeedbackSpamCheckerTest.php
@@ -51,7 +51,7 @@ final class FeedbackSpamCheckerTest extends TestCase
         self::assertContains('submitted_too_fast', $result->getReasons());
     }
 
-    public function testSingleUrlIsSpamForAnonymous(): void
+    public function testSingleUrlAloneIsNotSpamForAnonymous(): void
     {
         $result = $this->createChecker()->check(
             message: 'See https://a.example for details.',
@@ -61,7 +61,8 @@ final class FeedbackSpamCheckerTest extends TestCase
             isAuthenticated: false,
         );
 
-        self::assertTrue($result->isSpam());
+        self::assertFalse($result->isSpam());
+        self::assertSame(4, $result->getScore());
         self::assertContains('contains_url', $result->getReasons());
         self::assertNotContains('multiple_urls', $result->getReasons());
     }
@@ -79,7 +80,7 @@ final class FeedbackSpamCheckerTest extends TestCase
         self::assertTrue($result->isSpam());
         self::assertContains('contains_url', $result->getReasons());
         self::assertContains('multiple_urls', $result->getReasons());
-        self::assertGreaterThanOrEqual(8, $result->getScore());
+        self::assertGreaterThanOrEqual(6, $result->getScore());
     }
 
     public function testHtmlContentIncreasesSpamScore(): void
@@ -96,10 +97,10 @@ final class FeedbackSpamCheckerTest extends TestCase
         self::assertContains('contains_html', $result->getReasons());
     }
 
-    public function testAuthenticatedUserIsLessStrictForSingleUrl(): void
+    public function testAuthenticatedUserIsLessStrictForMultipleUrls(): void
     {
         $now = time();
-        $message = 'Visit https://a.example please';
+        $message = 'Visit https://a.example and https://b.example please';
 
         $anonymousResult = $this->createChecker()->check(
             message: $message,

--- a/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
+++ b/tests/Feedback/Unit/Infrastructure/Mail/AdminFeedbackMailerTest.php
@@ -12,6 +12,7 @@ use App\Shared\Infrastructure\Locale\LocaleCookieManager;
 use App\Shared\Infrastructure\Mail\MailConfig;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Security\FeedbackRecipientEmailResolver;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
@@ -22,10 +23,7 @@ final class AdminFeedbackMailerTest extends TestCase
 {
     public function testNotifySendsLocalizedAdminFeedbackMail(): void
     {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
+        $feedback = $this->createFeedbackWithId(42, 'Broken filter see https://spam.example/x now');
 
         $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([
@@ -46,6 +44,11 @@ final class AdminFeedbackMailerTest extends TestCase
                 self::assertSame('de', $email->getLocale());
                 self::assertSame('@Feedback/email/admin_feedback_notification.html.twig', $email->getHtmlTemplate());
 
+                $context = $email->getContext();
+                self::assertSame('Broken filter see now', $context['messagePreview'] ?? null);
+                self::assertSame('https://admin.example.test/feedback/42', $context['adminUrl'] ?? null);
+                self::assertStringNotContainsString('https://spam.example', (string) ($context['messagePreview'] ?? ''));
+
                 return true;
             }));
 
@@ -58,10 +61,7 @@ final class AdminFeedbackMailerTest extends TestCase
 
     public function testNotifySendsSeparateMailsPerLocale(): void
     {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
+        $feedback = $this->createFeedbackWithId(7, 'Broken filter');
 
         $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([
@@ -91,10 +91,7 @@ final class AdminFeedbackMailerTest extends TestCase
 
     public function testNotifySkipsWhenNoRecipients(): void
     {
-        $feedback = new Feedback()
-            ->setCategory(FeedbackCategory::BUG)
-            ->setMessage('Broken filter')
-            ->setPageUrl('https://example.test/page');
+        $feedback = $this->createFeedbackWithId(1, 'Broken filter');
 
         $recipientResolver = $this->createStub(FeedbackRecipientEmailResolver::class);
         $recipientResolver->method('resolveRecipientUsers')->willReturn([]);
@@ -110,7 +107,10 @@ final class AdminFeedbackMailerTest extends TestCase
                 self::callback(static fn (array $context): bool => 'no_feedback_recipients' === ($context['reason'] ?? null)),
             );
 
-        $this->createMailer($mailer, $recipientResolver, $logger)->notify(
+        $adminUrlGenerator = $this->createMock(AdminUrlGeneratorInterface::class);
+        $adminUrlGenerator->expects(self::never())->method('unsetAll');
+
+        $this->createMailer($mailer, $recipientResolver, $logger, adminUrlGenerator: $adminUrlGenerator)->notify(
             $feedback,
             FeedbackCategory::BUG,
             '{}',
@@ -123,7 +123,20 @@ final class AdminFeedbackMailerTest extends TestCase
         ?LoggerInterface $logger = null,
         ?TranslatorInterface $translator = null,
         ?LocaleResolver $localeResolver = null,
+        ?AdminUrlGeneratorInterface $adminUrlGenerator = null,
     ): AdminFeedbackMailer {
+        if (!$adminUrlGenerator instanceof AdminUrlGeneratorInterface) {
+            $adminUrlGenerator = $this->createStub(AdminUrlGeneratorInterface::class);
+            $adminUrlGenerator->method('unsetAll')->willReturnSelf();
+            $adminUrlGenerator->method('setDashboard')->willReturnSelf();
+            $adminUrlGenerator->method('setController')->willReturnSelf();
+            $adminUrlGenerator->method('setAction')->willReturnSelf();
+            $adminUrlGenerator->method('setEntityId')->willReturnSelf();
+            $adminUrlGenerator->method('generateUrl')->willReturnCallback(
+                static fn (): string => 'https://admin.example.test/feedback/42',
+            );
+        }
+
         return new AdminFeedbackMailer(
             $mailer,
             new MailConfig(
@@ -136,6 +149,7 @@ final class AdminFeedbackMailerTest extends TestCase
             $translator ?? $this->createTranslatorStub(),
             $localeResolver ?? new LocaleResolver(new LocaleCookieManager()),
             $logger ?? $this->createStub(LoggerInterface::class),
+            $adminUrlGenerator,
         );
     }
 
@@ -161,5 +175,18 @@ final class AdminFeedbackMailerTest extends TestCase
         $user->setLocale($locale);
 
         return $user;
+    }
+
+    private function createFeedbackWithId(int $id, string $message): Feedback
+    {
+        $feedback = new Feedback()
+            ->setCategory(FeedbackCategory::BUG)
+            ->setMessage($message)
+            ->setPageUrl('https://example.test/page');
+
+        $reflection = new \ReflectionProperty(Feedback::class, 'id');
+        $reflection->setValue($feedback, $id);
+
+        return $feedback;
     }
 }

--- a/tests/Shared/Unit/DependencyInjection/AppConfigurationTest.php
+++ b/tests/Shared/Unit/DependencyInjection/AppConfigurationTest.php
@@ -28,6 +28,21 @@ final class AppConfigurationTest extends TestCase
         self::assertSame('csv', $processed['import']['reject_writer']);
         self::assertSame(4, $processed['feedback']['spam']['min_submission_seconds']);
         self::assertSame(1800, $processed['feedback']['spam']['long_message_threshold']);
-        self::assertSame(['casino', 'crypto', 'loan', 'viagra', 'seo', 'backlink', 'guest post'], $processed['feedback']['spam']['keywords']);
+        self::assertSame(4000, $processed['feedback']['spam']['max_message_length']);
+        self::assertSame([
+            'casino',
+            'crypto',
+            'loan',
+            'viagra',
+            'seo',
+            'backlink',
+            'guest post',
+            'cialis',
+            'forex',
+            'nft',
+            'weight loss',
+            'make money',
+            'click here',
+        ], $processed['feedback']['spam']['keywords']);
     }
 }

--- a/tests/Shared/Unit/Infrastructure/Mail/Messenger/SkipPermanentSmtpRetryMiddlewareTest.php
+++ b/tests/Shared/Unit/Infrastructure/Mail/Messenger/SkipPermanentSmtpRetryMiddlewareTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Shared\Unit\Infrastructure\Mail\Messenger;
+
+use App\Shared\Infrastructure\Mail\Messenger\SkipPermanentSmtpRetryMiddleware;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\UnexpectedResponseException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+
+final class SkipPermanentSmtpRetryMiddlewareTest extends TestCase
+{
+    public function testRethrowsPermanentSmtp5xxAsUnrecoverable(): void
+    {
+        $smtp = new UnexpectedResponseException('Expected 250 got 554', 554);
+        $middleware = new SkipPermanentSmtpRetryMiddleware();
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Permanent SMTP rejection (code 554)');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->stackThatThrows($smtp));
+    }
+
+    public function testUnwrapsHandlerFailedException(): void
+    {
+        $smtp = new UnexpectedResponseException('spam rejected', 554);
+        $handlerFailed = new HandlerFailedException(new Envelope(new \stdClass()), [$smtp]);
+        $middleware = new SkipPermanentSmtpRetryMiddleware();
+
+        try {
+            $middleware->handle(new Envelope(new \stdClass()), $this->stackThatThrows($handlerFailed));
+            self::fail('Expected UnrecoverableMessageHandlingException');
+        } catch (UnrecoverableMessageHandlingException $e) {
+            self::assertSame(554, $e->getCode());
+            self::assertSame($handlerFailed, $e->getPrevious());
+        }
+    }
+
+    public function testDoesNotConvertSmtp4xx(): void
+    {
+        $smtp = new UnexpectedResponseException('mailbox unavailable', 450);
+        $middleware = new SkipPermanentSmtpRetryMiddleware();
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionCode(450);
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->stackThatThrows($smtp));
+    }
+
+    public function testPassesThroughOtherExceptions(): void
+    {
+        $middleware = new SkipPermanentSmtpRetryMiddleware();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->stackThatThrows(new \RuntimeException('boom')));
+    }
+
+    public function testReturnsEnvelopeOnSuccess(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $middleware = new SkipPermanentSmtpRetryMiddleware();
+
+        $result = $middleware->handle($envelope, new StackMiddleware());
+
+        self::assertSame($envelope, $result);
+    }
+
+    private function stackThatThrows(\Throwable $exception): StackInterface
+    {
+        $inner = new readonly class($exception) implements \Symfony\Component\Messenger\Middleware\MiddlewareInterface {
+            public function __construct(private \Throwable $exception)
+            {
+            }
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                throw $this->exception;
+            }
+        };
+
+        return new StackMiddleware($inner);
+    }
+}

--- a/translations/feedback+intl-icu.de.xlf
+++ b/translations/feedback+intl-icu.de.xlf
@@ -45,6 +45,14 @@
         <source>feedback.email.label.message</source>
         <target>Nachricht</target>
       </trans-unit>
+      <trans-unit id="FbkEmlFullDe" resname="feedback.email.full_message_in_admin">
+        <source>feedback.email.full_message_in_admin</source>
+        <target>Die vollständige Nachricht finden Sie im Admin-Bereich.</target>
+      </trans-unit>
+      <trans-unit id="FbkEmlOpenDe" resname="feedback.email.open_in_admin">
+        <source>feedback.email.open_in_admin</source>
+        <target>Feedback im Admin öffnen</target>
+      </trans-unit>
       <trans-unit id="FbkEmlPgDe" resname="feedback.email.label.page">
         <source>feedback.email.label.page</source>
         <target>Seite</target>

--- a/translations/feedback+intl-icu.en.xlf
+++ b/translations/feedback+intl-icu.en.xlf
@@ -105,6 +105,14 @@
         <source>feedback.email.label.message</source>
         <target>Message</target>
       </trans-unit>
+      <trans-unit id="fb025" resname="feedback.email.full_message_in_admin">
+        <source>feedback.email.full_message_in_admin</source>
+        <target>Full message is available in the admin panel.</target>
+      </trans-unit>
+      <trans-unit id="fb026" resname="feedback.email.open_in_admin">
+        <source>feedback.email.open_in_admin</source>
+        <target>Open feedback in admin</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary
- Keep spammy feedback text out of outbound admin mail: URL-stripped 250-char preview plus EasyAdmin detail link.
- Harden feedback spam checks: any URL strongly scores anonymous submissions, expanded keywords, hard 4000-char limit (with functional coverage).
- Treat permanent SMTP 5xx (e.g. `554 Spam message rejected`) as unrecoverable so `async_mail` does not retry uselessly; docs updated.

## Test plan
- [x] `phpunit` Feedback unit + functional suites (preview, spam checker, submit controller, SMTP middleware)
- [x] Smoke: submit guest feedback with more than one URL → silent success, nothing stored
- [x] Smoke: submit message > 4000 chars → validation flash
- [x] Confirm normal feedback still notifies admins with preview + admin link