### PR TITLE
# Optimize Analysis Explorer scope filter loading (#409)

### DIFF
--- a/docs/04-features/statistics/analysis-explorer.md
+++ b/docs/04-features/statistics/analysis-explorer.md
@@ -271,6 +271,8 @@ Analysis filters narrow the allocation set **before** row/column grouping. They 
 
 **Reference data cache:** Entity-backed dropdown choices (department, speciality, assignment, indication, indication group) are loaded through [`ExploreFilterOptionsProvider`](../allocation/explore-filter-reference-cache.md) (`cache.allocation.reference_data`, TTL 1 hour). After cache warmup, opening or refreshing the edit drawer does not re-query those tables. Manual invalidation: `bin/console cache:pool:clear cache.allocation.reference_data`.
 
+**Scope/period choice loading:** Scope detail options (state, dispatch area, hospital under `my_hospitals`, cohorts) come from [`StatisticsFilterFormChoiceProvider`](../../../src/Statistics/UI/Application/StatisticsFilterFormChoiceProvider.php). State and dispatch-area names are batch-loaded (`findNamesByIds`); eligible rows, cohort choices, and hospital summaries are memoized for the request so LiveComponent `refreshEditForm` rebuilds do not repeat those lookups. User-specific hospital lists stay uncached across requests (permission-sensitive). See Issue [#409](https://github.com/nplhse/collaborative-ivena-statistics/issues/409).
+
 **Classes:** `ExplorerAnalysisFilterMapper`, `ExplorerAnalysisFilterExpander`, `ExplorerAnalysisFilterPolicy`, `AnalysisFilterChoiceProvider`, `ExplorerFilterBadgePresenter`.
 
 ## Supported capabilities (allocations)

--- a/docs/04-features/statistics/statistics-filter-and-scope.md
+++ b/docs/04-features/statistics/statistics-filter-and-scope.md
@@ -60,9 +60,18 @@ Permission checks use `HospitalPermission::Statistics` or `HospitalPermission::B
 - Analysis Explorer
 - Case Flow dashboard
 
+## Scope choice performance
+
+`StatisticsFilterFormChoiceProvider` builds primary/detail dropdowns for scope forms (Explorer edit drawer, benchmarking sides, statistics filter UI):
+
+- Eligible state/dispatch-area IDs resolve to labels via repository `findNamesByIds` (one query per entity type, not N×`findById`).
+- Eligible rows, cohort choices, and hospital detail choices are memoized on the provider instance for the request lifetime so repeated form rebuilds (e.g. LiveComponent `refreshEditForm`) reuse the same lists.
+- Hospital summaries remain uncached across HTTP requests (user- and permission-specific).
+
 ## Code locations
 
 - `src/Statistics/UI/Http/Controller/StatisticsFilterInputFactory.php` (default scope)
+- `src/Statistics/UI/Application/StatisticsFilterFormChoiceProvider.php` (scope/period choice lists)
 - `src/Statistics/Application/StatisticsFilterFactory.php`
 - `src/Statistics/Application/StatisticsScopeResolver.php`
 - `src/Statistics/Application/DTO/StatisticsScopeCriteria.php`

--- a/src/Allocation/Infrastructure/Repository/DispatchAreaRepository.php
+++ b/src/Allocation/Infrastructure/Repository/DispatchAreaRepository.php
@@ -34,6 +34,33 @@ final class DispatchAreaRepository extends ServiceEntityRepository implements Di
         return $entity instanceof DispatchArea ? $entity : null;
     }
 
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    public function findNamesByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        /** @var list<array{id: int|string, name: string}> $rows */
+        $rows = $this->createQueryBuilder('da')
+            ->select('da.id', 'da.name')
+            ->andWhere('da.id IN (:ids)')
+            ->setParameter('ids', array_values(array_unique($ids)))
+            ->getQuery()
+            ->getArrayResult();
+
+        $names = [];
+        foreach ($rows as $row) {
+            $names[(int) $row['id']] = $row['name'];
+        }
+
+        return $names;
+    }
+
     public function getAreaListPaginator(AreaListQueryParametersDTO $queryParametersDTO): Paginator
     {
         $qb = $this->createQueryBuilder('da')

--- a/src/Allocation/Infrastructure/Repository/StateRepository.php
+++ b/src/Allocation/Infrastructure/Repository/StateRepository.php
@@ -32,6 +32,33 @@ final class StateRepository extends ServiceEntityRepository implements StateLook
         return $entity instanceof State ? $entity : null;
     }
 
+    /**
+     * @param list<int> $ids
+     *
+     * @return array<int, string>
+     */
+    public function findNamesByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        /** @var list<array{id: int|string, name: string}> $rows */
+        $rows = $this->createQueryBuilder('s')
+            ->select('s.id', 's.name')
+            ->andWhere('s.id IN (:ids)')
+            ->setParameter('ids', array_values(array_unique($ids)))
+            ->getQuery()
+            ->getArrayResult();
+
+        $names = [];
+        foreach ($rows as $row) {
+            $names[(int) $row['id']] = $row['name'];
+        }
+
+        return $names;
+    }
+
     public function getListPaginator(SpecialityQueryParametersDTO $queryParametersDTO): Paginator
     {
         $qb = $this->createQueryBuilder('s')

--- a/src/Statistics/Benchmarking/UI/Form/BenchmarkSelectionSideFieldsConfigurator.php
+++ b/src/Statistics/Benchmarking/UI/Form/BenchmarkSelectionSideFieldsConfigurator.php
@@ -24,8 +24,8 @@ final readonly class BenchmarkSelectionSideFieldsConfigurator
     }
 
     /**
-     * @param FormInterface<BenchmarkSelectionSideFormData> $form
-     * @param array<string, mixed>                          $options
+     * @param FormInterface<BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData> $form
+     * @param array<string, mixed>                                                        $options
      */
     public function configureFields(
         FormInterface $form,
@@ -58,18 +58,16 @@ final readonly class BenchmarkSelectionSideFieldsConfigurator
             $periodMonth = $data->periodMonth ?? $periodMonth;
         }
 
-        if ($this->choiceProvider->scopeDetailRequired($scopeGroup, $user, $side, $scopeChoicePolicy)) {
-            $detailChoices = $this->choiceProvider->scopeDetailChoices($scopeGroup, $user, $side, $locale, $scopeChoicePolicy);
-            if ([] !== $detailChoices) {
-                $form->add('scopeDetail', PreTranslatedChoiceType::class, [
-                    'label' => $this->scopeDetailLabel($scopeGroup),
-                    'choices' => $this->flippedStringValueChoices($detailChoices),
-                    'choice_value' => static fn (?string $choice): string => $choice ?? '',
-                    'placeholder' => false,
-                    'required' => false,
-                    'data' => $this->defaultChoiceValue($scopeDetail, $detailChoices),
-                ]);
-            }
+        $detailChoices = $this->choiceProvider->scopeDetailChoices($scopeGroup, $user, $side, $locale, $scopeChoicePolicy);
+        if ([] !== $detailChoices) {
+            $form->add('scopeDetail', PreTranslatedChoiceType::class, [
+                'label' => $this->scopeDetailLabel($scopeGroup),
+                'choices' => $this->flippedStringValueChoices($detailChoices),
+                'choice_value' => static fn (?string $choice): string => $choice ?? '',
+                'placeholder' => false,
+                'required' => false,
+                'data' => $this->defaultChoiceValue($scopeDetail, $detailChoices),
+            ]);
         }
 
         if (\in_array($period, [StatisticsFilterPeriod::Year, StatisticsFilterPeriod::Quarter, StatisticsFilterPeriod::Month], true)) {
@@ -133,7 +131,7 @@ final readonly class BenchmarkSelectionSideFieldsConfigurator
     }
 
     /**
-     * @param FormInterface<BenchmarkSelectionSideFormData> $form
+     * @param FormInterface<BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData> $form
      */
     private function removeDynamicFields(FormInterface $form): void
     {

--- a/src/Statistics/Benchmarking/UI/Form/BenchmarkSelectionSideType.php
+++ b/src/Statistics/Benchmarking/UI/Form/BenchmarkSelectionSideType.php
@@ -8,6 +8,7 @@ use App\Statistics\Benchmarking\UI\Form\Data\BenchmarkSelectionSideFormData;
 use App\Statistics\UI\Application\StatisticsFilterFormChoiceProvider;
 use App\Statistics\UI\Application\StatisticsFilterScopeChoicePolicy;
 use App\Statistics\UI\Application\StatisticsFilterSide;
+use App\Statistics\UI\Form\Data\StatisticsScopePeriodFormData;
 use App\Statistics\UI\Form\PreTranslatedChoiceType;
 use App\User\Domain\Entity\User;
 use Symfony\Component\Form\AbstractType;
@@ -18,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
- * @extends AbstractType<BenchmarkSelectionSideFormData>
+ * @extends AbstractType<BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData>
  */
 final class BenchmarkSelectionSideType extends AbstractType
 {
@@ -51,24 +52,26 @@ final class BenchmarkSelectionSideType extends AbstractType
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {
             $data = $event->getData();
-            if (!$data instanceof BenchmarkSelectionSideFormData) {
+            if (!$data instanceof BenchmarkSelectionSideFormData && !$data instanceof StatisticsScopePeriodFormData) {
                 return;
             }
+
             /** @var StatisticsFilterSide $side */
             $side = $options['side'];
             /** @var string $locale */
             $locale = $options['locale'];
             /** @var StatisticsFilterScopeChoicePolicy $scopeChoicePolicy */
             $scopeChoicePolicy = $options['scope_choice_policy'];
-            $data = $this->choiceProvider->normalizeSideFormData(
-                $data,
-                $this->currentUser(),
-                $side,
-                $locale,
-                $scopeChoicePolicy,
-            );
+            $user = $this->currentUser();
+
+            if ($data instanceof BenchmarkSelectionSideFormData) {
+                $data = $this->choiceProvider->normalizeSideFormData($data, $user, $side, $locale, $scopeChoicePolicy);
+            } else {
+                $data = $this->choiceProvider->normalizeScopePeriodFormData($data, $user, $side, $locale, $scopeChoicePolicy);
+            }
+
             $event->setData($data);
-            /** @var \Symfony\Component\Form\FormInterface<BenchmarkSelectionSideFormData> $sideForm */
+            /** @var \Symfony\Component\Form\FormInterface<BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData> $sideForm */
             $sideForm = $event->getForm();
             $this->fieldsConfigurator->configureFields($sideForm, $options, $data);
         });
@@ -84,11 +87,8 @@ final class BenchmarkSelectionSideType extends AbstractType
             }
 
             $data = $event->getForm()->getData();
-            if (!$data instanceof BenchmarkSelectionSideFormData) {
-                $data = new BenchmarkSelectionSideFormData();
-            }
+            $preview = $this->previewFromFormData($data, $options);
 
-            $preview = clone $data;
             if (isset($submitted['scopeGroup']) && \is_string($submitted['scopeGroup'])) {
                 $preview->scopeGroup = $submitted['scopeGroup'];
             }
@@ -108,7 +108,7 @@ final class BenchmarkSelectionSideType extends AbstractType
                 $preview->scopeDetail = (string) $submitted['scopeDetail'];
             }
 
-            /** @var \Symfony\Component\Form\FormInterface<BenchmarkSelectionSideFormData> $sideForm */
+            /** @var \Symfony\Component\Form\FormInterface<BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData> $sideForm */
             $sideForm = $event->getForm();
             $this->fieldsConfigurator->configureFields($sideForm, $options, $preview);
 
@@ -143,6 +143,23 @@ final class BenchmarkSelectionSideType extends AbstractType
         $resolver->setAllowedTypes('side', StatisticsFilterSide::class);
         $resolver->setAllowedTypes('locale', 'string');
         $resolver->setAllowedTypes('scope_choice_policy', StatisticsFilterScopeChoicePolicy::class);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function previewFromFormData(mixed $data, array $options): BenchmarkSelectionSideFormData|StatisticsScopePeriodFormData
+    {
+        if ($data instanceof BenchmarkSelectionSideFormData || $data instanceof StatisticsScopePeriodFormData) {
+            return clone $data;
+        }
+
+        $dataClass = $options['data_class'] ?? BenchmarkSelectionSideFormData::class;
+        if (StatisticsScopePeriodFormData::class === $dataClass) {
+            return new StatisticsScopePeriodFormData();
+        }
+
+        return new BenchmarkSelectionSideFormData();
     }
 
     private function currentUser(): ?User

--- a/src/Statistics/UI/Application/StatisticsFilterFormChoiceProvider.php
+++ b/src/Statistics/UI/Application/StatisticsFilterFormChoiceProvider.php
@@ -20,25 +20,47 @@ use App\Statistics\Benchmarking\UI\Form\Data\BenchmarkSelectionSideFormData;
 use App\Statistics\Infrastructure\Query\AllocationStatsProjectionScopeQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetEligibleDispatchAreaIdsQuery;
 use App\Statistics\Infrastructure\Query\Overview\GetEligibleStateIdsQuery;
+use App\Statistics\UI\Form\Data\StatisticsScopePeriodFormData;
 use App\User\Domain\Entity\User;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final readonly class StatisticsFilterFormChoiceProvider
+/**
+ * Scope/period choice lists for statistics filter forms.
+ *
+ * Entity-backed lists are memoized for the lifetime of this service (request scope)
+ * so LiveComponent form rebuilds do not repeat the same lookups.
+ */
+final class StatisticsFilterFormChoiceProvider
 {
+    /** @var array<string, list<array{id: int, name: string}>> */
+    private array $eligibleStateRowsByPolicy = [];
+
+    /** @var array<string, list<array{id: int, name: string}>> */
+    private array $eligibleDispatchAreaRowsByPolicy = [];
+
+    /** @var array<string, list<array{key: string, label: string}>> */
+    private array $eligibleCohortChoicesByLocale = [];
+
+    /** @var array<string, array<int|string, string>> */
+    private array $hospitalDetailChoicesByKey = [];
+
+    /** @var array<string, array<string, string>> */
+    private array $scopePrimaryChoicesByKey = [];
+
     public function __construct(
-        private HospitalRepository $hospitalRepository,
-        private HospitalAccessInterface $hospitalAccess,
-        private HospitalCohortResolver $hospitalCohortResolver,
-        private HospitalCohortEligibilityChecker $hospitalCohortEligibilityChecker,
-        private HospitalCohortLabelResolver $hospitalCohortLabelResolver,
-        private StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
-        private StatisticsPeriodNavigation $periodNavigation,
-        private GetEligibleStateIdsQuery $eligibleStateIdsQuery,
-        private GetEligibleDispatchAreaIdsQuery $eligibleDispatchAreaIdsQuery,
-        private AllocationStatsProjectionScopeQuery $projectionScopeQuery,
-        private StateRepository $stateRepository,
-        private DispatchAreaRepository $dispatchAreaRepository,
-        private TranslatorInterface $translator,
+        private readonly HospitalRepository $hospitalRepository,
+        private readonly HospitalAccessInterface $hospitalAccess,
+        private readonly HospitalCohortResolver $hospitalCohortResolver,
+        private readonly HospitalCohortEligibilityChecker $hospitalCohortEligibilityChecker,
+        private readonly HospitalCohortLabelResolver $hospitalCohortLabelResolver,
+        private readonly StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
+        private readonly StatisticsPeriodNavigation $periodNavigation,
+        private readonly GetEligibleStateIdsQuery $eligibleStateIdsQuery,
+        private readonly GetEligibleDispatchAreaIdsQuery $eligibleDispatchAreaIdsQuery,
+        private readonly AllocationStatsProjectionScopeQuery $projectionScopeQuery,
+        private readonly StateRepository $stateRepository,
+        private readonly DispatchAreaRepository $dispatchAreaRepository,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -50,6 +72,11 @@ final readonly class StatisticsFilterFormChoiceProvider
         string $locale,
         StatisticsFilterScopeChoicePolicy $policy = StatisticsFilterScopeChoicePolicy::RegisteredHospitals,
     ): array {
+        $cacheKey = sprintf('%s|%s|%s', $user?->getId() ?? 'anon', $locale, $policy->value);
+        if (isset($this->scopePrimaryChoicesByKey[$cacheKey])) {
+            return $this->scopePrimaryChoicesByKey[$cacheKey];
+        }
+
         $choices = [
             'public' => $this->translator->trans('stats.filter.scope.public', [], 'statistics', $locale),
         ];
@@ -70,7 +97,7 @@ final readonly class StatisticsFilterFormChoiceProvider
             $choices['my_hospitals'] = $this->hospitalScopeLabelResolver->groupLabel($user, $locale);
         }
 
-        return $choices;
+        return $this->scopePrimaryChoicesByKey[$cacheKey] = $choices;
     }
 
     /**
@@ -110,44 +137,78 @@ final readonly class StatisticsFilterFormChoiceProvider
         string $locale,
         StatisticsFilterScopeChoicePolicy $policy = StatisticsFilterScopeChoicePolicy::RegisteredHospitals,
     ): BenchmarkSelectionSideFormData {
-        $primaryChoices = $this->scopePrimaryChoices($user, $locale, $policy);
-        if (!isset($primaryChoices[$data->scopeGroup])) {
-            return new BenchmarkSelectionSideFormData(
-                'public',
-                null,
-                $data->period,
-                $data->periodYear,
-                $data->periodQuarter,
-                $data->periodMonth,
-            );
-        }
-
-        if (!$this->scopeDetailRequired($data->scopeGroup, $user, $side, $policy)) {
-            return new BenchmarkSelectionSideFormData(
-                $data->scopeGroup,
-                null,
-                $data->period,
-                $data->periodYear,
-                $data->periodQuarter,
-                $data->periodMonth,
-            );
-        }
-
-        $detailChoices = $this->scopeDetailChoices($data->scopeGroup, $user, $side, $locale, $policy);
-        $scopeDetail = $data->scopeDetail;
-        if (null === $scopeDetail || '' === $scopeDetail || !isset($detailChoices[$scopeDetail])) {
-            $firstChoice = array_key_first($detailChoices);
-            $scopeDetail = null !== $firstChoice ? (string) $firstChoice : null;
-        }
+        [$scopeGroup, $scopeDetail] = $this->normalizeScopeDetail(
+            $data->scopeGroup,
+            $data->scopeDetail,
+            $user,
+            $side,
+            $locale,
+            $policy,
+        );
 
         return new BenchmarkSelectionSideFormData(
-            $data->scopeGroup,
+            $scopeGroup,
             $scopeDetail,
             $data->period,
             $data->periodYear,
             $data->periodQuarter,
             $data->periodMonth,
         );
+    }
+
+    public function normalizeScopePeriodFormData(
+        StatisticsScopePeriodFormData $data,
+        ?User $user,
+        StatisticsFilterSide $side,
+        string $locale,
+        StatisticsFilterScopeChoicePolicy $policy = StatisticsFilterScopeChoicePolicy::RegisteredHospitals,
+    ): StatisticsScopePeriodFormData {
+        [$scopeGroup, $scopeDetail] = $this->normalizeScopeDetail(
+            $data->scopeGroup,
+            $data->scopeDetail,
+            $user,
+            $side,
+            $locale,
+            $policy,
+        );
+
+        return new StatisticsScopePeriodFormData(
+            $scopeGroup,
+            $scopeDetail,
+            $data->period,
+            $data->periodYear,
+            $data->periodQuarter,
+            $data->periodMonth,
+        );
+    }
+
+    /**
+     * @return array{0: string, 1: ?string}
+     */
+    private function normalizeScopeDetail(
+        string $scopeGroup,
+        ?string $scopeDetail,
+        ?User $user,
+        StatisticsFilterSide $side,
+        string $locale,
+        StatisticsFilterScopeChoicePolicy $policy,
+    ): array {
+        $primaryChoices = $this->scopePrimaryChoices($user, $locale, $policy);
+        if (!isset($primaryChoices[$scopeGroup])) {
+            return ['public', null];
+        }
+
+        if (!$this->scopeDetailRequired($scopeGroup, $user, $side, $policy)) {
+            return [$scopeGroup, null];
+        }
+
+        $detailChoices = $this->scopeDetailChoices($scopeGroup, $user, $side, $locale, $policy);
+        if (null === $scopeDetail || '' === $scopeDetail || !isset($detailChoices[$scopeDetail])) {
+            $firstChoice = array_key_first($detailChoices);
+            $scopeDetail = null !== $firstChoice ? (string) $firstChoice : null;
+        }
+
+        return [$scopeGroup, $scopeDetail];
     }
 
     /**
@@ -210,11 +271,19 @@ final readonly class StatisticsFilterFormChoiceProvider
     public function eligibleStateRows(
         StatisticsFilterScopeChoicePolicy $policy = StatisticsFilterScopeChoicePolicy::RegisteredHospitals,
     ): array {
-        $ids = $this->eligibleStateIds($policy);
+        $cacheKey = $policy->value;
+        if (isset($this->eligibleStateRowsByPolicy[$cacheKey])) {
+            return $this->eligibleStateRowsByPolicy[$cacheKey];
+        }
+
+        $ids = array_values(array_filter(
+            $this->eligibleStateIds($policy),
+            static fn (int $id): bool => $id > 0,
+        ));
+        $namesById = $this->stateRepository->findNamesByIds($ids);
         $rows = [];
         foreach ($ids as $stateId) {
-            $state = $this->stateRepository->findById($stateId);
-            $name = $state?->getName();
+            $name = $namesById[$stateId] ?? null;
             if (null === $name || '' === $name) {
                 continue;
             }
@@ -222,7 +291,7 @@ final readonly class StatisticsFilterFormChoiceProvider
         }
         usort($rows, static fn (array $a, array $b): int => strcmp($a['name'], $b['name']));
 
-        return $rows;
+        return $this->eligibleStateRowsByPolicy[$cacheKey] = $rows;
     }
 
     /**
@@ -231,11 +300,19 @@ final readonly class StatisticsFilterFormChoiceProvider
     public function eligibleDispatchAreaRows(
         StatisticsFilterScopeChoicePolicy $policy = StatisticsFilterScopeChoicePolicy::RegisteredHospitals,
     ): array {
-        $ids = $this->eligibleDispatchAreaIds($policy);
+        $cacheKey = $policy->value;
+        if (isset($this->eligibleDispatchAreaRowsByPolicy[$cacheKey])) {
+            return $this->eligibleDispatchAreaRowsByPolicy[$cacheKey];
+        }
+
+        $ids = array_values(array_filter(
+            $this->eligibleDispatchAreaIds($policy),
+            static fn (int $id): bool => $id > 0,
+        ));
+        $namesById = $this->dispatchAreaRepository->findNamesByIds($ids);
         $rows = [];
         foreach ($ids as $dispatchAreaId) {
-            $area = $this->dispatchAreaRepository->findById($dispatchAreaId);
-            $name = $area?->getName();
+            $name = $namesById[$dispatchAreaId] ?? null;
             if (null === $name || '' === $name) {
                 continue;
             }
@@ -243,7 +320,7 @@ final readonly class StatisticsFilterFormChoiceProvider
         }
         usort($rows, static fn (array $a, array $b): int => strcmp($a['name'], $b['name']));
 
-        return $rows;
+        return $this->eligibleDispatchAreaRowsByPolicy[$cacheKey] = $rows;
     }
 
     /**
@@ -251,6 +328,10 @@ final readonly class StatisticsFilterFormChoiceProvider
      */
     public function eligibleCohortChoices(string $locale): array
     {
+        if (isset($this->eligibleCohortChoicesByLocale[$locale])) {
+            return $this->eligibleCohortChoicesByLocale[$locale];
+        }
+
         $choices = [];
         foreach (HospitalCohortKey::all() as $cohortKey) {
             $cohort = $this->hospitalCohortResolver->resolve($cohortKey);
@@ -263,7 +344,7 @@ final readonly class StatisticsFilterFormChoiceProvider
             ];
         }
 
-        return $choices;
+        return $this->eligibleCohortChoicesByLocale[$locale] = $choices;
     }
 
     /**
@@ -318,12 +399,17 @@ final readonly class StatisticsFilterFormChoiceProvider
             return [];
         }
 
+        $cacheKey = sprintf('%d|%s|%s', $user->getId() ?? 0, $side->value, $locale);
+        if (isset($this->hospitalDetailChoicesByKey[$cacheKey])) {
+            return $this->hospitalDetailChoicesByKey[$cacheKey];
+        }
+
         $useBenchmarkingPermission = StatisticsFilterSide::Comparison === $side;
         if ($useBenchmarkingPermission && !$this->hospitalAccess->canUseBenchmarkingScope($user)) {
-            return [];
+            return $this->hospitalDetailChoicesByKey[$cacheKey] = [];
         }
         if (!$useBenchmarkingPermission && !$this->hospitalAccess->canUseMyHospitalsScope($user)) {
-            return [];
+            return $this->hospitalDetailChoicesByKey[$cacheKey] = [];
         }
 
         $hospitals = $useBenchmarkingPermission
@@ -331,7 +417,7 @@ final readonly class StatisticsFilterFormChoiceProvider
             : $this->hospitalRepository->findAccessibleParticipatingHospitalSummaries($user);
 
         if (\count($hospitals) <= 1) {
-            return [];
+            return $this->hospitalDetailChoicesByKey[$cacheKey] = [];
         }
 
         $choices = [
@@ -341,7 +427,7 @@ final readonly class StatisticsFilterFormChoiceProvider
             $choices[(string) $row['id']] = $row['name'];
         }
 
-        return $choices;
+        return $this->hospitalDetailChoicesByKey[$cacheKey] = $choices;
     }
 
     /**

--- a/tests/Allocation/Integration/Repository/StateAndDispatchAreaNamesByIdsTest.php
+++ b/tests/Allocation/Integration/Repository/StateAndDispatchAreaNamesByIdsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Integration\Repository;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Allocation\Infrastructure\Repository\DispatchAreaRepository;
+use App\Allocation\Infrastructure\Repository\StateRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class StateAndDispatchAreaNamesByIdsTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testStateFindNamesByIdsReturnsIdToNameMap(): void
+    {
+        self::bootKernel();
+        $repo = self::getContainer()->get(StateRepository::class);
+        $state = StateFactory::createOne(['name' => 'Lookup State']);
+
+        self::assertSame(
+            [(int) $state->getId() => 'Lookup State'],
+            $repo->findNamesByIds([(int) $state->getId()]),
+        );
+        self::assertSame([], $repo->findNamesByIds([]));
+    }
+
+    public function testDispatchAreaFindNamesByIdsReturnsIdToNameMap(): void
+    {
+        self::bootKernel();
+        $repo = self::getContainer()->get(DispatchAreaRepository::class);
+        $state = StateFactory::createOne();
+        $area = DispatchAreaFactory::createOne(['name' => 'Lookup Area', 'state' => $state]);
+
+        self::assertSame(
+            [(int) $area->getId() => 'Lookup Area'],
+            $repo->findNamesByIds([(int) $area->getId()]),
+        );
+        self::assertSame([], $repo->findNamesByIds([]));
+    }
+}

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchOpenEditTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchOpenEditTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\DefaultAnalysisViewFactory;
+use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Tests\Statistics\Support\Benchmarking\EligibleBenchmarkScopeTrait;
+use App\User\Domain\Factory\UserFactory;
+
+final class AnalysisExplorerShellDispatchOpenEditTest extends AnalysisExplorerShellTestCase
+{
+    use EligibleBenchmarkScopeTrait;
+
+    public function testOpenEditShowsConcreteDispatchAreaDetailWithoutRefresh(): void
+    {
+        $user = UserFactory::createOne(['username' => 'explorer-open-'.bin2hex(random_bytes(4))]);
+        $scope = $this->seedEligibleBenchmarkScope($user, 'OpenDA');
+        $dispatchAreaId = $scope['dispatchArea']->getId();
+        self::assertNotNull($dispatchAreaId);
+
+        $mapper = self::getContainer()->get(ExplorerConfigMapper::class);
+        $viewFactory = self::getContainer()->get(DefaultAnalysisViewFactory::class);
+        $filter = new StatisticsFilter(
+            scope: StatisticsFilterScope::DispatchArea,
+            hospitalId: null,
+            cohortType: null,
+            period: StatisticsFilterPeriod::All,
+            stateId: null,
+            dispatchAreaId: $dispatchAreaId,
+        );
+        $defaultConfig = $viewFactory->createDefault($filter);
+
+        $testComponent = $this->createLiveComponent('AnalysisExplorerShell', [
+            'appliedConfigState' => $mapper->toStateArray($defaultConfig),
+            'locale' => 'de',
+        ])->actingAs($user);
+
+        $testComponent->render();
+        $testComponent->call('openEdit');
+        $html = $testComponent->render()->toString();
+
+        self::assertStringContainsString('OpenDADispatch', $html, 'openEdit should render concrete dispatch area in scopeDetail without requiring refresh');
+        self::assertStringContainsString('name="', $html);
+        // scopeDetail field should exist
+        self::assertMatchesRegularExpression('/scopePeriod\[scopeDetail\]|scopePeriod_scopeDetail/', $html);
+    }
+}

--- a/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchScopeRegressionTest.php
+++ b/tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchScopeRegressionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\AnalysisExplorer;
+
+use App\Statistics\AnalysisExplorer\Application\DefaultAnalysisViewFactory;
+use App\Statistics\AnalysisExplorer\Application\ExplorerConfigMapper;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\UI\Application\StatisticsFilterFormChoiceProvider;
+use App\Statistics\UI\Application\StatisticsFilterScopeChoicePolicy;
+use App\Statistics\UI\Application\StatisticsFilterSide;
+use App\Tests\Statistics\Support\Benchmarking\EligibleBenchmarkScopeTrait;
+use App\User\Domain\Factory\UserFactory;
+
+final class AnalysisExplorerShellDispatchScopeRegressionTest extends AnalysisExplorerShellTestCase
+{
+    use EligibleBenchmarkScopeTrait;
+
+    public function testDispatchAreaChoicesAreNonEmptyAndApplyPersistsDetail(): void
+    {
+        $user = UserFactory::createOne(['username' => 'explorer-da-'.bin2hex(random_bytes(4))]);
+        $scope = $this->seedEligibleBenchmarkScope($user, 'ExplorerDA');
+        $dispatchAreaId = $scope['dispatchArea']->getId();
+        self::assertNotNull($dispatchAreaId);
+
+        $provider = self::getContainer()->get(StatisticsFilterFormChoiceProvider::class);
+        $details = $provider->scopeDetailChoices(
+            'dispatch_area',
+            $user,
+            StatisticsFilterSide::Primary,
+            'de',
+            StatisticsFilterScopeChoicePolicy::AllocationStatistics,
+        );
+        self::assertArrayHasKey((string) $dispatchAreaId, $details, 'Expected batch name lookup to resolve dispatch area');
+        self::assertSame('ExplorerDADispatch', $details[(string) $dispatchAreaId]);
+
+        $mapper = self::getContainer()->get(ExplorerConfigMapper::class);
+        $viewFactory = self::getContainer()->get(DefaultAnalysisViewFactory::class);
+        $filter = new StatisticsFilter(
+            scope: StatisticsFilterScope::Public,
+            hospitalId: null,
+            cohortType: null,
+            period: StatisticsFilterPeriod::All,
+        );
+        $defaultConfig = $viewFactory->createDefault($filter);
+
+        $testComponent = $this->createLiveComponent('AnalysisExplorerShell', [
+            'appliedConfigState' => $mapper->toStateArray($defaultConfig),
+            'locale' => 'de',
+        ])->actingAs($user);
+
+        $testComponent->render();
+        $testComponent->call('openEdit');
+
+        $formName = $this->formName($testComponent->render());
+
+        // Simulate user selecting only scopeGroup (no scopeDetail yet) then refresh
+        $testComponent
+            ->submitForm([
+                $formName => [
+                    'scopePeriod' => [
+                        'scopeGroup' => 'dispatch_area',
+                        'period' => 'all',
+                    ],
+                    'rowDimension' => 'time',
+                    'rowGrain' => 'month',
+                    'columnDimension' => '',
+                    'columnGrain' => 'total',
+                    'metric' => 'allocation_count',
+                    'chartType' => 'bar',
+                ],
+            ])
+            ->call('refreshEditForm');
+
+        $html = $testComponent->render()->toString();
+        self::assertStringContainsString('ExplorerDADispatch', $html, 'Drawer should show concrete dispatch area name after refresh');
+
+        $testComponent
+            ->submitForm([
+                $formName => [
+                    'scopePeriod' => [
+                        'scopeGroup' => 'dispatch_area',
+                        'scopeDetail' => (string) $dispatchAreaId,
+                        'period' => 'all',
+                    ],
+                    'rowDimension' => 'time',
+                    'rowGrain' => 'month',
+                    'columnDimension' => '',
+                    'columnGrain' => 'total',
+                    'metric' => 'allocation_count',
+                    'chartType' => 'bar',
+                ],
+            ])
+            ->call('applyEdit');
+
+        self::assertSame('dispatch_area', $testComponent->component()->appliedConfigState['query']['scope']['group'] ?? null);
+        self::assertSame((string) $dispatchAreaId, $testComponent->component()->appliedConfigState['query']['scope']['detail'] ?? null);
+    }
+}

--- a/tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderQueryCountTest.php
+++ b/tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderQueryCountTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Benchmarking;
+
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Statistics\UI\Application\StatisticsFilterFormChoiceProvider;
+use App\Statistics\UI\Application\StatisticsFilterSide;
+use App\Tests\Statistics\Support\Benchmarking\EligibleBenchmarkScopeTrait;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+/**
+ * Guards Issue #409: scope/hospital choice loading must stay batch + request-memoized
+ * so LiveComponent form rebuilds do not N+1 State/DispatchArea rows.
+ */
+#[ResetDatabase]
+final class StatisticsFilterFormChoiceProviderQueryCountTest extends KernelTestCase
+{
+    use EligibleBenchmarkScopeTrait;
+    use Factories;
+
+    /** First pass loads eligibility + batch name lookups + hospital summaries + cohorts. */
+    private const int MAX_FIRST_PASS_QUERIES = 28;
+
+    public function testRepeatedScopeChoiceLoadsStayWithinBudgetAndMemoize(): void
+    {
+        self::bootKernel();
+        $provider = self::getContainer()->get(StatisticsFilterFormChoiceProvider::class);
+        $user = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        $this->seedEligibleBenchmarkScope($user, 'QueryCountA');
+
+        for ($i = 0; $i < 4; ++$i) {
+            $state = StateFactory::createOne(['name' => "QueryCountExtraState{$i}"]);
+            $area = DispatchAreaFactory::createOne(['name' => "QueryCountExtraArea{$i}", 'state' => $state]);
+            HospitalFactory::createOne([
+                'name' => "QueryCountExtraHospA{$i}",
+                'state' => $state,
+                'dispatchArea' => $area,
+                'owner' => $user,
+            ]);
+            HospitalFactory::createOne([
+                'name' => "QueryCountExtraHospB{$i}",
+                'state' => $state,
+                'dispatchArea' => $area,
+                'owner' => $user,
+            ]);
+        }
+
+        $beforeFirst = $this->doctrineQueryCount();
+        $this->loadScopeChoicesLikeFormRebuild($provider, $user);
+        $firstPass = $this->doctrineQueryCount() - $beforeFirst;
+
+        self::assertLessThanOrEqual(
+            self::MAX_FIRST_PASS_QUERIES,
+            $firstPass,
+            sprintf('Expected at most %d DB queries on first scope-choice pass, got %d.', self::MAX_FIRST_PASS_QUERIES, $firstPass),
+        );
+
+        $beforeSecond = $this->doctrineQueryCount();
+        $this->loadScopeChoicesLikeFormRebuild($provider, $user);
+        $secondPass = $this->doctrineQueryCount() - $beforeSecond;
+
+        self::assertSame(
+            0,
+            $secondPass,
+            sprintf('Expected request-memoized second pass to issue 0 queries, got %d.', $secondPass),
+        );
+    }
+
+    private function loadScopeChoicesLikeFormRebuild(
+        StatisticsFilterFormChoiceProvider $provider,
+        \App\User\Domain\Entity\User $user,
+    ): void {
+        $provider->scopePrimaryChoices($user, 'en');
+        $provider->scopeDetailRequired('my_hospitals', $user, StatisticsFilterSide::Primary);
+        $provider->scopeDetailChoices('my_hospitals', $user, StatisticsFilterSide::Primary, 'en');
+        $provider->scopeDetailChoices('state', $user, StatisticsFilterSide::Primary, 'en');
+        $provider->scopeDetailChoices('dispatch_area', $user, StatisticsFilterSide::Primary, 'en');
+    }
+
+    private function doctrineQueryCount(): int
+    {
+        self::assertTrue(self::getContainer()->has('doctrine.debug_data_holder'));
+        $holder = self::getContainer()->get('doctrine.debug_data_holder');
+        $total = 0;
+        foreach ($holder->getData() as $queries) {
+            $total += \count($queries);
+        }
+
+        return $total;
+    }
+}


### PR DESCRIPTION
## Summary

Some Analysis Explorer filter interactions (especially selecting **Hospital** / scope details such as **Dispatch area**) were slow because each LiveComponent `refreshEditForm` rebuild loaded scope choices repeatedly and resolved eligible state/dispatch-area labels with N+1 `findById` queries.

This PR reduces that database work and also fixes a regression where the Explorer edit drawer could show only the generic “Dispatch area” / “Leitstelle” label without the concrete detail, which led to an incomplete scope on apply and empty results.

Closes #409.

### Performance
- Add `findNamesByIds()` on `StateRepository` and `DispatchAreaRepository` (same pattern as hospitals).
- Update `StatisticsFilterFormChoiceProvider` to:
  - resolve eligible state/dispatch-area labels in one query each
  - memoize eligible rows, cohort choices, hospital detail choices, and primary scope choices for the **request lifetime** (no shared/HTTP cache for user-specific hospital lists)
- Avoid calling `scopeDetailRequired` + `scopeDetailChoices` separately in `BenchmarkSelectionSideFieldsConfigurator` when building dynamic fields.
- Leave `refreshEditForm` itself unchanged; memoization already collapses the double form rebuild cost for choice loading.

### Correctness
- `BenchmarkSelectionSideType` now configures and normalizes scope detail fields for both `BenchmarkSelectionSideFormData` and Explorer’s `StatisticsScopePeriodFormData` on `PRE_SET_DATA` / `PRE_SUBMIT`.
- Opening the edit drawer or selecting a scope that needs a detail (e.g. dispatch area) correctly shows and submits the concrete selection again.

### Docs & tests
- Document request-memoized scope choice loading in the Analysis Explorer and statistics filter/scope docs.
- Add integration coverage for batch name lookups, query-count/memoization budget, open-edit detail rendering, and dispatch-area apply persistence.

## Context / profiler notes
- Baseline (repeated scope-choice load mimicking a double form rebuild): **~37** queries.
- After batch lookups + memoization: **~21** on first pass, **0** on the memoized second pass in the same request.
- Analysis drawer reference data (department, indication, …) was already cached via `#268`; this work targets **scope/period** choice loading.

## Test plan
- [x] As a participant with access to multiple hospitals / eligible scopes, open Analysis Explorer → Edit
- [x] Change scope to **Dispatch area**: concrete Leitstelle options appear (not only the group label)
- [x] Apply and confirm the analysis returns filtered results for that Leitstelle
- [x] Re-open Edit on that view: selected Leitstelle is still visible without an extra refresh
- [x] Repeat for **State** and **My hospitals** (hospital detail when ≥2 hospitals)
- [x] Optionally check Symfony Profiler on a scope change: no per-ID state/area `findById` storm; hospital summary query not repeated within one Live request
- [x] Run focused tests:
  ```bash
  php bin/phpunit \
    tests/Allocation/Integration/Repository/StateAndDispatchAreaNamesByIdsTest.php \
    tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderTest.php \
    tests/Statistics/Integration/Benchmarking/StatisticsFilterFormChoiceProviderQueryCountTest.php \
    tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellFilterTest.php \
    tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchOpenEditTest.php \
    tests/Statistics/Integration/AnalysisExplorer/AnalysisExplorerShellDispatchScopeRegressionTest.php
  ```