### PR TITLE
feat: Add page table of contents and frontend edit shortcuts

### DIFF
--- a/migrations/Version20260812082924.php
+++ b/migrations/Version20260812082924.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260812082924 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional show_toc flag to page_translation for frontend table of contents';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE page_translation ADD show_toc BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE page_translation DROP show_toc');
+    }
+}

--- a/src/Admin/UI/Http/Controller/Page/PageTranslationCrudController.php
+++ b/src/Admin/UI/Http/Controller/Page/PageTranslationCrudController.php
@@ -26,6 +26,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -187,6 +188,8 @@ final class PageTranslationCrudController extends AbstractCrudController
                 'Published' => PageTranslation::STATUS_PUBLISHED,
             ])
             ->renderAsBadges();
+        yield BooleanField::new('showToc', new TranslatableMessage('label.show_toc', domain: 'content'))
+            ->setHelp(new TranslatableMessage('help.page.show_toc', domain: 'content'));
         yield TextField::new('path', 'label.path')
             ->hideOnForm()
             ->hideOnIndex();

--- a/src/Content/Application/Page/PageTableOfContentsBuilder.php
+++ b/src/Content/Application/Page/PageTableOfContentsBuilder.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+use App\Content\Application\Slug\SlugGenerator;
+
+/**
+ * Builds a hierarchical table of contents from page content blocks and injects
+ * stable heading anchor IDs at render time (headline + richtext only).
+ *
+ * @phpstan-type ContentBlock array{type: string, data: array<string, mixed>, enabled?: bool}
+ */
+final readonly class PageTableOfContentsBuilder
+{
+    private const array HEADING_LEVELS = ['h1' => 1, 'h2' => 2, 'h3' => 3];
+
+    public function __construct(
+        private SlugGenerator $slugGenerator,
+    ) {
+    }
+
+    /**
+     * @param list<ContentBlock> $content
+     */
+    public function build(array $content, bool $showToc): PageTableOfContentsResult
+    {
+        if (!$showToc) {
+            return new PageTableOfContentsResult($content, []);
+        }
+
+        $usedIds = [];
+        $items = [];
+        $processed = [];
+
+        foreach ($content as $block) {
+            if (false === ($block['enabled'] ?? true)) {
+                $processed[] = $block;
+                continue;
+            }
+
+            $type = $block['type'] ?? '';
+
+            if ('headline' === $type) {
+                $processed[] = $this->processHeadlineBlock($block, $items, $usedIds);
+                continue;
+            }
+
+            if ('richtext' === $type) {
+                $processed[] = $this->processRichtextBlock($block, $items, $usedIds);
+                continue;
+            }
+
+            $processed[] = $block;
+        }
+
+        if ([] === $items) {
+            return new PageTableOfContentsResult($content, []);
+        }
+
+        return new PageTableOfContentsResult($processed, $items);
+    }
+
+    /**
+     * @param ContentBlock                                      $block
+     * @param list<array{id: string, text: string, level: int}> $items
+     * @param array<string, true>                               $usedIds
+     *
+     * @return ContentBlock
+     */
+    private function processHeadlineBlock(array $block, array &$items, array &$usedIds): array
+    {
+        $levelTag = (string) ($block['data']['level'] ?? 'h2');
+        if (!isset(self::HEADING_LEVELS[$levelTag])) {
+            return $block;
+        }
+
+        $text = trim(html_entity_decode(strip_tags((string) ($block['data']['text'] ?? '')), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        if ('' === $text) {
+            return $block;
+        }
+
+        $id = $this->uniqueId($text, $usedIds);
+        $block['data']['id'] = $id;
+        $items[] = [
+            'id' => $id,
+            'text' => $text,
+            'level' => self::HEADING_LEVELS[$levelTag],
+        ];
+
+        return $block;
+    }
+
+    /**
+     * @param ContentBlock                                      $block
+     * @param list<array{id: string, text: string, level: int}> $items
+     * @param array<string, true>                               $usedIds
+     *
+     * @return ContentBlock
+     */
+    private function processRichtextBlock(array $block, array &$items, array &$usedIds): array
+    {
+        $html = (string) ($block['data']['html'] ?? '');
+        if ('' === trim($html)) {
+            return $block;
+        }
+
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $loaded = $dom->loadHTML(
+            '<?xml encoding="UTF-8"><body>'.$html.'</body>',
+            LIBXML_HTML_NODEFDTD,
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if (!$loaded) {
+            return $block;
+        }
+
+        $xpath = new \DOMXPath($dom);
+        $headings = $xpath->query('//body//h1|//body//h2|//body//h3');
+        if (!$headings instanceof \DOMNodeList || 0 === $headings->length) {
+            return $block;
+        }
+
+        $changed = false;
+        foreach ($headings as $heading) {
+            if (!$heading instanceof \DOMElement) {
+                continue;
+            }
+
+            $text = trim(html_entity_decode($heading->textContent, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            if ('' === $text) {
+                continue;
+            }
+
+            $levelTag = strtolower($heading->tagName);
+            if (!isset(self::HEADING_LEVELS[$levelTag])) {
+                continue;
+            }
+
+            $existingId = trim($heading->getAttribute('id'));
+            if ('' !== $existingId && !isset($usedIds[$existingId])) {
+                $id = $existingId;
+            } else {
+                $id = $this->uniqueId($text, $usedIds);
+                $heading->setAttribute('id', $id);
+                $changed = true;
+            }
+
+            $usedIds[$id] = true;
+            $items[] = [
+                'id' => $id,
+                'text' => $text,
+                'level' => self::HEADING_LEVELS[$levelTag],
+            ];
+        }
+
+        if ($changed) {
+            $block['data']['html'] = $this->innerHtml($dom);
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param array<string, true> $usedIds
+     */
+    private function uniqueId(string $text, array &$usedIds): string
+    {
+        try {
+            $base = $this->slugGenerator->normalize($text, 80);
+        } catch (\InvalidArgumentException) {
+            $base = 'section';
+        }
+
+        $candidate = $base;
+        $counter = 2;
+        while (isset($usedIds[$candidate])) {
+            $suffix = '-'.$counter;
+            $candidate = rtrim(substr($base, 0, max(1, 80 - strlen($suffix))), '-').$suffix;
+            ++$counter;
+        }
+
+        $usedIds[$candidate] = true;
+
+        return $candidate;
+    }
+
+    private function innerHtml(\DOMDocument $dom): string
+    {
+        $body = $dom->getElementsByTagName('body')->item(0);
+        if (!$body instanceof \DOMElement) {
+            return '';
+        }
+
+        $html = '';
+        foreach ($body->childNodes as $child) {
+            $html .= $dom->saveHTML($child);
+        }
+
+        return $html;
+    }
+}

--- a/src/Content/Application/Page/PageTableOfContentsResult.php
+++ b/src/Content/Application/Page/PageTableOfContentsResult.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Page;
+
+/**
+ * @phpstan-type TocItem array{id: string, text: string, level: int}
+ * @phpstan-type ContentBlock array{type: string, data: array<string, mixed>, enabled?: bool}
+ */
+final readonly class PageTableOfContentsResult
+{
+    /**
+     * @param list<ContentBlock> $content
+     * @param list<TocItem>      $items
+     */
+    public function __construct(
+        public array $content,
+        public array $items,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->items;
+    }
+}

--- a/src/Content/Domain/Entity/PageTranslation.php
+++ b/src/Content/Domain/Entity/PageTranslation.php
@@ -63,6 +63,9 @@ class PageTranslation implements \Stringable
     #[ORM\Column(length: 32)]
     private string $status = self::STATUS_DRAFT;
 
+    #[ORM\Column(options: ['default' => false])]
+    private bool $showToc = false;
+
     /**
      * @var list<array{
      *   type: string,
@@ -157,6 +160,18 @@ class PageTranslation implements \Stringable
     public function setStatus(string $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function isShowToc(): bool
+    {
+        return $this->showToc;
+    }
+
+    public function setShowToc(bool $showToc): self
+    {
+        $this->showToc = $showToc;
 
         return $this;
     }

--- a/src/Content/Infrastructure/Factory/PageTranslationFactory.php
+++ b/src/Content/Infrastructure/Factory/PageTranslationFactory.php
@@ -34,6 +34,7 @@ final class PageTranslationFactory extends PersistentObjectFactory
             'slug' => $slug,
             'path' => '/'.$slug,
             'status' => PageTranslation::STATUS_PUBLISHED,
+            'showToc' => false,
             'content' => [
                 [
                     'type' => 'richtext',

--- a/src/Content/UI/Http/Controller/PageController.php
+++ b/src/Content/UI/Http/Controller/PageController.php
@@ -7,6 +7,7 @@ namespace App\Content\UI\Http\Controller;
 use App\Content\Application\Page\PageAccessChecker;
 use App\Content\Application\Page\PageLocaleAlternateLinkBuilder;
 use App\Content\Application\Page\PageSidebarDataProvider;
+use App\Content\Application\Page\PageTableOfContentsBuilder;
 use App\Content\Application\Page\PageTranslationResolver;
 use App\Content\Domain\Entity\Page;
 use App\Content\Domain\Entity\PageTranslation;
@@ -25,6 +26,7 @@ final class PageController extends AbstractController
         private readonly PageSidebarDataProvider $pageSidebarDataProvider,
         private readonly PageTranslationResolver $pageTranslationResolver,
         private readonly PageLocaleAlternateLinkBuilder $pageLocaleAlternateLinkBuilder,
+        private readonly PageTableOfContentsBuilder $pageTableOfContentsBuilder,
         private readonly TranslatorInterface $translator,
     ) {
     }
@@ -55,9 +57,16 @@ final class PageController extends AbstractController
             ),
         );
 
+        $tableOfContents = $this->pageTableOfContentsBuilder->build(
+            $translation->getContent(),
+            $translation->isShowToc(),
+        );
+
         return $this->render('@Content/page/show.html.twig', [
             'page' => $page,
             'translation' => $translation,
+            'content' => $tableOfContents->content,
+            'toc' => $tableOfContents->isEmpty() ? [] : $tableOfContents->items,
             'breadcrumbItems' => $this->buildBreadcrumbItems($page, $translation),
             'currentPage' => $page,
             ...$this->pageSidebarDataProvider->getData(),

--- a/src/Content/UI/Twig/templates/blog/show.html.twig
+++ b/src/Content/UI/Twig/templates/blog/show.html.twig
@@ -41,6 +41,20 @@
                 {% endif %}
                 </div>
             </div>
+            {% if is_granted('ROLE_ADMIN') %}
+                <div class="col-auto ms-auto d-print-none">
+                    <div class="btn-list">
+                        <span class="d-none d-sm-inline">
+                            <a class="btn btn-primary"
+                               data-testid="post-edit-action"
+                               href="{{ path('app_admin_dashboard_post_edit', {entityId: post.id}) }}">
+                                <twig:ux:icon name="tabler:edit" width="1em" height="1em" />&nbsp;
+                                {{ 'label.edit'|trans({}, 'messages') }}
+                            </a>
+                        </span>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/src/Content/UI/Twig/templates/page/_sidebar.html.twig
+++ b/src/Content/UI/Twig/templates/page/_sidebar.html.twig
@@ -1,4 +1,32 @@
 <div class="row row-cards" data-testid="page-sidebar">
+    {% if toc is defined and toc is not empty %}
+        <div class="col-12">
+            <div class="card" data-testid="page-toc">
+                <div class="card-header bg-light">
+                    <h3 class="card-title d-flex align-items-center gap-2">
+                        <twig:ux:icon name="tabler:list" class="w-4 h-4" />
+                        {{ 'page.toc.title'|trans({}, 'content') }}
+                    </h3>
+                </div>
+                <div class="card-body py-2">
+                    <nav aria-label="{{ 'page.toc.title'|trans({}, 'content') }}">
+                        <ul class="list-unstyled mb-0 page-toc-list">
+                            {% for item in toc %}
+                                {% set level = item.level %}
+                                <li class="{% if level == 1 %}mb-2{% else %}mb-1{% endif %}{% if level == 2 %} ps-3 ms-1 border-start{% elseif level >= 3 %} ps-4 ms-2 border-start{% endif %}">
+                                    <a href="#{{ item.id }}"
+                                       class="{% if level == 1 %}link-dark{% elseif level == 2 %}link-secondary{% else %}small link-secondary{% endif %}">
+                                        {{ item.text }}
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     <div class="col-12">
         <div class="card">
             <div class="card-header bg-light">

--- a/src/Content/UI/Twig/templates/page/blocks/headline.html.twig
+++ b/src/Content/UI/Twig/templates/page/blocks/headline.html.twig
@@ -22,4 +22,4 @@
     md: 'mb-3',
     lg: 'mb-4',
 }[spacingAfter] ?? 'mb-3' %}
-<{{ level }} class="page-content-headline fw-bold {{ alignClass }} {{ spacingBeforeClass }} {{ spacingAfterClass }}">{{ block.data.text|default('') }}</{{ level }}>
+<{{ level }}{% if block.data.id|default('') %} id="{{ block.data.id }}"{% endif %} class="page-content-headline fw-bold {{ alignClass }} {{ spacingBeforeClass }} {{ spacingAfterClass }}">{{ block.data.text|default('') }}</{{ level }}>

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -9,6 +9,20 @@
             <div class="col">
                 <h1 class="fw-bold mb-0">{{ translation.title }}</h1>
             </div>
+            {% if is_granted('ROLE_ADMIN') %}
+                <div class="col-auto ms-auto d-print-none">
+                    <div class="btn-list">
+                        <span class="d-none d-sm-inline">
+                            <a class="btn btn-primary"
+                               data-testid="page-edit-action"
+                               href="{{ path('app_admin_dashboard_page_translation_edit', {entityId: translation.id}) }}">
+                                <twig:ux:icon name="tabler:edit" width="1em" height="1em" />&nbsp;
+                                {{ 'label.edit'|trans({}, 'messages') }}
+                            </a>
+                        </span>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/src/Content/UI/Twig/templates/page/show.html.twig
+++ b/src/Content/UI/Twig/templates/page/show.html.twig
@@ -5,7 +5,11 @@
 {% block page_header %}
     <div class="container-xl">
         <twig:Breadcrumbs :items="breadcrumbItems" />
-        <h1 class="fw-bold">{{ translation.title }}</h1>
+        <div class="row align-items-center">
+            <div class="col">
+                <h1 class="fw-bold mb-0">{{ translation.title }}</h1>
+            </div>
+        </div>
     </div>
 {% endblock %}
 
@@ -19,7 +23,7 @@
                             <div class="page-content-blocks content"
                                  data-controller="lightbox"
                                  data-lightbox-gallery-value="content-gallery">
-                                {% for block in translation.content %}
+                                {% for block in content %}
                                     {% if block.enabled is not defined or block.enabled %}
                                         {% if block.type in page_content_block_types() %}
                                             <div class="page-content-block page-content-block--{{ block.type }}">

--- a/tests/Content/Functional/Controller/BlogControllerTest.php
+++ b/tests/Content/Functional/Controller/BlogControllerTest.php
@@ -415,4 +415,40 @@ final class BlogControllerTest extends WebTestCase
         $client->followRedirect();
         self::assertSelectorTextContains('body', 'Nested reply');
     }
+
+    public function testAdminSeesEditShortcutToPostBackend(): void
+    {
+        $client = self::createClient();
+        $category = PostCategoryFactory::createOne(['name' => 'Edit', 'slug' => 'edit-cat']);
+
+        $post = PostFactory::createOne([
+            'title' => 'Editable Post',
+            'slug' => 'editable-post',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-1 hour'),
+            'category' => $category,
+            'content' => '<p>Post body</p>',
+        ]);
+
+        $client->request(Request::METHOD_GET, '/blog/editable-post');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="post-edit-action"]');
+
+        $user = UserFactory::createOne();
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/blog/editable-post');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="post-edit-action"]');
+
+        $admin = UserFactory::new()->asAdmin()->create();
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/blog/editable-post');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="post-edit-action"]');
+        self::assertSelectorExists(sprintf(
+            '[data-testid="post-edit-action"][href="/admin/post/%d/edit"]',
+            $post->getId(),
+        ));
+    }
 }

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -383,4 +383,48 @@ final class PageControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSelectorNotExists('[data-testid="page-toc"]');
     }
+
+    public function testAdminSeesEditShortcutToTranslationBackend(): void
+    {
+        $client = self::createClient();
+
+        $page = PageFactory::new()->withoutDefaultTranslation()->create([
+            'title' => 'Editable',
+            'slug' => 'editable-page',
+            'path' => '/editable-page',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        $translation = PageTranslationFactory::createOne([
+            'page' => $page,
+            'locale' => SupportedLocales::DEFAULT,
+            'title' => 'Editable',
+            'slug' => 'editable-page',
+            'path' => '/editable-page',
+            'status' => PageTranslation::STATUS_PUBLISHED,
+            'content' => [['type' => 'richtext', 'enabled' => true, 'data' => ['html' => '<p>Edit me</p>']]],
+        ]);
+
+        $client->request(Request::METHOD_GET, '/editable-page');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="page-edit-action"]');
+
+        $user = UserFactory::createOne();
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/editable-page');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="page-edit-action"]');
+
+        $admin = UserFactory::new()->asAdmin()->create();
+        $client->loginUser($admin);
+        $client->request(Request::METHOD_GET, '/editable-page');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="page-edit-action"]');
+        self::assertSelectorExists(sprintf(
+            '[data-testid="page-edit-action"][href="/admin/page-translation/%d/edit"]',
+            $translation->getId(),
+        ));
+    }
 }

--- a/tests/Content/Functional/Controller/PageControllerTest.php
+++ b/tests/Content/Functional/Controller/PageControllerTest.php
@@ -288,4 +288,99 @@ final class PageControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('[data-testid="page-sidebar"]', 'Nur Mitglieder');
     }
+
+    public function testTableOfContentsIsRenderedWhenEnabledAndHeadingsExist(): void
+    {
+        $client = self::createClient();
+
+        $page = PageFactory::new()->withoutDefaultTranslation()->create([
+            'title' => 'Guide',
+            'slug' => 'guide',
+            'path' => '/guide',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageTranslationFactory::createOne([
+            'page' => $page,
+            'locale' => SupportedLocales::DEFAULT,
+            'title' => 'Guide',
+            'slug' => 'guide',
+            'path' => '/guide',
+            'status' => PageTranslation::STATUS_PUBLISHED,
+            'showToc' => true,
+            'content' => [
+                [
+                    'type' => 'headline',
+                    'enabled' => true,
+                    'data' => ['text' => 'Getting started', 'level' => 'h2'],
+                ],
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => '<h3>First steps</h3><p>Hello</p>'],
+                ],
+            ],
+        ]);
+
+        $client->request(Request::METHOD_GET, '/guide');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="page-toc"]');
+        self::assertSelectorExists('[data-testid="page-toc"] a[href="#getting-started"]');
+        self::assertSelectorExists('[data-testid="page-toc"] a[href="#first-steps"]');
+        self::assertSelectorExists('h2#getting-started.page-content-headline');
+        self::assertSelectorExists('h3#first-steps');
+    }
+
+    public function testTableOfContentsIsHiddenWhenDisabledOrWithoutHeadings(): void
+    {
+        $client = self::createClient();
+
+        PageFactory::createOne([
+            'title' => 'No Toc Flag',
+            'slug' => 'no-toc-flag',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+            'content' => [
+                [
+                    'type' => 'headline',
+                    'data' => ['text' => 'Heading', 'level' => 'h2'],
+                ],
+            ],
+        ]);
+
+        $pageWithoutHeadings = PageFactory::new()->withoutDefaultTranslation()->create([
+            'title' => 'Empty Toc',
+            'slug' => 'empty-toc',
+            'path' => '/empty-toc',
+            'status' => Page::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_PUBLIC,
+        ]);
+
+        PageTranslationFactory::createOne([
+            'page' => $pageWithoutHeadings,
+            'locale' => SupportedLocales::DEFAULT,
+            'title' => 'Empty Toc',
+            'slug' => 'empty-toc',
+            'path' => '/empty-toc',
+            'status' => PageTranslation::STATUS_PUBLISHED,
+            'showToc' => true,
+            'content' => [
+                [
+                    'type' => 'richtext',
+                    'enabled' => true,
+                    'data' => ['html' => '<p>No headings here</p>'],
+                ],
+            ],
+        ]);
+
+        $client->request(Request::METHOD_GET, '/no-toc-flag');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="page-toc"]');
+
+        $client->request(Request::METHOD_GET, '/empty-toc');
+        self::assertResponseIsSuccessful();
+        self::assertSelectorNotExists('[data-testid="page-toc"]');
+    }
 }

--- a/tests/Content/Unit/Page/PageTableOfContentsBuilderTest.php
+++ b/tests/Content/Unit/Page/PageTableOfContentsBuilderTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Page;
+
+use App\Content\Application\Page\PageTableOfContentsBuilder;
+use App\Content\Application\Slug\SlugGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final class PageTableOfContentsBuilderTest extends TestCase
+{
+    private PageTableOfContentsBuilder $builder;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->builder = new PageTableOfContentsBuilder(new SlugGenerator(new AsciiSlugger()));
+    }
+
+    public function testDisabledShowTocReturnsEmptyItemsAndOriginalContent(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Intro', 'level' => 'h2'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, false);
+
+        self::assertTrue($result->isEmpty());
+        self::assertSame($content, $result->content);
+    }
+
+    public function testNoHeadingsReturnsEmptyItems(): void
+    {
+        $content = [
+            [
+                'type' => 'richtext',
+                'enabled' => true,
+                'data' => ['html' => '<p>Only paragraphs</p>'],
+            ],
+            [
+                'type' => 'accordion',
+                'enabled' => true,
+                'data' => [
+                    'items' => [
+                        ['title' => 'FAQ', 'html' => '<p>Answer</p>', 'openByDefault' => false],
+                    ],
+                ],
+            ],
+            [
+                'type' => 'cta',
+                'enabled' => true,
+                'data' => ['headline' => 'Call to action', 'buttonLabel' => 'Go', 'buttonUrl' => '/'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertTrue($result->isEmpty());
+        self::assertSame($content, $result->content);
+    }
+
+    public function testBuildsHierarchyFromHeadlineAndRichtext(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Chapter One', 'level' => 'h1'],
+            ],
+            [
+                'type' => 'richtext',
+                'enabled' => true,
+                'data' => ['html' => '<h2>Section A</h2><p>Text</p><h3>Detail</h3>'],
+            ],
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Skipped H4', 'level' => 'h4'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertFalse($result->isEmpty());
+        self::assertCount(3, $result->items);
+        self::assertSame('Chapter One', $result->items[0]['text']);
+        self::assertSame(1, $result->items[0]['level']);
+        self::assertSame('chapter-one', $result->items[0]['id']);
+        self::assertSame('Section A', $result->items[1]['text']);
+        self::assertSame(2, $result->items[1]['level']);
+        self::assertSame('section-a', $result->items[1]['id']);
+        self::assertSame('Detail', $result->items[2]['text']);
+        self::assertSame(3, $result->items[2]['level']);
+
+        self::assertSame('chapter-one', $result->content[0]['data']['id'] ?? null);
+        self::assertStringContainsString('id="section-a"', (string) $result->content[1]['data']['html']);
+        self::assertStringContainsString('id="detail"', (string) $result->content[1]['data']['html']);
+        self::assertArrayNotHasKey('id', $result->content[2]['data']);
+    }
+
+    public function testDuplicateHeadingTextsGetUniqueIds(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Overview', 'level' => 'h2'],
+            ],
+            [
+                'type' => 'richtext',
+                'enabled' => true,
+                'data' => ['html' => '<h2>Overview</h2>'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(2, $result->items);
+        self::assertSame('overview', $result->items[0]['id']);
+        self::assertSame('overview-2', $result->items[1]['id']);
+    }
+
+    public function testIgnoresDisabledBlocksAndEmptyHeadings(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => false,
+                'data' => ['text' => 'Hidden', 'level' => 'h2'],
+            ],
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => '   ', 'level' => 'h2'],
+            ],
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Visible', 'level' => 'h2'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(1, $result->items);
+        self::assertSame('Visible', $result->items[0]['text']);
+        self::assertSame('visible', $result->items[0]['id']);
+    }
+
+    public function testReusesExistingUniqueRichtextHeadingIds(): void
+    {
+        $content = [
+            [
+                'type' => 'richtext',
+                'enabled' => true,
+                'data' => ['html' => '<h2 id="custom-anchor">Section</h2><p>Body</p>'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(1, $result->items);
+        self::assertSame('custom-anchor', $result->items[0]['id']);
+        self::assertSame('Section', $result->items[0]['text']);
+        self::assertStringContainsString('id="custom-anchor"', (string) $result->content[0]['data']['html']);
+    }
+
+    public function testConflictingExistingIdIsReplacedWithUniqueSlug(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => 'Intro', 'level' => 'h2'],
+            ],
+            [
+                'type' => 'richtext',
+                'enabled' => true,
+                'data' => ['html' => '<h2 id="intro">Also Intro</h2>'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(2, $result->items);
+        self::assertSame('intro', $result->items[0]['id']);
+        self::assertSame('also-intro', $result->items[1]['id']);
+        self::assertStringContainsString('id="also-intro"', (string) $result->content[1]['data']['html']);
+        self::assertStringNotContainsString('id="intro"', (string) $result->content[1]['data']['html']);
+    }
+
+    public function testFallsBackToSectionIdWhenHeadingCannotBeSlugified(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => '!!!', 'level' => 'h2'],
+            ],
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => '???', 'level' => 'h3'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(2, $result->items);
+        self::assertSame('section', $result->items[0]['id']);
+        self::assertSame('section-2', $result->items[1]['id']);
+    }
+
+    public function testStripsMarkupFromHeadlineText(): void
+    {
+        $content = [
+            [
+                'type' => 'headline',
+                'enabled' => true,
+                'data' => ['text' => '<em>Safe</em> heading', 'level' => 'h2'],
+            ],
+        ];
+
+        $result = $this->builder->build($content, true);
+
+        self::assertCount(1, $result->items);
+        self::assertSame('Safe heading', $result->items[0]['text']);
+        self::assertSame('safe-heading', $result->items[0]['id']);
+    }
+}

--- a/translations/content+intl-icu.de.xlf
+++ b/translations/content+intl-icu.de.xlf
@@ -1009,6 +1009,18 @@
         <source>public.stats.users</source>
         <target>Benutzer</target>
       </trans-unit>
+      <trans-unit id="DePageToc001" resname="label.show_toc">
+        <source>label.show_toc</source>
+        <target>Inhaltsverzeichnis anzeigen</target>
+      </trans-unit>
+      <trans-unit id="DePageToc002" resname="help.page.show_toc">
+        <source>help.page.show_toc</source>
+        <target>Wenn aktiviert, erscheint in der Seitenleiste ein Inhaltsverzeichnis, sofern der Inhalt H1–H3-Überschriften enthält.</target>
+      </trans-unit>
+      <trans-unit id="DePageToc003" resname="page.toc.title">
+        <source>page.toc.title</source>
+        <target>Auf dieser Seite</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/content+intl-icu.en.xlf
+++ b/translations/content+intl-icu.en.xlf
@@ -1009,6 +1009,18 @@
         <source>help.page.cta_media_pdf</source>
         <target>Select a PDF uploaded in the media library.</target>
       </trans-unit>
+      <trans-unit id="pageToc001" resname="label.show_toc">
+        <source>label.show_toc</source>
+        <target>Show table of contents</target>
+      </trans-unit>
+      <trans-unit id="pageToc002" resname="help.page.show_toc">
+        <source>help.page.show_toc</source>
+        <target>When enabled, a table of contents is shown in the page sidebar if the content contains H1–H3 headings.</target>
+      </trans-unit>
+      <trans-unit id="pageToc003" resname="page.toc.title">
+        <source>page.toc.title</source>
+        <target>On this page</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary
- Adds an optional per-translation table of contents for pages (`showToc`), rendered as a sidebar card from H1–H3 headings in `headline` and `richtext` blocks with stable anchor IDs.
- Adds an admin-only **Edit** action on page and post frontend views that links to the existing EasyAdmin edit screens (no duplicate frontend editing).
- Covers the new behavior with unit and functional tests; `make ci` is green.

Closes #434  
Closes #435

## Test plan
- [x] Enable **Show table of contents** on a page translation with H1–H3 headings and confirm the sidebar TOC links jump to the correct sections
- [x] Confirm TOC is hidden when the flag is off or when no suitable headings exist
- [x] As `ROLE_ADMIN`, open a page and a post and verify **Edit** opens the matching EasyAdmin edit form
- [x] As anonymous and regular users, confirm the Edit action is not shown