### PR TITLE
refactoring: Localize overview time-series labels and declutter KPI cards

### DIFF
--- a/assets/controllers/indication-dashboard-charts_controller.js
+++ b/assets/controllers/indication-dashboard-charts_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import { buildHeatmapSeries } from '../lib/build-heatmap-series.js';
+import { formatChartMonthLabel } from '../lib/format-chart-month-label.js';
 import { loadApexCharts } from '../lib/load-apexcharts.js';
 
 /* stimulusFetch: 'lazy' */
@@ -133,7 +134,7 @@ export default class extends Controller {
             const slice = values.slice(start, index + 1);
             const sum = slice.reduce((total, value) => total + value, 0);
 
-            return Math.round((sum / slice.length) * 10) / 10;
+            return Math.round(sum / slice.length);
         });
     }
 
@@ -170,10 +171,15 @@ export default class extends Controller {
                 labels: {
                     rotate: 0,
                     hideOverlappingLabels: true,
-                    formatter: (value) =>
-                        typeof value === 'string' && value.includes('-')
-                            ? value.slice(2).replace('-', '/')
-                            : value,
+                    formatter: (value) => formatChartMonthLabel(value),
+                },
+            },
+            tooltip: {
+                x: {
+                    formatter: (value) => formatChartMonthLabel(value),
+                },
+                y: {
+                    formatter: (value) => Math.round(value).toString(),
                 },
             },
             stroke: showMovingAverage
@@ -184,6 +190,10 @@ export default class extends Controller {
             yaxis: {
                 min: 0,
                 forceNiceScale: true,
+                decimalsInFloat: 0,
+                labels: {
+                    formatter: (value) => Math.round(value).toString(),
+                },
             },
             legend: {
                 show: showMovingAverage,
@@ -219,9 +229,7 @@ export default class extends Controller {
                     rotate: options.labelRotate ?? 0,
                     hideOverlappingLabels: true,
                     formatter: (value) =>
-                        options.sparseTicks && typeof value === 'string' && value.includes('-')
-                            ? value.slice(2).replace('-', '/')
-                            : value,
+                        options.sparseTicks ? formatChartMonthLabel(value) : value,
                 },
             },
             dataLabels: { enabled: false },

--- a/assets/lib/format-chart-month-label.js
+++ b/assets/lib/format-chart-month-label.js
@@ -1,0 +1,70 @@
+const MONTH_KEY_PATTERN = /^(\d{4})-(\d{2})$/;
+
+/** @type {Map<string, Intl.DateTimeFormat>} */
+const formattersByLocale = new Map();
+
+/**
+ * @param {string} [locale]
+ * @returns {string}
+ */
+function resolveLocale(locale) {
+    if (typeof locale === 'string' && locale !== '') {
+        return locale;
+    }
+
+    if (typeof document !== 'undefined') {
+        const lang = document.documentElement?.lang;
+        if (typeof lang === 'string' && lang !== '') {
+            return lang;
+        }
+    }
+
+    return 'en';
+}
+
+/**
+ * @param {string} locale
+ * @returns {Intl.DateTimeFormat}
+ */
+function getFormatter(locale) {
+    let formatter = formattersByLocale.get(locale);
+    if (!formatter) {
+        formatter = new Intl.DateTimeFormat(locale, {
+            month: 'short',
+            year: '2-digit',
+        });
+        formattersByLocale.set(locale, formatter);
+    }
+
+    return formatter;
+}
+
+/**
+ * Formats a chart month category (`YYYY-MM`) for axis ticks and tooltips.
+ * Non-matching values are returned unchanged.
+ *
+ * @param {unknown} value
+ * @param {string} [locale]
+ * @returns {unknown}
+ */
+export function formatChartMonthLabel(value, locale) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    const match = MONTH_KEY_PATTERN.exec(value);
+    if (!match) {
+        return value;
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    if (!Number.isInteger(year) || month < 1 || month > 12) {
+        return value;
+    }
+
+    // Local calendar date is enough: we only format month + year.
+    const date = new Date(year, month - 1, 1);
+
+    return getFormatter(resolveLocale(locale)).format(date);
+}

--- a/src/Statistics/Application/Overview/OverviewKpiPresentationFactory.php
+++ b/src/Statistics/Application/Overview/OverviewKpiPresentationFactory.php
@@ -21,11 +21,4 @@ final readonly class OverviewKpiPresentationFactory
             'cases_per_day' => $casesPerDayKey,
         ];
     }
-
-    public function casesPerDayHintTranslationKey(StatisticsFilter $filter): ?string
-    {
-        return OverviewScopeClassifier::isAggregateScope($filter->scope)
-            ? 'stats.overview.kpi.cases_per_day_aggregate_hint'
-            : null;
-    }
 }

--- a/src/Statistics/UI/Http/Controller/DashboardController.php
+++ b/src/Statistics/UI/Http/Controller/DashboardController.php
@@ -104,8 +104,6 @@ final class DashboardController extends AbstractController
             'executiveDashboard' => $executiveDashboard,
             'overviewPortalLinks' => $this->overviewPortalNavigationFactory->build(),
             'overviewKpiMetricLabelKeys' => $this->overviewKpiPresentationFactory->metricLabelKeys($filter),
-            'overviewKpiCasesPerDayHintKey' => $this->overviewKpiPresentationFactory->casesPerDayHintTranslationKey($filter),
-            'overviewKpiHintBelowValue' => $user instanceof User && $user->getHospitals()->isEmpty(),
             'hospitalSummaryWidgets' => $this->hospitalSummaryProvider->build($context, $overviewMetrics),
             'clinicalFeatureWidgets' => $this->clinicalFeaturesProvider->build($context, $overviewMetrics),
             'statisticsFilter' => $pageViewModel->filter,

--- a/src/Statistics/UI/Http/Controller/OverviewSelfBenchmarkController.php
+++ b/src/Statistics/UI/Http/Controller/OverviewSelfBenchmarkController.php
@@ -43,8 +43,6 @@ final class OverviewSelfBenchmarkController extends AbstractController
         return $this->render('@Statistics/dashboard/_overview_self_benchmark_frame.html.twig', [
             'selfBenchmarkFrame' => $selfBenchmarkFrame,
             'overviewKpiMetricLabelKeys' => $this->overviewKpiPresentationFactory->metricLabelKeys($filter),
-            'overviewKpiCasesPerDayHintKey' => $this->overviewKpiPresentationFactory->casesPerDayHintTranslationKey($filter),
-            'overviewKpiHintBelowValue' => $user instanceof User && $user->getHospitals()->isEmpty(),
         ]);
     }
 }

--- a/src/Statistics/UI/Twig/templates/_kpi_compare_tiles.html.twig
+++ b/src/Statistics/UI/Twig/templates/_kpi_compare_tiles.html.twig
@@ -7,8 +7,6 @@
             {% set ratioTone = metric.ratio > 1 ? 'success' : (metric.ratio < 1 ? 'danger' : 'primary') %}
             {% set ratioBadgeClass = ratioTone == 'danger' ? 'bg-red-lt' : (ratioTone == 'success' ? 'bg-green-lt' : 'bg-primary-lt') %}
             {% set labelKey = metricLabelKeys[metric.key.value]|default('stats.benchmark.metric.' ~ metric.key.value) %}
-            {% set hintKey = (metricHintKeys|default({}))[metric.key.value]|default(null) %}
-            {% set hintBelowValue = metricHintBelowValue|default(false) %}
             {% set tileColumnClass = columnClass|default('col-sm-6 col-lg-4') %}
 
             {% if metric.format.value == 'percent' %}
@@ -39,9 +37,6 @@
                         <div class="subheader mb-2">
                             {{ labelKey|trans({}, 'statistics') }}
                         </div>
-                        {% if hintKey and not hintBelowValue %}
-                            <p class="text-muted small mb-2">{{ hintKey|trans({}, 'statistics') }}</p>
-                        {% endif %}
 
                         {% if not suppressRatios %}
                             <div class="d-flex align-items-baseline gap-2 mb-3">
@@ -57,9 +52,6 @@
                                     <div class="h3 mb-0 text-muted">{{ comparisonLabel }}</div>
                                 </div>
                             </div>
-                        {% endif %}
-                        {% if hintKey and hintBelowValue %}
-                            <p class="text-muted small mb-2">{{ hintKey|trans({}, 'statistics') }}</p>
                         {% endif %}
 
                         <div class="mt-auto d-flex justify-content-between small">

--- a/src/Statistics/UI/Twig/templates/dashboard/_executive_kpi_grid.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_executive_kpi_grid.html.twig
@@ -7,7 +7,5 @@
         testIdPrefix: 'stats-executive-kpi',
         columnClass: 'col-12 col-md-4',
         metricLabelKeys: overviewKpiMetricLabelKeys|default({}),
-        metricHintKeys: overviewKpiCasesPerDayHintKey is defined and overviewKpiCasesPerDayHintKey is not null ? {cases_per_day: overviewKpiCasesPerDayHintKey} : {},
-        metricHintBelowValue: overviewKpiHintBelowValue|default(false),
     }) }}
 </div>

--- a/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_frame.html.twig
+++ b/src/Statistics/UI/Twig/templates/dashboard/_overview_self_benchmark_frame.html.twig
@@ -10,8 +10,6 @@
                     testIdPrefix: 'stats-executive-kpi',
                     columnClass: 'col-12 col-md-4',
                     metricLabelKeys: overviewKpiMetricLabelKeys|default({}),
-                    metricHintKeys: overviewKpiCasesPerDayHintKey is defined and overviewKpiCasesPerDayHintKey is not null ? {cases_per_day: overviewKpiCasesPerDayHintKey} : {},
-                    metricHintBelowValue: overviewKpiHintBelowValue|default(false),
                 }) }}
             </div>
         </div>

--- a/tests/Statistics/Functional/Controller/DashboardControllerWidgetsTest.php
+++ b/tests/Statistics/Functional/Controller/DashboardControllerWidgetsTest.php
@@ -12,7 +12,6 @@ use App\Allocation\Infrastructure\Factory\AllocationFactory;
 use App\Allocation\Infrastructure\Factory\AssignmentFactory;
 use App\Allocation\Infrastructure\Factory\DepartmentFactory;
 use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
-use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
 use App\Allocation\Infrastructure\Factory\HospitalFactory;
 use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
 use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
@@ -20,7 +19,6 @@ use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\User\Domain\Factory\UserFactory;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
 final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
@@ -110,34 +108,6 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
             0,
             $crawler->filter('[data-data-quality-indicator-target="badge"]')->count(),
         );
-    }
-
-    public function testOverviewShowsAggregateCasesPerDayHintBelowValueForParticipantWithoutOwnedHospitals(): void
-    {
-        $client = self::createClient();
-        $participant = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
-        $hospitalOwner = UserFactory::createOne();
-        $hospital = HospitalFactory::createOne(['owner' => $hospitalOwner]);
-        HospitalAccessGrantFactory::createOne(['user' => $participant, 'hospital' => $hospital]);
-        $client->loginUser($participant);
-
-        $crawler = $client->request(Request::METHOD_GET, '/statistics/overview/self-benchmark?scope=public&period=all_time');
-
-        $this->assertResponseIsSuccessful();
-        $this->assertCasesPerDayAggregateHintPosition($crawler, belowValue: true);
-    }
-
-    public function testOverviewShowsAggregateCasesPerDayHintAboveValueForHospitalOwner(): void
-    {
-        $client = self::createClient();
-        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
-        HospitalFactory::createOne(['owner' => $owner]);
-        $client->loginUser($owner);
-
-        $crawler = $client->request(Request::METHOD_GET, '/statistics/overview/self-benchmark?scope=public&period=all_time');
-
-        $this->assertResponseIsSuccessful();
-        $this->assertCasesPerDayAggregateHintPosition($crawler, belowValue: false);
     }
 
     public function testOverviewRendersPortalNavigationLinks(): void
@@ -264,29 +234,6 @@ final class DashboardControllerWidgetsTest extends DashboardControllerTestCase
         $this->assertResponseIsSuccessful();
         $this->assertCount(7, $crawler->filter('[data-testid="stats-overview-features"] .progress'));
         $this->assertCount(2, $crawler->filter('[data-testid="stats-overview-resources"] .progress'));
-    }
-
-    private function assertCasesPerDayAggregateHintPosition(Crawler $crawler, bool $belowValue): void
-    {
-        $cardBody = $crawler->filter('[data-testid="stats-executive-kpi-cases_per_day"] .card-body');
-        self::assertGreaterThan(0, $cardBody->count());
-
-        $hintText = 'Aggregated across all hospitals in the selected scope.';
-        self::assertStringContainsString($hintText, $cardBody->text());
-
-        $bodyHtml = $cardBody->html();
-        $hintPos = strpos($bodyHtml, $hintText);
-        self::assertNotFalse($hintPos);
-
-        preg_match('/class="h[23]/', $bodyHtml, $matches, PREG_OFFSET_CAPTURE);
-        self::assertNotEmpty($matches);
-        $valuePos = $matches[0][1];
-
-        if ($belowValue) {
-            self::assertGreaterThan($valuePos, $hintPos, 'Expected aggregate hint below the KPI value.');
-        } else {
-            self::assertLessThan($valuePos, $hintPos, 'Expected aggregate hint above the KPI value.');
-        }
     }
 
     private function seedOverviewHospitalInsightsScenario(): void

--- a/tests/Statistics/Unit/Application/Overview/OverviewKpiPresentationFactoryTest.php
+++ b/tests/Statistics/Unit/Application/Overview/OverviewKpiPresentationFactoryTest.php
@@ -27,10 +27,6 @@ final class OverviewKpiPresentationFactoryTest extends TestCase
         $keys = $this->factory->metricLabelKeys($this->filterForScope($scope));
 
         self::assertSame('stats.overview.kpi.cases_per_day_aggregate', $keys['cases_per_day']);
-        self::assertSame(
-            'stats.overview.kpi.cases_per_day_aggregate_hint',
-            $this->factory->casesPerDayHintTranslationKey($this->filterForScope($scope)),
-        );
     }
 
     #[DataProvider('hospitalLikeScopeProvider')]
@@ -39,7 +35,6 @@ final class OverviewKpiPresentationFactoryTest extends TestCase
         $keys = $this->factory->metricLabelKeys($this->filterForScope($scope));
 
         self::assertSame('stats.overview.kpi.cases_per_day', $keys['cases_per_day']);
-        self::assertNull($this->factory->casesPerDayHintTranslationKey($this->filterForScope($scope)));
     }
 
     /**

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -4501,10 +4501,6 @@
         <source>stats.overview.kpi.cases_per_day_aggregate</source>
         <target>Durchschnittliches Tagesvolumen</target>
       </trans-unit>
-      <trans-unit id="Deac891283" resname="stats.overview.kpi.cases_per_day_aggregate_hint">
-        <source>stats.overview.kpi.cases_per_day_aggregate_hint</source>
-        <target>Aggregiert über alle Krankenhäuser im gewählten Bereich.</target>
-      </trans-unit>
       <trans-unit id="De73e07de7" resname="stats.overview.kpi.current_short">
         <source>stats.overview.kpi.current_short</source>
         <target>Zeitraum</target>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -1325,10 +1325,6 @@
         <source>stats.overview.kpi.cases_per_day_aggregate</source>
         <target>Average daily volume</target>
       </trans-unit>
-      <trans-unit id="statsOvKp03" resname="stats.overview.kpi.cases_per_day_aggregate_hint">
-        <source>stats.overview.kpi.cases_per_day_aggregate_hint</source>
-        <target>Aggregated across all hospitals in the selected scope.</target>
-      </trans-unit>
       <trans-unit id="statsOvKp04" resname="stats.overview.kpi.current_short">
         <source>stats.overview.kpi.current_short</source>
         <target>Period</target>


### PR DESCRIPTION
## Summary
- Localize Overview and Indication Dashboard time-series month ticks/tooltips via `Intl.DateTimeFormat` (e.g. `Sept. 25` / `Sep 25` instead of ambiguous `25/09`), and keep case counts as whole numbers on the Y-axis, tooltip, and moving average.
- Remove the aggregate-scope caption (“Aggregated across all hospitals in the selected scope.”) from Overview executive KPI cards to reduce visual clutter.

## Test plan
- [x] Open Overview with locale `de` and confirm time-series ticks/tooltips show short German months (e.g. `Sept. 25`)
- [x] Switch to locale `en` and confirm English short months (e.g. `Sep 25`)
- [x] Confirm Y-axis and tooltip case values are integers (no decimal places)
- [x] Confirm Overview KPI cards no longer show the aggregate hospital scope hint
- [x] Spot-check an Indication Dashboard time-series chart for the same localized labels