### PR TITLE
refactor(admin): Exclude admin area from usage request tracking

### DIFF
--- a/docs/04-features/analytics/usage-analytics.md
+++ b/docs/04-features/analytics/usage-analytics.md
@@ -115,6 +115,22 @@ Event names live in `App\Analytics\Domain\UsageEventName`. Context must be non-P
 
 Resolved from Symfony route names: `home`, `dashboard`, `statistics`, `analysis`, `explore`, `import`, `export`, `admin`, `blog`, `pages`, `other`.
 
+### Admin area exclusion
+
+Requests under the Admin UI (`app_admin_*` routes / path `/admin`) are **not** written to `analytics_request`. Product events and normal app usage (including by users with `ROLE_ADMIN`) remain tracked.
+
+After deploying this exclusion, remove historical admin request rows once (optional but recommended so Overview/Performance are not skewed):
+
+```bash
+# Preview
+php bin/console dbal:run-sql "SELECT COUNT(*) AS n FROM analytics_request WHERE feature_area = 'admin' OR route_name LIKE 'app_admin_%'"
+
+# Delete
+php bin/console dbal:run-sql "DELETE FROM analytics_request WHERE feature_area = 'admin' OR route_name LIKE 'app_admin_%'"
+```
+
+Do **not** delete `analytics_product_event` rows for this cleanup.
+
 ## Engagement depth (levels)
 
 Derived in the dashboard (not stored). Max level per `analytics_user_key` over 30 days from events and requests:

--- a/docs/05-operations/deployment.md
+++ b/docs/05-operations/deployment.md
@@ -186,6 +186,7 @@ After deploying the Analytics migration (`Version20260804151958`) and the new `a
 
    Details: [../04-features/analytics/usage-analytics.md](../04-features/analytics/usage-analytics.md#rollout-re-prompt-after-introducing-analytics).
 3. Smoke-check Admin → **Usage analytics** → Overview after accepting cookies with “Accept all”.
+4. Optional one-off: delete historical admin UI request rows so Overview/Performance are not skewed — see [../04-features/analytics/usage-analytics.md](../04-features/analytics/usage-analytics.md#admin-area-exclusion).
 
 Recommended beta operations rhythm:
 - Weekly (minimum): `cd ~/www/current && php bin/console messenger:failed:show`

--- a/docs/06-reference/console-commands.md
+++ b/docs/06-reference/console-commands.md
@@ -97,7 +97,7 @@ Commands are invokable classes with `#[AsCommand]` and autoconfiguration via `co
 
 | Command | Purpose |
 |---|---|
-| `dbal:run-sql '…'` | Run a single SQL statement (ops one-offs). Example: reset cookie consents after introducing the `analytics` preference — see [../04-features/analytics/usage-analytics.md](../04-features/analytics/usage-analytics.md#rollout-re-prompt-after-introducing-analytics). |
+| `dbal:run-sql '…'` | Run a single SQL statement (ops one-offs). Examples: reset cookie consents after introducing the `analytics` preference; delete historical admin UI rows from `analytics_request` — see [../04-features/analytics/usage-analytics.md](../04-features/analytics/usage-analytics.md). |
 
 ### DataFixtures (dev/test only)
 

--- a/src/Analytics/Infrastructure/Http/AnalyticsRequestSubscriber.php
+++ b/src/Analytics/Infrastructure/Http/AnalyticsRequestSubscriber.php
@@ -189,6 +189,10 @@ final readonly class AnalyticsRequestSubscriber
     {
         $route = $request->attributes->get('_route');
         if (\is_string($route)) {
+            if (str_starts_with($route, 'app_admin_')) {
+                return true;
+            }
+
             foreach (self::SKIP_ROUTE_PREFIXES as $prefix) {
                 if (str_starts_with($route, $prefix)) {
                     return true;
@@ -198,7 +202,9 @@ final readonly class AnalyticsRequestSubscriber
 
         $path = $request->getPathInfo();
 
-        return str_starts_with($path, '/_wdt')
+        return '/admin' === $path
+            || str_starts_with($path, '/admin/')
+            || str_starts_with($path, '/_wdt')
             || str_starts_with($path, '/_profiler')
             || str_starts_with($path, '/assets/')
             || str_starts_with($path, '/build/')

--- a/tests/Analytics/Functional/AnalyticsRequestTrackingTest.php
+++ b/tests/Analytics/Functional/AnalyticsRequestTrackingTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Tests\Analytics\Functional;
 
 use App\Analytics\Domain\Entity\AnalyticsRequest;
+use App\Analytics\Domain\Enum\FeatureArea;
 use App\Analytics\Infrastructure\Http\AnalyticsCookieManager;
 use App\Analytics\Infrastructure\Repository\AnalyticsRequestRepository;
 use App\User\Domain\Factory\UserFactory;
+use App\User\Domain\Security\UserRole;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -126,5 +128,54 @@ final class AnalyticsRequestTrackingTest extends WebTestCase
             self::assertStringNotContainsString('user_id', $html);
             self::assertStringNotContainsString('User ID', $html);
         }
+    }
+
+    public function testAdminAreaRequestsAreNotTracked(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create([
+            'username' => 'analytics-skip-admin-'.bin2hex(random_bytes(4)),
+        ]);
+        $client->loginUser($admin);
+
+        $repository = self::getContainer()->get(AnalyticsRequestRepository::class);
+        $beforeAdminRows = $repository->count(['featureArea' => FeatureArea::Admin]);
+
+        $client->request(Request::METHOD_GET, '/admin/operations/usage-analytics/overview');
+        self::assertResponseIsSuccessful();
+
+        self::assertSame(
+            $beforeAdminRows,
+            $repository->count(['featureArea' => FeatureArea::Admin]),
+            'Admin area requests must not create analytics_request rows.',
+        );
+
+        $appAdminRows = $repository->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->where('r.routeName LIKE :prefix')
+            ->setParameter('prefix', 'app_admin_%')
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+        self::assertSame(0, (int) $appAdminRows);
+    }
+
+    public function testAdminHomeRequestIsStillTracked(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::new()->asAdmin()->create([
+            'username' => 'analytics-admin-home-'.bin2hex(random_bytes(4)),
+        ]);
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $repository = self::getContainer()->get(AnalyticsRequestRepository::class);
+        /** @var list<AnalyticsRequest> $rows */
+        $rows = $repository->findBy(['routeName' => 'app_default'], ['id' => 'DESC'], 5);
+        self::assertNotEmpty($rows);
+        self::assertSame(FeatureArea::Home, $rows[0]->getFeatureArea());
+        self::assertSame(UserRole::ADMIN, $rows[0]->getUserRole());
     }
 }


### PR DESCRIPTION
## Summary

- Skip `app_admin_*` routes and `/admin` paths in request tracking so EasyAdmin traffic no longer enters `analytics_request` or skews Overview/Performance metrics.
- Keep product events and normal app requests (including by `ROLE_ADMIN` users) unchanged.
- Document a one-off SQL cleanup for historical admin request rows (no permanent dashboard filters).

Closes #411

## Test plan

- [x] As admin, open `/admin/operations/usage-analytics/overview` — no new `analytics_request` rows with `feature_area = admin` / `route_name LIKE 'app_admin_%'`
- [x] As admin with analytics consent, open `/` — request is still tracked (`user_role = ROLE_ADMIN`, `analytics_user_key` set) and can appear in DAU
- [x] Confirm product events (e.g. Explore/Benchmarking) still record for admins
- [x] Optionally run the documented DELETE on `analytics_request` for historical admin rows and verify Overview counts drop accordingly
- [x] `./bin/phpunit --no-coverage tests/Analytics/Functional/AnalyticsRequestTrackingTest.php`