### PR TITLE
Optimize Statistics Overview for admins: public default, lazy self-benchmark, and period-scoped charts

### DIFF
--- a/assets/controllers/indication-dashboard-charts_controller.js
+++ b/assets/controllers/indication-dashboard-charts_controller.js
@@ -181,6 +181,10 @@ export default class extends Controller {
                 : { curve: 'smooth', width: 3 },
             markers: { size: 0 },
             dataLabels: { enabled: false },
+            yaxis: {
+                min: 0,
+                forceNiceScale: true,
+            },
             legend: {
                 show: showMovingAverage,
                 position: 'top',

--- a/docs/04-features/statistics/README.md
+++ b/docs/04-features/statistics/README.md
@@ -23,7 +23,8 @@
 | [data-quality-indicator.md](data-quality-indicator.md) | Traffic-light badge dimensions |
 | [analysis-explorer.md](analysis-explorer.md) | Explorer V2 architecture and schema |
 | [analysis-explorer-library-standards.md](analysis-explorer-library-standards.md) | Product standards and dashboard alignment |
-| [indication-dashboard-performance.md](indication-dashboard-performance.md) | SQL optimisation notes |
+| [indication-dashboard-performance.md](indication-dashboard-performance.md) | Indication detail SQL optimisation notes |
+| [overview-dashboard-performance.md](overview-dashboard-performance.md) | Overview default scope and profiler hotspots |
 | [case-flow.md](case-flow.md) | Case flow dashboard |
 | [hospital-population.md](hospital-population.md) | Hospital population dashboard |
 

--- a/docs/04-features/statistics/overview-dashboard-performance.md
+++ b/docs/04-features/statistics/overview-dashboard-performance.md
@@ -1,0 +1,54 @@
+# Overview dashboard performance
+
+Notes from profiling for [issue #408](https://github.com/nplhse/collaborative-ivena-statistics/issues/408).
+
+## Admin default scope (Aug 2026)
+
+Administrators previously defaulted to `my_hospitals`, which resolves to **all** hospital IDs and applies `hospital_id IN (...)` across overview metrics, slice, and self-benchmark — same population as `public`, but a worse filter for the planner.
+
+`StatisticsFilterInputFactory` now defaults admins to `public`. Participants with hospital access still default to `my_hospitals`. Explicit `?scope=my_hospitals` remains available for admins.
+
+## Profiler snapshots
+
+### Single hospital (earlier)
+
+Request: `GET /statistics/?hospital=40&period=all&scope=hospital`
+
+| Metric | Value |
+|--------|-------|
+| Database queries | 52 |
+| Query time | ~1032 ms |
+
+Dominant: Self-benchmark ~570 ms, metrics ~354 ms, slice ~38 ms.
+
+### Public `period=all` (after admin default)
+
+Request: `GET /statistics/?period=all`
+
+| Metric | Value |
+|--------|-------|
+| Database queries | 50 |
+| Query time | **~5347 ms** |
+
+Dominant:
+
+| Approx. time | Source |
+|--------------|--------|
+| ~3425 ms | Self-benchmark distributions (`WHERE (period OR 1=1)` full scan + large `UNION ALL`) |
+| ~1671 ms | Self-benchmark core metrics (same tautological union where) |
+| ~127 ms | `OverviewSliceQuery` |
+
+Self-benchmark compares `period=all` (primary) to `all_time` (comparison). Public + `all_time` → comparison predicate `1 = 1`.
+
+## Mitigation (Aug 2026)
+
+1. **Lazy Turbo-Frame** `GET /statistics/overview/self-benchmark` — KPI grid + hospital insights load after first paint (same pattern as Top Reports).
+2. **Sync path** only runs metrics + slice (plus `transport_type` buckets in `OverviewSliceQuery`; charts no longer need `BenchmarkReport`).
+3. **Slim overview aggregation** `BenchmarkAggregationProvider::aggregateForOverview` — reduced core counters + `indication` distribution only (full provider unchanged for `/statistics/benchmarking`).
+
+Sync query budget: `tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php` (max 30 queries; asserts no self-benchmark SQL on sync).
+
+## Follow-up ideas
+
+- Further tune metrics percentiles / indexes on `allocation_stats_projection` for public scopes
+- Optional: period-bounded baseline for aggregate public (product change) to avoid comparison `1 = 1`

--- a/docs/04-features/statistics/statistics-filter-and-scope.md
+++ b/docs/04-features/statistics/statistics-filter-and-scope.md
@@ -19,6 +19,16 @@ Most statistics pages share a common filter model resolved by `StatisticsFilterF
 
 `StatisticsFilterPeriod`: `all`, `all_time`, `year`, `quarter`, `month`.
 
+## Default scope (no `scope` query parameter)
+
+`StatisticsFilterInputFactory` chooses the initial scope:
+
+- Administrators (`ROLE_ADMIN`) → `public` (system-wide overview; avoids a large `hospital_id IN (...)` for all hospitals)
+- Participants with hospital access → `my_hospitals`
+- Everyone else / anonymous → `public`
+
+Admins can still select `my_hospitals` explicitly via `?scope=my_hospitals`.
+
 ## Resolution and fallbacks
 
 `StatisticsFilterFactory` normalizes URL input and applies access rules:
@@ -44,6 +54,7 @@ Permission checks use `HospitalPermission::Statistics` or `HospitalPermission::B
 
 ## Code locations
 
+- `src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php` (default scope)
 - `src/Statistics/Application/StatisticsFilterFactory.php`
 - `src/Statistics/Application/ComparisonScopeResolver.php`
 - `src/Statistics/Application/DTO/StatisticsFilterScope.php`
@@ -52,4 +63,5 @@ Permission checks use `HospitalPermission::Statistics` or `HospitalPermission::B
 
 - [permission-model.md](../../02-architecture/permission-model.md)
 - [projection-and-materialized-views.md](projection-and-materialized-views.md)
+- [overview-dashboard-performance.md](overview-dashboard-performance.md)
 - [analysis-explorer.md](analysis-explorer.md)

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -63,14 +63,51 @@ final readonly class MonthlyReminderSender
             return ['monthly_reminder.error.opted_out'];
         }
 
+        $lock = null;
         if (MonthlyReminderTrigger::Admin === $trigger) {
+            $hospitalId = (int) $hospital->getId();
+            $since = new \DateTimeImmutable(
+                sprintf('-%d seconds', self::MANUAL_LOCK_TTL_SECONDS),
+                new \DateTimeZone('Europe/Berlin'),
+            );
+            if ($this->dispatchRepository->hasRecentDispatchForHospitalAndTrigger(
+                $hospitalId,
+                $trigger->value,
+                $since,
+            )) {
+                return ['monthly_reminder.error.already_sent_recently'];
+            }
+
             $lock = $this->lockFactory->createLock(
-                sprintf('reminder-manual-%d', (int) $hospital->getId()),
+                sprintf('reminder-manual-%d', $hospitalId),
                 self::MANUAL_LOCK_TTL_SECONDS,
             );
             if (!$lock->acquire()) {
                 return ['monthly_reminder.error.already_sent_recently'];
             }
+        }
+
+        try {
+            return $this->sendForHospitalUnlocked($hospital, $trigger, $referenceDate, $bulkIndex);
+        } finally {
+            if (null !== $lock && $lock->isAcquired()) {
+                $lock->release();
+            }
+        }
+    }
+
+    /**
+     * @return list<string> validation errors; empty list means sent
+     */
+    private function sendForHospitalUnlocked(
+        Hospital $hospital,
+        MonthlyReminderTrigger $trigger,
+        ?\DateTimeImmutable $referenceDate,
+        int $bulkIndex,
+    ): array {
+        $owner = $hospital->getOwner();
+        if (!$owner instanceof User) {
+            return ['monthly_reminder.error.no_owner'];
         }
 
         $period = $this->periodResolver->resolve($referenceDate);
@@ -87,6 +124,7 @@ final readonly class MonthlyReminderSender
             return ['monthly_reminder.error.already_sent_for_period'];
         }
 
+        $email = trim((string) $owner->getEmail());
         $ownerLocale = $this->localeResolver->resolveForUser($owner);
         $content = $this->contentBuilder->build($hospital, $referenceDate, $ownerLocale);
         $reportingMonth = $content->reportingPeriodLabel;

--- a/src/Engagement/Application/MonthlyReminderSender.php
+++ b/src/Engagement/Application/MonthlyReminderSender.php
@@ -13,6 +13,7 @@ use App\Shared\Application\Locale\LocaleResolver;
 use App\Shared\Infrastructure\Audit\AuditContext;
 use App\User\Domain\Entity\User;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 
 final readonly class MonthlyReminderSender
 {
@@ -90,7 +91,7 @@ final readonly class MonthlyReminderSender
         try {
             return $this->sendForHospitalUnlocked($hospital, $trigger, $referenceDate, $bulkIndex);
         } finally {
-            if (null !== $lock && $lock->isAcquired()) {
+            if ($lock instanceof LockInterface && $lock->isAcquired()) {
                 $lock->release();
             }
         }

--- a/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
+++ b/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
@@ -7,6 +7,7 @@ namespace App\Engagement\Infrastructure\Repository;
 use App\Engagement\Domain\Entity\MonthlyReminderDispatch;
 use App\Engagement\Domain\Enum\MonthlyReminderDispatchStatus;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -72,7 +73,7 @@ final class MonthlyReminderDispatchRepository extends ServiceEntityRepository
             ->andWhere('dispatch.sentAt >= :since')
             ->setParameter('hospitalId', $hospitalId)
             ->setParameter('trigger', $trigger)
-            ->setParameter('since', $since)
+            ->setParameter('since', $since, Types::DATETIME_IMMUTABLE)
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();

--- a/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
+++ b/src/Engagement/Infrastructure/Repository/MonthlyReminderDispatchRepository.php
@@ -61,6 +61,23 @@ final class MonthlyReminderDispatchRepository extends ServiceEntityRepository
         ]);
     }
 
+    public function hasRecentDispatchForHospitalAndTrigger(
+        int $hospitalId,
+        string $trigger,
+        \DateTimeImmutable $since,
+    ): bool {
+        return null !== $this->createQueryBuilder('dispatch')
+            ->andWhere('dispatch.hospital = :hospitalId')
+            ->andWhere('dispatch.trigger = :trigger')
+            ->andWhere('dispatch.sentAt >= :since')
+            ->setParameter('hospitalId', $hospitalId)
+            ->setParameter('trigger', $trigger)
+            ->setParameter('since', $since)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function save(MonthlyReminderDispatch $dispatch): void
     {
         $this->getEntityManager()->persist($dispatch);

--- a/src/Statistics/Application/Overview/Dto/OverviewSelfBenchmarkFrameViewModel.php
+++ b/src/Statistics/Application/Overview/Dto/OverviewSelfBenchmarkFrameViewModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Overview\Dto;
+
+use App\Statistics\Application\Insights\HospitalInsight;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetric;
+
+final readonly class OverviewSelfBenchmarkFrameViewModel
+{
+    /**
+     * @param list<BenchmarkMetric> $kpiMetrics
+     * @param list<HospitalInsight> $hospitalInsights
+     */
+    public function __construct(
+        public array $kpiMetrics,
+        public array $hospitalInsights,
+        public bool $benchmarkSuppressRatios,
+        public string $benchmarkingUrl,
+    ) {
+    }
+}

--- a/src/Statistics/Application/Overview/OverviewChartsFactory.php
+++ b/src/Statistics/Application/Overview/OverviewChartsFactory.php
@@ -7,9 +7,10 @@ namespace App\Statistics\Application\Overview;
 use App\Statistics\Application\IndicationDashboard\DTO\IndicationDistributionRow;
 use App\Statistics\Application\IndicationDashboard\DTO\IndicationHeatmapData;
 use App\Statistics\Application\IndicationDashboard\IndicationDashboardAssembler;
+use App\Statistics\Application\Mapping\AllocationStatsTransportTypeProjectionCode;
 use App\Statistics\Application\Overview\Dto\OverviewChartsViewModel;
-use App\Statistics\Benchmarking\Application\DTO\BenchmarkReport;
 use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewDashboardMetricsResult;
+use App\Statistics\Infrastructure\Query\Overview\Dto\OverviewSliceData;
 use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
 use App\Statistics\Infrastructure\Query\Overview\OverviewSliceQuery;
 
@@ -24,7 +25,6 @@ final readonly class OverviewChartsFactory
     public function build(
         OverviewQueryCriteria $criteria,
         OverviewDashboardMetricsResult $metrics,
-        BenchmarkReport $benchmarkReport,
     ): OverviewChartsViewModel {
         $slice = ($this->sliceQuery)($criteria);
         $total = $metrics->scopedTotal;
@@ -43,7 +43,7 @@ final readonly class OverviewChartsFactory
                 'heatmapShift' => $this->heatmapPayload($shiftHeatmap),
             ],
             $this->indicationDashboardAssembler->buildAgeGroupDistribution($metrics->ageGroupCounts, $total),
-            $this->buildTransportDistribution($benchmarkReport, $total),
+            $this->buildTransportDistribution($slice, $total),
             $this->indicationDashboardAssembler->buildTransportTimeDistribution($slice->transportTimeBucketCounts, $total),
             $metrics->medianAge,
             $metrics->medianTransportMinutes,
@@ -53,19 +53,23 @@ final readonly class OverviewChartsFactory
     /**
      * @return list<IndicationDistributionRow>
      */
-    private function buildTransportDistribution(BenchmarkReport $benchmarkReport, int $total): array
+    private function buildTransportDistribution(OverviewSliceData $slice, int $total): array
     {
         $rows = [];
+        $counts = $slice->transportTypeBucketCounts;
 
-        foreach ($benchmarkReport->transportType->buckets as $bucket) {
-            if ('unknown' === $bucket->key) {
-                continue;
-            }
+        foreach (AllocationStatsTransportTypeProjectionCode::displayOrder() as $case) {
+            $bucketKey = (string) $case->value;
+            $count = $counts[$bucketKey] ?? 0;
+            $label = match ($case) {
+                AllocationStatsTransportTypeProjectionCode::Ground => 'stats.indication.transport.ground',
+                AllocationStatsTransportTypeProjectionCode::Air => 'stats.indication.transport.air',
+            };
 
             $rows[] = new IndicationDistributionRow(
-                $bucket->label,
-                $bucket->primaryCount,
-                $total > 0 ? round(100 * $bucket->primaryCount / $total, 1) : 0.0,
+                $label,
+                $count,
+                $total > 0 ? round(100 * $count / $total, 1) : 0.0,
             );
         }
 

--- a/src/Statistics/Application/Overview/OverviewExecutiveDashboardAssembler.php
+++ b/src/Statistics/Application/Overview/OverviewExecutiveDashboardAssembler.php
@@ -16,11 +16,6 @@ final readonly class OverviewExecutiveDashboardAssembler
 {
     public function __construct(
         private StatisticsScopeResolver $scopeResolver,
-        private OverviewPeriodComparisonService $periodComparison,
-        private OverviewExecutiveKpiFactory $executiveKpiFactory,
-        private OverviewSelfBenchmarkFactory $selfBenchmarkFactory,
-        private OverviewBenchmarkSummaryFactory $benchmarkSummaryFactory,
-        private OverviewHospitalInsightsProvider $hospitalInsightsProvider,
         private OverviewIndicationSectionFactory $indicationSectionFactory,
         private OverviewPopulationProfileFactory $populationProfileFactory,
         private OverviewChartsFactory $chartsFactory,
@@ -32,37 +27,24 @@ final readonly class OverviewExecutiveDashboardAssembler
         Request $request,
         StatisticsContext $context,
         OverviewDashboardMetricsResult $metrics,
-        string $reportingPeriodLabel,
     ): OverviewExecutiveDashboardViewModel {
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
         $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
-        $previousScopedTotal = $this->periodComparison->fetchPreviousScopedTotal($context);
-
-        $benchmarkReport = $this->selfBenchmarkFactory->build($context);
-        $indicationSection = $this->indicationSectionFactory->build($request, $context, $metrics->scopedTotal);
         $benchmarkingUrl = $this->navigationUrlBuilder->build($request, 'app_stats_benchmarking');
 
         return new OverviewExecutiveDashboardViewModel(
-            $this->executiveKpiFactory->build($context, $benchmarkReport),
-            $this->hospitalInsightsProvider->build(
-                $context,
-                $benchmarkReport,
-                $metrics->scopedTotal,
-                $previousScopedTotal,
-                $benchmarkingUrl,
-                $reportingPeriodLabel,
-            ),
-            $indicationSection,
-            $this->benchmarkSummaryFactory->buildScorecard($benchmarkReport),
-            $this->benchmarkSummaryFactory->buildDeviations($request, $benchmarkReport),
-            $benchmarkReport->hasInsufficientData,
-            $benchmarkReport->suppressRatios,
+            [],
+            [],
+            $this->indicationSectionFactory->build($request, $context, $metrics->scopedTotal),
+            [],
+            ['positive' => [], 'negative' => []],
+            false,
+            false,
             $benchmarkingUrl,
             $this->populationProfileFactory->build($metrics),
             $this->chartsFactory->build(
                 OverviewQueryCriteria::fromPeriodBounds($bounds, $hospitalIds),
                 $metrics,
-                $benchmarkReport,
             ),
             [],
         );

--- a/src/Statistics/Application/Overview/OverviewSelfBenchmarkFactory.php
+++ b/src/Statistics/Application/Overview/OverviewSelfBenchmarkFactory.php
@@ -23,7 +23,7 @@ final readonly class OverviewSelfBenchmarkFactory
     {
         $baselineFilter = $this->baselineFilterFor($context->filter);
 
-        return $this->benchmarkReportService->build(
+        return $this->benchmarkReportService->buildForOverview(
             $this->benchmarkCriteriaFactory->create($context, $baselineFilter),
         );
     }

--- a/src/Statistics/Application/Overview/OverviewSelfBenchmarkFrameFactory.php
+++ b/src/Statistics/Application/Overview/OverviewSelfBenchmarkFrameFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\Overview;
+
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\Overview\Dto\OverviewSelfBenchmarkFrameViewModel;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Application\StatisticsScopeResolver;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class OverviewSelfBenchmarkFrameFactory
+{
+    public function __construct(
+        private StatisticsScopeResolver $scopeResolver,
+        private OverviewPeriodComparisonService $periodComparison,
+        private OverviewExecutiveKpiFactory $executiveKpiFactory,
+        private OverviewSelfBenchmarkFactory $selfBenchmarkFactory,
+        private OverviewHospitalInsightsProvider $hospitalInsightsProvider,
+        private ProjectionTimeSeriesQuery $timeSeriesQuery,
+        private StatisticsNavigationUrlBuilder $navigationUrlBuilder,
+    ) {
+    }
+
+    public function build(
+        Request $request,
+        StatisticsContext $context,
+        string $reportingPeriodLabel,
+    ): OverviewSelfBenchmarkFrameViewModel {
+        $bounds = StatisticsPeriodResolver::resolve($context->filter);
+        $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
+        $scopedTotal = $this->timeSeriesQuery->countCreatedInPeriod(
+            $bounds->from,
+            $bounds->toExclusive,
+            $hospitalIds,
+        );
+        $previousScopedTotal = $this->periodComparison->fetchPreviousScopedTotal($context);
+        $benchmarkReport = $this->selfBenchmarkFactory->build($context);
+        $benchmarkingUrl = $this->navigationUrlBuilder->build($request, 'app_stats_benchmarking');
+
+        return new OverviewSelfBenchmarkFrameViewModel(
+            $this->executiveKpiFactory->build($context, $benchmarkReport),
+            $this->hospitalInsightsProvider->build(
+                $context,
+                $benchmarkReport,
+                $scopedTotal,
+                $previousScopedTotal,
+                $benchmarkingUrl,
+                $reportingPeriodLabel,
+            ),
+            $benchmarkReport->suppressRatios,
+            $benchmarkingUrl,
+        );
+    }
+}

--- a/src/Statistics/Benchmarking/Application/BenchmarkReportService.php
+++ b/src/Statistics/Benchmarking/Application/BenchmarkReportService.php
@@ -6,8 +6,12 @@ namespace App\Statistics\Benchmarking\Application;
 
 use App\Statistics\Benchmarking\Application\Contract\BenchmarkAggregationProviderInterface;
 use App\Statistics\Benchmarking\Application\DTO\BenchmarkCriteria;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkDistribution;
 use App\Statistics\Benchmarking\Application\DTO\BenchmarkHeader;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkHeatmapData;
+use App\Statistics\Benchmarking\Application\DTO\BenchmarkMetricKey;
 use App\Statistics\Benchmarking\Application\DTO\BenchmarkReport;
+use App\Statistics\Benchmarking\Infrastructure\Query\Dto\BenchmarkAggregationResult;
 
 final readonly class BenchmarkReportService
 {
@@ -34,8 +38,28 @@ final readonly class BenchmarkReportService
             $criteria->comparisonPeriod,
         );
 
+        return $this->mapAggregationToReport($criteria, $aggregation);
+    }
+
+    public function buildForOverview(BenchmarkCriteria $criteria): BenchmarkReport
+    {
+        $aggregation = $this->aggregationProvider->aggregateForOverview(
+            $criteria->primaryScope,
+            $criteria->primaryPeriod,
+            $criteria->comparisonScope,
+            $criteria->comparisonPeriod,
+        );
+
+        return $this->mapAggregationToReport($criteria, $aggregation, overview: true);
+    }
+
+    private function mapAggregationToReport(
+        BenchmarkCriteria $criteria,
+        BenchmarkAggregationResult $aggregation,
+        bool $overview = false,
+    ): BenchmarkReport {
         $kpiMetrics = $this->metricBuilder->buildIndicationCompareKpiMetrics($aggregation);
-        $insights = $this->insightProvider->build($aggregation, $kpiMetrics);
+        $insights = $overview ? [] : $this->insightProvider->build($aggregation, $kpiMetrics);
         $suppressRatios = $aggregation->primary->total < self::MIN_CASES_RATIOS
             || $aggregation->comparison->total < self::MIN_CASES_RATIOS;
 
@@ -51,20 +75,25 @@ final readonly class BenchmarkReportService
             $insights,
             $kpiMetrics,
             $this->metricBuilder->buildIndicationMix($aggregation),
-            $this->heatmapBuilder->buildDayTimeCaseDistribution($aggregation),
-            $this->heatmapBuilder->buildShiftCaseDistribution($aggregation),
-            $this->metricBuilder->buildGenderDistribution($aggregation),
-            $this->metricBuilder->buildAgeGroupDistribution($aggregation),
-            $this->metricBuilder->buildTransportTimeDistribution($aggregation),
-            $this->metricBuilder->buildTransportTypeDistribution($aggregation),
-            $this->metricBuilder->buildDayTimeBucketDistribution($aggregation),
-            $this->metricBuilder->buildShiftBucketDistribution($aggregation),
-            $this->metricBuilder->buildUrgencyDistribution($aggregation),
-            $this->metricBuilder->buildResourcesDistribution($aggregation),
-            $this->metricBuilder->buildClinicalFeaturesDistribution($aggregation),
+            $overview ? BenchmarkHeatmapData::empty() : $this->heatmapBuilder->buildDayTimeCaseDistribution($aggregation),
+            $overview ? BenchmarkHeatmapData::empty() : $this->heatmapBuilder->buildShiftCaseDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::Gender) : $this->metricBuilder->buildGenderDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::AgeGroups) : $this->metricBuilder->buildAgeGroupDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::TransportTimes) : $this->metricBuilder->buildTransportTimeDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::TransportType) : $this->metricBuilder->buildTransportTypeDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::DayTimeBuckets) : $this->metricBuilder->buildDayTimeBucketDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::ShiftBuckets) : $this->metricBuilder->buildShiftBucketDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::Urgency) : $this->metricBuilder->buildUrgencyDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::ResourceProfile) : $this->metricBuilder->buildResourcesDistribution($aggregation),
+            $overview ? $this->emptyDistribution(BenchmarkMetricKey::ClinicalFeatures) : $this->metricBuilder->buildClinicalFeaturesDistribution($aggregation),
             $aggregation->primary->total < self::MIN_PRIMARY_CASES
                 || $aggregation->comparison->total < self::MIN_COMPARISON_CASES,
             $suppressRatios,
         );
+    }
+
+    private function emptyDistribution(BenchmarkMetricKey $key): BenchmarkDistribution
+    {
+        return new BenchmarkDistribution($key, []);
     }
 }

--- a/src/Statistics/Benchmarking/Application/Contract/BenchmarkAggregationProviderInterface.php
+++ b/src/Statistics/Benchmarking/Application/Contract/BenchmarkAggregationProviderInterface.php
@@ -16,4 +16,14 @@ interface BenchmarkAggregationProviderInterface
         StatisticsScopeCriteria $comparisonScope,
         StatisticsPeriodBounds $comparisonPeriod,
     ): BenchmarkAggregationResult;
+
+    /**
+     * Overview self-benchmark: reduced core counters + indication distribution only.
+     */
+    public function aggregateForOverview(
+        StatisticsScopeCriteria $primaryScope,
+        StatisticsPeriodBounds $primaryPeriod,
+        StatisticsScopeCriteria $comparisonScope,
+        StatisticsPeriodBounds $comparisonPeriod,
+    ): BenchmarkAggregationResult;
 }

--- a/src/Statistics/Benchmarking/Infrastructure/Query/BenchmarkAggregationProvider.php
+++ b/src/Statistics/Benchmarking/Infrastructure/Query/BenchmarkAggregationProvider.php
@@ -78,6 +78,52 @@ final readonly class BenchmarkAggregationProvider implements BenchmarkAggregatio
         );
     }
 
+    #[\Override]
+    public function aggregateForOverview(
+        StatisticsScopeCriteria $primaryScope,
+        StatisticsPeriodBounds $primaryPeriod,
+        StatisticsScopeCriteria $comparisonScope,
+        StatisticsPeriodBounds $comparisonPeriod,
+    ): BenchmarkAggregationResult {
+        if ($this->isEmptyScope($primaryScope) && $this->isEmptyScope($comparisonScope)) {
+            return BenchmarkAggregationResult::empty();
+        }
+
+        [$primaryPred, $primaryParams, $primaryTypes] = BenchmarkSqlFilter::buildSidePredicate(
+            $primaryScope,
+            $primaryPeriod,
+            'primary',
+        );
+        [$comparisonPred, $comparisonParams, $comparisonTypes] = BenchmarkSqlFilter::buildSidePredicate(
+            $comparisonScope,
+            $comparisonPeriod,
+            'comparison',
+        );
+
+        if ('1 = 0' === $primaryPred && '1 = 0' === $comparisonPred) {
+            return BenchmarkAggregationResult::empty();
+        }
+
+        $params = array_merge($primaryParams, $comparisonParams);
+        $types = array_merge($primaryTypes, $comparisonTypes);
+
+        $coreRow = $this->fetchOverviewCoreMetrics($primaryPred, $comparisonPred, $params, $types);
+        [$primaryPredAliased] = BenchmarkSqlFilter::buildSidePredicate($primaryScope, $primaryPeriod, 'primary', 'p');
+        [$comparisonPredAliased] = BenchmarkSqlFilter::buildSidePredicate($comparisonScope, $comparisonPeriod, 'comparison', 'p');
+        $distributionRows = $this->fetchOverviewDistributionRows(
+            $primaryPredAliased,
+            $comparisonPredAliased,
+            $params,
+            $types,
+        );
+
+        return new BenchmarkAggregationResult(
+            $this->mapSideCounts($coreRow, 'primary'),
+            $this->mapSideCounts($coreRow, 'comparison'),
+            $distributionRows,
+        );
+    }
+
     /**
      * @param array<string, mixed>                             $params
      * @param array<string, \Doctrine\DBAL\ArrayParameterType> $types
@@ -119,6 +165,56 @@ SELECT
         FILTER (WHERE {$comparisonPred}) AS comparison_median_transport,
     {$meanTransport} FILTER (WHERE {$primaryPred}) AS primary_mean_transport,
     {$meanTransport} FILTER (WHERE {$comparisonPred}) AS comparison_mean_transport
+FROM allocation_stats_projection
+WHERE {$unionWhere}
+SQL;
+
+        $row = $this->connection->fetchAssociative($sql, $params, $types);
+
+        return false === $row ? [] : $row;
+    }
+
+    /**
+     * @param array<string, mixed>                             $params
+     * @param array<string, \Doctrine\DBAL\ArrayParameterType> $types
+     *
+     * @return array<string, mixed>
+     */
+    private function fetchOverviewCoreMetrics(
+        string $primaryPred,
+        string $comparisonPred,
+        array $params,
+        array $types,
+    ): array {
+        $unionWhere = sprintf('(%s OR %s)', $primaryPred, $comparisonPred);
+        $medianTransport = StatisticsTransportTimeSql::medianPreciseMinutes();
+        $nightCode = AllocationStatsDayTimeBucketProjectionCode::Night->value;
+        $countSelect = implode(",\n    ", [
+            sprintf('COUNT(*) FILTER (WHERE true AND %s)::int AS primary_total', $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE true AND %s)::int AS comparison_total', $comparisonPred),
+            sprintf('COUNT(*) FILTER (WHERE is_with_physician = true AND %s)::int AS primary_with_physician', $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE is_with_physician = true AND %s)::int AS comparison_with_physician', $comparisonPred),
+            sprintf('COUNT(*) FILTER (WHERE requires_resus = true AND %s)::int AS primary_resus', $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE requires_resus = true AND %s)::int AS comparison_resus', $comparisonPred),
+            sprintf('COUNT(*) FILTER (WHERE day_time_bucket_code = %d AND %s)::int AS primary_night_daytime', $nightCode, $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE day_time_bucket_code = %d AND %s)::int AS comparison_night_daytime', $nightCode, $comparisonPred),
+            sprintf('COUNT(*) FILTER (WHERE created_weekday IN (6, 7) AND %s)::int AS primary_weekend', $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE created_weekday IN (6, 7) AND %s)::int AS comparison_weekend', $comparisonPred),
+            sprintf('COUNT(*) FILTER (WHERE age >= 80 AND %s)::int AS primary_age_80_plus', $primaryPred),
+            sprintf('COUNT(*) FILTER (WHERE age >= 80 AND %s)::int AS comparison_age_80_plus', $comparisonPred),
+        ]);
+
+        $sql = <<<SQL
+SELECT
+    {$countSelect},
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY age)
+        FILTER (WHERE age IS NOT NULL AND {$primaryPred}) AS primary_median_age,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY age)
+        FILTER (WHERE age IS NOT NULL AND {$comparisonPred}) AS comparison_median_age,
+    {$medianTransport}
+        FILTER (WHERE {$primaryPred}) AS primary_median_transport,
+    {$medianTransport}
+        FILTER (WHERE {$comparisonPred}) AS comparison_median_transport
 FROM allocation_stats_projection
 WHERE {$unionWhere}
 SQL;
@@ -240,6 +336,50 @@ UNION ALL
 SELECT 'indication', p.indication_normalized_id::text, n.name,
     COUNT(*) FILTER (WHERE ({$primaryPredAliased}))::int,
     COUNT(*) FILTER (WHERE ({$comparisonPredAliased}))::int
+FROM allocation_stats_projection p
+LEFT JOIN indication_normalized n ON n.id = p.indication_normalized_id
+WHERE ({$primaryPredAliased} OR {$comparisonPredAliased}) AND p.indication_normalized_id IS NOT NULL
+GROUP BY p.indication_normalized_id, n.name
+SQL;
+
+        /** @var list<array{dimension:string,bucket_key:?string,bucket_label:?string,primary_count:int|string,comparison_count:int|string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params, $types);
+
+        $result = [];
+        foreach ($rows as $row) {
+            $bucketKey = $row['bucket_key'] ?? '';
+            if ('' === $bucketKey) {
+                continue;
+            }
+
+            $result[] = new BenchmarkDistributionRow(
+                $row['dimension'],
+                $bucketKey,
+                $row['bucket_label'] ?? null,
+                (int) $row['primary_count'],
+                (int) $row['comparison_count'],
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed>                             $params
+     * @param array<string, \Doctrine\DBAL\ArrayParameterType> $types
+     *
+     * @return list<BenchmarkDistributionRow>
+     */
+    private function fetchOverviewDistributionRows(
+        string $primaryPredAliased,
+        string $comparisonPredAliased,
+        array $params,
+        array $types,
+    ): array {
+        $sql = <<<SQL
+SELECT 'indication' AS dimension, p.indication_normalized_id::text AS bucket_key, n.name AS bucket_label,
+    COUNT(*) FILTER (WHERE ({$primaryPredAliased}))::int AS primary_count,
+    COUNT(*) FILTER (WHERE ({$comparisonPredAliased}))::int AS comparison_count
 FROM allocation_stats_projection p
 LEFT JOIN indication_normalized n ON n.id = p.indication_normalized_id
 WHERE ({$primaryPredAliased} OR {$comparisonPredAliased}) AND p.indication_normalized_id IS NOT NULL

--- a/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPeriodViewModelFactory.php
+++ b/src/Statistics/Benchmarking/UI/Http/Controller/BenchmarkComparisonPeriodViewModelFactory.php
@@ -45,8 +45,8 @@ final readonly class BenchmarkComparisonPeriodViewModelFactory
             $nextFilter instanceof StatisticsFilter ? $this->urlForFilter($request, $routeName, $nextFilter) : null,
             $previousFilter instanceof StatisticsFilter ? $this->periodLabel($previousFilter, $locale) : null,
             $nextFilter instanceof StatisticsFilter ? $this->periodLabel($nextFilter, $locale) : null,
-            $showNavigation && $this->periodNavigation->isPreviousEnabled($filter),
-            $showNavigation && $this->periodNavigation->isNextEnabled($filter),
+            $showNavigation && $previousFilter instanceof StatisticsFilter,
+            $showNavigation && $nextFilter instanceof StatisticsFilter,
             $showNavigation,
         );
     }

--- a/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewSliceData.php
+++ b/src/Statistics/Infrastructure/Query/Overview/Dto/OverviewSliceData.php
@@ -10,6 +10,7 @@ final readonly class OverviewSliceData
      * @param list<array{year:int,month:int,count:int}>                $monthlyRows
      * @param array<string, int>                                       $ageGroupCounts
      * @param array<string, int>                                       $transportTimeBucketCounts
+     * @param array<array-key, int>                                    $transportTypeBucketCounts keyed by projection code as string
      * @param list<array{weekday:int,dayTimeBucketCode:int,count:int}> $dayTimeHeatmapCells
      * @param list<array{weekday:int,shiftBucketCode:int,count:int}>   $shiftHeatmapCells
      */
@@ -17,6 +18,7 @@ final readonly class OverviewSliceData
         public array $monthlyRows,
         public array $ageGroupCounts,
         public array $transportTimeBucketCounts,
+        public array $transportTypeBucketCounts,
         public array $dayTimeHeatmapCells,
         public array $shiftHeatmapCells,
     ) {
@@ -24,6 +26,6 @@ final readonly class OverviewSliceData
 
     public static function empty(): self
     {
-        return new self([], [], [], [], []);
+        return new self([], [], [], [], [], []);
     }
 }

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewSliceQuery.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewSliceQuery.php
@@ -21,56 +21,16 @@ final readonly class OverviewSliceQuery
             return OverviewSliceData::empty();
         }
 
-        $needsAllTimeMonthlyRows = $criteria->from instanceof \DateTimeImmutable || $criteria->toExclusive instanceof \DateTimeImmutable;
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
         $transportBucketCase = StatisticsTransportTimeBucketSql::CASE_EXPRESSION;
 
-        if ($needsAllTimeMonthlyRows) {
-            [$scopedWhere, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
-            [$allTimeWhere] = OverviewProjectionSqlFilter::buildWhereClause(new OverviewQueryCriteria(
-                null,
-                null,
-                $criteria->hospitalIds,
-            ));
-
-            $sql = <<<SQL
-WITH scoped_slice AS (
-    SELECT
-        transport_time_minutes,
-        created_weekday,
-        day_time_bucket_code,
-        shift_bucket_code
-    FROM allocation_stats_projection
-    WHERE {$scopedWhere}
-),
-all_time_slice AS (
-    SELECT
-        created_year,
-        created_month
-    FROM allocation_stats_projection
-    WHERE {$allTimeWhere}
-)
-SELECT 'time_series_all_time' AS slice_kind, created_year::text AS dim1, created_month::text AS dim2, COUNT(*)::int AS count
-FROM all_time_slice GROUP BY created_year, created_month
-UNION ALL
-SELECT 'transport_time', bucket, NULL, COUNT(*)::int
-FROM (SELECT {$transportBucketCase} AS bucket FROM scoped_slice) grouped
-GROUP BY bucket
-UNION ALL
-SELECT 'day_time_heatmap', created_weekday::text, day_time_bucket_code::text, COUNT(*)::int
-FROM scoped_slice GROUP BY created_weekday, day_time_bucket_code
-UNION ALL
-SELECT 'shift_heatmap', created_weekday::text, shift_bucket_code::text, COUNT(*)::int
-FROM scoped_slice GROUP BY created_weekday, shift_bucket_code
-SQL;
-        } else {
-            [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause($criteria);
-
-            $sql = <<<SQL
+        $sql = <<<SQL
 WITH slice AS (
     SELECT
         created_year,
         created_month,
         transport_time_minutes,
+        transport_type_code,
         created_weekday,
         day_time_bucket_code,
         shift_bucket_code
@@ -84,13 +44,17 @@ SELECT 'transport_time', bucket, NULL, COUNT(*)::int
 FROM (SELECT {$transportBucketCase} AS bucket FROM slice) grouped
 GROUP BY bucket
 UNION ALL
+SELECT 'transport_type', transport_type_code::text, NULL, COUNT(*)::int
+FROM slice
+WHERE transport_type_code IS NOT NULL
+GROUP BY transport_type_code
+UNION ALL
 SELECT 'day_time_heatmap', created_weekday::text, day_time_bucket_code::text, COUNT(*)::int
 FROM slice GROUP BY created_weekday, day_time_bucket_code
 UNION ALL
 SELECT 'shift_heatmap', created_weekday::text, shift_bucket_code::text, COUNT(*)::int
 FROM slice GROUP BY created_weekday, shift_bucket_code
 SQL;
-        }
 
         /** @var list<array{slice_kind:string,dim1:?string,dim2:?string,count:int|string}> $rows */
         $rows = $this->connection->fetchAllAssociative($sql, $params);
@@ -105,6 +69,7 @@ SQL;
     {
         $monthlyRows = [];
         $transportTimeBucketCounts = [];
+        $transportTypeBucketCounts = [];
         $dayTimeHeatmapCells = [];
         $shiftHeatmapCells = [];
 
@@ -115,12 +80,13 @@ SQL;
             $dim2 = $row['dim2'] ?? '';
 
             match ($kind) {
-                'time_series', 'time_series_all_time' => $monthlyRows[] = [
+                'time_series' => $monthlyRows[] = [
                     'year' => (int) $dim1,
                     'month' => (int) $dim2,
                     'count' => $count,
                 ],
                 'transport_time' => $transportTimeBucketCounts[$dim1] = $count,
+                'transport_type' => $transportTypeBucketCounts[$dim1] = $count,
                 'day_time_heatmap' => $dayTimeHeatmapCells[] = [
                     'weekday' => (int) $dim1,
                     'dayTimeBucketCode' => (int) $dim2,
@@ -144,6 +110,7 @@ SQL;
             $monthlyRows,
             [],
             $transportTimeBucketCounts,
+            $transportTypeBucketCounts,
             $dayTimeHeatmapCells,
             $shiftHeatmapCells,
         );

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -38,33 +38,17 @@ final readonly class ProjectionTimeSeriesQuery
 
     public function countBefore(\DateTimeImmutable $before): int
     {
-        static $cache = [];
-        $cacheKey = $before->format(\DateTimeInterface::ATOM);
-        if (\array_key_exists($cacheKey, $cache)) {
-            return $cache[$cacheKey];
-        }
-
-        $count = (int) $this->entityManager->createQueryBuilder()
+        return (int) $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p')
             ->select('COUNT(p.id)')
             ->where('p.createdAt < :before')
             ->setParameter('before', $before, Types::DATETIME_IMMUTABLE)
             ->getQuery()
             ->getSingleScalarResult();
-
-        $cache[$cacheKey] = $count;
-
-        return $count;
     }
 
     public function getEarliestCreatedAt(): ?\DateTimeImmutable
     {
-        static $cached = null;
-        static $loaded = false;
-        if ($loaded) {
-            return $cached;
-        }
-
         $value = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p')
             ->select('MIN(p.createdAt) AS min_created_at')
@@ -72,22 +56,14 @@ final readonly class ProjectionTimeSeriesQuery
             ->getSingleScalarResult();
 
         if (null === $value || '' === $value) {
-            $loaded = true;
-
             return null;
         }
 
         if ($value instanceof \DateTimeInterface) {
-            $cached = \DateTimeImmutable::createFromInterface($value);
-            $loaded = true;
-
-            return $cached;
+            return \DateTimeImmutable::createFromInterface($value);
         }
 
-        $cached = new \DateTimeImmutable((string) $value);
-        $loaded = true;
-
-        return $cached;
+        return new \DateTimeImmutable((string) $value);
     }
 
     /**
@@ -176,22 +152,13 @@ final readonly class ProjectionTimeSeriesQuery
 
     public function countWithCreatedYearBefore(int $beforeYear): int
     {
-        static $cache = [];
-        if (\array_key_exists($beforeYear, $cache)) {
-            return $cache[$beforeYear];
-        }
-
-        $count = (int) $this->entityManager->createQueryBuilder()
+        return (int) $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p')
             ->select('COUNT(p.id)')
             ->where('p.createdYear < :beforeYear')
             ->setParameter('beforeYear', $beforeYear)
             ->getQuery()
             ->getSingleScalarResult();
-
-        $cache[$beforeYear] = $count;
-
-        return $count;
     }
 
     /**

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -12,8 +12,12 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 
-final readonly class ProjectionTimeSeriesQuery
+final class ProjectionTimeSeriesQuery
 {
+    private bool $earliestCreatedAtLoaded = false;
+
+    private ?\DateTimeImmutable $earliestCreatedAt = null;
+
     public function __construct(
         private EntityManagerInterface $entityManager,
         private ProjectionFilterApplier $filterApplier,
@@ -49,6 +53,10 @@ final readonly class ProjectionTimeSeriesQuery
 
     public function getEarliestCreatedAt(): ?\DateTimeImmutable
     {
+        if ($this->earliestCreatedAtLoaded) {
+            return $this->earliestCreatedAt;
+        }
+
         $value = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p')
             ->select('MIN(p.createdAt) AS min_created_at')
@@ -56,14 +64,23 @@ final readonly class ProjectionTimeSeriesQuery
             ->getSingleScalarResult();
 
         if (null === $value || '' === $value) {
+            $this->earliestCreatedAt = null;
+            $this->earliestCreatedAtLoaded = true;
+
             return null;
         }
 
         if ($value instanceof \DateTimeInterface) {
-            return \DateTimeImmutable::createFromInterface($value);
+            $this->earliestCreatedAt = \DateTimeImmutable::createFromInterface($value);
+            $this->earliestCreatedAtLoaded = true;
+
+            return $this->earliestCreatedAt;
         }
 
-        return new \DateTimeImmutable((string) $value);
+        $this->earliestCreatedAt = new \DateTimeImmutable((string) $value);
+        $this->earliestCreatedAtLoaded = true;
+
+        return $this->earliestCreatedAt;
     }
 
     /**

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -19,9 +19,9 @@ final class ProjectionTimeSeriesQuery
     private ?\DateTimeImmutable $earliestCreatedAt = null;
 
     public function __construct(
-        private EntityManagerInterface $entityManager,
-        private ProjectionFilterApplier $filterApplier,
-        private ProjectionDrawerFilterApplier $drawerFilterApplier,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ProjectionFilterApplier $filterApplier,
+        private readonly ProjectionDrawerFilterApplier $drawerFilterApplier,
     ) {
     }
 

--- a/src/Statistics/UI/Http/Controller/DashboardController.php
+++ b/src/Statistics/UI/Http/Controller/DashboardController.php
@@ -92,13 +92,13 @@ final class DashboardController extends AbstractController
             $request,
             $context,
             $overviewMetrics,
-            $overviewPeriodViewModel->headingLabel,
         );
 
         return $this->render('@Statistics/dashboard/index.html.twig', [
             'dataQualityLazyLoad' => true,
             'dataQualityDrawerUrl' => $this->navigationUrlBuilder->build($request, 'app_stats_data_quality_drawer'),
             'overviewTopReportsUrl' => $this->navigationUrlBuilder->build($request, 'app_stats_overview_top_reports'),
+            'overviewSelfBenchmarkUrl' => $this->navigationUrlBuilder->build($request, 'app_stats_overview_self_benchmark'),
             'executiveDashboard' => $executiveDashboard,
             'overviewPortalLinks' => $this->overviewPortalNavigationFactory->build(),
             'overviewKpiMetricLabelKeys' => $this->overviewKpiPresentationFactory->metricLabelKeys($filter),

--- a/src/Statistics/UI/Http/Controller/OverviewPeriodViewModelFactory.php
+++ b/src/Statistics/UI/Http/Controller/OverviewPeriodViewModelFactory.php
@@ -44,8 +44,8 @@ final readonly class OverviewPeriodViewModelFactory
             $nextFilter instanceof StatisticsFilter ? $this->urlForFilter($request, $routeName, $nextFilter) : null,
             $previousFilter instanceof StatisticsFilter ? $this->periodLabel($previousFilter, $locale) : null,
             $nextFilter instanceof StatisticsFilter ? $this->periodLabel($nextFilter, $locale) : null,
-            $showNavigation && $this->periodNavigation->isPreviousEnabled($filter),
-            $showNavigation && $this->periodNavigation->isNextEnabled($filter),
+            $showNavigation && $previousFilter instanceof StatisticsFilter,
+            $showNavigation && $nextFilter instanceof StatisticsFilter,
             $showNavigation,
         );
     }

--- a/src/Statistics/UI/Http/Controller/OverviewSelfBenchmarkController.php
+++ b/src/Statistics/UI/Http/Controller/OverviewSelfBenchmarkController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\UI\Http\Controller;
+
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\Overview\OverviewKpiPresentationFactory;
+use App\Statistics\Application\Overview\OverviewSelfBenchmarkFrameFactory;
+use App\Statistics\Application\StatisticsContextFactory;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\ValueResolver;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+final class OverviewSelfBenchmarkController extends AbstractController
+{
+    public function __construct(
+        private readonly StatisticsContextFactory $statisticsContextFactory,
+        private readonly OverviewSelfBenchmarkFrameFactory $selfBenchmarkFrameFactory,
+        private readonly OverviewPeriodViewModelFactory $overviewPeriodViewModelFactory,
+        private readonly OverviewKpiPresentationFactory $overviewKpiPresentationFactory,
+    ) {
+    }
+
+    #[Route('/statistics/overview/self-benchmark', name: 'app_stats_overview_self_benchmark', methods: ['GET'])]
+    public function frame(
+        Request $request,
+        #[CurrentUser] ?User $user,
+        #[ValueResolver(StatisticsFilterValueResolver::class)] StatisticsFilter $filter,
+    ): Response {
+        $context = $this->statisticsContextFactory->create($user, $filter);
+        $overviewPeriodViewModel = $this->overviewPeriodViewModelFactory->create($request, 'app_stats_dashboard', $filter);
+        $selfBenchmarkFrame = $this->selfBenchmarkFrameFactory->build(
+            $request,
+            $context,
+            $overviewPeriodViewModel->headingLabel,
+        );
+
+        return $this->render('@Statistics/dashboard/_overview_self_benchmark_frame.html.twig', [
+            'selfBenchmarkFrame' => $selfBenchmarkFrame,
+            'overviewKpiMetricLabelKeys' => $this->overviewKpiPresentationFactory->metricLabelKeys($filter),
+            'overviewKpiCasesPerDayHintKey' => $this->overviewKpiPresentationFactory->casesPerDayHintTranslationKey($filter),
+            'overviewKpiHintBelowValue' => $user instanceof User && $user->getHospitals()->isEmpty(),
+        ]);
+    }
+}

--- a/src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php
+++ b/src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php
@@ -24,9 +24,13 @@ final readonly class StatisticsFilterInputFactory
      */
     public function fromQuery(InputBag $query, ?User $user): StatisticsFilterInput
     {
-        $defaultScope = $user instanceof User && $this->hospitalAccess->canUseMyHospitalsScope($user)
-            ? StatisticsFilterScope::MyHospitals->value
-            : StatisticsFilterScope::Public->value;
+        $defaultScope = StatisticsFilterScope::Public->value;
+        if ($user instanceof User
+            && !$this->hospitalAccess->isAdminHospitalScopeUser($user)
+            && $this->hospitalAccess->canUseMyHospitalsScope($user)
+        ) {
+            $defaultScope = StatisticsFilterScope::MyHospitals->value;
+        }
 
         return new StatisticsFilterInput(
             scope: $query->getString('scope', $defaultScope),

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_main.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_main.html.twig
@@ -1,6 +1,4 @@
 <div class="col-lg-8 d-flex flex-column gap-3">
-    {{ include('@Statistics/dashboard/_executive_kpi_grid.html.twig') }}
-
     <div class="card" data-testid="stats-overview-time-series">
         <div class="card-header py-2">
             {{ include('@Statistics/dashboard/_linked_card_title.html.twig', {
@@ -79,10 +77,6 @@
                  loading="lazy"
                  target="_top"
                  data-testid="stats-overview-top-reports-frame">
-        <div class="row g-3" data-testid="stats-overview-top-reports">
-            <div class="col-12 text-center text-muted py-4">
-                <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
-            </div>
-        </div>
+        {{ include('@Statistics/dashboard/_overview_top_reports_placeholder.html.twig') }}
     </turbo-frame>
 </div>

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_sidebar.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_charts_sidebar.html.twig
@@ -1,5 +1,4 @@
 <div class="col-lg-4 d-flex flex-column gap-3">
-    {{ include('@Statistics/dashboard/_hospital_insights_sidebar.html.twig') }}
     {% if resourcesWidget is not null %}
         {{ include('@Statistics/dashboard/_widget_renderer.html.twig', {widget: resourcesWidget}) }}
     {% endif %}

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_frame.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_frame.html.twig
@@ -1,0 +1,52 @@
+<turbo-frame id="stats-overview-self-benchmark">
+    <div class="row g-3 mb-1">
+        <div class="col-lg-8 min-w-0">
+            <div data-testid="stats-executive-kpis">
+                {{ include('@Statistics/_kpi_compare_tiles.html.twig', {
+                    metrics: selfBenchmarkFrame.kpiMetrics,
+                    suppressRatios: selfBenchmarkFrame.benchmarkSuppressRatios,
+                    sideAShortKey: 'stats.overview.kpi.current_short',
+                    sideBShortKey: 'stats.overview.kpi.base_short',
+                    testIdPrefix: 'stats-executive-kpi',
+                    columnClass: 'col-12 col-md-4',
+                    metricLabelKeys: overviewKpiMetricLabelKeys|default({}),
+                    metricHintKeys: overviewKpiCasesPerDayHintKey is defined and overviewKpiCasesPerDayHintKey is not null ? {cases_per_day: overviewKpiCasesPerDayHintKey} : {},
+                    metricHintBelowValue: overviewKpiHintBelowValue|default(false),
+                }) }}
+            </div>
+        </div>
+        <div class="col-lg-4 d-flex flex-column gap-3">
+            {% if selfBenchmarkFrame.hospitalInsights is not empty %}
+                {% set hasOwnedHospitals = app.user is not null and app.user.hospitals|length > 0 %}
+                <div class="card" data-testid="stats-overview-hospital-insights">
+                    <div class="card-header py-2">
+                        <h3 class="card-title mb-0">{% if hasOwnedHospitals %}{{ 'monthly_reminder.section.insights'|trans({}, 'engagement') }}{% else %}{{ 'stats.overview.section.key_findings'|trans({}, 'statistics') }}{% endif %}</h3>
+                    </div>
+                    <div class="card-body d-flex flex-column gap-3 py-3">
+                        {% for insight in selfBenchmarkFrame.hospitalInsights %}
+                            <div class="d-flex align-items-start gap-2{% if not loop.last %} pb-3 border-bottom{% endif %}"
+                                 data-testid="stats-overview-hospital-insight-{{ loop.index }}">
+                                <span class="mt-1 flex-shrink-0 {% if insight.trend.value == 'up' %}text-success{% elseif insight.trend.value == 'down' %}text-danger{% else %}text-secondary{% endif %}">
+                                    {% if insight.trend.value == 'up' %}
+                                        <twig:ux:icon name="tabler:arrow-up" class="icon icon-sm" />
+                                    {% elseif insight.trend.value == 'down' %}
+                                        <twig:ux:icon name="tabler:arrow-down" class="icon icon-sm" />
+                                    {% else %}
+                                        <twig:ux:icon name="tabler:circle-filled" class="icon icon-xs" />
+                                    {% endif %}
+                                </span>
+                                <div class="min-w-0">
+                                    <div class="fw-medium mb-1">{{ insight.title }}</div>
+                                    <p class="text-secondary small mb-1">{{ insight.body }}</p>
+                                    {% if insight.linkUrl %}
+                                        <a href="{{ insight.linkUrl }}" class="small">{{ 'monthly_reminder.insight.link'|trans({}, 'engagement') }}</a>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</turbo-frame>

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_placeholder.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_placeholder.html.twig
@@ -1,0 +1,41 @@
+{# Skeleton for lazy-loaded overview self-benchmark (KPI tiles + insights). #}
+<div class="row g-3 mb-1" data-testid="stats-overview-self-benchmark-placeholder" aria-busy="true" aria-live="polite">
+    <div class="col-lg-8 min-w-0">
+        <div class="row row-deck row-cards g-3">
+            {% for i in 1..6 %}
+                <div class="col-12 col-md-4">
+                    <div class="card h-100 placeholder-glow">
+                        <div class="card-body d-flex flex-column">
+                            <div class="placeholder placeholder-xs col-7 mb-3"></div>
+                            <div class="placeholder col-5 mb-3" style="height: 1.75rem;"></div>
+                            <div class="mt-auto d-flex justify-content-between">
+                                <div class="placeholder placeholder-xs col-4"></div>
+                                <div class="placeholder placeholder-xs col-4"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="card h-100 placeholder-glow">
+            <div class="card-header py-2">
+                <div class="placeholder placeholder-xs col-6"></div>
+            </div>
+            <div class="card-body d-flex flex-column gap-3 py-3">
+                {% for i in 1..3 %}
+                    <div class="d-flex align-items-start gap-2{% if not loop.last %} pb-3 border-bottom{% endif %}">
+                        <div class="avatar avatar-sm placeholder flex-shrink-0 mt-1"></div>
+                        <div class="min-w-0 flex-fill">
+                            <div class="placeholder placeholder-xs col-8 mb-2"></div>
+                            <div class="placeholder placeholder-xs col-11 mb-1"></div>
+                            <div class="placeholder placeholder-xs col-9"></div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    <span class="visually-hidden">{{ 'stats.overview.self_benchmark.loading'|trans({}, 'statistics') }}</span>
+</div>

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_top_reports_placeholder.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_top_reports_placeholder.html.twig
@@ -1,0 +1,37 @@
+{# Skeleton for lazy-loaded overview top-report cards. #}
+<div class="row g-3" data-testid="stats-overview-top-reports-placeholder" aria-busy="true" aria-live="polite">
+    {% for i in 1..6 %}
+        <div class="col-md-6">
+            <div class="card h-100 placeholder-glow">
+                <div class="card-header py-2">
+                    <div class="placeholder placeholder-xs col-6"></div>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table mb-0">
+                            <thead>
+                                <tr>
+                                    <th><div class="placeholder placeholder-xs col-4"></div></th>
+                                    <th><div class="placeholder placeholder-xs col-8"></div></th>
+                                    <th class="text-end"><div class="placeholder placeholder-xs col-6 ms-auto"></div></th>
+                                    <th class="text-end"><div class="placeholder placeholder-xs col-6 ms-auto"></div></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in 1..5 %}
+                                    <tr>
+                                        <td><div class="placeholder placeholder-xs col-3"></div></td>
+                                        <td><div class="placeholder placeholder-xs col-9"></div></td>
+                                        <td class="text-end"><div class="placeholder placeholder-xs col-5 ms-auto"></div></td>
+                                        <td class="text-end"><div class="placeholder placeholder-xs col-5 ms-auto"></div></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+    <span class="visually-hidden">{{ 'stats.overview.top_reports.loading'|trans({}, 'statistics') }}</span>
+</div>

--- a/src/Statistics/UI/Twig/templates/dashboard/index.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/index.html.twig
@@ -64,6 +64,15 @@
                  data-testid="stats-charts"
                  data-controller="indication-dashboard-charts"
                  data-indication-dashboard-charts-payload-value="{{ executiveDashboard.charts.chartPayload|json_encode|e('html_attr') }}">
+                <div class="col-12">
+                    <turbo-frame id="stats-overview-self-benchmark"
+                                 src="{{ overviewSelfBenchmarkUrl }}"
+                                 loading="lazy"
+                                 target="_top"
+                                 data-testid="stats-overview-self-benchmark-frame">
+                        {{ include('@Statistics/dashboard/_overview_self_benchmark_placeholder.html.twig') }}
+                    </turbo-frame>
+                </div>
                 {{ include('@Statistics/dashboard/_overview_charts_main.html.twig') }}
                 {{ include('@Statistics/dashboard/_overview_charts_sidebar.html.twig') }}
             </div>

--- a/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
+++ b/tests/Engagement/Integration/Application/MonthlyReminderSenderTest.php
@@ -137,6 +137,23 @@ final class MonthlyReminderSenderTest extends DatabaseKernelTestCase
         }
     }
 
+    public function testAdminTriggerReturnsErrorWhenAlreadySentRecently(): void
+    {
+        $hospital = $this->createHospital(optedOut: false);
+        $referenceDate = $this->frozenReferenceDate();
+
+        self::assertSame([], $this->sender->sendForHospital(
+            $hospital,
+            MonthlyReminderTrigger::Admin,
+            $referenceDate,
+        ));
+
+        self::assertSame(
+            ['monthly_reminder.error.already_sent_recently'],
+            $this->sender->sendForHospital($hospital, MonthlyReminderTrigger::Admin, $referenceDate),
+        );
+    }
+
     public function testSchedulerSendPersistsDispatchLogForReportingPeriod(): void
     {
         $hospital = $this->createHospital(optedOut: false);

--- a/tests/Statistics/Functional/Controller/DashboardControllerWidgetsTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerWidgetsTest.php
@@ -41,20 +41,26 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         $this->assertSelectorTextContains('[data-testid="stats-hospital-summary"]', 'Total allocations');
         $this->assertSelectorTextContains('[data-testid="stats-hospital-summary"]', 'Gender distribution');
         $this->assertSelectorTextContains('[data-testid="stats-hospital-summary"]', 'Emergency');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpis"]');
-        $this->assertCount(6, $crawler->filter('[data-testid="stats-executive-kpis"] .card'));
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-cases_per_day"]');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-median_age"]');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-age_80_plus"]');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-night_daytime"]');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-weekend"]');
-        $this->assertSelectorExists('[data-testid="stats-executive-kpi-median_transport"]');
+        $this->assertSelectorExists('[data-testid="stats-overview-self-benchmark-frame"]');
+        self::assertSame(
+            '_top',
+            $crawler->filter('[data-testid="stats-overview-self-benchmark-frame"]')->attr('target'),
+        );
+        self::assertStringContainsString(
+            '/statistics/overview/self-benchmark',
+            (string) $crawler->filter('[data-testid="stats-overview-self-benchmark-frame"]')->attr('src'),
+        );
+        $this->assertSelectorExists('[data-testid="stats-overview-self-benchmark-placeholder"]');
+        $this->assertSelectorExists('[data-testid="stats-overview-self-benchmark-placeholder"] .placeholder-glow');
+        $this->assertSelectorNotExists('[data-testid="stats-executive-kpis"]');
         $this->assertSelectorExists('[data-testid="stats-executive-indications"]');
         $this->assertSelectorExists('[data-testid="stats-overview-top-reports-frame"]');
         self::assertSame(
             '_top',
             $crawler->filter('[data-testid="stats-overview-top-reports-frame"]')->attr('target'),
         );
+        $this->assertSelectorExists('[data-testid="stats-overview-top-reports-placeholder"]');
+        $this->assertSelectorExists('[data-testid="stats-overview-top-reports-placeholder"] .placeholder-glow');
         $this->assertSelectorNotExists('[data-testid="stats-overview-top-specialities"]');
         $this->assertSelectorExists('[data-testid="stats-overview-time-series"]');
         $this->assertSelectorExists('[data-testid="stats-overview-heatmap"]');
@@ -74,16 +80,16 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         $client = $this->createClientAsRoleUser();
         $this->seedOverviewHospitalInsightsScenario();
 
-        $crawler = $client->request(
+        $client->request(
             Request::METHOD_GET,
-            '/statistics/?scope=public&period=month&year=2026&month=6',
+            '/statistics/overview/self-benchmark?scope=public&period=month&year=2026&month=6',
         );
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorExists('[data-testid="stats-overview-hospital-insights"]');
         $this->assertGreaterThanOrEqual(
             1,
-            $crawler->filter('[data-testid^="stats-overview-hospital-insight-"]')->count(),
+            $client->getCrawler()->filter('[data-testid^="stats-overview-hospital-insight-"]')->count(),
         );
     }
 
@@ -115,7 +121,7 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         HospitalAccessGrantFactory::createOne(['user' => $participant, 'hospital' => $hospital]);
         $client->loginUser($participant);
 
-        $crawler = $client->request(Request::METHOD_GET, '/statistics/?scope=public&period=all_time');
+        $crawler = $client->request(Request::METHOD_GET, '/statistics/overview/self-benchmark?scope=public&period=all_time');
 
         $this->assertResponseIsSuccessful();
         $this->assertCasesPerDayAggregateHintPosition($crawler, belowValue: true);
@@ -128,7 +134,7 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         HospitalFactory::createOne(['owner' => $owner]);
         $client->loginUser($owner);
 
-        $crawler = $client->request(Request::METHOD_GET, '/statistics/?scope=public&period=all_time');
+        $crawler = $client->request(Request::METHOD_GET, '/statistics/overview/self-benchmark?scope=public&period=all_time');
 
         $this->assertResponseIsSuccessful();
         $this->assertCasesPerDayAggregateHintPosition($crawler, belowValue: false);
@@ -187,6 +193,26 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         $this->assertSelectorExists('[data-testid="stats-overview-top-occasions"]');
         $this->assertSelectorExists('[data-testid="stats-overview-top-infections"]');
         $this->assertSelectorExists('[data-testid="stats-overview-top-secondary-indications"]');
+    }
+
+    public function testOverviewSelfBenchmarkLazyEndpointRendersKpis(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/statistics/overview/self-benchmark?scope=public&period=month&year=2025&month=6',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('turbo-frame#stats-overview-self-benchmark');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpis"]');
+        $this->assertCount(6, $crawler->filter('[data-testid="stats-executive-kpis"] .card'));
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-cases_per_day"]');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-median_age"]');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-age_80_plus"]');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-night_daytime"]');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-weekend"]');
+        $this->assertSelectorExists('[data-testid="stats-executive-kpi-median_transport"]');
     }
 
     public function testDataQualityDrawerEndpointRendersDimensions(): void

--- a/tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php
+++ b/tests/Statistics/Functional/Controller/OverviewDashboardQueryCountTest.php
@@ -13,9 +13,8 @@ use Zenstruck\Foundry\Attribute\ResetDatabase;
 use Zenstruck\Foundry\Test\Factories;
 
 /**
- * Baseline before optimization (Jun 2026): 44 queries / ~299 ms on /statistics/ with broad hospital scope.
- * Target after Phase 1+2: ~18–22 queries on the synchronous overview path.
- * All-time time series is loaded in the same OverviewSliceQuery as scoped heatmaps (no extra round-trip).
+ * Sync overview path excludes Self-Benchmark (lazy Turbo-Frame).
+ * See docs/04-features/statistics/overview-dashboard-performance.md.
  */
 #[ResetDatabase]
 final class OverviewDashboardQueryCountTest extends WebTestCase
@@ -26,7 +25,7 @@ final class OverviewDashboardQueryCountTest extends WebTestCase
 
     private const int MAX_SYNC_QUERIES = 30;
 
-    public function testOverviewDashboardUsesBoundedQueryCount(): void
+    public function testOverviewDashboardUsesBoundedQueryCountWithoutSelfBenchmark(): void
     {
         $client = $this->createClientAsRoleUser();
         $client->enableProfiler();
@@ -46,5 +45,15 @@ final class OverviewDashboardQueryCountTest extends WebTestCase
             $queryCount,
             sprintf('Expected at most %d DB queries on overview sync path, got %d.', self::MAX_SYNC_QUERIES, $queryCount),
         );
+
+        $sqlParts = [];
+        foreach ($collector->getQueries() as $connectionQueries) {
+            foreach ($connectionQueries as $query) {
+                $sqlParts[] = (string) ($query['sql'] ?? '');
+            }
+        }
+        $sqlBlob = strtolower(implode("\n", $sqlParts));
+        self::assertStringNotContainsString(' as is_primary', $sqlBlob);
+        self::assertStringNotContainsString('as is_comparison', $sqlBlob);
     }
 }

--- a/tests/Statistics/Integration/Application/Overview/OverviewPeriodComparisonServiceIntegrationTest.php
+++ b/tests/Statistics/Integration/Application/Overview/OverviewPeriodComparisonServiceIntegrationTest.php
@@ -38,6 +38,19 @@ final class OverviewPeriodComparisonServiceIntegrationTest extends KernelTestCas
     {
         self::bootKernel();
 
+        $currentMonthStart = new \DateTimeImmutable('first day of this month')->setTime(0, 0, 0);
+        $previousMonthStart = $currentMonthStart->modify('-1 month');
+        $previousMonthMid = $previousMonthStart->setDate(
+            (int) $previousMonthStart->format('Y'),
+            (int) $previousMonthStart->format('n'),
+            10,
+        )->setTime(10, 0, 0);
+        $currentMonthMid = $currentMonthStart->setDate(
+            (int) $currentMonthStart->format('Y'),
+            (int) $currentMonthStart->format('n'),
+            10,
+        )->setTime(10, 0, 0);
+
         $user = UserFactory::createOne(['username' => 'overview-pop-'.bin2hex(random_bytes(4))]);
         $state = StateFactory::createOne(['name' => 'OverviewPopState']);
         $dispatchArea = DispatchAreaFactory::createOne(['name' => 'OverviewPopDispatch', 'state' => $state]);
@@ -65,8 +78,8 @@ final class OverviewPeriodComparisonServiceIntegrationTest extends KernelTestCas
             'gender' => AllocationGender::MALE,
             'urgency' => AllocationUrgency::EMERGENCY,
             'indicationNormalized' => $indicationNormalized,
-            'createdAt' => new \DateTimeImmutable('2025-05-10 10:00:00'),
-            'arrivalAt' => new \DateTimeImmutable('2025-05-10 10:20:00'),
+            'createdAt' => $previousMonthMid,
+            'arrivalAt' => $previousMonthMid->modify('+20 minutes'),
         ]);
         AllocationFactory::createMany(18, [
             'import' => $import,
@@ -76,8 +89,8 @@ final class OverviewPeriodComparisonServiceIntegrationTest extends KernelTestCas
             'gender' => AllocationGender::FEMALE,
             'urgency' => AllocationUrgency::INPATIENT,
             'indicationNormalized' => $indicationNormalized,
-            'createdAt' => new \DateTimeImmutable('2025-06-10 10:00:00'),
-            'arrivalAt' => new \DateTimeImmutable('2025-06-10 10:20:00'),
+            'createdAt' => $currentMonthMid,
+            'arrivalAt' => $currentMonthMid->modify('+20 minutes'),
         ]);
 
         self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($import->getId());
@@ -89,8 +102,8 @@ final class OverviewPeriodComparisonServiceIntegrationTest extends KernelTestCas
                 null,
                 null,
                 StatisticsFilterPeriod::Month,
-                2025,
-                6,
+                (int) $currentMonthStart->format('Y'),
+                (int) $currentMonthStart->format('n'),
             ),
         );
 

--- a/tests/Statistics/Integration/Application/StatisticsFilterInputFactoryTest.php
+++ b/tests/Statistics/Integration/Application/StatisticsFilterInputFactoryTest.php
@@ -45,6 +45,24 @@ final class StatisticsFilterInputFactoryTest extends DatabaseKernelTestCase
         self::assertSame('my_hospitals', $input->scope);
     }
 
+    public function testDefaultScopeIsPublicForAdmin(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $input = $this->factory->fromQuery($this->queryBag([]), $user);
+
+        self::assertSame('public', $input->scope);
+        self::assertFalse($input->hasScopeQueryParameter);
+    }
+
+    public function testAdminCanExplicitlySelectMyHospitalsScope(): void
+    {
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_ADMIN']]);
+        $input = $this->factory->fromQuery($this->queryBag(['scope' => 'my_hospitals']), $user);
+
+        self::assertSame('my_hospitals', $input->scope);
+        self::assertTrue($input->hasScopeQueryParameter);
+    }
+
     /**
      * @param array<string, string> $parameters
      *

--- a/tests/Statistics/Integration/Query/Benchmarking/BenchmarkAggregationProviderTest.php
+++ b/tests/Statistics/Integration/Query/Benchmarking/BenchmarkAggregationProviderTest.php
@@ -102,6 +102,66 @@ final class BenchmarkAggregationProviderTest extends KernelTestCase
         self::assertGreaterThan(0, \count($result->distributionRows));
     }
 
+    public function testAggregateForOverviewReturnsCoreKpisAndIndicationRowsOnly(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'benchmark-ov-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'BenchmarkOvState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'BenchmarkOvDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'BenchmarkOvHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'BenchmarkOvSpec']);
+        DepartmentFactory::createOne(['name' => 'BenchmarkOvDept']);
+        AssignmentFactory::createOne(['name' => 'BenchmarkOvAssign']);
+        IndicationRawFactory::createOne(['name' => 'BenchmarkOvRaw', 'code' => 912_410]);
+        $indication = IndicationNormalizedFactory::createOne(['name' => 'Benchmark Overview STEMI']);
+
+        $import = ImportFactory::createOne(['name' => 'BenchmarkOvImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createMany(3, [
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'age' => 82,
+            'isWithPhysician' => true,
+            'requiresResus' => true,
+            'indicationNormalized' => $indication,
+            'createdAt' => new \DateTimeImmutable('2026-03-15 02:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2026-03-15 02:30:00'),
+        ]);
+
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)->rebuildForImport($import->getId());
+
+        /** @var BenchmarkAggregationProvider $provider */
+        $provider = self::getContainer()->get(BenchmarkAggregationProvider::class);
+
+        $result = $provider->aggregateForOverview(
+            new StatisticsScopeCriteria([$hospital->getId()]),
+            new StatisticsPeriodBounds(new \DateTimeImmutable('2026-01-01 00:00:00')),
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+        );
+
+        self::assertSame(3, $result->primary->total);
+        self::assertSame(3, $result->primary->withPhysician);
+        self::assertSame(3, $result->primary->resus);
+        self::assertSame(0, $result->primary->cathlab);
+        self::assertNotEmpty($result->distributionRows);
+        foreach ($result->distributionRows as $row) {
+            self::assertSame('indication', $row->dimension);
+        }
+    }
+
     public function testReturnsEmptyResultForEmptyScopes(): void
     {
         self::bootKernel();

--- a/tests/Statistics/Integration/Query/Overview/OverviewSliceQueryTest.php
+++ b/tests/Statistics/Integration/Query/Overview/OverviewSliceQueryTest.php
@@ -36,7 +36,7 @@ final class OverviewSliceQueryTest extends KernelTestCase
 {
     use Factories;
 
-    public function testReturnsAllTimeMonthlyRowsWithScopedHeatmaps(): void
+    public function testReturnsPeriodScopedMonthlyRowsWithScopedHeatmaps(): void
     {
         self::bootKernel();
 
@@ -83,7 +83,6 @@ final class OverviewSliceQueryTest extends KernelTestCase
 
         self::assertSame(
             [
-                ['year' => 2024, 'month' => 1, 'count' => 1],
                 ['year' => 2025, 'month' => 6, 'count' => 1],
             ],
             $slice->monthlyRows,
@@ -91,6 +90,7 @@ final class OverviewSliceQueryTest extends KernelTestCase
         self::assertSame(1, $this->sumHeatmapCounts($slice->dayTimeHeatmapCells));
         self::assertSame(1, $this->sumHeatmapCounts($slice->shiftHeatmapCells));
         self::assertSame(1, array_sum($slice->transportTimeBucketCounts));
+        self::assertSame(1, $slice->transportTypeBucketCounts['1'] ?? 0);
     }
 
     public function testAllTimePeriodUsesSingleSlice(): void
@@ -145,6 +145,7 @@ final class OverviewSliceQueryTest extends KernelTestCase
         );
         self::assertSame(2, $this->sumHeatmapCounts($slice->dayTimeHeatmapCells));
         self::assertSame(2, array_sum($slice->transportTimeBucketCounts));
+        self::assertSame(2, $slice->transportTypeBucketCounts['1'] ?? 0);
     }
 
     /**

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkReportServiceTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkReportServiceTest.php
@@ -95,6 +95,54 @@ final class BenchmarkReportServiceTest extends TestCase
         self::assertFalse($report->suppressRatios);
     }
 
+    public function testBuildForOverviewSkipsHeavyDistributionsButKeepsKpis(): void
+    {
+        $aggregation = new BenchmarkAggregationResult(
+            new BenchmarkSideCounts(
+                500, 300, 40, 20, 50, 30, 10, 5, 3, 8, 200, 150, 150,
+                100, 90, 80, 260, 210, 0, 65.0, 45.0, 46.0,
+            ),
+            new BenchmarkSideCounts(
+                5000, 2500, 400, 200, 500, 300, 100, 50, 30, 80, 2000, 1500, 1500,
+                1000, 900, 800, 2600, 2100, 0, 65.0, 45.0, 46.0,
+            ),
+            [
+                new BenchmarkDistributionRow('indication', '7', 'STEMI', 120, 900),
+                new BenchmarkDistributionRow('transport_type', '1', null, 400, 4000),
+            ],
+        );
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $service = new BenchmarkReportService(
+            new FixedBenchmarkAggregationProvider($aggregation),
+            new BenchmarkMetricBuilder(),
+            new BenchmarkHeatmapBuilder($translator),
+            new BenchmarkInsightProvider(),
+        );
+
+        $report = $service->buildForOverview(new BenchmarkCriteria(
+            StatisticsScopeCriteria::public(),
+            StatisticsScopeCriteria::public(),
+            new StatisticsPeriodBounds(null),
+            new StatisticsPeriodBounds(null),
+            'Primary',
+            'Comparison',
+            '2024',
+            '2024',
+        ));
+
+        self::assertNotEmpty($report->kpiMetrics);
+        self::assertSame(BenchmarkMetricKey::IndicationMix, $report->indicationMix->dimension);
+        self::assertNotEmpty($report->indicationMix->buckets);
+        self::assertSame([], $report->insights);
+        self::assertSame([], $report->transportType->buckets);
+        self::assertSame([], $report->gender->buckets);
+        self::assertSame([], $report->dayTimeCaseDistribution->rowLabels);
+        self::assertSame([], $report->shiftCaseDistribution->rowLabels);
+    }
+
     public function testSuppressesRatiosWhenEitherSideHasFewerThanTwentyCases(): void
     {
         $aggregation = new BenchmarkAggregationResult(

--- a/tests/Statistics/Unit/Benchmarking/Stub/FixedBenchmarkAggregationProvider.php
+++ b/tests/Statistics/Unit/Benchmarking/Stub/FixedBenchmarkAggregationProvider.php
@@ -25,4 +25,14 @@ final readonly class FixedBenchmarkAggregationProvider implements BenchmarkAggre
     ): BenchmarkAggregationResult {
         return $this->result;
     }
+
+    #[\Override]
+    public function aggregateForOverview(
+        StatisticsScopeCriteria $primaryScope,
+        StatisticsPeriodBounds $primaryPeriod,
+        StatisticsScopeCriteria $comparisonScope,
+        StatisticsPeriodBounds $comparisonPeriod,
+    ): BenchmarkAggregationResult {
+        return $this->result;
+    }
 }

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -4489,6 +4489,14 @@
         <source>stats.overview.pretitle</source>
         <target>Statistik</target>
       </trans-unit>
+      <trans-unit id="DstatsOvSbLoad01" resname="stats.overview.self_benchmark.loading">
+        <source>stats.overview.self_benchmark.loading</source>
+        <target>Kennzahlen werden geladen…</target>
+      </trans-unit>
+      <trans-unit id="DstatsOvTrLoad01" resname="stats.overview.top_reports.loading">
+        <source>stats.overview.top_reports.loading</source>
+        <target>Top-Reports werden geladen…</target>
+      </trans-unit>
       <trans-unit id="Ded1014259" resname="stats.overview.section.key_findings">
         <source>stats.overview.section.key_findings</source>
         <target>Wesentliches</target>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -1277,6 +1277,14 @@
         <source>stats.overview.pretitle</source>
         <target>Statistics</target>
       </trans-unit>
+      <trans-unit id="statsOvSbLoad01" resname="stats.overview.self_benchmark.loading">
+        <source>stats.overview.self_benchmark.loading</source>
+        <target>Loading key metrics…</target>
+      </trans-unit>
+      <trans-unit id="statsOvTrLoad01" resname="stats.overview.top_reports.loading">
+        <source>stats.overview.top_reports.loading</source>
+        <target>Loading top reports…</target>
+      </trans-unit>
       <trans-unit id="statsOvKf01" resname="stats.overview.section.key_findings">
         <source>stats.overview.section.key_findings</source>
         <target>Key findings</target>


### PR DESCRIPTION
## Summary

This PR addresses [#408](https://github.com/nplhse/collaborative-ivena-statistics/issues/408) and follow-up overview performance/UX work discovered while profiling public/admin loads.

### Admin default scope
- Administrators opening `/statistics/` without an explicit `scope` query parameter now default to **`public`** instead of **`my_hospitals`**.
- For admins, `my_hospitals` previously expanded to *all* hospital IDs and applied expensive `hospital_id IN (...)` predicates across metrics/slice/benchmark — same population as public, worse plan.
- Participants with hospital access still default to `my_hospitals`; admins can still select that scope explicitly.

### First-paint performance
Profiler evidence for `GET /statistics/?period=all` (public) showed ~**5.3s** DB time dominated by self-benchmark:
- ~3.4s distribution aggregation (`WHERE (period OR 1=1)` full scan + large `UNION ALL`)
- ~1.7s core dual-scope metrics

Changes:
- **Defer** KPI tiles + hospital insights to a lazy Turbo Frame: `GET /statistics/overview/self-benchmark`.
- Sync overview path keeps metrics + slice charts only (no self-benchmark SQL on first paint).
- Add **`aggregateForOverview`**: reduced core counters + indication distribution only (full benchmarking page unchanged).
- Transport-type chart data moves into `OverviewSliceQuery` so charts no longer depend on `BenchmarkReport` on the sync path.

### Chart correctness & UX
- **Cases over time** now respects the selected period (previously forced all-time monthly rows whenever a period filter was present).
- Time-series Y-axis is pinned to **0** for a stable visual baseline.
- Tabler **`placeholder-glow`** skeletons for self-benchmark and top-reports lazy frames (replacing empty spinner-only states).

### Docs
- Documented admin default scope in `statistics-filter-and-scope.md`.
- Added `overview-dashboard-performance.md` with profiler findings and mitigation notes.

## Commits

1. `fix(statistics): default admin overview scope to public`
2. `fix(statistics): scope overview time series to the selected period`
3. `perf(statistics): lazy-load overview self-benchmark with slim aggregation`

## Test plan

- [x] As `ROLE_ADMIN`, open `/statistics/` with no `scope` → UI/query uses **public**; `?scope=my_hospitals` still works.
- [x] As participant with owned hospitals, default remains **my_hospitals**.
- [x] Overview first paint shows skeletons for KPIs/insights and top reports, then fills via Turbo Frames.
- [x] With `period=month` (or year/quarter), **Cases over time** only includes months inside that period.
- [x] Time-series chart Y-axis starts at 0.
- [x] `/statistics/benchmarking` still behaves as before (full aggregation path).
- [x] `make ci` passes; targeted Statistics tests for filter defaults, slice query, aggregation, widgets, and sync query budget pass.