### PR TITLE
chore: Align PostgreSQL 18 and harden backup/restore for PostGIS hosts

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ APP_SECRET=
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
-DATABASE_URL="postgresql://app:password@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+DATABASE_URL="postgresql://app:password@127.0.0.1:5432/app?serverVersion=18&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/messenger ###

--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ APP_SECRET=
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-DATABASE_URL="postgresql://app:password@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+DATABASE_URL="postgresql://app:password@127.0.0.1:5432/app?serverVersion=18&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/messenger ###

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
             SYMFONY_DEPRECATIONS_HELPER: 'max[total]=0&verbose=1'
         services:
             postgres:
-                image: postgres:16
+                image: postgres:18
                 ports:
                     - 5432:5432
                 env:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import and validation to statistical analysis and reporting.
 ### Requirements
 
 - PHP `>=8.4`
-- PostgreSQL `>=16`
+- PostgreSQL `>=18`
 - A running web server or Symfony CLI
 - Optional Docker for local infrastructure
 

--- a/bin/ops/_lib.sh
+++ b/bin/ops/_lib.sh
@@ -60,6 +60,36 @@ ops_database_url_without_query() {
     echo "${DATABASE_URL%%\?*}"
 }
 
+# Userinfo from postgresql://user:pass@host/db (password may contain URL-encoding).
+ops_database_user_from_url() {
+    local url rest userinfo
+    url="$(ops_database_url_without_query)"
+    rest="${url#*://}"
+    userinfo="${rest%%@*}"
+    echo "${userinfo%%:*}"
+}
+
+# pg_restore -l lines to skip (PostGIS / extensions from shared hosting dumps).
+ops_pg_restore_toc_exclude_ere() {
+    echo 'EXTENSION|spatial_ref_sys|geometry_columns|geography_columns'
+}
+
+# Extra pg_dump flags so backups stay app-schema-only on hosts with PostGIS in public.
+ops_pg_dump_postgis_exclude_args() {
+    echo --exclude-table=spatial_ref_sys
+    echo --exclude-table=geometry_columns
+    echo --exclude-table=geography_columns
+}
+
+ops_filter_pg_restore_toc() {
+    local dump_file="$1"
+    local list_file="$2"
+    local pattern
+    pattern="$(ops_pg_restore_toc_exclude_ere)"
+    # grep exits 1 when every line is excluded; that is fine for an empty TOC filter result.
+    pg_restore -l "$dump_file" | grep -v -E "$pattern" >"$list_file" || true
+}
+
 ops_docker_compose_available() {
     command -v docker >/dev/null 2>&1 \
         && docker compose version >/dev/null 2>&1

--- a/bin/ops/backup-database.sh
+++ b/bin/ops/backup-database.sh
@@ -15,13 +15,16 @@ ops_log "Database backup starting → $OUTPUT_FILE"
 
 if ops_docker_database_running; then
     ops_log "Using Docker Compose service 'database' (pg_dump inside container)"
+    # shellcheck disable=SC2046
     docker compose exec -T database \
-        pg_dump -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" -Fc \
+        pg_dump -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" \
+        --schema=public $(ops_pg_dump_postgis_exclude_args) -Fc \
         >"$OUTPUT_FILE"
 elif command -v pg_dump >/dev/null 2>&1; then
     DATABASE_URL_CLEAN="$(ops_database_url_without_query)"
     ops_log "Using local pg_dump with DATABASE_URL"
-    pg_dump "$DATABASE_URL_CLEAN" -Fc -f "$OUTPUT_FILE"
+    # shellcheck disable=SC2046
+    pg_dump "$DATABASE_URL_CLEAN" --schema=public $(ops_pg_dump_postgis_exclude_args) -Fc -f "$OUTPUT_FILE"
 else
     ops_die "Neither a running Docker database service nor pg_dump on PATH is available."
 fi

--- a/bin/ops/restore-database.sh
+++ b/bin/ops/restore-database.sh
@@ -18,8 +18,9 @@ Environment:
   RESTORE_CONFIRM   Must be "yes" to proceed (safety gate)
   DATABASE_URL      Target database (from env or .env.local / .env)
 
-This replaces objects in the target database. Use only on dev/staging or after
-a confirmed incident on production.
+Replaces schema public (DROP … CASCADE + recreate), then restores from the dump.
+PostGIS extensions and tables (spatial_ref_sys, …) in the dump TOC are skipped.
+Use only on dev/staging or after a confirmed incident on production.
 EOF
 }
 
@@ -44,20 +45,59 @@ fi
 
 cd "$ROOT"
 
+# Resolve to an absolute path for docker cp / host tooling.
+BACKUP_FILE="$(cd "$(dirname "$BACKUP_FILE")" && pwd)/$(basename "$BACKUP_FILE")"
+
 ops_log "Database restore starting from $BACKUP_FILE"
+
+ops_reset_public_schema_docker() {
+    local user db
+    user="${POSTGRES_USER:-app}"
+    db="${POSTGRES_DB:-app}"
+    ops_log "Resetting schema public (Docker)"
+    docker compose exec -T database psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -c 'DROP SCHEMA public CASCADE;'
+    docker compose exec -T database psql -U "$user" -d "$db" -v ON_ERROR_STOP=1 -c \
+        "CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO \"${user}\"; GRANT ALL ON SCHEMA public TO public;"
+}
+
+ops_reset_public_schema_host() {
+    local url user
+    url="$(ops_database_url_without_query)"
+    user="$(ops_database_user_from_url)"
+    ops_log "Resetting schema public (host psql)"
+    psql "$url" -v ON_ERROR_STOP=1 -c 'DROP SCHEMA public CASCADE;'
+    psql "$url" -v ON_ERROR_STOP=1 -c \
+        "CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO \"${user}\"; GRANT ALL ON SCHEMA public TO public;"
+}
 
 if ops_docker_database_running; then
     ops_log "Using Docker Compose service 'database' (pg_restore inside container)"
+    user="${POSTGRES_USER:-app}"
+    db="${POSTGRES_DB:-app}"
+    container="$(docker compose ps -q database)"
+    if [[ -z "$container" ]]; then
+        ops_die "Could not resolve Docker container for service 'database'."
+    fi
+
+    ops_reset_public_schema_docker
+
+    docker cp "$BACKUP_FILE" "$container:/tmp/restore.dump"
+    docker compose exec -T database sh -c \
+        "pg_restore -l /tmp/restore.dump | grep -v -E '$(ops_pg_restore_toc_exclude_ere)' > /tmp/restore.list || true"
     docker compose exec -T database \
-        pg_restore --clean --if-exists --no-owner --no-acl \
-        -U "${POSTGRES_USER:-app}" -d "${POSTGRES_DB:-app}" \
-        <"$BACKUP_FILE"
-elif command -v pg_restore >/dev/null 2>&1; then
+        pg_restore --no-owner --no-acl -U "$user" -d "$db" -L /tmp/restore.list /tmp/restore.dump
+    docker compose exec -T database rm -f /tmp/restore.dump /tmp/restore.list
+elif command -v pg_restore >/dev/null 2>&1 && command -v psql >/dev/null 2>&1; then
     DATABASE_URL_CLEAN="$(ops_database_url_without_query)"
     ops_log "Using local pg_restore with DATABASE_URL"
-    pg_restore --clean --if-exists --no-owner --no-acl -d "$DATABASE_URL_CLEAN" "$BACKUP_FILE"
+    LIST_FILE="$(mktemp)"
+    trap 'rm -f "$LIST_FILE"' EXIT
+
+    ops_reset_public_schema_host
+    ops_filter_pg_restore_toc "$BACKUP_FILE" "$LIST_FILE"
+    pg_restore --no-owner --no-acl -d "$DATABASE_URL_CLEAN" -L "$LIST_FILE" "$BACKUP_FILE"
 else
-    ops_die "Neither a running Docker database service nor pg_restore on PATH is available."
+    ops_die "Neither a running Docker database service nor pg_restore+psql on PATH is available."
 fi
 
 ops_log "Database restore finished. Run: php bin/console cache:clear"

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@
 services:
 ###> doctrine/doctrine-bundle ###
   database:
-    image: postgres:${POSTGRES_VERSION:-16}-alpine
+    image: postgres:${POSTGRES_VERSION:-18}-alpine
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-app}
       # You should definitely change the password in production
@@ -14,9 +14,10 @@ services:
       retries: 5
       start_period: 60s
     volumes:
-      - database_data:/var/lib/postgresql/data:rw
+      # Postgres 18+ images expect the mount at /var/lib/postgresql (not .../data)
+      - database_data:/var/lib/postgresql:rw
       # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-      # - ./docker/db/data:/var/lib/postgresql/data:rw
+      # - ./docker/db/data:/var/lib/postgresql:rw
 ###< doctrine/doctrine-bundle ###
 
 volumes:

--- a/docs/01-getting-started/local-setup.md
+++ b/docs/01-getting-started/local-setup.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - PHP `>=8.4`
-- PostgreSQL `>=16`
+- PostgreSQL `>=18`
 - Composer
 - Node.js `>=22.13` and npm (required for JavaScript linting in development)
 - Symfony CLI (recommended)

--- a/docs/05-operations/backup-restore.md
+++ b/docs/05-operations/backup-restore.md
@@ -17,9 +17,9 @@ Backups are written to `var/backups/` locally (override with `BACKUP_DIR`).
 
 | Script | Purpose |
 |--------|---------|
-| `bin/ops/backup-database.sh` | `pg_dump` custom format (`.dump`) |
+| `bin/ops/backup-database.sh` | `pg_dump` custom format (`.dump`), schema `public` only (skips PostGIS schemas `tiger`/`topology` and PostGIS tables in `public`) |
 | `bin/ops/backup-files.sh` | `tar.gz` of imports + media |
-| `bin/ops/restore-database.sh` | `pg_restore` from `.dump` (requires `RESTORE_CONFIRM=yes`) |
+| `bin/ops/restore-database.sh` | Reset schema `public` (CASCADE), then `pg_restore` (requires `RESTORE_CONFIRM=yes`; skips PostGIS extensions/tables in the dump TOC) |
 | `bin/ops/verify-restore.sh` | Capture/compare row counts for restore drills |
 
 ### Make targets
@@ -211,7 +211,7 @@ Cron is configured on Uberspace outside this repository.
 
 4. Smoke test: `curl -sS https://<host>/health | jq` (expect HTTP 200, `checks.database: ok`), then login, import list, statistics dashboard.
 
-`pg_restore --clean --if-exists` drops and recreates objects from the dump. Schema drift after restore is unlikely if the dump matches the deployed code version; if not, run `php bin/console doctrine:migrations:status`.
+`restore-database.sh` drops and recreates schema `public` (`DROP SCHEMA public CASCADE`), then restores from the dump without `--clean`. PostGIS extensions and tables (`spatial_ref_sys`, …) listed in the dump TOC are skipped so restores work on plain Postgres (e.g. local Docker) even when the dump came from a host with PostGIS. Schema drift after restore is unlikely if the dump matches the deployed code version; if not, run `php bin/console doctrine:migrations:status`.
 
 ### 2. Import and media files
 

--- a/docs/05-operations/deployment.md
+++ b/docs/05-operations/deployment.md
@@ -76,7 +76,7 @@ Further reading:
 
 On the server:
 
-- PHP 8.4+ and PostgreSQL 16+ (same as the web application)
+- PHP 8.4+ and PostgreSQL 18+ (same as the web application)
 - Document root pointing at `public/` under the Deployer `current` symlink
 - Server `.env.local` (shared across releases via Deployer)
 


### PR DESCRIPTION
## Summary

- Bump local Docker, CI, Doctrine `serverVersion`, and docs from PostgreSQL 16 to **18** to match production (Uberspace 18.4), including the Postgres 18 volume mount at `/var/lib/postgresql`.
- Make database backups dump **schema `public` only**, excluding PostGIS tables (`spatial_ref_sys`, `geometry_columns`, `geography_columns`) that break dumps/restores on shared hosts.
- Harden restore: reset `public` with `DROP SCHEMA … CASCADE`, then `pg_restore` with a TOC filter that skips PostGIS extensions/tables so production dumps restore cleanly into plain Docker Postgres (works on host without Docker as well).

## Test plan

- [x] `docker compose up -d database` and confirm `postgres --version` reports 18.x
- [x] `make backup-db` succeeds locally
- [x] `make restore-db BACKUP_FILE=var/backups/<dump>.dump RESTORE_CONFIRM=yes` succeeds (including a production dump that previously failed on PostGIS/`--clean`)
- [x] On Uberspace (after deploy): `BACKUP_DIR=~/backups ./bin/ops/backup-database.sh` with sourced `shared/.env.local` succeeds without `tiger` permission errors