### PR TITLE
feat: Localize export column labels and dimension cell values

### DIFF
--- a/docs/03-development/translations.md
+++ b/docs/03-development/translations.md
@@ -134,6 +134,8 @@ Use this table when adding a new key. When in doubt, prefer the **feature domain
 |---|---|---|---|
 | Export form | `messages` (field labels) | `allocation` (help texts) | Use `TranslatableMessage` for mixed fields |
 | Export clinical checkboxes | `allocation` | — | `allocations.field.isVentilated`, etc. |
+| Export CSV column headers | `messages` / `allocation` | — | Reuse UI field/label keys; CSV-only keys under `export.column.*` (`allocation`). Request locale via `RequestStack`. |
+| Export CSV cell values | `messages` (gender, transport) / `allocation` (booleans) | — | SK labels and entity names stay untranslated; bools use `export.boolean.true`/`false` (`True`/`False`, `Wahr`/`Falsch`) |
 | Export period accordion title | `import` | — | `label.export.period` |
 | Export clinical accordion title | `statistics` | — | `stats.analysis_explorer.dimension_group.clinical_care` |
 | Hospital edit enums (tier, location, size) | `allocation` | — | `choice_translation_domain => 'allocation'` |
@@ -146,7 +148,7 @@ Use this table when adding a new key. When in doubt, prefer the **feature domain
 | Key starts with… | Domain |
 |---|---|
 | `stats.` / `statistics.` | `statistics` |
-| `flash.indication.` / `help.export.` / `allocations.field.` / `hospital.tier.` / `hospital.location.` / `hospital.size.` | `allocation` |
+| `flash.indication.` / `help.export.` / `export.column.` / `export.boolean.` / `allocations.field.` / `hospital.tier.` / `hospital.location.` / `hospital.size.` | `allocation` |
 | `flash.import.` / `title.import.` | `import` |
 | `onboarding.` | `onboarding` |
 | `feedback.` | `feedback` |

--- a/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
+++ b/src/Allocation/Application/Export/OwnHospitalAllocationsExporter.php
@@ -9,13 +9,17 @@ use App\Allocation\Infrastructure\Query\OwnHospitalAllocationsExportQuery;
 use App\Shared\Application\Export\CsvStreamExportResponseFactory;
 use App\Shared\Application\Export\ExporterInterface;
 use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
 {
     public const string KEY = 'own_hospital_allocations';
 
     /**
+     * Technical column keys (stable order). Labels are resolved via {@see CSV_HEADER_TRANSLATIONS}.
+     *
      * @var list<string>
      */
     private const array BASE_CSV_HEADERS = [
@@ -53,11 +57,46 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
         'infection',
     ];
 
+    /**
+     * @var array<string, array{0: string, 1: string}>
+     */
+    private const array CSV_HEADER_TRANSLATIONS = [
+        'row' => ['export.column.row', 'allocation'],
+        'arrivalAt' => ['label.arrival_at', 'messages'],
+        'createdAt' => ['label.created_at', 'messages'],
+        'hospital' => ['label.hospital', 'messages'],
+        'state' => ['label.state', 'messages'],
+        'dispatchArea' => ['label.dispatch_area', 'messages'],
+        'gender' => ['field.gender', 'messages'],
+        'age' => ['field.age', 'messages'],
+        'urgency' => ['field.urgency', 'messages'],
+        'transportType' => ['field.transportType', 'messages'],
+        'indicationNormalized' => ['label.indication.normalized', 'messages'],
+        'indicationRaw' => ['label.indication.raw', 'messages'],
+        'secondaryTransport' => ['label.secondary_transport', 'messages'],
+        'department' => ['label.department', 'messages'],
+        'speciality' => ['label.speciality', 'messages'],
+        'departmentWasClosed' => ['field.departmentWasClosed', 'messages'],
+        'assignment' => ['label.assignment', 'messages'],
+        'occasion' => ['label.occasion', 'messages'],
+        'requiresResus' => ['field.requiresResus', 'messages'],
+        'requiresCathlab' => ['field.requiresCathlab', 'messages'],
+        'isCPR' => ['field.isCPR', 'messages'],
+        'isVentilated' => ['allocations.field.isVentilated', 'allocation'],
+        'isShock' => ['allocations.field.isShock', 'allocation'],
+        'isPregnant' => ['allocations.field.isPregnant', 'allocation'],
+        'isWorkAccident' => ['allocations.field.isWorkAccident', 'allocation'],
+        'isWithPhysician' => ['field.isWithPhysician', 'messages'],
+        'infection' => ['label.infection', 'messages'],
+    ];
+
     public function __construct(
         private ExportAccessService $exportAccessService,
         private OwnHospitalAllocationsExportQuery $exportQuery,
         private CsvStreamExportResponseFactory $csvStreamExportResponseFactory,
         private AllocationExportValueFormatter $exportValueFormatter,
+        private TranslatorInterface $translator,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -96,12 +135,13 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
     public function writeCsv(User $user, object $criteria, $stream): int
     {
         $filter = $this->assertFilter($criteria);
-        $this->csvStreamExportResponseFactory->writeRow($stream, $this->resolveCsvHeaders($filter));
+        $locale = $this->resolveLocale();
+        $this->csvStreamExportResponseFactory->writeRow($stream, $this->resolveCsvHeaders($filter, $locale));
 
         $written = 0;
         foreach ($this->exportQuery->iterateRows($this->resolveHospitalIdsForExport($user, $filter), $filter) as $row) {
             ++$written;
-            $this->csvStreamExportResponseFactory->writeRow($stream, $this->formatRow($written, $row, $filter));
+            $this->csvStreamExportResponseFactory->writeRow($stream, $this->formatRow($written, $row, $filter, $locale));
         }
 
         return $written;
@@ -139,14 +179,31 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
     /**
      * @return list<string>
      */
-    private function resolveCsvHeaders(OwnHospitalAllocationsExportFilter $filter): array
+    private function resolveCsvHeaders(OwnHospitalAllocationsExportFilter $filter, ?string $locale): array
     {
-        $headers = self::BASE_CSV_HEADERS;
+        $keys = self::BASE_CSV_HEADERS;
         if ($filter->includeIndicationRaw) {
-            $headers[] = 'indicationRaw';
+            $keys[] = 'indicationRaw';
         }
 
-        return array_merge($headers, self::TAIL_CSV_HEADERS);
+        $keys = array_merge($keys, self::TAIL_CSV_HEADERS);
+
+        return array_map(
+            fn (string $key): string => $this->translateHeader($key, $locale),
+            $keys,
+        );
+    }
+
+    private function translateHeader(string $columnKey, ?string $locale): string
+    {
+        $mapping = self::CSV_HEADER_TRANSLATIONS[$columnKey] ?? null;
+        if (null === $mapping) {
+            return $columnKey;
+        }
+
+        [$translationKey, $domain] = $mapping;
+
+        return $this->translator->trans($translationKey, [], $domain, $locale);
     }
 
     /**
@@ -154,43 +211,50 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
      *
      * @return list<string|int|float|null>
      */
-    private function formatRow(int $rowNumber, array $row, OwnHospitalAllocationsExportFilter $filter): array
+    private function formatRow(int $rowNumber, array $row, OwnHospitalAllocationsExportFilter $filter, ?string $locale): array
     {
+        /** @var list<string|int|float|null> $values */
         $values = [
             $rowNumber,
             $this->formatDateTime($row['arrivalAt'] ?? null),
             $this->formatDateTime($row['createdAt'] ?? null),
-            $row['hospital'] ?? null,
-            $row['state'] ?? null,
-            $row['dispatchArea'] ?? null,
-            $this->exportValueFormatter->gender($row['gender'] ?? null),
-            $row['age'] ?? null,
+            $this->scalarCell($row['hospital'] ?? null),
+            $this->scalarCell($row['state'] ?? null),
+            $this->scalarCell($row['dispatchArea'] ?? null),
+            $this->exportValueFormatter->gender($row['gender'] ?? null, $locale),
+            $this->scalarCell($row['age'] ?? null),
             $this->exportValueFormatter->urgency($row['urgency'] ?? null),
-            $this->exportValueFormatter->transportType($row['transportType'] ?? null),
-            $row['indicationNormalized'] ?? null,
+            $this->exportValueFormatter->transportType($row['transportType'] ?? null, $locale),
+            $this->scalarCell($row['indicationNormalized'] ?? null),
         ];
 
         if ($filter->includeIndicationRaw) {
-            $values[] = $row['indicationRaw'] ?? null;
+            $values[] = $this->scalarCell($row['indicationRaw'] ?? null);
         }
 
-        return array_merge($values, [
-            $row['secondaryTransport'] ?? null,
-            $row['department'] ?? null,
-            $row['speciality'] ?? null,
-            $this->formatBool($row['departmentWasClosed'] ?? null),
-            $row['assignment'] ?? null,
-            $row['occasion'] ?? null,
-            $this->formatBool($row['requiresResus'] ?? null),
-            $this->formatBool($row['requiresCathlab'] ?? null),
-            $this->formatBool($row['isCPR'] ?? null),
-            $this->formatBool($row['isVentilated'] ?? null),
-            $this->formatBool($row['isShock'] ?? null),
-            $this->formatBool($row['isPregnant'] ?? null),
-            $this->formatBool($row['isWorkAccident'] ?? null),
-            $this->formatBool($row['isWithPhysician'] ?? null),
-            $row['infection'] ?? null,
-        ]);
+        return [
+            ...$values,
+            $this->scalarCell($row['secondaryTransport'] ?? null),
+            $this->scalarCell($row['department'] ?? null),
+            $this->scalarCell($row['speciality'] ?? null),
+            $this->formatBool($row['departmentWasClosed'] ?? null, $locale),
+            $this->scalarCell($row['assignment'] ?? null),
+            $this->scalarCell($row['occasion'] ?? null),
+            $this->formatBool($row['requiresResus'] ?? null, $locale),
+            $this->formatBool($row['requiresCathlab'] ?? null, $locale),
+            $this->formatBool($row['isCPR'] ?? null, $locale),
+            $this->formatBool($row['isVentilated'] ?? null, $locale),
+            $this->formatBool($row['isShock'] ?? null, $locale),
+            $this->formatBool($row['isPregnant'] ?? null, $locale),
+            $this->formatBool($row['isWorkAccident'] ?? null, $locale),
+            $this->formatBool($row['isWithPhysician'] ?? null, $locale),
+            $this->scalarCell($row['infection'] ?? null),
+        ];
+    }
+
+    private function resolveLocale(): ?string
+    {
+        return $this->requestStack->getCurrentRequest()?->getLocale();
     }
 
     private function formatDateTime(mixed $value): ?string
@@ -199,15 +263,40 @@ final readonly class OwnHospitalAllocationsExporter implements ExporterInterface
             return $value->format('Y-m-d H:i:s');
         }
 
-        return null === $value ? null : (string) $value;
+        if (null === $value) {
+            return null;
+        }
+
+        if (\is_string($value) || \is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+
+        return null;
     }
 
-    private function formatBool(mixed $value): ?string
+    private function scalarCell(mixed $value): string|int|float|null
+    {
+        if (null === $value || \is_string($value) || \is_int($value) || \is_float($value)) {
+            return $value;
+        }
+
+        if ($value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+
+    private function formatBool(mixed $value, ?string $locale): ?string
     {
         if (null === $value) {
             return null;
         }
 
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+        $key = filter_var($value, FILTER_VALIDATE_BOOLEAN)
+            ? 'export.boolean.true'
+            : 'export.boolean.false';
+
+        return $this->translator->trans($key, [], 'allocation', $locale);
     }
 }

--- a/src/Statistics/AnalysisExplorer/Application/AnalysisDimensionLabelResolver.php
+++ b/src/Statistics/AnalysisExplorer/Application/AnalysisDimensionLabelResolver.php
@@ -82,7 +82,7 @@ final class AnalysisDimensionLabelResolver
         $bucketKey = $this->bucketKey($bucket);
 
         if ('__null__' === $bucketKey) {
-            return 'Unknown';
+            return $this->translator->trans('stats.analysis_explorer.bucket.unknown', [], 'statistics');
         }
 
         if ('hospital_cohort' === $dimension->key || 'hospital_master_cohort' === $dimension->key) {
@@ -133,7 +133,7 @@ final class AnalysisDimensionLabelResolver
             $formatted = \IntlDateFormatter::formatObject(
                 new \DateTimeImmutable(sprintf('2024-%02d-01', $month)),
                 'MMM',
-                'en',
+                $this->translator->getLocale(),
             );
 
             return false !== $formatted && '' !== $formatted ? $formatted : (string) $month;

--- a/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
+++ b/src/Statistics/GenericAnalysis/Registry/DimensionRegistry.php
@@ -105,14 +105,14 @@ SQL;
             type: AnalysisDimensionType::Temporal,
             recommendedChartType: 'bar',
             fixedBuckets: [1, 2, 3, 4, 5, 6, 7],
-            valueLabels: [
-                1 => 'Monday',
-                2 => 'Tuesday',
-                3 => 'Wednesday',
-                4 => 'Thursday',
-                5 => 'Friday',
-                6 => 'Saturday',
-                7 => 'Sunday',
+            valueLabelTranslationKeys: [
+                1 => 'stats.indication.weekday.1',
+                2 => 'stats.indication.weekday.2',
+                3 => 'stats.indication.weekday.3',
+                4 => 'stats.indication.weekday.4',
+                5 => 'stats.indication.weekday.5',
+                6 => 'stats.indication.weekday.6',
+                7 => 'stats.indication.weekday.7',
             ],
         ));
         $this->register($this->temporalDimension('hour', 'created_hour', 'Hour', range(0, 23)));
@@ -156,7 +156,9 @@ SQL;
                 '70_79' => '70–79',
                 '80_89' => '80–89',
                 '90_99' => '90–99',
-                'unknown' => 'Unknown',
+            ],
+            valueLabelTranslationKeys: [
+                'unknown' => 'stats.benchmark.age_group.unknown',
             ],
             nullBucketKeys: ['unknown'],
             requiresNonNullSourceColumn: 'age',
@@ -205,10 +207,6 @@ SQL;
             label: $label,
             type: AnalysisDimensionType::Boolean,
             fixedBuckets: [1, 0],
-            valueLabels: [
-                1 => 'Yes',
-                0 => 'No',
-            ],
         );
 
         $this->register($boolean('resus', 'requires_resus', 'Resuscitation required'));

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
@@ -24,6 +24,8 @@ use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\User\Domain\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
 
@@ -65,8 +67,8 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
 
         $csv = $this->exportCsv($exporter, $owner, $filter);
 
-        self::assertStringContainsString('arrivalAt', $csv);
-        self::assertStringContainsString('dispatchArea', $csv);
+        self::assertStringContainsString('Arrival at', $csv);
+        self::assertStringContainsString('Dispatch Area', $csv);
         self::assertStringContainsString('CSV Owned Hospital', $csv);
         self::assertStringNotContainsString('CSV Foreign Hospital', $csv);
     }
@@ -143,8 +145,8 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
         $csvWithoutRaw = $this->exportCsv($exporter, $owner, $filterWithoutRaw);
         $csvWithRaw = $this->exportCsv($exporter, $owner, $filterWithRaw);
 
-        self::assertStringNotContainsString('indicationRaw', $csvWithoutRaw);
-        self::assertStringContainsString('indicationRaw', $csvWithRaw);
+        self::assertStringNotContainsString('Raw Indication', $csvWithoutRaw);
+        self::assertStringContainsString('Raw Indication', $csvWithRaw);
         self::assertStringContainsString('Original indication text', $csvWithRaw);
     }
 
@@ -179,12 +181,13 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
 
         $csv = $this->exportCsv($exporter, $owner, $filter);
 
-        self::assertStringContainsString('departmentWasClosed', $csv);
-        self::assertStringContainsString('assignment', $csv);
-        self::assertStringContainsString('occasion', $csv);
+        self::assertStringContainsString('Department was closed', $csv);
+        self::assertStringContainsString('Assignment', $csv);
+        self::assertStringContainsString('Occasion', $csv);
         self::assertStringContainsString('Emergency assignment', $csv);
         self::assertStringContainsString('Holiday occasion', $csv);
-        self::assertMatchesRegularExpression('/,1,/', $csv);
+        self::assertStringContainsString('True', $csv);
+        self::assertStringNotContainsString(',1,', $csv);
     }
 
     public function testWriteCsvUsesSequentialRowNumbers(): void
@@ -217,9 +220,88 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
         $csv = $this->exportCsv($exporter, $owner, $filter);
         $lines = array_values(array_filter(explode("\n", trim($csv))));
 
-        self::assertSame('row', str_getcsv($lines[0], escape: '\\')[0]);
+        self::assertSame('Row', str_getcsv($lines[0], escape: '\\')[0]);
         self::assertSame('1', str_getcsv($lines[1], escape: '\\')[0]);
         self::assertSame('2', str_getcsv($lines[2], escape: '\\')[0]);
+    }
+
+    public function testWriteCsvUsesGermanHeadersAndEnumLabelsForDeLocale(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'gender' => AllocationGender::MALE,
+            'transportType' => AllocationTransportType::AIR,
+        ]);
+
+        $request = Request::create('/');
+        $request->setLocale('de');
+        $stack = self::getContainer()->get(RequestStack::class);
+        self::assertInstanceOf(RequestStack::class, $stack);
+        $stack->push($request);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+
+        self::assertStringContainsString('Ankunft am', $csv);
+        self::assertStringContainsString('Leitstelle', $csv);
+        self::assertStringContainsString('Zeile', $csv);
+        self::assertStringContainsString('Männlich', $csv);
+        self::assertStringContainsString('Luft', $csv);
+    }
+
+    public function testWriteCsvUsesGermanBooleanLabelsForDeLocale(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+            'departmentWasClosed' => true,
+            'requiresResus' => false,
+        ]);
+
+        $request = Request::create('/');
+        $request->setLocale('de');
+        $stack = self::getContainer()->get(RequestStack::class);
+        self::assertInstanceOf(RequestStack::class, $stack);
+        $stack->push($request);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        $csv = $this->exportCsv($exporter, $owner, $filter);
+
+        self::assertStringContainsString('Wahr', $csv);
+        self::assertStringContainsString('Falsch', $csv);
+        self::assertStringNotContainsString(',1,', $csv);
+        self::assertStringNotContainsString(',0,', $csv);
     }
 
     public function testWriteCsvRespectsSelectedHospitalIds(): void

--- a/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
+++ b/tests/Allocation/Integration/Export/OwnHospitalAllocationsExporterTest.php
@@ -342,6 +342,60 @@ final class OwnHospitalAllocationsExporterTest extends KernelTestCase
         self::assertStringNotContainsString('Hospital Beta', $csv);
     }
 
+    public function testPublicExporterMetadataAndCount(): void
+    {
+        self::bootKernel();
+
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospital = HospitalFactory::createOne(['owner' => $owner]);
+        $this->seedAllocationDependencies($hospital);
+
+        AllocationFactory::createOne([
+            'hospital' => $hospital,
+            'arrivalAt' => new \DateTimeImmutable('2026-01-15 10:00:00'),
+        ]);
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $filter = new OwnHospitalAllocationsExportFilter(
+            dateFrom: new \DateTimeImmutable('2026-01-01'),
+            dateTo: new \DateTimeImmutable('2026-01-31'),
+        );
+
+        self::assertSame(OwnHospitalAllocationsExporter::KEY, $exporter->key());
+        self::assertMatchesRegularExpression('/^allocations-export-\d{4}-\d{2}-\d{2}\.csv$/', $exporter->buildFilename());
+        self::assertSame([(int) $hospital->getId()], $exporter->resolveScopeHospitalIds($owner));
+        self::assertSame(1, $exporter->count($owner, $filter));
+        self::assertArrayHasKey('dateFrom', $exporter->serializeCriteria($filter));
+    }
+
+    public function testCountRejectsInvalidCriteria(): void
+    {
+        self::bootKernel();
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $exporter->count(UserFactory::createOne(), new \stdClass());
+    }
+
+    public function testAssertCanExportDeniesUsersWithoutExportAccess(): void
+    {
+        self::bootKernel();
+
+        $exporter = self::getContainer()->get(OwnHospitalAllocationsExporter::class);
+        self::assertInstanceOf(OwnHospitalAllocationsExporter::class, $exporter);
+
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER']]);
+
+        $this->expectException(\Symfony\Component\Security\Core\Exception\AccessDeniedException::class);
+        $exporter->assertCanExport($user);
+    }
+
     private function exportCsv(OwnHospitalAllocationsExporter $exporter, object $user, OwnHospitalAllocationsExportFilter $filter): string
     {
         $stream = fopen('php://temp', 'w+');

--- a/tests/Allocation/Unit/Export/AllocationExportValueFormatterTest.php
+++ b/tests/Allocation/Unit/Export/AllocationExportValueFormatterTest.php
@@ -13,29 +13,25 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AllocationExportValueFormatterTest extends TestCase
 {
-    private AllocationExportValueFormatter $formatter;
-
-    #[\Override]
-    protected function setUp(): void
+    public function testFormatsGenderTransportAndUrgencyForExport(): void
     {
-        $translator = $this->createMock(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturnCallback(
-            static fn (string $id): string => match ($id) {
-                'label.gender.male' => 'Male',
-                'label.transportType.ground' => 'Ground',
-                'label.transportType.air' => 'Air',
+            static fn (string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string => match ($id) {
+                'label.gender.male' => 'de' === $locale ? 'Männlich' : 'Male',
+                'label.transportType.ground' => 'de' === $locale ? 'Boden' : 'Ground',
+                'label.transportType.air' => 'de' === $locale ? 'Luft' : 'Air',
                 default => $id,
             },
         );
 
-        $this->formatter = new AllocationExportValueFormatter($translator);
-    }
+        $formatter = new AllocationExportValueFormatter($translator);
 
-    public function testFormatsGenderTransportAndUrgencyForExport(): void
-    {
-        self::assertSame('Male', $this->formatter->gender(AllocationGender::MALE));
-        self::assertSame('SK1', $this->formatter->urgency(AllocationUrgency::EMERGENCY));
-        self::assertSame('Ground', $this->formatter->transportType(AllocationTransportType::GROUND));
-        self::assertSame('Air', $this->formatter->transportType('A'));
+        self::assertSame('Male', $formatter->gender(AllocationGender::MALE));
+        self::assertSame('SK1', $formatter->urgency(AllocationUrgency::EMERGENCY));
+        self::assertSame('Ground', $formatter->transportType(AllocationTransportType::GROUND));
+        self::assertSame('Air', $formatter->transportType('A'));
+        self::assertSame('Männlich', $formatter->gender(AllocationGender::MALE, 'de'));
+        self::assertSame('Luft', $formatter->transportType(AllocationTransportType::AIR, 'de'));
     }
 }

--- a/tests/Allocation/Unit/Export/OwnHospitalAllocationsExporterHelpersTest.php
+++ b/tests/Allocation/Unit/Export/OwnHospitalAllocationsExporterHelpersTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Export;
+
+use App\Allocation\Application\Export\OwnHospitalAllocationsExporter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Covers defensive private helpers that the integration export path does not exercise.
+ */
+final class OwnHospitalAllocationsExporterHelpersTest extends TestCase
+{
+    public function testTranslateHeaderFallsBackToColumnKey(): void
+    {
+        $exporter = $this->exporterForHelpers();
+        $method = new \ReflectionMethod(OwnHospitalAllocationsExporter::class, 'translateHeader');
+
+        self::assertSame('unknownColumn', $method->invoke($exporter, 'unknownColumn', 'en'));
+    }
+
+    public function testFormatDateTimeCoversNonDateTimeBranches(): void
+    {
+        $exporter = $this->exporterForHelpers();
+        $method = new \ReflectionMethod(OwnHospitalAllocationsExporter::class, 'formatDateTime');
+
+        self::assertNull($method->invoke($exporter, null));
+        self::assertSame('2026-01-15 10:00:00', $method->invoke($exporter, '2026-01-15 10:00:00'));
+        self::assertSame('123', $method->invoke($exporter, 123));
+        self::assertSame('1.5', $method->invoke($exporter, 1.5));
+        self::assertNull($method->invoke($exporter, new \stdClass()));
+    }
+
+    public function testScalarCellCoversStringableAndNonScalarBranches(): void
+    {
+        $exporter = $this->exporterForHelpers();
+        $method = new \ReflectionMethod(OwnHospitalAllocationsExporter::class, 'scalarCell');
+
+        self::assertNull($method->invoke($exporter, null));
+        self::assertSame('ok', $method->invoke($exporter, 'ok'));
+        self::assertSame(7, $method->invoke($exporter, 7));
+        self::assertSame(
+            'Stringable Hospital',
+            $method->invoke($exporter, new class implements \Stringable {
+                public function __toString(): string
+                {
+                    return 'Stringable Hospital';
+                }
+            }),
+        );
+        self::assertNull($method->invoke($exporter, ['not-a-scalar']));
+        self::assertNull($method->invoke($exporter, new \stdClass()));
+    }
+
+    public function testFormatBoolReturnsNullForMissingValues(): void
+    {
+        $exporter = $this->exporterForHelpers();
+        $method = new \ReflectionMethod(OwnHospitalAllocationsExporter::class, 'formatBool');
+
+        self::assertNull($method->invoke($exporter, null, 'en'));
+        self::assertSame('export.boolean.true', $method->invoke($exporter, true, 'en'));
+        self::assertSame('export.boolean.false', $method->invoke($exporter, false, 'en'));
+    }
+
+    private function exporterForHelpers(): OwnHospitalAllocationsExporter
+    {
+        $exporter = new \ReflectionClass(OwnHospitalAllocationsExporter::class)->newInstanceWithoutConstructor();
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => $id,
+        );
+
+        $reflection = new \ReflectionClass($exporter);
+        $reflection->getProperty('translator')->setValue($exporter, $translator);
+        $reflection->getProperty('requestStack')->setValue($exporter, new RequestStack());
+
+        return $exporter;
+    }
+}

--- a/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionLabelResolverTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/AnalysisDimensionLabelResolverTest.php
@@ -8,8 +8,6 @@ use App\Statistics\AnalysisExplorer\Application\AnalysisDimensionLabelResolver;
 use App\Statistics\Application\Cohort\HospitalCohortLabelResolver;
 use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
 use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
-use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisDimension;
-use App\Statistics\GenericAnalysis\Domain\Enum\AnalysisDimensionType;
 use App\Statistics\GenericAnalysis\Registry\DimensionRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -44,15 +42,76 @@ final class AnalysisDimensionLabelResolverTest extends TestCase
         );
 
         $resolver = $this->resolver($translator);
-        $resus = new AnalysisDimension(
-            key: 'resus',
-            column: 'requires_resus',
-            label: 'Resuscitation required',
-            type: AnalysisDimensionType::Boolean,
-        );
+        $resus = new DimensionRegistry()->get('resus');
 
         self::assertSame('Yes', $resolver->labelFor($resus, 1));
         self::assertSame('No', $resolver->labelFor($resus, 0));
+    }
+
+    public function testWeekdayUsesTranslationKeys(): void
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = [], ?string $domain = null): string => match ($id) {
+                'stats.indication.weekday.1' => 'Montag',
+                default => $id,
+            },
+        );
+
+        $resolver = $this->resolver($translator);
+        $weekday = new DimensionRegistry()->get('weekday');
+
+        self::assertSame('Montag', $resolver->labelFor($weekday, 1));
+    }
+
+    public function testAgeGroupUnknownUsesTranslationKey(): void
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = [], ?string $domain = null): string => match ($id) {
+                'stats.benchmark.age_group.unknown' => 'Unbekannt',
+                default => $id,
+            },
+        );
+
+        $resolver = $this->resolver($translator);
+        $ageGroup = new DimensionRegistry()->get('age_group');
+
+        self::assertSame('Unbekannt', $resolver->labelFor($ageGroup, 'unknown'));
+        self::assertSame('0–18', $resolver->labelFor($ageGroup, '0_18'));
+    }
+
+    public function testNullBucketUsesUnknownTranslation(): void
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = [], ?string $domain = null): string => match ($id) {
+                'stats.analysis_explorer.bucket.unknown' => 'Unbekannt',
+                default => $id,
+            },
+        );
+
+        $resolver = $this->resolver($translator);
+        $month = new DimensionRegistry()->get('month');
+
+        self::assertSame('Unbekannt', $resolver->labelFor($month, '__null__'));
+    }
+
+    public function testMonthUsesTranslatorLocale(): void
+    {
+        $translatorDe = $this->createStub(TranslatorInterface::class);
+        $translatorDe->method('getLocale')->willReturn('de');
+
+        $translatorEn = $this->createStub(TranslatorInterface::class);
+        $translatorEn->method('getLocale')->willReturn('en');
+
+        $month = new DimensionRegistry()->get('month');
+        $deLabel = $this->resolver($translatorDe)->labelFor($month, 3);
+        $enLabel = $this->resolver($translatorEn)->labelFor($month, 3);
+
+        self::assertNotSame('', $deLabel);
+        self::assertNotSame('', $enLabel);
+        self::assertNotSame($enLabel, $deLabel);
     }
 
     private function resolver(TranslatorInterface $translator): AnalysisDimensionLabelResolver

--- a/translations/allocation+intl-icu.de.xlf
+++ b/translations/allocation+intl-icu.de.xlf
@@ -217,6 +217,18 @@
         <source>help.export.period</source>
         <target>Ohne Uhrzeit gilt Tagesbeginn (00:00:00) bzw. Tagesende (23:59:59). Datum und Uhrzeit bilden ein durchgängiges Intervall.</target>
       </trans-unit>
+      <trans-unit id="ExpColDe01" resname="export.column.row">
+        <source>export.column.row</source>
+        <target>Zeile</target>
+      </trans-unit>
+      <trans-unit id="ExpBoolDe01" resname="export.boolean.true">
+        <source>export.boolean.true</source>
+        <target>Wahr</target>
+      </trans-unit>
+      <trans-unit id="ExpBoolDe02" resname="export.boolean.false">
+        <source>export.boolean.false</source>
+        <target>Falsch</target>
+      </trans-unit>
       <trans-unit id="HlpIndAdmDe" resname="help.indication.review.admin_fast_path">
         <source>help.indication.review.admin_fast_path</source>
         <target>Admin: Match setzen und direkt freigeben (ohne Vier-Augen-Prüfung).</target>

--- a/translations/allocation+intl-icu.en.xlf
+++ b/translations/allocation+intl-icu.en.xlf
@@ -1021,6 +1021,18 @@
         <source>help.export.department_was_closed_filter</source>
         <target>Include only allocations where the department was closed.</target>
       </trans-unit>
+      <trans-unit id="ExpColEn01" resname="export.column.row">
+        <source>export.column.row</source>
+        <target>Row</target>
+      </trans-unit>
+      <trans-unit id="ExpBoolEn01" resname="export.boolean.true">
+        <source>export.boolean.true</source>
+        <target>True</target>
+      </trans-unit>
+      <trans-unit id="ExpBoolEn02" resname="export.boolean.false">
+        <source>export.boolean.false</source>
+        <target>False</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -1337,6 +1337,10 @@
         <source>stats.analysis_explorer.empty_state.unsupported</source>
         <target>Diese Analyse-Konfiguration kann nicht angezeigt werden.</target>
       </trans-unit>
+      <trans-unit id="statsAexBukUnkDe" resname="stats.analysis_explorer.bucket.unknown">
+        <source>stats.analysis_explorer.bucket.unknown</source>
+        <target>Unbekannt</target>
+      </trans-unit>
       <trans-unit id="statsAexExp01" resname="stats.analysis_explorer.export.csv_table">
         <source>stats.analysis_explorer.export.csv_table</source>
         <target>CSV exportieren</target>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -3845,6 +3845,10 @@
         <source>stats.analysis_explorer.validation.invalid</source>
         <target>Invalid analysis configuration.</target>
       </trans-unit>
+      <trans-unit id="statsAexBukUnk" resname="stats.analysis_explorer.bucket.unknown">
+        <source>stats.analysis_explorer.bucket.unknown</source>
+        <target>Unknown</target>
+      </trans-unit>
       <trans-unit id="statsAexExp01" resname="stats.analysis_explorer.export.csv_table">
         <source>stats.analysis_explorer.export.csv_table</source>
         <target>Export CSV</target>


### PR DESCRIPTION
## Summary
- Translate own-hospital allocations CSV headers and sensible cell values (enums, booleans) using the request locale (`True`/`False`, `Wahr`/`Falsch`).
- Localize Analysis Explorer dimension bucket labels (weekdays, yes/no, unknown, months) for UI and CSV/PNG exports.
- Closes #410

## Test plan
- [x] Export allocations CSV in English and German; confirm translated headers and `True`/`False` vs `Wahr`/`Falsch`
- [x] Confirm SK labels, hospital/entity names, and date formats are unchanged
- [x] Open Analysis Explorer views with weekday/boolean/month/age-group dimensions in `de` and `en`
- [x] Export explorer CSV and verify localized row/column labels
- [x] `make lint-trans`