### PR TITLE
feat: Add explore entity cross references

### DIFF
--- a/src/Allocation/Application/Explore/ExploreShowUrlResolver.php
+++ b/src/Allocation/Application/Explore/ExploreShowUrlResolver.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\Application\Explore;
+
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Assignment;
+use App\Allocation\Domain\Entity\Department;
+use App\Allocation\Domain\Entity\DispatchArea;
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\IndicationGroup;
+use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Allocation\Domain\Entity\Infection;
+use App\Allocation\Domain\Entity\MciCase;
+use App\Allocation\Domain\Entity\Occasion;
+use App\Allocation\Domain\Entity\SecondaryTransport;
+use App\Allocation\Domain\Entity\Speciality;
+use App\Allocation\Domain\Entity\State;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class ExploreShowUrlResolver
+{
+    /**
+     * @var array<class-string, string>
+     */
+    private const array ROUTES = [
+        Allocation::class => 'app_explore_allocation_show',
+        Assignment::class => 'app_explore_assignment_show',
+        Department::class => 'app_explore_department_show',
+        DispatchArea::class => 'app_explore_dispatch_area_show',
+        Hospital::class => 'app_explore_hospital_show',
+        IndicationGroup::class => 'app_explore_indication_group_show',
+        IndicationNormalized::class => 'app_explore_indication_show',
+        Infection::class => 'app_explore_infection_show',
+        MciCase::class => 'app_explore_mci_case_show',
+        Occasion::class => 'app_explore_occasion_show',
+        SecondaryTransport::class => 'app_explore_secondary_transport_show',
+        Speciality::class => 'app_explore_speciality_show',
+        State::class => 'app_explore_state_show',
+    ];
+
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function resolveUrl(?object $entity): ?string
+    {
+        if (null === $entity) {
+            return null;
+        }
+
+        $route = $this->routeFor($entity);
+        if (null === $route) {
+            return null;
+        }
+
+        $publicId = $this->publicIdFor($entity);
+        if (null === $publicId) {
+            return null;
+        }
+
+        return $this->urlGenerator->generate($route, ['publicId' => $publicId]);
+    }
+
+    private function routeFor(object $entity): ?string
+    {
+        $class = $entity::class;
+        if (isset(self::ROUTES[$class])) {
+            return self::ROUTES[$class];
+        }
+
+        $parents = class_parents($class);
+        if (false === $parents) {
+            return null;
+        }
+
+        foreach ($parents as $parent) {
+            if (isset(self::ROUTES[$parent])) {
+                return self::ROUTES[$parent];
+            }
+        }
+
+        return null;
+    }
+
+    private function publicIdFor(object $entity): ?string
+    {
+        if (!method_exists($entity, 'getPublicId')) {
+            return null;
+        }
+
+        $publicId = $entity->getPublicId();
+        if (!$publicId instanceof Uuid) {
+            return null;
+        }
+
+        return $publicId->toRfc4122();
+    }
+}

--- a/src/Allocation/UI/Twig/ExploreEntityLinkExtension.php
+++ b/src/Allocation/UI/Twig/ExploreEntityLinkExtension.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Allocation\UI\Twig;
+
+use App\Allocation\Application\Explore\ExploreShowUrlResolver;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ExploreEntityLinkExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly ExploreShowUrlResolver $urlResolver,
+    ) {
+    }
+
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('explore_entity_url', $this->exploreEntityUrl(...)),
+            new TwigFunction('explore_entity_link', $this->exploreEntityLink(...), ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function exploreEntityUrl(?object $entity): ?string
+    {
+        return $this->urlResolver->resolveUrl($entity);
+    }
+
+    /**
+     * @param array{label?: string, class?: string, empty?: string} $options
+     */
+    public function exploreEntityLink(?object $entity, array $options = []): string
+    {
+        $empty = $options['empty'] ?? '—';
+        if (null === $entity) {
+            return $this->escape($empty);
+        }
+
+        $label = $this->escape($this->labelFor($entity, $options, $empty));
+        $url = $this->urlResolver->resolveUrl($entity);
+        if (null === $url) {
+            return $label;
+        }
+
+        $class = $options['class'] ?? '';
+        $classAttr = '' !== $class ? ' class="'.$this->escape($class).'"' : '';
+
+        return sprintf('<a href="%s"%s>%s</a>', $this->escape($url), $classAttr, $label);
+    }
+
+    /**
+     * @param array{label?: string, class?: string, empty?: string} $options
+     */
+    private function labelFor(object $entity, array $options, string $empty): string
+    {
+        if (isset($options['label'])) {
+            return $options['label'];
+        }
+
+        if ($entity instanceof \Stringable) {
+            return (string) $entity;
+        }
+
+        return $empty;
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/Allocation/UI/Twig/templates/allocations/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/allocations/show.html.twig
@@ -33,7 +33,7 @@
                     <div class="list-inline list-inline-dots text-muted">
                         <div class="list-inline-item">
                             <twig:ux:icon name="tabler:map" class="w-3 h-3" />
-                            {{ allocation.dispatchArea }}, {{ allocation.state }}
+                            {{ explore_entity_link(allocation.dispatchArea, {class: 'link-secondary'}) }}, {{ explore_entity_link(allocation.state, {class: 'link-secondary'}) }}
                         </div>
                     </div>
                 </div>
@@ -60,8 +60,8 @@
                 >
                     <div class="department-line">
                         <div class="d-flex align-items-center">
-                            <span class="fw-bold me-1">{{ allocation.department }}</span>
-                            <span class="text-muted">({{ allocation.speciality }})</span>
+                            <span class="fw-bold me-1">{{ explore_entity_link(allocation.department) }}</span>
+                            <span class="text-muted">({{ explore_entity_link(allocation.speciality) }})</span>
 
                             {% if allocation.departmentWasClosed %}
                                 {{ include('@Allocation/allocations/_department_was_closed_indicator.html.twig') }}
@@ -81,7 +81,7 @@
                         <p>
                             {{ 'label.indication.normalized'|trans({}, 'messages') }}:
                             {% if allocation.indicationNormalized is not null %}
-                                <strong>{{ allocation.indicationNormalized.name }}</strong> <span class="badge">{{ allocation.indicationNormalized.code }}</span>
+                                <strong>{{ explore_entity_link(allocation.indicationNormalized) }}</strong> <span class="badge">{{ allocation.indicationNormalized.code }}</span>
                             {% else %}
                                 <strong>{{ 'label.no_indication'|trans({}, 'messages') }}</strong>
                             {% endif %}
@@ -97,7 +97,7 @@
                         <p>
                             {{ 'label.indication.secondary_normalized'|trans({}, 'messages') }}:
                             {% if allocation.secondaryIndicationNormalized is not null %}
-                                <strong>{{ allocation.secondaryIndicationNormalized.name }}</strong> <span class="badge">{{ allocation.secondaryIndicationNormalized.code }}</span>
+                                <strong>{{ explore_entity_link(allocation.secondaryIndicationNormalized) }}</strong> <span class="badge">{{ allocation.secondaryIndicationNormalized.code }}</span>
                             {% else %}
                                 <strong>{{ 'label.no_secondary_indication'|trans({}, 'messages') }}</strong>
                             {% endif %}
@@ -111,12 +111,12 @@
                 >
                     <div class="allocation-assignment row">
                         <div class="col-6">
-                            {{ 'label.assignment'|trans({}, 'messages') }}: <strong>{{ allocation.assignment }}</strong>
+                            {{ 'label.assignment'|trans({}, 'messages') }}: <strong>{{ explore_entity_link(allocation.assignment) }}</strong>
                         </div>
                         <div class="col-6">
                             {{ 'label.occasion'|trans({}, 'messages') }}:
                             {% if allocation.occasion is not null %}
-                                <strong>{{ allocation.occasion }}</strong>
+                                <strong>{{ explore_entity_link(allocation.occasion) }}</strong>
                             {% else %}
                                 <strong>{{ 'label.no_occasion'|trans({}, 'messages') }}</strong>
                             {% endif %}
@@ -124,7 +124,7 @@
                         <div class="col-6 mt-2">
                             {{ 'label.secondary_transport'|trans({}, 'messages') }}:
                             {% if allocation.secondaryTransport is not null %}
-                                <strong>{{ allocation.secondaryTransport }}</strong>
+                                <strong>{{ explore_entity_link(allocation.secondaryTransport) }}</strong>
                             {% else %}
                                 <strong>{{ 'label.no_secondary_transport'|trans({}, 'messages') }}</strong>
                             {% endif %}
@@ -251,13 +251,13 @@
                     {% import '@Shared/_macros/badges.html.twig' as badges %}
 
                     <h3 class="card-title mb-1 fs-3">
-                        {{ allocation.hospital.name }}
+                        {{ explore_entity_link(allocation.hospital) }}
                     </h3>
 
                     <div class="text-muted small mb-3 d-flex align-items-center gap-2">
                         <twig:ux:icon name="tabler:building" class="w-3 h-3" />
                         <span>
-                            {{ allocation.hospital.dispatchArea }} · {{ allocation.hospital.state }}
+                            {{ explore_entity_link(allocation.hospital.dispatchArea, {class: 'link-secondary'}) }} · {{ explore_entity_link(allocation.hospital.state, {class: 'link-secondary'}) }}
                         </span>
                     </div>
 
@@ -352,7 +352,7 @@
                             <twig:ux:icon name="tabler:biohazard" class="w-3 h-3" />
                             {{ 'field.infection'|trans({}, 'messages') }}
                             {% if allocation.infection is not null %}
-                                <span class="badge bg-orange text-orange-fg">{{ allocation.infection.name }}</span>
+                                {{ explore_entity_link(allocation.infection, {class: 'badge bg-orange text-orange-fg'}) }}
                             {% else %}
                                 <strong>{{ 'label.no_infection'|trans({}, 'messages') }}</strong>
                             {% endif %}

--- a/src/Allocation/UI/Twig/templates/dispatch_areas/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/dispatch_areas/show.html.twig
@@ -90,11 +90,7 @@
                             {% if dispatchArea.state %}
                                 <div{% if dispatchArea.hospitals is not empty %} class="mb-3"{% endif %}>
                                     <div class="text-muted mb-1">{{ 'catalog.relation.state'|trans({}, 'allocation') }}</div>
-                                    {% if dispatchArea.state.publicId %}
-                                        <a href="{{ path('app_explore_state_show', {publicId: dispatchArea.state.publicId}) }}">{{ dispatchArea.state.name }}</a>
-                                    {% else %}
-                                        {{ dispatchArea.state.name }}
-                                    {% endif %}
+                                    {{ explore_entity_link(dispatchArea.state) }}
                                 </div>
                             {% endif %}
 
@@ -104,11 +100,7 @@
                                     <ul class="list-unstyled mb-0">
                                         {% for hospital in dispatchArea.hospitals|sort((a, b) => a.name <=> b.name) %}
                                             <li class="mb-1">
-                                                {% if hospital.publicId %}
-                                                    <a href="{{ path('app_explore_hospital_show', {publicId: hospital.publicId}) }}">{{ hospital.name }}</a>
-                                                {% else %}
-                                                    {{ hospital.name }}
-                                                {% endif %}
+                                                {{ explore_entity_link(hospital) }}
                                             </li>
                                         {% endfor %}
                                     </ul>

--- a/src/Allocation/UI/Twig/templates/hospitals/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/hospitals/show.html.twig
@@ -34,7 +34,7 @@
                 <div class="list-inline list-inline-dots text-muted">
                     <div class="list-inline-item">
                         <twig:ux:icon name="tabler:map" width="1em" height="1em" />
-                        {{ hospital.dispatchArea }}, {{ hospital.state }}
+                        {{ explore_entity_link(hospital.dispatchArea, {class: 'link-secondary'}) }}, {{ explore_entity_link(hospital.state, {class: 'link-secondary'}) }}
                     </div>
                     <div id="hospital-owned-by" class="list-inline-item">
                         <twig:ux:icon name="tabler:user-square" width="1em" height="1em" />

--- a/src/Allocation/UI/Twig/templates/indication_groups/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/indication_groups/show.html.twig
@@ -100,11 +100,7 @@
                             <ul class="list-unstyled mb-0">
                                 {% for indication in indicationGroup.indications %}
                                     <li class="mb-1">
-                                        {% if indication.publicId %}
-                                            <a href="{{ path('app_explore_indication_show', {publicId: indication.publicId}) }}">{{ indication.name }}</a>
-                                        {% else %}
-                                            {{ indication.name }}
-                                        {% endif %}
+                                        {{ explore_entity_link(indication) }}
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/src/Allocation/UI/Twig/templates/indications/show_normalized.html.twig
+++ b/src/Allocation/UI/Twig/templates/indications/show_normalized.html.twig
@@ -101,11 +101,7 @@
                             <ul class="list-unstyled mb-0">
                                 {% for group in indication.groups %}
                                     <li class="mb-1">
-                                        {% if group.publicId %}
-                                            <a href="{{ path('app_explore_indication_group_show', {publicId: group.publicId}) }}">{{ group.name }}</a>
-                                        {% else %}
-                                            {{ group.name }}
-                                        {% endif %}
+                                        {{ explore_entity_link(group) }}
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/src/Allocation/UI/Twig/templates/mci_cases/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/mci_cases/show.html.twig
@@ -31,7 +31,11 @@
                 <div class="list-inline list-inline-dots text-muted">
                     <div class="list-inline-item">
                         <twig:ux:icon name="tabler:map" class="w-3 h-3" />
-                        {{ mciCase.dispatchArea }}, {{ mciCase.state }}
+                        {{ explore_entity_link(mciCase.dispatchArea, {class: 'link-secondary'}) }}, {{ explore_entity_link(mciCase.state, {class: 'link-secondary'}) }}
+                    </div>
+                    <div class="list-inline-item">
+                        <twig:ux:icon name="tabler:building-hospital" class="w-3 h-3" />
+                        {{ explore_entity_link(mciCase.hospital, {class: 'link-secondary'}) }}
                     </div>
                 </div>
             </div>
@@ -56,8 +60,8 @@
                 <twig:Card title="{{ 'label.speciality'|trans({}, 'messages') }}">
                     <div class="department-line">
                         <div class="d-flex align-items-center">
-                            <span class="fw-bold me-1">{{ mciCase.department ?? '—' }}</span>
-                            <span class="text-muted">({{ mciCase.speciality ?? '—' }})</span>
+                            <span class="fw-bold me-1">{{ explore_entity_link(mciCase.department) }}</span>
+                            <span class="text-muted">({{ explore_entity_link(mciCase.speciality) }})</span>
 
                             {% if mciCase.departmentWasClosed is same as true %}
                                 <span class="badge bg-red-lt text-red ms-2 d-inline-flex align-items-center" title="Department was closed">
@@ -85,7 +89,7 @@
                         <p class="mb-0">
                             {{ 'label.indication.normalized'|trans({}, 'messages') }}:
                             {% if mciCase.indicationNormalized is not null %}
-                                <strong>{{ mciCase.indicationNormalized.name }}</strong>
+                                <strong>{{ explore_entity_link(mciCase.indicationNormalized) }}</strong>
                                 <span class="badge">{{ mciCase.indicationNormalized.code }}</span>
                             {% else %}
                                 <strong>{{ 'label.no_indication'|trans({}, 'messages') }}</strong>
@@ -250,7 +254,7 @@
                             <twig:ux:icon name="tabler:biohazard" class="w-3 h-3" />
                             {{ 'field.infection'|trans({}, 'messages') }}
                             {% if mciCase.infection is not null %}
-                                <span class="badge bg-orange text-orange-fg">{{ mciCase.infection.name }}</span>
+                                {{ explore_entity_link(mciCase.infection, {class: 'badge bg-orange text-orange-fg'}) }}
                             {% else %}
                                 <strong>{{ 'label.no_infection'|trans({}, 'messages') }}</strong>
                             {% endif %}

--- a/src/Allocation/UI/Twig/templates/states/show.html.twig
+++ b/src/Allocation/UI/Twig/templates/states/show.html.twig
@@ -90,11 +90,7 @@
                         <ul class="list-unstyled mb-0">
                             {% for area in state.dispatchAreas|sort((a, b) => a.name <=> b.name) %}
                                 <li class="mb-1">
-                                    {% if area.publicId %}
-                                        <a href="{{ path('app_explore_dispatch_area_show', {publicId: area.publicId}) }}">{{ area.name }}</a>
-                                    {% else %}
-                                        {{ area.name }}
-                                    {% endif %}
+                                    {{ explore_entity_link(area) }}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Allocations/ShowAllocationControllerTest.php
@@ -204,6 +204,65 @@ final class ShowAllocationControllerTest extends WebTestCase
         self::assertStringContainsString(HospitalSize::cases()[0]->value, $pageText);
         self::assertStringContainsString(HospitalLocation::cases()[0]->value, $pageText);
         self::assertStringContainsString(HospitalTier::cases()[0]->value, $pageText);
+
+        self::assertSelectorExists('a[href="/explore/hospital/'.$hospital->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/dispatch_area/'.$dispatch->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/state/'.$state->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/department/'.$department->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/speciality/'.$speciality->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/indication/'.$indicationNormalized->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/assignment/'.$assignment->getPublicIdString().'"]');
+        $occasion = $allocation->getOccasion();
+        self::assertNotNull($occasion);
+        self::assertSelectorExists('a[href="/explore/occasion/'.$occasion->getPublicIdString().'"]');
+        self::assertSelectorNotExists('a[href*="/explore/indication/raw/"]');
+    }
+
+    public function testShowLinksOptionalRelatedExplorerEntities(): void
+    {
+        $client = $this->createClientAsParticipant();
+
+        $owner = UserFactory::createOne(['username' => 'owner-user']);
+        $createdBy = UserFactory::createOne(['username' => 'area-user']);
+        $state = StateFactory::createOne(['name' => 'Hessen']);
+        $dispatch = DispatchAreaFactory::createOne(['name' => 'Dispatch Area', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'state' => $state,
+            'dispatchArea' => $dispatch,
+            'createdBy' => $createdBy,
+            'owner' => $owner,
+        ]);
+        $import = ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $createdBy,
+        ]);
+        $secondaryIndicationNormalized = IndicationNormalizedFactory::createOne(['name' => 'Secondary Norm']);
+        $secondaryTransport = SecondaryTransportFactory::createOne();
+        $infection = InfectionFactory::createOne(['name' => 'MRSA']);
+        $allocation = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'dispatchArea' => $dispatch,
+            'state' => $state,
+            'assignment' => AssignmentFactory::createOne(),
+            'department' => DepartmentFactory::createOne(),
+            'speciality' => SpecialityFactory::createOne(),
+            'indicationRaw' => IndicationRawFactory::createOne(),
+            'indicationNormalized' => IndicationNormalizedFactory::createOne(),
+            'secondaryIndicationRaw' => IndicationRawFactory::createOne(),
+            'secondaryIndicationNormalized' => $secondaryIndicationNormalized,
+            'secondaryTransport' => $secondaryTransport,
+            'infection' => $infection,
+            'occasion' => OccasionFactory::createOne(),
+        ]);
+
+        $client->request(Request::METHOD_GET, '/explore/allocation/'.$allocation->getPublicIdString());
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href="/explore/indication/'.$secondaryIndicationNormalized->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/secondary_transport/'.$secondaryTransport->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/infection/'.$infection->getPublicIdString().'"]');
+        self::assertSelectorNotExists('a[href*="/explore/indication/raw/"]');
     }
 
     public function testShowDisplaysDepartmentWasClosedIndicator(): void

--- a/tests/Allocation/Functional/Controller/DispatchAreas/ShowDispatchAreaControllerTest.php
+++ b/tests/Allocation/Functional/Controller/DispatchAreas/ShowDispatchAreaControllerTest.php
@@ -24,7 +24,7 @@ final class ShowDispatchAreaControllerTest extends WebTestCase
         $client = $this->createClientAsAreaUser();
         $state = StateFactory::createOne(['name' => 'Hessen']);
         $area = DispatchAreaFactory::createOne(['name' => 'Frankfurt', 'state' => $state]);
-        HospitalFactory::createOne([
+        $hospital = HospitalFactory::createOne([
             'name' => 'Klinik am Main',
             'state' => $state,
             'dispatchArea' => $area,
@@ -38,6 +38,12 @@ final class ShowDispatchAreaControllerTest extends WebTestCase
         self::assertSelectorExists('[data-testid="catalog-orientation-map"]');
         self::assertSelectorTextContains('[data-testid="catalog-related-entities"]', 'Hessen');
         self::assertSelectorTextContains('[data-testid="catalog-related-entities"]', 'Klinik am Main');
+        self::assertSelectorExists(
+            '[data-testid="catalog-related-entities"] a[href="/explore/state/'.$state->getPublicIdString().'"]',
+        );
+        self::assertSelectorExists(
+            '[data-testid="catalog-related-entities"] a[href="/explore/hospital/'.$hospital->getPublicIdString().'"]',
+        );
         self::assertSelectorExists('[data-testid="catalog-basic-info"] a[href^="/explore/user/"]');
 
         $href = $crawler->filter('[data-testid="catalog-action"]')->first()->attr('href');

--- a/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Hospitals/ShowHospitalControllerTest.php
@@ -71,6 +71,8 @@ final class ShowHospitalControllerTest extends WebTestCase
         self::assertSelectorTextContains('#hospital-beds', '321');
         self::assertSelectorTextContains('#hospital-location', HospitalLocation::cases()[0]->value);
         self::assertSelectorTextContains('#hospital-tier', HospitalTier::cases()[0]->value);
+        self::assertSelectorExists('a[href="/explore/dispatch_area/'.$dispatch->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/state/'.$state->getPublicIdString().'"]');
         self::assertSelectorNotExists('a.btn-primary[href="/hospitals/'.$hospital->getId().'/edit"]');
         self::assertSelectorExists('[data-testid="catalog-orientation-map"]');
         $map = $crawler->filter('[data-testid="catalog-orientation-map"]');

--- a/tests/Allocation/Functional/Controller/Indications/ShowIndicationGroupControllerTest.php
+++ b/tests/Allocation/Functional/Controller/Indications/ShowIndicationGroupControllerTest.php
@@ -48,6 +48,9 @@ final class ShowIndicationGroupControllerTest extends WebTestCase
         self::assertSelectorNotExists('[data-testid="catalog-description"]');
         self::assertSelectorTextContains('[data-testid="catalog-editorial-note"]', 'Cardiac indication group.');
         self::assertSelectorTextContains('[data-testid="catalog-related-entities"]', 'STEMI');
+        self::assertSelectorExists(
+            '[data-testid="catalog-related-entities"] a[href="/explore/indication/'.$indication->getPublicIdString().'"]',
+        );
         self::assertSelectorExists('[data-testid="catalog-basic-info"] a[href^="/explore/user/"]');
 
         $href = $crawler->filter('[data-testid="catalog-action"]')->first()->attr('href');

--- a/tests/Allocation/Functional/Controller/MciCases/ShowMciCaseControllerTest.php
+++ b/tests/Allocation/Functional/Controller/MciCases/ShowMciCaseControllerTest.php
@@ -39,6 +39,29 @@ final class ShowMciCaseControllerTest extends WebTestCase
         self::assertSelectorTextContains('h1.fw-bold', 'Mass casualty incident alpha');
         self::assertSelectorTextContains('#mci-case-mci-title', $mciCase->getMciId() ?? '');
         self::assertSelectorTextContains('a.btn', 'Back to list');
+
+        $hospital = $mciCase->getHospital();
+        $dispatchArea = $mciCase->getDispatchArea();
+        $state = $mciCase->getState();
+        $department = $mciCase->getDepartment();
+        $speciality = $mciCase->getSpeciality();
+        $indicationNormalized = $mciCase->getIndicationNormalized();
+        $infection = $mciCase->getInfection();
+        self::assertNotNull($hospital);
+        self::assertNotNull($dispatchArea);
+        self::assertNotNull($state);
+        self::assertNotNull($department);
+        self::assertNotNull($speciality);
+        self::assertNotNull($indicationNormalized);
+        self::assertNotNull($infection);
+        self::assertSelectorExists('a[href="/explore/hospital/'.$hospital->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/dispatch_area/'.$dispatchArea->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/state/'.$state->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/department/'.$department->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/speciality/'.$speciality->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/indication/'.$indicationNormalized->getPublicIdString().'"]');
+        self::assertSelectorExists('a[href="/explore/infection/'.$infection->getPublicIdString().'"]');
+        self::assertSelectorNotExists('a[href*="/explore/indication/raw/"]');
     }
 
     public function testDetailPageRejectsPostMethod(): void

--- a/tests/Allocation/Functional/Controller/States/ShowStateControllerTest.php
+++ b/tests/Allocation/Functional/Controller/States/ShowStateControllerTest.php
@@ -22,7 +22,7 @@ final class ShowStateControllerTest extends WebTestCase
     {
         $client = $this->createClientAsAreaUser();
         $state = StateFactory::createOne(['name' => 'Hessen']);
-        DispatchAreaFactory::createOne(['name' => 'Frankfurt', 'state' => $state]);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'Frankfurt', 'state' => $state]);
 
         $client->request(Request::METHOD_GET, '/explore/state');
         self::assertResponseIsSuccessful();
@@ -37,6 +37,9 @@ final class ShowStateControllerTest extends WebTestCase
         self::assertSelectorExists('[data-testid="catalog-orientation-map"]');
         self::assertSelectorNotExists('[data-testid="catalog-basic-info"] .list-unstyled');
         self::assertSelectorTextContains('[data-testid="catalog-related-entities"]', 'Frankfurt');
+        self::assertSelectorExists(
+            '[data-testid="catalog-related-entities"] a[href="/explore/dispatch_area/'.$dispatchArea->getPublicIdString().'"]',
+        );
 
         $actionHrefs = $crawler->filter('[data-testid="catalog-action"]')->each(
             static fn ($node): ?string => $node->attr('href'),

--- a/tests/Allocation/Unit/Application/Explore/ExploreShowUrlResolverTest.php
+++ b/tests/Allocation/Unit/Application/Explore/ExploreShowUrlResolverTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\Application\Explore;
+
+use App\Allocation\Application\Explore\ExploreShowUrlResolver;
+use App\Allocation\Domain\Entity\Allocation;
+use App\Allocation\Domain\Entity\Assignment;
+use App\Allocation\Domain\Entity\Department;
+use App\Allocation\Domain\Entity\DispatchArea;
+use App\Allocation\Domain\Entity\Hospital;
+use App\Allocation\Domain\Entity\IndicationGroup;
+use App\Allocation\Domain\Entity\IndicationNormalized;
+use App\Allocation\Domain\Entity\IndicationRaw;
+use App\Allocation\Domain\Entity\Infection;
+use App\Allocation\Domain\Entity\MciCase;
+use App\Allocation\Domain\Entity\Occasion;
+use App\Allocation\Domain\Entity\SecondaryTransport;
+use App\Allocation\Domain\Entity\Speciality;
+use App\Allocation\Domain\Entity\State;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class ExploreShowUrlResolverTest extends TestCase
+{
+    private const string PUBLIC_ID = '11111111-1111-4111-8111-111111111111';
+
+    #[DataProvider('supportedEntityProvider')]
+    public function testResolveUrlForSupportedEntities(object $entity, string $expectedRoute, string $expectedPath): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::once())
+            ->method('generate')
+            ->with($expectedRoute, ['publicId' => self::PUBLIC_ID])
+            ->willReturn($expectedPath);
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertSame($expectedPath, $resolver->resolveUrl($entity));
+    }
+
+    public function testResolveUrlReturnsNullForNullEntity(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::never())->method('generate');
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertNull($resolver->resolveUrl(null));
+    }
+
+    public function testResolveUrlReturnsNullForUnsupportedEntity(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::never())->method('generate');
+
+        $raw = new IndicationRaw();
+        $raw->setPublicId(Uuid::fromString(self::PUBLIC_ID));
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertNull($resolver->resolveUrl($raw));
+    }
+
+    public function testResolveUrlReturnsNullWhenPublicIdIsMissing(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::never())->method('generate');
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertNull($resolver->resolveUrl(new Department()));
+    }
+
+    public function testResolveUrlFollowsParentClassForDoctrineProxies(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::once())
+            ->method('generate')
+            ->with('app_explore_department_show', ['publicId' => self::PUBLIC_ID])
+            ->willReturn('/explore/department/'.self::PUBLIC_ID);
+
+        $proxy = new class extends Department {};
+        $proxy->setPublicId(Uuid::fromString(self::PUBLIC_ID));
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertSame('/explore/department/'.self::PUBLIC_ID, $resolver->resolveUrl($proxy));
+    }
+
+    public function testResolveUrlReturnsNullForUnknownClass(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects(self::never())->method('generate');
+
+        $resolver = new ExploreShowUrlResolver($urlGenerator);
+
+        self::assertNull($resolver->resolveUrl(new \stdClass()));
+    }
+
+    /**
+     * @return iterable<string, array{object, string, string}>
+     */
+    public static function supportedEntityProvider(): iterable
+    {
+        yield 'allocation' => [self::withPublicId(new Allocation()), 'app_explore_allocation_show', '/explore/allocation/'.self::PUBLIC_ID];
+        yield 'assignment' => [self::withPublicId(new Assignment()), 'app_explore_assignment_show', '/explore/assignment/'.self::PUBLIC_ID];
+        yield 'department' => [self::withPublicId(new Department()), 'app_explore_department_show', '/explore/department/'.self::PUBLIC_ID];
+        yield 'dispatch area' => [self::withPublicId(new DispatchArea()), 'app_explore_dispatch_area_show', '/explore/dispatch_area/'.self::PUBLIC_ID];
+        yield 'hospital' => [self::withPublicId(new Hospital()), 'app_explore_hospital_show', '/explore/hospital/'.self::PUBLIC_ID];
+        yield 'indication group' => [self::withPublicId(new IndicationGroup()), 'app_explore_indication_group_show', '/explore/indication_group/'.self::PUBLIC_ID];
+        yield 'indication' => [self::withPublicId(new IndicationNormalized()), 'app_explore_indication_show', '/explore/indication/'.self::PUBLIC_ID];
+        yield 'infection' => [self::withPublicId(new Infection()), 'app_explore_infection_show', '/explore/infection/'.self::PUBLIC_ID];
+        yield 'mci case' => [self::withPublicId(new MciCase()), 'app_explore_mci_case_show', '/explore/mci_case/'.self::PUBLIC_ID];
+        yield 'occasion' => [self::withPublicId(new Occasion()), 'app_explore_occasion_show', '/explore/occasion/'.self::PUBLIC_ID];
+        yield 'secondary transport' => [self::withPublicId(new SecondaryTransport()), 'app_explore_secondary_transport_show', '/explore/secondary_transport/'.self::PUBLIC_ID];
+        yield 'speciality' => [self::withPublicId(new Speciality()), 'app_explore_speciality_show', '/explore/speciality/'.self::PUBLIC_ID];
+        yield 'state' => [self::withPublicId(new State()), 'app_explore_state_show', '/explore/state/'.self::PUBLIC_ID];
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param T $entity
+     *
+     * @return T
+     */
+    private static function withPublicId(object $entity): object
+    {
+        if (!method_exists($entity, 'setPublicId')) {
+            throw new \LogicException(sprintf('%s is missing setPublicId.', $entity::class));
+        }
+
+        $entity->setPublicId(Uuid::fromString(self::PUBLIC_ID));
+
+        return $entity;
+    }
+}

--- a/tests/Allocation/Unit/UI/Twig/ExploreEntityLinkExtensionTest.php
+++ b/tests/Allocation/Unit/UI/Twig/ExploreEntityLinkExtensionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Allocation\Unit\UI\Twig;
+
+use App\Allocation\Application\Explore\ExploreShowUrlResolver;
+use App\Allocation\Domain\Entity\Department;
+use App\Allocation\Domain\Entity\IndicationRaw;
+use App\Allocation\UI\Twig\ExploreEntityLinkExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class ExploreEntityLinkExtensionTest extends TestCase
+{
+    private const string PUBLIC_ID = '11111111-1111-4111-8111-111111111111';
+
+    public function testExploreEntityUrlDelegatesToResolver(): void
+    {
+        $department = $this->department('Cardiology');
+        $extension = $this->extension();
+
+        self::assertSame(
+            '/explore/department/'.self::PUBLIC_ID,
+            $extension->exploreEntityUrl($department),
+        );
+    }
+
+    public function testExploreEntityLinkRendersAnchorForResolvableEntity(): void
+    {
+        $department = $this->department('Cardiology');
+        $extension = $this->extension();
+
+        self::assertSame(
+            '<a href="/explore/department/'.self::PUBLIC_ID.'">Cardiology</a>',
+            $extension->exploreEntityLink($department),
+        );
+    }
+
+    public function testExploreEntityLinkAppliesClassAndCustomLabel(): void
+    {
+        $department = $this->department('Cardiology');
+        $extension = $this->extension();
+
+        self::assertSame(
+            '<a href="/explore/department/'.self::PUBLIC_ID.'" class="link-secondary">Dept</a>',
+            $extension->exploreEntityLink($department, [
+                'label' => 'Dept',
+                'class' => 'link-secondary',
+            ]),
+        );
+    }
+
+    public function testExploreEntityLinkEscapesLabelAndClass(): void
+    {
+        $department = $this->department('A <b>bold</b> name');
+        $extension = $this->extension();
+
+        self::assertSame(
+            '<a href="/explore/department/'.self::PUBLIC_ID.'" class="x&quot;onclick">A &lt;b&gt;bold&lt;/b&gt; name</a>',
+            $extension->exploreEntityLink($department, ['class' => 'x"onclick']),
+        );
+    }
+
+    public function testExploreEntityLinkRendersPlainTextWhenEntityHasNoDestination(): void
+    {
+        $raw = new IndicationRaw();
+        $raw->setName('Raw indication');
+        $raw->setPublicId(Uuid::fromString(self::PUBLIC_ID));
+
+        $extension = $this->extension();
+
+        self::assertSame('Raw indication', $extension->exploreEntityLink($raw));
+        self::assertNull($extension->exploreEntityUrl($raw));
+    }
+
+    public function testExploreEntityLinkRendersEmptyFallbackForNullEntity(): void
+    {
+        $extension = $this->extension();
+
+        self::assertSame('—', $extension->exploreEntityLink(null));
+        self::assertSame('n/a', $extension->exploreEntityLink(null, ['empty' => 'n/a']));
+    }
+
+    public function testExploreEntityLinkRendersPlainTextWhenPublicIdIsMissing(): void
+    {
+        $department = new Department();
+        $department->setName('Unpublished');
+
+        $extension = $this->extension();
+
+        self::assertSame('Unpublished', $extension->exploreEntityLink($department));
+    }
+
+    private function extension(): ExploreEntityLinkExtension
+    {
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturnCallback(
+            static fn (string $route, array $params = []): string => match ($route) {
+                'app_explore_department_show' => '/explore/department/'.($params['publicId'] ?? ''),
+                default => throw new \InvalidArgumentException($route),
+            },
+        );
+
+        return new ExploreEntityLinkExtension(new ExploreShowUrlResolver($urlGenerator));
+    }
+
+    private function department(string $name): Department
+    {
+        $department = new Department();
+        $department->setName($name);
+        $department->setPublicId(Uuid::fromString(self::PUBLIC_ID));
+
+        return $department;
+    }
+}


### PR DESCRIPTION
## Summary

Related Explorer entities on detail pages are now clickable cross-references instead of plain text. Users can move directly between Allocations, MCI cases, hospitals, indications, and other catalog entities without going back to search or list views.

A shared URL resolver and Twig helpers (`explore_entity_link` / `explore_entity_url`) generate these links consistently. Missing, unresolved, or unsupported references stay as plain text. Existing Explorer routes and authorization are unchanged: links are only rendered when a meaningful Explorer destination exists, and raw indications are not linked because they have no catalog show page.

## Test plan

- [x] Open an Allocation detail page and confirm related hospitals, indications, departments, specialties, dispatch areas, states, assignments, occasions, secondary transports, and infections link to their Explorer detail pages.
- [x] Confirm raw / secondary raw indications remain plain text (no link to the review workflow).
- [x] Open an MCI case detail page and confirm the same cross-references, including the new hospital link in the header.
- [x] Open a Hospital detail page and confirm dispatch area and state in the header are clickable.
- [x] Open State, Dispatch Area, Indication, and Indication Group detail pages and confirm related-entity lists still work and use the same link style.
- [x] Confirm missing or null related values still render as fallback text without broken links.
- [x] Confirm a participant can follow the links, and a non-participant still cannot access `/explore`.