### PR TITLE
feat(export): add admin-only select-all for hospital filters

### DIFF
--- a/assets/controllers/checkbox-select-all_controller.js
+++ b/assets/controllers/checkbox-select-all_controller.js
@@ -4,14 +4,31 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
     static targets = ['toggle', 'item'];
 
+    connect() {
+        this.syncToggle();
+    }
+
     toggleAll() {
         if (!this.hasToggleTarget) {
             return;
         }
 
         const checked = this.toggleTarget.checked;
+        this.toggleTarget.indeterminate = false;
         this.itemTargets.forEach((checkbox) => {
             checkbox.checked = checked;
         });
+    }
+
+    syncToggle() {
+        if (!this.hasToggleTarget || 0 === this.itemTargets.length) {
+            return;
+        }
+
+        const total = this.itemTargets.length;
+        const checkedCount = this.itemTargets.filter((checkbox) => checkbox.checked).length;
+
+        this.toggleTarget.checked = checkedCount === total;
+        this.toggleTarget.indeterminate = checkedCount > 0 && checkedCount < total;
     }
 }

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -304,6 +304,35 @@
     box-shadow: none;
 }
 
+.export-filter-accordion .row.g-2 {
+    --bs-gutter-y: 0.375rem;
+    --bs-gutter-x: 0.5rem;
+}
+
+.export-filter-accordion .export-hospitals-select-all {
+    min-height: 1.75rem;
+    padding-bottom: 0.375rem;
+    margin-bottom: 0.125rem;
+    border-bottom: 1px solid var(--tblr-border-color, rgba(0, 0, 0, 0.08));
+}
+
+.export-filter-accordion .export-hospitals-select-all .form-check-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.4;
+    color: var(--tblr-secondary, #6c757d);
+}
+
+.export-filter-accordion .form-check {
+    min-height: 1.75rem;
+    margin-bottom: 0;
+}
+
+.export-filter-accordion .form-check-label {
+    font-size: 0.9375rem;
+    line-height: 1.4;
+}
+
 .filter-drawer .mb-3,
 .analysis-explorer-edit-drawer .mb-3 {
     margin-bottom: 0.375rem !important;

--- a/src/Allocation/Application/Export/ExportHospitalFormOptionsProvider.php
+++ b/src/Allocation/Application/Export/ExportHospitalFormOptionsProvider.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace App\Allocation\Application\Export;
 
 use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Statistics\Application\Contract\HospitalAccessInterface;
 use App\Statistics\Application\StatisticsHospitalScopeLabelResolver;
 use App\User\Domain\Entity\User;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class ExportHospitalFormOptionsProvider
 {
     public function __construct(
         private HospitalRepository $hospitalRepository,
         private StatisticsHospitalScopeLabelResolver $hospitalScopeLabelResolver,
-        private TranslatorInterface $translator,
+        private HospitalAccessInterface $hospitalAccess,
     ) {
     }
 
@@ -57,9 +57,7 @@ final readonly class ExportHospitalFormOptionsProvider
             'hospital_choices' => $choices,
             'default_hospital_ids' => $hospitalIds,
             'hospitals_section_label' => $this->hospitalScopeLabelResolver->groupLabel($user, $locale),
-            'hospitals_help' => \count($hospitals) > 1
-                ? $this->translator->trans('help.export.hospitals', [], 'allocation', $locale)
-                : '',
+            'hospitals_select_all' => $this->hospitalAccess->isAdminHospitalScopeUser($user) && \count($hospitals) > 1,
         ];
     }
 }

--- a/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
+++ b/src/Allocation/UI/Form/OwnHospitalAllocationsExportType.php
@@ -182,7 +182,7 @@ final class OwnHospitalAllocationsExportType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['hospitals_section_label'] = $options['hospitals_section_label'];
-        $view->vars['hospitals_help'] = $options['hospitals_help'];
+        $view->vars['hospitals_select_all'] = $options['hospitals_select_all'];
     }
 
     #[\Override]
@@ -194,12 +194,12 @@ final class OwnHospitalAllocationsExportType extends AbstractType
             'constraints' => [new ExportDateRangeValid()],
             'hospital_choices' => [],
             'hospitals_section_label' => 'label.hospital',
-            'hospitals_help' => '',
+            'hospitals_select_all' => false,
         ]);
 
         $resolver->setAllowedTypes('hospital_choices', 'array');
         $resolver->setAllowedTypes('hospitals_section_label', 'string');
-        $resolver->setAllowedTypes('hospitals_help', 'string');
+        $resolver->setAllowedTypes('hospitals_select_all', 'bool');
     }
 
     /**

--- a/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
+++ b/src/Allocation/UI/Twig/templates/export/_export_allocation_filters.html.twig
@@ -12,14 +12,42 @@
             ) }}
             {{ editAccordion.panel_start('export-filter-hospital-panel', 'export-filter-hospital-heading', true) }}
                 <div class="accordion-body">
-                    <div class="row g-2">
-                        {% for hospitalField in form.hospitals %}
-                            <div class="col-md-6">{{ form_widget(hospitalField) }}</div>
-                        {% endfor %}
+                    {% set hospitalsSelectAll = form.vars.hospitals_select_all %}
+                    <div{% if hospitalsSelectAll %} data-controller="checkbox-select-all"{% endif %}>
+                        <div class="row g-2">
+                            {% if hospitalsSelectAll %}
+                                <div class="col-12">
+                                    <div class="form-check export-hospitals-select-all mb-0">
+                                        <input type="checkbox"
+                                               class="form-check-input"
+                                               id="export-hospitals-select-all"
+                                               data-testid="export-hospitals-select-all"
+                                               data-checkbox-select-all-target="toggle"
+                                               data-action="change->checkbox-select-all#toggleAll"
+                                               checked
+                                               aria-label="{{ 'label.export.hospitals_select_all'|trans({}, 'allocation') }}">
+                                        <label class="form-check-label" for="export-hospitals-select-all">
+                                            {{ 'label.export.hospitals_select_all'|trans({}, 'allocation') }}
+                                        </label>
+                                    </div>
+                                </div>
+                            {% endif %}
+                            {% for hospitalField in form.hospitals %}
+                                <div class="col-md-6">
+                                    {% if hospitalsSelectAll %}
+                                        {{ form_widget(hospitalField, {
+                                            attr: {
+                                                'data-checkbox-select-all-target': 'item',
+                                                'data-action': 'change->checkbox-select-all#syncToggle',
+                                            },
+                                        }) }}
+                                    {% else %}
+                                        {{ form_widget(hospitalField) }}
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
                     </div>
-                    {% if form.vars.hospitals_help %}
-                        <p class="text-muted small mb-0 mt-2">{{ form.vars.hospitals_help }}</p>
-                    {% endif %}
                 </div>
             {{ editAccordion.panel_end() }}
         </div>

--- a/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Export/AllocationsExportControllerTest.php
@@ -78,6 +78,44 @@ final class AllocationsExportControllerTest extends WebTestCase
         self::assertSelectorExists('[data-testid="export-allocations-prepare"]');
         self::assertSelectorExists('[data-testid="export-filter-section-hospital"]');
         self::assertSelectorExists('input[type="checkbox"][name*="[hospitals]"]:checked');
+        self::assertSelectorNotExists('[data-testid="export-hospitals-select-all"]');
+        self::assertSelectorNotExists('[data-controller="checkbox-select-all"]');
+    }
+
+    public function testOwnerWithMultipleHospitalsDoesNotSeeSelectAllControl(): void
+    {
+        [$client, $owner] = $this->createOwnerClient();
+        HospitalFactory::createOne(['owner' => $owner, 'name' => 'Second Export Hospital']);
+
+        $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('input[type="checkbox"][name*="[hospitals]"]:checked');
+        self::assertSelectorNotExists('[data-testid="export-hospitals-select-all"]');
+        self::assertSelectorNotExists('[data-controller="checkbox-select-all"]');
+    }
+
+    public function testAdminWithMultipleHospitalsSeesSelectAllControl(): void
+    {
+        $client = self::createClient();
+        $admin = UserFactory::createOne([
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT', 'ROLE_ADMIN'],
+            'username' => 'export-admin-'.bin2hex(random_bytes(4)),
+        ]);
+        StateFactory::createOne();
+        DispatchAreaFactory::createOne();
+        $hospitalA = HospitalFactory::createOne(['name' => 'Admin Export Hospital A']);
+        HospitalFactory::createOne(['name' => 'Admin Export Hospital B']);
+        $this->seedAllocationDependencies($hospitalA);
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/hospitals/export/allocations');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-controller="checkbox-select-all"]');
+        self::assertSelectorExists('[data-testid="export-hospitals-select-all"]');
+        self::assertSelectorExists('input[type="checkbox"][name*="[hospitals]"][data-checkbox-select-all-target="item"]');
+        self::assertSelectorExists('#export-hospitals-select-all:checked');
     }
 
     public function testExportPageHasNoMissingTranslationsInGerman(): void

--- a/tests/Allocation/Integration/Export/ExportHospitalFormOptionsProviderTest.php
+++ b/tests/Allocation/Integration/Export/ExportHospitalFormOptionsProviderTest.php
@@ -37,11 +37,24 @@ final class ExportHospitalFormOptionsProviderTest extends KernelTestCase
         self::assertCount(1, $options['hospital_choices']);
         self::assertSame([(int) $hospital->getId()], $options['default_hospital_ids']);
         self::assertArrayNotHasKey('default_hospital_ids', $formOptions);
-        self::assertSame('', $options['hospitals_help']);
+        self::assertFalse($options['hospitals_select_all']);
         self::assertSame('My hospitals', $options['hospitals_section_label']);
     }
 
-    public function testAdminGetsHospitalsLabelAndHelpForMultipleChoices(): void
+    public function testOwnerWithMultipleHospitalsDoesNotGetSelectAll(): void
+    {
+        $owner = UserFactory::createOne(['roles' => ['ROLE_USER', 'ROLE_PARTICIPANT']]);
+        HospitalFactory::createOne(['owner' => $owner, 'name' => 'Hospital A']);
+        HospitalFactory::createOne(['owner' => $owner, 'name' => 'Hospital B']);
+
+        $options = $this->provider->optionsFor($owner, 'en');
+
+        self::assertCount(2, $options['hospital_choices']);
+        self::assertFalse($options['hospitals_select_all']);
+        self::assertSame('My hospitals', $options['hospitals_section_label']);
+    }
+
+    public function testAdminGetsHospitalsLabelAndSelectAllForMultipleChoices(): void
     {
         $admin = UserFactory::createOne(['roles' => [UserRole::ADMIN, 'ROLE_USER']]);
         HospitalFactory::createOne(['name' => 'Hospital A']);
@@ -50,7 +63,7 @@ final class ExportHospitalFormOptionsProviderTest extends KernelTestCase
         $options = $this->provider->optionsFor($admin, 'en');
 
         self::assertGreaterThanOrEqual(2, \count($options['hospital_choices']));
-        self::assertNotSame('', $options['hospitals_help']);
+        self::assertTrue($options['hospitals_select_all']);
         self::assertSame('Hospitals', $options['hospitals_section_label']);
     }
 }

--- a/translations/allocation+intl-icu.de.xlf
+++ b/translations/allocation+intl-icu.de.xlf
@@ -205,9 +205,9 @@
         <source>help.export.department_was_closed_filter</source>
         <target>Nur Zuweisungen exportieren, bei denen der Fachbereich abgemeldet war.</target>
       </trans-unit>
-      <trans-unit id="ExpHlpDe03" resname="help.export.hospitals">
-        <source>help.export.hospitals</source>
-        <target>Alle zugänglichen Krankenhäuser sind standardmäßig ausgewählt. Deaktivieren Sie ein Krankenhaus, um es vom Export auszuschließen.</target>
+      <trans-unit id="ExpLblDe01" resname="label.export.hospitals_select_all">
+        <source>label.export.hospitals_select_all</source>
+        <target>Alle auswählen</target>
       </trans-unit>
       <trans-unit id="ExpHlpDe04" resname="help.export.include_indication_raw">
         <source>help.export.include_indication_raw</source>

--- a/translations/allocation+intl-icu.en.xlf
+++ b/translations/allocation+intl-icu.en.xlf
@@ -1009,9 +1009,9 @@
         <source>help.export.period</source>
         <target>Without a time, day start (00:00:00) or day end (23:59:59) applies. Date and time form one continuous interval.</target>
       </trans-unit>
-      <trans-unit id="ExpHlpEn03" resname="help.export.hospitals">
-        <source>help.export.hospitals</source>
-        <target>All accessible hospitals are selected by default. Uncheck any to exclude them from the export.</target>
+      <trans-unit id="ExpLblEn01" resname="label.export.hospitals_select_all">
+        <source>label.export.hospitals_select_all</source>
+        <target>Select all</target>
       </trans-unit>
       <trans-unit id="ExpHlpEn04" resname="help.export.include_indication_raw">
         <source>help.export.include_indication_raw</source>


### PR DESCRIPTION
## Summary
- Admins exporting allocations see a long, fully preselected hospital list and previously had no way to quickly clear or reselect everything.
- Adds a master **Select all** checkbox (admin-only, when more than one hospital is available), wired through the shared Stimulus `checkbox-select-all` controller with checked / unchecked / indeterminate sync.
- Removes the redundant hospital help text under the filter and styles the control to match the export accordion checkbox list.

## Test plan
- [x] As a non-admin with multiple hospitals: export page shows hospital checkboxes, but **no** select-all control
- [x] As an admin with multiple hospitals: select-all appears; toggling it checks/unchecks all hospitals
- [x] As an admin: unchecking one hospital sets the master checkbox to indeterminate; unchecking all clears it
- [x] Estimate/download still respect the selected hospital IDs
- [x] `ExportHospitalFormOptionsProviderTest` and `AllocationsExportControllerTest` pass