### PR TITLE
fix(statistics): filter dispatch_area scope by allocation origin

### DIFF
--- a/docs/04-features/statistics/statistics-filter-and-scope.md
+++ b/docs/04-features/statistics/statistics-filter-and-scope.md
@@ -10,10 +10,16 @@ Most statistics pages share a common filter model resolved by `StatisticsFilterF
 |-------|---------|
 | `public` | Aggregated public view (anonymous or fallback) |
 | `my_hospitals` | Hospitals the current user can access |
-| `hospital` | Single hospital (`scope:hospital:ID`) |
+| `hospital` | Allocations **to** a single hospital (`scope=hospital:ID` → `hospital_id = ID`) |
 | `hospital_cohort` | Cohort of hospitals |
-| `state` | Federal state |
-| `dispatch_area` | Dispatch area |
+| `state` | Federal state via hospital attribution (see note below) |
+| `dispatch_area` | Allocations **originating from** a dispatch area (`scope=dispatch_area:ID` → `dispatch_area_id = ID`) |
+
+Hospital and dispatch area are orthogonal: destination hospital ≠ origin dispatch area. A hospital can receive cases from multiple Leitstellen; dispatch-area scope always filters projection rows by origin `dispatch_area_id`, never by expanding a 1:1 hospital portfolio.
+
+### State scope note
+
+`state` currently expands to hospital IDs via `mv_projection_hospital_dimensions` (`MIN(state_id)` per hospital), then applies `hospital_id IN (...)`. Whether state should mean allocation origin (`state_id` on the projection) like dispatch area is an open follow-up; do not assume the same semantics as `dispatch_area`.
 
 ## Periods
 
@@ -39,6 +45,8 @@ Admins can still select `my_hospitals` explicitly via `?scope=my_hospitals`.
 - Cohort too small → `public` with notice `cohort_too_small`
 - State/dispatch area with fewer than 2 hospitals → `public` with `state_invalid` / `dispatch_area_invalid`
 
+Dispatch-area eligibility uses distinct hospitals that appear with that origin `dispatch_area_id` (count MV). Filtering then uses `dispatch_area_id = :id` on `allocation_stats_projection` via `StatisticsScopeCriteria.dispatchAreaId`.
+
 ## Comparison scope
 
 `ComparisonScopeResolver` builds a secondary filter for benchmarking and comparison views. It derives a default cohort from the primary scope's dominant location/tier via `AllocationStatsProjectionScopeQuery`.
@@ -56,6 +64,8 @@ Permission checks use `HospitalPermission::Statistics` or `HospitalPermission::B
 
 - `src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php` (default scope)
 - `src/Statistics/Application/StatisticsFilterFactory.php`
+- `src/Statistics/Application/StatisticsScopeResolver.php`
+- `src/Statistics/Application/DTO/StatisticsScopeCriteria.php`
 - `src/Statistics/Application/ComparisonScopeResolver.php`
 - `src/Statistics/Application/DTO/StatisticsFilterScope.php`
 

--- a/src/Statistics/Application/DTO/StatisticsScopeCriteria.php
+++ b/src/Statistics/Application/DTO/StatisticsScopeCriteria.php
@@ -18,6 +18,7 @@ final readonly class StatisticsScopeCriteria
         public ?array $locationCodes = null,
         public ?array $tierCodes = null,
         public ?HospitalCohortKey $cohortType = null,
+        public ?int $dispatchAreaId = null,
     ) {
     }
 

--- a/src/Statistics/Application/HospitalSummaryQuery.php
+++ b/src/Statistics/Application/HospitalSummaryQuery.php
@@ -21,8 +21,10 @@ final readonly class HospitalSummaryQuery
     public function summarize(StatisticsContext $context, OverviewDashboardMetricsResult $metrics): HospitalSummaryData
     {
         $scope = $context->filter->scope;
+        $criteria = $this->scopeResolver->resolveCriteria($context);
         $usedUnscopedFallback = StatisticsFilterScope::Public !== $scope
-            && null === $this->scopeResolver->resolveCriteria($context)->hospitalIds;
+            && null === $criteria->hospitalIds
+            && null === $criteria->dispatchAreaId;
 
         return $this->buildDataFromDistributions(
             $metrics->platformTotal,

--- a/src/Statistics/Application/Overview/OverviewDefaultPeriodResolver.php
+++ b/src/Statistics/Application/Overview/OverviewDefaultPeriodResolver.php
@@ -22,8 +22,8 @@ final readonly class OverviewDefaultPeriodResolver
 
     public function resolveDefaultPeriod(StatisticsContext $context): StatisticsFilterPeriod
     {
-        $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
-        if (\is_array($hospitalIds) && [] === $hospitalIds) {
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
+        if (\is_array($scopeCriteria->hospitalIds) && [] === $scopeCriteria->hospitalIds) {
             return StatisticsFilterPeriod::AllTime;
         }
 
@@ -31,7 +31,8 @@ final readonly class OverviewDefaultPeriodResolver
         foreach ($this->timeSeriesQuery->countByMonthInPeriod(
             StatisticsPeriod::overviewPeriodStart(),
             null,
-            $hospitalIds,
+            $scopeCriteria->hospitalIds,
+            $scopeCriteria->dispatchAreaId,
         ) as $row) {
             if ($row['count'] > 0) {
                 ++$monthsWithData;

--- a/src/Statistics/Application/Overview/OverviewExecutiveDashboardAssembler.php
+++ b/src/Statistics/Application/Overview/OverviewExecutiveDashboardAssembler.php
@@ -29,7 +29,7 @@ final readonly class OverviewExecutiveDashboardAssembler
         OverviewDashboardMetricsResult $metrics,
     ): OverviewExecutiveDashboardViewModel {
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
         $benchmarkingUrl = $this->navigationUrlBuilder->build($request, 'app_stats_benchmarking');
 
         return new OverviewExecutiveDashboardViewModel(
@@ -43,7 +43,11 @@ final readonly class OverviewExecutiveDashboardAssembler
             $benchmarkingUrl,
             $this->populationProfileFactory->build($metrics),
             $this->chartsFactory->build(
-                OverviewQueryCriteria::fromPeriodBounds($bounds, $hospitalIds),
+                OverviewQueryCriteria::fromPeriodBounds(
+                    $bounds,
+                    $scopeCriteria->hospitalIds,
+                    $scopeCriteria->dispatchAreaId,
+                ),
                 $metrics,
             ),
             [],

--- a/src/Statistics/Application/Overview/OverviewPeriodComparisonService.php
+++ b/src/Statistics/Application/Overview/OverviewPeriodComparisonService.php
@@ -38,12 +38,14 @@ final readonly class OverviewPeriodComparisonService
 
         $previousContext = new StatisticsContext($context->user, $previousFilter);
         $bounds = StatisticsPeriodResolver::resolve($previousFilter);
-        $hospitalIds = $this->scopeResolver->resolveCriteria($previousContext)->hospitalIds;
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($previousContext);
 
         return $this->timeSeriesQuery->countCreatedInPeriod(
             $bounds->from,
             $bounds->toExclusive,
-            $hospitalIds,
+            $scopeCriteria->hospitalIds,
+            null,
+            $scopeCriteria->dispatchAreaId,
         );
     }
 

--- a/src/Statistics/Application/Overview/OverviewTopReportsFactory.php
+++ b/src/Statistics/Application/Overview/OverviewTopReportsFactory.php
@@ -31,9 +31,13 @@ final readonly class OverviewTopReportsFactory
     public function build(Request $request, StatisticsContext $context, int $scopedTotal): array
     {
         $bounds = StatisticsPeriodResolver::resolve($context->filter);
-        $hospitalIds = $this->scopeResolver->resolveCriteria($context)->hospitalIds;
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
         $batch = ($this->batchQuery)(
-            OverviewQueryCriteria::fromPeriodBounds($bounds, $hospitalIds),
+            OverviewQueryCriteria::fromPeriodBounds(
+                $bounds,
+                $scopeCriteria->hospitalIds,
+                $scopeCriteria->dispatchAreaId,
+            ),
             self::TOP_LIMIT,
         );
 

--- a/src/Statistics/Application/StatisticsScopeResolver.php
+++ b/src/Statistics/Application/StatisticsScopeResolver.php
@@ -10,7 +10,6 @@ use App\Statistics\Application\DTO\StatisticsContext;
 use App\Statistics\Application\DTO\StatisticsFilterScope;
 use App\Statistics\Application\DTO\StatisticsScopeCriteria;
 use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByCohortQuery;
-use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByDispatchAreaQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery;
 use App\User\Domain\Entity\User;
 
@@ -24,7 +23,6 @@ final class StatisticsScopeResolver
         private readonly HospitalAccessInterface $hospitalAccess,
         private readonly HospitalCohortResolver $hospitalCohortResolver,
         private readonly GetDistinctHospitalIdsByStateQuery $distinctHospitalIdsByStateQuery,
-        private readonly GetDistinctHospitalIdsByDispatchAreaQuery $distinctHospitalIdsByDispatchAreaQuery,
         private readonly GetDistinctHospitalIdsByCohortQuery $distinctHospitalIdsByCohortQuery,
     ) {
     }
@@ -59,9 +57,10 @@ final class StatisticsScopeResolver
 
             $criteria = new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
         } elseif (StatisticsFilterScope::DispatchArea === $filter->scope && null !== $filter->dispatchAreaId) {
-            $hospitalIds = ($this->distinctHospitalIdsByDispatchAreaQuery)($filter->dispatchAreaId);
-
-            $criteria = new StatisticsScopeCriteria([] === $hospitalIds ? null : $hospitalIds);
+            $criteria = new StatisticsScopeCriteria(
+                hospitalIds: null,
+                dispatchAreaId: $filter->dispatchAreaId,
+            );
         } elseif (StatisticsFilterScope::HospitalCohort === $filter->scope && $filter->cohortType instanceof Cohort\HospitalCohortKey) {
             $cohort = $this->hospitalCohortResolver->resolve($filter->cohortType);
             $hospitalIds = ($this->distinctHospitalIdsByCohortQuery)($cohort);

--- a/src/Statistics/Application/TopDiagnosesQuery.php
+++ b/src/Statistics/Application/TopDiagnosesQuery.php
@@ -38,6 +38,7 @@ final readonly class TopDiagnosesQuery
             $scopeCriteria->hospitalIds,
             $limit,
             $drawerFilter,
+            $scopeCriteria->dispatchAreaId,
         );
 
         $total = $totalAllocations ?? $this->timeSeriesQuery->countCreatedInPeriod(
@@ -45,6 +46,7 @@ final readonly class TopDiagnosesQuery
             $bounds->toExclusive,
             $scopeCriteria->hospitalIds,
             $drawerFilter,
+            $scopeCriteria->dispatchAreaId,
         );
 
         return [

--- a/src/Statistics/Application/TopEntityQuery.php
+++ b/src/Statistics/Application/TopEntityQuery.php
@@ -43,6 +43,7 @@ final readonly class TopEntityQuery
             $projectionJoinProperty,
             $entityFqcn,
             $drawerFilter,
+            $scopeCriteria->dispatchAreaId,
         );
 
         $total = $totalAllocations ?? $this->timeSeriesQuery->countCreatedInPeriod(
@@ -50,6 +51,7 @@ final readonly class TopEntityQuery
             $bounds->toExclusive,
             $scopeCriteria->hospitalIds,
             $drawerFilter,
+            $scopeCriteria->dispatchAreaId,
         );
 
         return [

--- a/src/Statistics/Application/TopIndicationGroupsQuery.php
+++ b/src/Statistics/Application/TopIndicationGroupsQuery.php
@@ -33,9 +33,16 @@ final readonly class TopIndicationGroupsQuery
             $bounds->toExclusive,
             $scopeCriteria->hospitalIds,
             $limit,
+            $scopeCriteria->dispatchAreaId,
         );
 
-        $total = $this->timeSeriesQuery->countCreatedInPeriod($bounds->from, $bounds->toExclusive, $scopeCriteria->hospitalIds);
+        $total = $this->timeSeriesQuery->countCreatedInPeriod(
+            $bounds->from,
+            $bounds->toExclusive,
+            $scopeCriteria->hospitalIds,
+            null,
+            $scopeCriteria->dispatchAreaId,
+        );
 
         return [
             'rows' => $rows,

--- a/src/Statistics/Benchmarking/Infrastructure/Query/BenchmarkSqlFilter.php
+++ b/src/Statistics/Benchmarking/Infrastructure/Query/BenchmarkSqlFilter.php
@@ -49,6 +49,11 @@ final class BenchmarkSqlFilter
             $types[sprintf('%s_hospital_ids', $prefix)] = ArrayParameterType::INTEGER;
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = sprintf('%sdispatch_area_id = :%s_dispatch_area_id', $columnPrefix, $prefix);
+            $params[sprintf('%s_dispatch_area_id', $prefix)] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $locationCodes = array_map(intval(...), $scope->locationCodes);
             $conditions[] = sprintf('%shospital_location_code IN (:%s_location_codes)', $columnPrefix, $prefix);

--- a/src/Statistics/CaseFlow/Infrastructure/Query/CaseFlowSqlFilter.php
+++ b/src/Statistics/CaseFlow/Infrastructure/Query/CaseFlowSqlFilter.php
@@ -48,6 +48,11 @@ final class CaseFlowSqlFilter
             }
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = sprintf('%sdispatch_area_id = :dispatch_area_id', $prefix);
+            $params['dispatch_area_id'] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $locationCodes = array_map(intval(...), $scope->locationCodes);
             $conditions[] = sprintf('%shospital_location_code IN (:location_codes)', $prefix);

--- a/src/Statistics/DataQuality/Infrastructure/Query/DataQualitySqlFilter.php
+++ b/src/Statistics/DataQuality/Infrastructure/Query/DataQualitySqlFilter.php
@@ -54,6 +54,11 @@ final class DataQualitySqlFilter
             }
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = sprintf('%sdispatch_area_id = :dispatch_area_id', $prefix);
+            $params['dispatch_area_id'] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $locationCodes = array_map(intval(...), $scope->locationCodes);
             $conditions[] = sprintf('%shospital_location_code IN (:location_codes)', $prefix);

--- a/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAnalysisScopeSqlFilter.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericAnalysisScopeSqlFilter.php
@@ -44,6 +44,11 @@ final class GenericAnalysisScopeSqlFilter
             }
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = 'dispatch_area_id = :scope_dispatch_area_id';
+            $params['scope_dispatch_area_id'] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $conditions[] = 'hospital_location_code IN (:scope_location_codes)';
             $params['scope_location_codes'] = $scope->locationCodes;

--- a/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericHospitalScopeSqlFilter.php
+++ b/src/Statistics/GenericAnalysis/Infrastructure/Query/GenericHospitalScopeSqlFilter.php
@@ -31,6 +31,11 @@ final class GenericHospitalScopeSqlFilter
             }
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = 'h.id IN (SELECT DISTINCT asp.hospital_id FROM allocation_stats_projection asp WHERE asp.dispatch_area_id = :scope_dispatch_area_id)';
+            $params['scope_dispatch_area_id'] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $locations = [];
             foreach ($scope->locationCodes as $code) {

--- a/src/Statistics/Infrastructure/Query/IndicationDashboard/IndicationDashboardSqlFilter.php
+++ b/src/Statistics/Infrastructure/Query/IndicationDashboard/IndicationDashboardSqlFilter.php
@@ -48,6 +48,11 @@ final class IndicationDashboardSqlFilter
             }
         }
 
+        if (null !== $scope->dispatchAreaId) {
+            $conditions[] = sprintf('%sdispatch_area_id = :dispatch_area_id', $prefix);
+            $params['dispatch_area_id'] = $scope->dispatchAreaId;
+        }
+
         if (null !== $scope->locationCodes) {
             $locationCodes = array_map(intval(...), $scope->locationCodes);
             $conditions[] = sprintf('%shospital_location_code IN (:location_codes)', $prefix);

--- a/src/Statistics/Infrastructure/Query/IndicationGroup/ProjectionTopIndicationGroupsQuery.php
+++ b/src/Statistics/Infrastructure/Query/IndicationGroup/ProjectionTopIndicationGroupsQuery.php
@@ -23,8 +23,13 @@ final readonly class ProjectionTopIndicationGroupsQuery
      *
      * @return list<array{groupId: int, label: string, count: int}>
      */
-    public function fetchTopGroupAggregates(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds, int $limit): array
-    {
+    public function fetchTopGroupAggregates(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $toExclusive,
+        ?array $hospitalIds,
+        int $limit,
+        ?int $dispatchAreaId = null,
+    ): array {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p')
             ->innerJoin(IndicationNormalized::class, 'inorm', 'WITH', 'inorm.id = p.indicationNormalizedId')
@@ -36,6 +41,7 @@ final readonly class ProjectionTopIndicationGroupsQuery
 
         $this->filterApplier->applyCreatedAtRange($qb, 'p.createdAt', $from, $toExclusive);
         $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+        $this->filterApplier->applyDispatchAreaScope($qb, 'p.dispatchAreaId', $dispatchAreaId);
 
         /** @var list<array{groupId:int|string,label:string,cnt:numeric-string|int}> $rows */
         $rows = $qb->getQuery()->getArrayResult();

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewProjectionSqlFilter.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewProjectionSqlFilter.php
@@ -33,6 +33,11 @@ final class OverviewProjectionSqlFilter
             $conditions[] = sprintf('%shospital_id IN (%s)', $prefix, implode(',', $ids));
         }
 
+        if (null !== $criteria->dispatchAreaId) {
+            $conditions[] = sprintf('%sdispatch_area_id = :dispatch_area_id', $prefix);
+            $params['dispatch_area_id'] = $criteria->dispatchAreaId;
+        }
+
         return [implode(' AND ', $conditions), $params];
     }
 }

--- a/src/Statistics/Infrastructure/Query/Overview/OverviewQueryCriteria.php
+++ b/src/Statistics/Infrastructure/Query/Overview/OverviewQueryCriteria.php
@@ -15,15 +15,19 @@ final readonly class OverviewQueryCriteria
         public ?\DateTimeImmutable $from,
         public ?\DateTimeImmutable $toExclusive,
         public ?array $hospitalIds,
+        public ?int $dispatchAreaId = null,
     ) {
     }
 
     /**
      * @param list<int>|null $hospitalIds
      */
-    public static function fromPeriodBounds(StatisticsPeriodBounds $bounds, ?array $hospitalIds): self
-    {
-        return new self($bounds->from, $bounds->toExclusive, $hospitalIds);
+    public static function fromPeriodBounds(
+        StatisticsPeriodBounds $bounds,
+        ?array $hospitalIds,
+        ?int $dispatchAreaId = null,
+    ): self {
+        return new self($bounds->from, $bounds->toExclusive, $hospitalIds, $dispatchAreaId);
     }
 
     public function hasEmptyHospitalScope(): bool

--- a/src/Statistics/Infrastructure/Query/ProjectionDiagnosisQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionDiagnosisQuery.php
@@ -29,8 +29,9 @@ final readonly class ProjectionDiagnosisQuery
         ?array $hospitalIds,
         int $limit,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): array {
-        $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds, $drawerFilter)
+        $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds, $drawerFilter, $dispatchAreaId)
             ->leftJoin(\App\Allocation\Domain\Entity\IndicationNormalized::class, 'inorm', 'WITH', 'inorm.id = p.indicationNormalizedId')
             ->select('inorm.id AS indicationId', 'COALESCE(inorm.name, :unknown) AS label', 'COUNT(p.id) AS cnt')
             ->setParameter('unknown', 'Unknown')
@@ -63,11 +64,13 @@ final readonly class ProjectionDiagnosisQuery
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): QueryBuilder {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');
         $this->filterApplier->applyCreatedAtRange($qb, 'p.createdAt', $from, $toExclusive);
         $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+        $this->filterApplier->applyDispatchAreaScope($qb, 'p.dispatchAreaId', $dispatchAreaId);
 
         if ($drawerFilter instanceof StatisticsDrawerFilter && $drawerFilter->isActive()) {
             $this->drawerFilterApplier->apply($qb, $drawerFilter);

--- a/src/Statistics/Infrastructure/Query/ProjectionFilterApplier.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionFilterApplier.php
@@ -46,14 +46,29 @@ final class ProjectionFilterApplier
             ->setParameter('hospitalIds', $hospitalIds);
     }
 
+    public function applyDispatchAreaScope(QueryBuilder $qb, string $field, ?int $dispatchAreaId): void
+    {
+        if (null === $dispatchAreaId) {
+            return;
+        }
+
+        $qb->andWhere(sprintf('%s = :dispatchAreaId', $field))
+            ->setParameter('dispatchAreaId', $dispatchAreaId);
+    }
+
     public function applyScopeCriteria(
         QueryBuilder $qb,
         string $hospitalIdField,
         StatisticsScopeCriteria $criteria,
         ?string $locationCodeField = null,
         ?string $tierCodeField = null,
+        ?string $dispatchAreaIdField = null,
     ): void {
         $this->applyHospitalScope($qb, $hospitalIdField, $criteria->hospitalIds);
+
+        if (null !== $dispatchAreaIdField) {
+            $this->applyDispatchAreaScope($qb, $dispatchAreaIdField, $criteria->dispatchAreaId);
+        }
 
         if (null !== $locationCodeField && null !== $criteria->locationCodes) {
             $qb->andWhere(sprintf('%s IN (:cohortLocationCodes)', $locationCodeField))

--- a/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTimeSeriesQuery.php
@@ -33,8 +33,9 @@ final class ProjectionTimeSeriesQuery
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): int {
-        return (int) $this->createBaseCountQb($from, $toExclusive, $hospitalIds, $drawerFilter)
+        return (int) $this->createBaseCountQb($from, $toExclusive, $hospitalIds, $drawerFilter, $dispatchAreaId)
             ->select('COUNT(p.id)')
             ->getQuery()
             ->getSingleScalarResult();
@@ -88,9 +89,13 @@ final class ProjectionTimeSeriesQuery
      *
      * @return list<array{year:int,month:int,count:int}>
      */
-    public function countByMonthInPeriod(?\DateTimeImmutable $from, ?\DateTimeImmutable $toExclusive, ?array $hospitalIds): array
-    {
-        $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds)
+    public function countByMonthInPeriod(
+        ?\DateTimeImmutable $from,
+        ?\DateTimeImmutable $toExclusive,
+        ?array $hospitalIds,
+        ?int $dispatchAreaId = null,
+    ): array {
+        $qb = $this->createBaseCountQb($from, $toExclusive, $hospitalIds, null, $dispatchAreaId)
             ->select('p.createdYear AS year', 'p.createdMonth AS month', 'COUNT(p.id) AS count')
             ->groupBy('year', 'month')
             ->orderBy('year', 'ASC')
@@ -361,11 +366,13 @@ final class ProjectionTimeSeriesQuery
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): QueryBuilder {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');
         $this->filterApplier->applyCreatedAtRange($qb, 'p.createdAt', $from, $toExclusive);
         $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+        $this->filterApplier->applyDispatchAreaScope($qb, 'p.dispatchAreaId', $dispatchAreaId);
 
         if ($drawerFilter instanceof StatisticsDrawerFilter && $drawerFilter->isActive()) {
             $this->drawerFilterApplier->apply($qb, $drawerFilter);

--- a/src/Statistics/Infrastructure/Query/ProjectionTopEntityQuery.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionTopEntityQuery.php
@@ -31,8 +31,9 @@ final readonly class ProjectionTopEntityQuery
         string $projectionJoinProperty,
         string $entityFqcn,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): array {
-        $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds, $drawerFilter)
+        $qb = $this->createBaseQb($from, $toExclusive, $hospitalIds, $drawerFilter, $dispatchAreaId)
             ->leftJoin($entityFqcn, 'ent', 'WITH', sprintf('ent.id = p.%s', $projectionJoinProperty))
             ->select('COALESCE(ent.name, :unknown) AS label', 'COUNT(p.id) AS cnt')
             ->setParameter('unknown', 'Unknown')
@@ -57,11 +58,13 @@ final readonly class ProjectionTopEntityQuery
         ?\DateTimeImmutable $toExclusive,
         ?array $hospitalIds,
         ?StatisticsDrawerFilter $drawerFilter = null,
+        ?int $dispatchAreaId = null,
     ): QueryBuilder {
         $qb = $this->entityManager->createQueryBuilder()
             ->from(AllocationStatsProjection::class, 'p');
         $this->filterApplier->applyCreatedAtRange($qb, 'p.createdAt', $from, $toExclusive);
         $this->filterApplier->applyHospitalScope($qb, 'p.hospitalId', $hospitalIds);
+        $this->filterApplier->applyDispatchAreaScope($qb, 'p.dispatchAreaId', $dispatchAreaId);
 
         if ($drawerFilter instanceof StatisticsDrawerFilter && $drawerFilter->isActive()) {
             $this->drawerFilterApplier->apply($qb, $drawerFilter);

--- a/src/Statistics/UI/Http/Controller/DashboardController.php
+++ b/src/Statistics/UI/Http/Controller/DashboardController.php
@@ -73,9 +73,11 @@ final class DashboardController extends AbstractController
         }
 
         $context = $this->statisticsContextFactory->create($user, $filter);
+        $scopeCriteria = $this->statisticsScopeResolver->resolveCriteria($context);
         $overviewMetrics = ($this->overviewDashboardMetricsQuery)(OverviewQueryCriteria::fromPeriodBounds(
             StatisticsPeriodResolver::resolve($filter),
-            $this->statisticsScopeResolver->resolveCriteria($context)->hospitalIds,
+            $scopeCriteria->hospitalIds,
+            $scopeCriteria->dispatchAreaId,
         ));
         $pageViewModel = $this->statisticsPageViewModelFactory->create(
             $request,

--- a/src/Statistics/UI/Http/Controller/OverviewTopReportsController.php
+++ b/src/Statistics/UI/Http/Controller/OverviewTopReportsController.php
@@ -36,11 +36,13 @@ final class OverviewTopReportsController extends AbstractController
     ): Response {
         $context = $this->statisticsContextFactory->create($user, $filter);
         $bounds = StatisticsPeriodResolver::resolve($filter);
-        $hospitalIds = $this->statisticsScopeResolver->resolveCriteria($context)->hospitalIds;
+        $scopeCriteria = $this->statisticsScopeResolver->resolveCriteria($context);
         $scopedTotal = $this->timeSeriesQuery->countCreatedInPeriod(
             $bounds->from,
             $bounds->toExclusive,
-            $hospitalIds,
+            $scopeCriteria->hospitalIds,
+            null,
+            $scopeCriteria->dispatchAreaId,
         );
 
         return $this->render('@Statistics/dashboard/_overview_top_reports_frame.html.twig', [

--- a/tests/Statistics/Integration/Application/DispatchAreaOriginScopeTest.php
+++ b/tests/Statistics/Integration/Application/DispatchAreaOriginScopeTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Application;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\InfectionFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\StatisticsScopeResolver;
+use App\Statistics\GenericAnalysis\Domain\DTO\AnalysisQuery;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAllocationAnalysisQuery;
+use App\Statistics\Infrastructure\Query\Overview\GetOverviewDashboardMetricsQuery;
+use App\Statistics\Infrastructure\Query\Overview\OverviewQueryCriteria;
+use App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DispatchAreaOriginScopeTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testMultiDispatchAreaHospitalCountsByOriginNotHospitalPortfolio(): void
+    {
+        self::bootKernel();
+
+        $user = UserFactory::createOne(['username' => 'dispatch-origin-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'DispatchOriginState']);
+        $dispatchAreaA = DispatchAreaFactory::createOne(['name' => 'DispatchOriginA', 'state' => $state]);
+        $dispatchAreaB = DispatchAreaFactory::createOne(['name' => 'DispatchOriginB', 'state' => $state]);
+
+        $sharedHospital = HospitalFactory::createOne([
+            'name' => 'DispatchOriginSharedHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchAreaA,
+            'tier' => HospitalTier::BASIC,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $hospitalOnlyA = HospitalFactory::createOne([
+            'name' => 'DispatchOriginHospitalOnlyA',
+            'state' => $state,
+            'dispatchArea' => $dispatchAreaA,
+            'tier' => HospitalTier::BASIC,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $hospitalOnlyB = HospitalFactory::createOne([
+            'name' => 'DispatchOriginHospitalOnlyB',
+            'state' => $state,
+            'dispatchArea' => $dispatchAreaB,
+            'tier' => HospitalTier::BASIC,
+            'location' => HospitalLocation::URBAN,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'DispatchOriginSpec']);
+        DepartmentFactory::createOne(['name' => 'DispatchOriginDept']);
+        AssignmentFactory::createOne(['name' => 'DispatchOriginAssign']);
+        OccasionFactory::createOne(['name' => 'DispatchOriginOcc']);
+        SecondaryTransportFactory::createOne(['name' => 'DispatchOriginSec']);
+        InfectionFactory::createOne(['name' => 'DispatchOriginInf']);
+        IndicationRawFactory::createOne(['name' => 'DispatchOriginRaw', 'code' => 912_415]);
+        $indicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'DispatchOriginNorm']);
+
+        $importShared = ImportFactory::createOne([
+            'name' => 'DispatchOriginImportShared',
+            'hospital' => $sharedHospital,
+            'createdBy' => $user,
+        ]);
+        $importOnlyA = ImportFactory::createOne([
+            'name' => 'DispatchOriginImportOnlyA',
+            'hospital' => $hospitalOnlyA,
+            'createdBy' => $user,
+        ]);
+        $importOnlyB = ImportFactory::createOne([
+            'name' => 'DispatchOriginImportOnlyB',
+            'hospital' => $hospitalOnlyB,
+            'createdBy' => $user,
+        ]);
+
+        $defaults = [
+            'state' => $state,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'age' => 40,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'isCPR' => false,
+            'isVentilated' => false,
+            'isWorkAccident' => false,
+            'isWithPhysician' => false,
+            'occasion' => null,
+            'infection' => null,
+            'indicationNormalized' => $indicationNormalized,
+            'createdAt' => new \DateTimeImmutable('2025-04-01 08:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-04-01 08:30:00'),
+        ];
+
+        // Shared hospital receives cases from both dispatch areas A and B.
+        AllocationFactory::createOne(array_merge($defaults, [
+            'import' => $importShared,
+            'hospital' => $sharedHospital,
+            'dispatchArea' => $dispatchAreaA,
+        ]));
+        AllocationFactory::createOne(array_merge($defaults, [
+            'import' => $importShared,
+            'hospital' => $sharedHospital,
+            'dispatchArea' => $dispatchAreaA,
+        ]));
+        AllocationFactory::createOne(array_merge($defaults, [
+            'import' => $importShared,
+            'hospital' => $sharedHospital,
+            'dispatchArea' => $dispatchAreaB,
+        ]));
+
+        // Second hospital per dispatch area (eligibility / volume).
+        AllocationFactory::createOne(array_merge($defaults, [
+            'import' => $importOnlyA,
+            'hospital' => $hospitalOnlyA,
+            'dispatchArea' => $dispatchAreaA,
+        ]));
+        AllocationFactory::createOne(array_merge($defaults, [
+            'import' => $importOnlyB,
+            'hospital' => $hospitalOnlyB,
+            'dispatchArea' => $dispatchAreaB,
+        ]));
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($importShared->getId());
+        $rebuilder->rebuildForImport($importOnlyA->getId());
+        $rebuilder->rebuildForImport($importOnlyB->getId());
+
+        $scopeResolver = self::getContainer()->get(StatisticsScopeResolver::class);
+        $timeSeriesQuery = self::getContainer()->get(ProjectionTimeSeriesQuery::class);
+        $overviewMetricsQuery = self::getContainer()->get(GetOverviewDashboardMetricsQuery::class);
+        $analysisQuery = self::getContainer()->get(GenericAllocationAnalysisQuery::class);
+
+        $filterA = new StatisticsFilter(
+            StatisticsFilterScope::DispatchArea,
+            null,
+            null,
+            StatisticsFilterPeriod::AllTime,
+            dispatchAreaId: $dispatchAreaA->getId(),
+        );
+        $filterB = new StatisticsFilter(
+            StatisticsFilterScope::DispatchArea,
+            null,
+            null,
+            StatisticsFilterPeriod::AllTime,
+            dispatchAreaId: $dispatchAreaB->getId(),
+        );
+        $filterHospital = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $sharedHospital->getId(),
+            null,
+            StatisticsFilterPeriod::AllTime,
+        );
+
+        $criteriaA = $scopeResolver->resolveCriteria(new StatisticsContext(null, $filterA));
+        $criteriaB = $scopeResolver->resolveCriteria(new StatisticsContext(null, $filterB));
+        $criteriaHospital = $scopeResolver->resolveCriteria(new StatisticsContext(null, $filterHospital));
+
+        self::assertNull($criteriaA->hospitalIds);
+        self::assertSame($dispatchAreaA->getId(), $criteriaA->dispatchAreaId);
+        self::assertNull($criteriaB->hospitalIds);
+        self::assertSame($dispatchAreaB->getId(), $criteriaB->dispatchAreaId);
+
+        $countA = $timeSeriesQuery->countCreatedInPeriod(
+            null,
+            null,
+            $criteriaA->hospitalIds,
+            null,
+            $criteriaA->dispatchAreaId,
+        );
+        $countB = $timeSeriesQuery->countCreatedInPeriod(
+            null,
+            null,
+            $criteriaB->hospitalIds,
+            null,
+            $criteriaB->dispatchAreaId,
+        );
+        $countSharedHospital = $timeSeriesQuery->countCreatedInPeriod(
+            null,
+            null,
+            $criteriaHospital->hospitalIds,
+        );
+
+        // A: 2 shared + 1 onlyA = 3; B: 1 shared + 1 onlyB = 2; shared hospital: 2A + 1B = 3
+        self::assertSame(3, $countA);
+        self::assertSame(2, $countB);
+        self::assertSame(3, $countSharedHospital);
+
+        $overviewA = ($overviewMetricsQuery)(OverviewQueryCriteria::fromPeriodBounds(
+            new StatisticsPeriodBounds(null),
+            $criteriaA->hospitalIds,
+            $criteriaA->dispatchAreaId,
+        ));
+        $overviewB = ($overviewMetricsQuery)(OverviewQueryCriteria::fromPeriodBounds(
+            new StatisticsPeriodBounds(null),
+            $criteriaB->hospitalIds,
+            $criteriaB->dispatchAreaId,
+        ));
+
+        self::assertSame(3, $overviewA->scopedTotal);
+        self::assertSame(2, $overviewB->scopedTotal);
+
+        $explorerA = $analysisQuery->execute(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: $criteriaA,
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+        $explorerB = $analysisQuery->execute(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: $criteriaB,
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertSame($overviewA->scopedTotal, $explorerA->grandTotal);
+        self::assertSame($overviewB->scopedTotal, $explorerB->grandTotal);
+    }
+}

--- a/tests/Statistics/Integration/Application/StatisticsScopeResolverTest.php
+++ b/tests/Statistics/Integration/Application/StatisticsScopeResolverTest.php
@@ -94,4 +94,24 @@ final class StatisticsScopeResolverTest extends DatabaseKernelTestCase
 
         self::assertSame([], $criteria->hospitalIds);
     }
+
+    public function testDispatchAreaScopeUsesOriginIdWithoutHospitalExpansion(): void
+    {
+        self::bootKernel();
+        $resolver = self::getContainer()->get(StatisticsScopeResolver::class);
+
+        $criteria = $resolver->resolveCriteria(new StatisticsContext(
+            null,
+            new StatisticsFilter(
+                StatisticsFilterScope::DispatchArea,
+                null,
+                null,
+                StatisticsFilterPeriod::All,
+                dispatchAreaId: 10,
+            ),
+        ));
+
+        self::assertNull($criteria->hospitalIds);
+        self::assertSame(10, $criteria->dispatchAreaId);
+    }
 }

--- a/tests/Statistics/Unit/Benchmarking/BenchmarkSqlFilterTest.php
+++ b/tests/Statistics/Unit/Benchmarking/BenchmarkSqlFilterTest.php
@@ -85,4 +85,17 @@ final class BenchmarkSqlFilterTest extends TestCase
         self::assertArrayHasKey('primary_location_codes', $types);
         self::assertArrayHasKey('primary_tier_codes', $types);
     }
+
+    public function testBuildsDispatchAreaOriginPredicate(): void
+    {
+        [$sql, $params] = BenchmarkSqlFilter::buildSidePredicate(
+            new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 9),
+            new StatisticsPeriodBounds(null),
+            'primary',
+        );
+
+        self::assertStringContainsString('dispatch_area_id = :primary_dispatch_area_id', $sql);
+        self::assertStringNotContainsString('hospital_id', $sql);
+        self::assertSame(9, $params['primary_dispatch_area_id']);
+    }
 }

--- a/tests/Statistics/Unit/CaseFlow/CaseFlowSqlFilterTest.php
+++ b/tests/Statistics/Unit/CaseFlow/CaseFlowSqlFilterTest.php
@@ -64,4 +64,19 @@ final class CaseFlowSqlFilterTest extends TestCase
         self::assertSame([], $params);
         self::assertSame([], $types);
     }
+
+    public function testDispatchAreaScopeFiltersByOriginId(): void
+    {
+        [$where, $params, $types] = CaseFlowSqlFilter::buildScopePeriodWhere(
+            null,
+            null,
+            new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 55),
+            'asp',
+        );
+
+        self::assertStringContainsString('asp.dispatch_area_id = :dispatch_area_id', $where);
+        self::assertStringNotContainsString('hospital_id', $where);
+        self::assertSame(55, $params['dispatch_area_id']);
+        self::assertSame([], $types);
+    }
 }

--- a/tests/Statistics/Unit/DataQuality/DataQualitySqlFilterTest.php
+++ b/tests/Statistics/Unit/DataQuality/DataQualitySqlFilterTest.php
@@ -53,4 +53,18 @@ final class DataQualitySqlFilterTest extends TestCase
         self::assertSame('2024-01-01 00:00:00', $params['from']);
         self::assertSame('2024-02-01 00:00:00', $params['to_exclusive']);
     }
+
+    public function testBuildWhereIncludesDispatchAreaOriginFilter(): void
+    {
+        [$where, $params] = DataQualitySqlFilter::buildWhere(
+            null,
+            null,
+            null,
+            new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 33),
+        );
+
+        self::assertStringContainsString('dispatch_area_id = :dispatch_area_id', $where);
+        self::assertStringNotContainsString('hospital_id', $where);
+        self::assertSame(33, $params['dispatch_area_id']);
+    }
 }

--- a/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericAllocationAnalysisSqlBuilderTest.php
@@ -52,6 +52,19 @@ final class GenericAllocationAnalysisSqlBuilderTest extends TestCase
         self::assertSame([10, 20], $params['scope_hospital_ids']);
     }
 
+    public function testBuildsDispatchAreaOriginScopeFilter(): void
+    {
+        [$sql, $params] = $this->builder->build(new AnalysisQuery(
+            primaryDimensionKey: 'month',
+            scopeCriteria: new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 10),
+            periodBounds: new StatisticsPeriodBounds(null),
+        ));
+
+        self::assertStringContainsString('dispatch_area_id = :scope_dispatch_area_id', $sql);
+        self::assertStringNotContainsString('hospital_id IN', $sql);
+        self::assertSame(10, $params['scope_dispatch_area_id']);
+    }
+
     public function testRejectsUnknownDimensionKey(): void
     {
         $this->expectException(UnknownAnalysisDimensionException::class);

--- a/tests/Statistics/Unit/GenericAnalysis/GenericHospitalScopeSqlFilterTest.php
+++ b/tests/Statistics/Unit/GenericAnalysis/GenericHospitalScopeSqlFilterTest.php
@@ -39,4 +39,17 @@ final class GenericHospitalScopeSqlFilterTest extends TestCase
 
         self::assertContains('1 = 0', $conditions);
     }
+
+    public function testDispatchAreaScopeFiltersHospitalsViaProjectionOrigin(): void
+    {
+        [$conditions, $params] = $this->filter->applyHospitalScope(
+            new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 17),
+        );
+
+        self::assertContains(
+            'h.id IN (SELECT DISTINCT asp.hospital_id FROM allocation_stats_projection asp WHERE asp.dispatch_area_id = :scope_dispatch_area_id)',
+            $conditions,
+        );
+        self::assertSame(17, $params['scope_dispatch_area_id']);
+    }
 }

--- a/tests/Statistics/Unit/IndicationDashboard/IndicationDashboardSqlFilterTest.php
+++ b/tests/Statistics/Unit/IndicationDashboard/IndicationDashboardSqlFilterTest.php
@@ -51,4 +51,17 @@ final class IndicationDashboardSqlFilterTest extends TestCase
         self::assertSame([], $params);
         self::assertSame([], $types);
     }
+
+    public function testDispatchAreaScopeFiltersByOriginId(): void
+    {
+        [$where, $params] = IndicationDashboardSqlFilter::buildScopePeriodWhere(
+            null,
+            null,
+            new StatisticsScopeCriteria(hospitalIds: null, dispatchAreaId: 44),
+        );
+
+        self::assertStringContainsString('dispatch_area_id = :dispatch_area_id', $where);
+        self::assertStringNotContainsString('hospital_id', $where);
+        self::assertSame(44, $params['dispatch_area_id']);
+    }
 }

--- a/tests/Statistics/Unit/Infrastructure/Query/OverviewProjectionSqlFilterTest.php
+++ b/tests/Statistics/Unit/Infrastructure/Query/OverviewProjectionSqlFilterTest.php
@@ -45,4 +45,15 @@ final class OverviewProjectionSqlFilterTest extends TestCase
         self::assertSame('2021-04-01 00:00:00', $params['from']);
         self::assertSame('2021-07-01 00:00:00', $params['to_exclusive']);
     }
+
+    public function testAddsDispatchAreaIdFilter(): void
+    {
+        [$where, $params] = OverviewProjectionSqlFilter::buildWhereClause(
+            new OverviewQueryCriteria(null, null, null, 42),
+        );
+
+        self::assertStringContainsString('dispatch_area_id = :dispatch_area_id', $where);
+        self::assertSame(42, $params['dispatch_area_id']);
+        self::assertStringNotContainsString('hospital_id', $where);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `scope=dispatch_area:ID` so it filters `allocation_stats_projection.dispatch_area_id` (allocation origin) instead of expanding a lossy hospital portfolio via `MIN(dispatch_area_id)` in `mv_projection_hospital_dimensions`.
- Propagate `StatisticsScopeCriteria.dispatchAreaId` through Overview, Analysis Explorer, Case Flow, Benchmarking, Indication, Data Quality, and top-report/time-series query paths.
- Keep `state` scope on the existing hospital-attribution model for now and document it as a follow-up.

Closes #415

## Test plan
- [x] Open Overview with `period=all_time&scope=dispatch_area:<id>` for a Leitstelle that sends cases to hospitals also used by other areas; Total allocations should match Explorer with the same scope/period.
- [x] Confirm a hospital that receives cases from two dispatch areas contributes only the matching origin rows to each dispatch-area scope, and that hospital scope equals the sum of those origin rows for that hospital.
- [x] Confirm dispatch areas with fewer than 2 distinct origin hospitals still fall back to `dispatch_area_invalid` / public.
- [x] Spot-check Analysis Explorer, Case Flow, and Benchmarking under `dispatch_area` scope still load and respect the origin filter.