### PR TITLE
fix(export): reject invalid allocations export date ranges in form validation

### DIFF
--- a/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
+++ b/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
@@ -14,6 +14,7 @@ use App\Allocation\Infrastructure\Repository\OccasionRepository;
 use App\Allocation\Infrastructure\Repository\SecondaryTransportRepository;
 use App\Allocation\Infrastructure\Repository\SpecialityRepository;
 use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use App\Allocation\UI\Form\Validation\ExportDateRangeValid;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -190,6 +191,7 @@ final class OwnHospitalAllocationsExportType extends AbstractType
         $resolver->setDefaults([
             'data_class' => OwnHospitalAllocationsExportFormData::class,
             'translation_domain' => 'messages',
+            'constraints' => [new ExportDateRangeValid()],
             'hospital_choices' => [],
             'hospitals_section_label' => 'label.hospital',
             'hospitals_help' => '',

--- a/src/Allocation/UI/Form/Validation/ExportDateRangeValid.php
+++ b/src/Allocation/UI/Form/Validation/ExportDateRangeValid.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form\Validation;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ExportDateRangeValid extends Constraint
+{
+    /**
+     * @param array<int, string>|null $groups
+     */
+    public function __construct(
+        public string $message = 'error.export.date_range_invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(groups: $groups, payload: $payload);
+    }
+
+    #[\Override]
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    #[\Override]
+    public function validatedBy(): string
+    {
+        return ExportDateRangeValidValidator::class;
+    }
+}

--- a/src/Allocation/UI/Form/Validation/ExportDateRangeValidValidator.php
+++ b/src/Allocation/UI/Form/Validation/ExportDateRangeValidValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Form\Validation;
+
+use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ExportDateRangeValidValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly ExportDateTimeRangeResolver $dateTimeRangeResolver,
+    ) {
+    }
+
+    #[\Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ExportDateRangeValid) {
+            throw new UnexpectedTypeException($constraint, ExportDateRangeValid::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof OwnHospitalAllocationsExportFormData) {
+            throw new UnexpectedValueException($value, OwnHospitalAllocationsExportFormData::class);
+        }
+
+        if (!$value->dateFrom instanceof \DateTimeInterface || !$value->dateTo instanceof \DateTimeInterface) {
+            return;
+        }
+
+        try {
+            $this->dateTimeRangeResolver->resolve(
+                $value->dateFrom,
+                $value->dateTo,
+                $value->timeFrom,
+                $value->timeTo,
+            );
+        } catch (\InvalidArgumentException) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->atPath('dateTo')
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
@@ -105,6 +105,31 @@ final class AllocationsExportControllerTest extends WebTestCase
         self::assertSelectorNotExists('#export-estimate #export-allocations-download-form');
     }
 
+    public function testEstimateRejectsReversedDateRangeWithUnprocessableEntity(): void
+    {
+        [$client] = $this->createOwnerClient();
+
+        $crawler = $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('#export-allocations-form')->form();
+        $form['own_hospital_allocations_export[dateFrom]'] = '2026-02-01';
+        $form['own_hospital_allocations_export[dateTo]'] = '2026-01-01';
+        $values = $form->getPhpValues();
+
+        $client->request(
+            Request::METHOD_POST,
+            '/hospitals/export/allocations/estimate',
+            $values,
+            [],
+            ['HTTP_TURBO_FRAME' => 'export-estimate'],
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        self::assertSelectorExists('[data-testid="export-estimate-error"]');
+        self::assertSelectorNotExists('[data-testid="export-estimate-ok"]');
+    }
+
     public function testExportEstimateIsRateLimited(): void
     {
         [$client, $owner] = $this->createOwnerClient();

--- a/tests/Allocation/Unit/Export/ExportDateTimeRangeResolverTest.php
+++ b/tests/Allocation/Unit/Export/ExportDateTimeRangeResolverTest.php
@@ -56,21 +56,34 @@ final class ExportDateTimeRangeResolverTest extends TestCase
     }
 
     #[DataProvider('invalidRangeProvider')]
-    public function testRejectsStartAfterEnd(\DateTimeInterface $from, \DateTimeInterface $to): void
-    {
+    public function testRejectsStartAfterEnd(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        ?\DateTimeInterface $timeFrom = null,
+        ?\DateTimeInterface $timeTo = null,
+    ): void {
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->resolver->resolve($from, $to);
+        $this->resolver->resolve($from, $to, $timeFrom, $timeTo);
     }
 
     /**
-     * @return iterable<string, array{\DateTimeInterface, \DateTimeInterface}>
+     * @return iterable<string, array{\DateTimeInterface, \DateTimeInterface, ?\DateTimeInterface, ?\DateTimeInterface}>
      */
     public static function invalidRangeProvider(): iterable
     {
         yield 'dates reversed' => [
             new \DateTimeImmutable('2026-02-01'),
             new \DateTimeImmutable('2026-01-01'),
+            null,
+            null,
+        ];
+
+        yield 'same day times reversed' => [
+            new \DateTimeImmutable('2026-01-15'),
+            new \DateTimeImmutable('2026-01-15'),
+            new \DateTimeImmutable('1970-01-01 18:00:00'),
+            new \DateTimeImmutable('1970-01-01 08:00:00'),
         ];
     }
 }

--- a/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidTest.php
+++ b/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Form\Validation;
+
+use App\Allocation\UI\Form\Validation\ExportDateRangeValid;
+use App\Allocation\UI\Form\Validation\ExportDateRangeValidValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+
+final class ExportDateRangeValidTest extends TestCase
+{
+    public function testIsClassConstraintValidatedByExportDateRangeValidValidator(): void
+    {
+        $constraint = new ExportDateRangeValid();
+
+        self::assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+        self::assertSame(ExportDateRangeValidValidator::class, $constraint->validatedBy());
+    }
+}

--- a/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidValidatorTest.php
+++ b/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidValidatorTest.php
@@ -8,6 +8,9 @@ use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
 use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
 use App\Allocation\UI\Form\Validation\ExportDateRangeValid;
 use App\Allocation\UI\Form\Validation\ExportDateRangeValidValidator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -39,6 +42,27 @@ final class ExportDateRangeValidValidatorTest extends ConstraintValidatorTestCas
         $this->validator->validate($data, new ExportDateRangeValid());
 
         $this->assertNoViolation();
+    }
+
+    public function testSkipsNullValue(): void
+    {
+        $this->validator->validate(null, new ExportDateRangeValid());
+
+        $this->assertNoViolation();
+    }
+
+    public function testThrowsForInvalidConstraintType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate(null, new NotBlank());
+    }
+
+    public function testThrowsForNonFormDataValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->validator->validate(new \stdClass(), new ExportDateRangeValid());
     }
 
     public function testViolationWhenDatesReversed(): void

--- a/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidValidatorTest.php
+++ b/tests/Allocation/Unit/Form/Validation/ExportDateRangeValidValidatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Form\Validation;
+
+use App\Allocation\Application\Export\ExportDateTimeRangeResolver;
+use App\Allocation\UI\Form\Model\OwnHospitalAllocationsExportFormData;
+use App\Allocation\UI\Form\Validation\ExportDateRangeValid;
+use App\Allocation\UI\Form\Validation\ExportDateRangeValidValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<ExportDateRangeValidValidator>
+ */
+final class ExportDateRangeValidValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ExportDateRangeValidValidator
+    {
+        return new ExportDateRangeValidValidator(new ExportDateTimeRangeResolver());
+    }
+
+    public function testNoViolationForValidDateRange(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-31');
+
+        $this->validator->validate($data, new ExportDateRangeValid());
+
+        $this->assertNoViolation();
+    }
+
+    public function testNoViolationWhenDatesMissing(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-01');
+
+        $this->validator->validate($data, new ExportDateRangeValid());
+
+        $this->assertNoViolation();
+    }
+
+    public function testViolationWhenDatesReversed(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-02-01');
+        $data->dateTo = new \DateTimeImmutable('2026-01-01');
+
+        $constraint = new ExportDateRangeValid();
+
+        $this->validator->validate($data, $constraint);
+
+        $this
+            ->buildViolation($constraint->message)
+            ->atPath('property.path.dateTo')
+            ->assertRaised();
+    }
+
+    public function testViolationWhenSameDayTimesReversed(): void
+    {
+        $data = new OwnHospitalAllocationsExportFormData();
+        $data->dateFrom = new \DateTimeImmutable('2026-01-15');
+        $data->dateTo = new \DateTimeImmutable('2026-01-15');
+        $data->timeFrom = new \DateTimeImmutable('1970-01-01 18:00:00');
+        $data->timeTo = new \DateTimeImmutable('1970-01-01 08:00:00');
+
+        $constraint = new ExportDateRangeValid();
+
+        $this->validator->validate($data, $constraint);
+
+        $this
+            ->buildViolation($constraint->message)
+            ->atPath('property.path.dateTo')
+            ->assertRaised();
+    }
+}

--- a/translations/errors+intl-icu.de.xlf
+++ b/translations/errors+intl-icu.de.xlf
@@ -61,6 +61,10 @@
         <source>error.export.invalid_filter</source>
         <target>Bitte prüfen Sie die Export-Filter.</target>
       </trans-unit>
+      <trans-unit id="ExpErrDe03" resname="error.export.date_range_invalid">
+        <source>error.export.date_range_invalid</source>
+        <target>Das Start-Datum darf nicht nach dem End-Datum liegen.</target>
+      </trans-unit>
       <trans-unit id="ExpErrDe01" resname="error.export.too_many_rows">
         <source>error.export.too_many_rows</source>
         <target>Export blockiert: {count, number} Datensätze überschreiten das Limit. Bitte Filter enger setzen.</target>

--- a/translations/errors+intl-icu.en.xlf
+++ b/translations/errors+intl-icu.en.xlf
@@ -69,6 +69,10 @@
         <source>error.export.invalid_filter</source>
         <target>Please check the export filters.</target>
       </trans-unit>
+      <trans-unit id="ExpErrEn03" resname="error.export.date_range_invalid">
+        <source>error.export.date_range_invalid</source>
+        <target>The start date must not be after the end date.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -849,6 +849,10 @@
         <source>page.validation.image_float_requires_non_full_width</source>
         <target>Textumfluss erfordert ein Bild ohne volle Breite.</target>
       </trans-unit>
+      <trans-unit id="ExpValDe01" resname="error.export.date_range_invalid">
+        <source>error.export.date_range_invalid</source>
+        <target>Das Start-Datum darf nicht nach dem End-Datum liegen.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -849,6 +849,10 @@
         <source>page.validation.image_float_requires_non_full_width</source>
         <target>Text wrap requires a non-full-width image.</target>
       </trans-unit>
+      <trans-unit id="ExpValEn01" resname="error.export.date_range_invalid">
+        <source>error.export.date_range_invalid</source>
+        <target>The start date must not be after the end date.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

- Fixes Sentry **PHP-SYMFONY-1Y** (`InvalidArgumentException: Export date range start must not be after end`) on `POST /hospitals/export/allocations/estimate`.
- Adds a class-level form constraint that reuses `ExportDateTimeRangeResolver`, so reversed dates/times fail form validation (422) instead of bubbling as an uncaught 500.
- Keeps the resolver invariant as defense-in-depth; covers reversed dates and same-day `timeFrom` > `timeTo` with unit + functional tests.

## Test plan

- [x] Open `/hospitals/export/allocations`, set `dateFrom` after `dateTo`, run estimate → 422 + filter error UI (no 500)
- [x] Same day with `timeFrom` after `timeTo` → estimate rejected
- [x] Valid range still returns estimate / download as before
- [x] `XDEBUG_MODE=coverage php bin/phpunit --testsuite unit --filter 'ExportDateRangeValid|ExportDateTimeRangeResolver'`
- [x] `XDEBUG_MODE=coverage php bin/phpunit --testsuite functional --filter testEstimateRejectsReversedDateRangeWithUnprocessableEntity`

Closes #405.