### PR TITLE
refactor(statistics): Shorten hospital cohort labels with compact location · tier format

### DIFF
--- a/src/Statistics/Application/Cohort/HospitalCohortLabelResolver.php
+++ b/src/Statistics/Application/Cohort/HospitalCohortLabelResolver.php
@@ -19,15 +19,15 @@ final readonly class HospitalCohortLabelResolver
             'stats.filter.cohort.label',
             [
                 'location' => $this->translator->trans(
-                    'hospital.location.'.$key->location->value,
+                    'stats.filter.cohort.location.'.$key->location->value,
                     [],
-                    'messages',
+                    'statistics',
                     $locale,
                 ),
                 'tier' => $this->translator->trans(
-                    'hospital.tier.'.$key->tier->value,
+                    'stats.filter.cohort.tier.'.$key->tier->value,
                     [],
-                    'messages',
+                    'statistics',
                     $locale,
                 ),
             ],

--- a/tests/Statistics/Functional/Controller/DashboardControllerScopeTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerScopeTest.php
@@ -51,7 +51,7 @@ final class DashboardControllerScopeTest extends DashboardControllerTestCase
         $this->assertResponseIsSuccessful();
         $content = (string) $client->getResponse()->getContent();
         self::assertStringNotContainsString('stats.filter.cohort.', $content);
-        self::assertStringContainsString('Urban Location Basic Tier', $content);
+        self::assertStringContainsString('Urban · Basic', $content);
     }
 
     public function testStateScopeWithoutStateIdRedirectsToPublic(): void

--- a/tests/Statistics/Integration/Application/HospitalCohortLabelResolverTest.php
+++ b/tests/Statistics/Integration/Application/HospitalCohortLabelResolverTest.php
@@ -27,7 +27,7 @@ final class HospitalCohortLabelResolverTest extends KernelTestCase
             new HospitalCohortKey(HospitalLocation::URBAN, HospitalTier::FULL),
         );
 
-        self::assertSame('Urban Location Full Tier', $label);
+        self::assertSame('Urban · Full', $label);
         self::assertStringNotContainsString('stats.filter.cohort.', $label);
         self::assertStringNotContainsString('urban_full', $label);
     }
@@ -38,6 +38,6 @@ final class HospitalCohortLabelResolverTest extends KernelTestCase
             new HospitalCohortKey(HospitalLocation::MIXED, HospitalTier::EXTENDED),
         );
 
-        self::assertSame('Mixed Location Extended Tier', $label);
+        self::assertSame('Mixed · Extended', $label);
     }
 }

--- a/tests/Statistics/Unit/AnalysisExplorer/ExplorerAnalysisSummaryLabelResolverTest.php
+++ b/tests/Statistics/Unit/AnalysisExplorer/ExplorerAnalysisSummaryLabelResolverTest.php
@@ -133,14 +133,14 @@ final class ExplorerAnalysisSummaryLabelResolverTest extends TestCase
     public function testHospitalCohortScopeUsesResolverAndFallback(): void
     {
         $resolver = $this->resolver([
-            'stats.filter.cohort.label' => '{location} / {tier}',
-            'hospital.location.Urban' => 'Urban',
-            'hospital.tier.Basic' => 'Basic',
+            'stats.filter.cohort.label' => '{location} · {tier}',
+            'stats.filter.cohort.location.Urban' => 'Urban',
+            'stats.filter.cohort.tier.Basic' => 'Basic',
             'stats.filter.scope.hospital_cohort' => 'Hospital cohort',
         ]);
 
         self::assertSame(
-            'Urban / Basic',
+            'Urban · Basic',
             $resolver->scopeLabel(new StatisticsFilter(
                 scope: StatisticsFilterScope::HospitalCohort,
                 hospitalId: null,

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -2847,7 +2847,31 @@
       </trans-unit>
       <trans-unit id="Ded334e64e" resname="stats.filter.cohort.label">
         <source>stats.filter.cohort.label</source>
-        <target>{location} {tier}</target>
+        <target>{location} · {tier}</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocUrbanDe" resname="stats.filter.cohort.location.Urban">
+        <source>stats.filter.cohort.location.Urban</source>
+        <target>Städtisch</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocMixedDe" resname="stats.filter.cohort.location.Mixed">
+        <source>stats.filter.cohort.location.Mixed</source>
+        <target>Gemischt</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocRuralDe" resname="stats.filter.cohort.location.Rural">
+        <source>stats.filter.cohort.location.Rural</source>
+        <target>Ländlich</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierBasicDe" resname="stats.filter.cohort.tier.Basic">
+        <source>stats.filter.cohort.tier.Basic</source>
+        <target>Basis</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierExtendedDe" resname="stats.filter.cohort.tier.Extended">
+        <source>stats.filter.cohort.tier.Extended</source>
+        <target>Erweitert</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierFullDe" resname="stats.filter.cohort.tier.Full">
+        <source>stats.filter.cohort.tier.Full</source>
+        <target>Umfassend</target>
       </trans-unit>
       <trans-unit id="Debe6652b8" resname="stats.filter.hospital.all_hospitals">
         <source>stats.filter.hospital.all_hospitals</source>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -883,7 +883,31 @@
       </trans-unit>
       <trans-unit id="statsCohortLabel" resname="stats.filter.cohort.label">
         <source>stats.filter.cohort.label</source>
-        <target>{location} {tier}</target>
+        <target>{location} · {tier}</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocUrbanEn" resname="stats.filter.cohort.location.Urban">
+        <source>stats.filter.cohort.location.Urban</source>
+        <target>Urban</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocMixedEn" resname="stats.filter.cohort.location.Mixed">
+        <source>stats.filter.cohort.location.Mixed</source>
+        <target>Mixed</target>
+      </trans-unit>
+      <trans-unit id="statsCohortLocRuralEn" resname="stats.filter.cohort.location.Rural">
+        <source>stats.filter.cohort.location.Rural</source>
+        <target>Rural</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierBasicEn" resname="stats.filter.cohort.tier.Basic">
+        <source>stats.filter.cohort.tier.Basic</source>
+        <target>Basic</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierExtendedEn" resname="stats.filter.cohort.tier.Extended">
+        <source>stats.filter.cohort.tier.Extended</source>
+        <target>Extended</target>
+      </trans-unit>
+      <trans-unit id="statsCohortTierFullEn" resname="stats.filter.cohort.tier.Full">
+        <source>stats.filter.cohort.tier.Full</source>
+        <target>Full</target>
       </trans-unit>
       <trans-unit id="statsFlt04" resname="stats.filter.hospital_label">
         <source>stats.filter.hospital_label</source>


### PR DESCRIPTION
## Summary
- Replace long combined hospital cohort labels (e.g. "Urban Location Full Tier") with a compact middle-dot format (e.g. "Urban · Full" / "Städtisch · Umfassend").
- Introduce dedicated short `stats.filter.cohort.location.*` and `stats.filter.cohort.tier.*` translation keys used only for combined cohort labels.
- Keep standalone `hospital.location.*` / `hospital.tier.*` labels unchanged for badges and hospital forms.

## Test plan
- [x] Open Benchmarking → Comparison, select Hospital Cohorts and confirm dropdown options use the short labels
- [x] Confirm the same short labels appear in statistics header scope controls and Analysis Explorer when a hospital cohort is selected
- [x] Spot-check hospital list/detail badges still show the full location/tier wording