### PR TITLE
feat: Backfill legacy User.createdAt from historical imports

### DIFF
--- a/docs/06-reference/console-commands.md
+++ b/docs/06-reference/console-commands.md
@@ -23,7 +23,7 @@ Examples: `app:import:allocations`, `app:statistics:rebuild-projection`.
 | `--<entity>-id` | Optional or filter scoping | `--hospital-id`, `--user-id`, `--only-id`, `--page-id` |
 | `--dry-run` | Preview destructive or write operations without persisting | Backfill, requeue, deduplicate, content migration |
 
-**Dry-run rule:** Analysis-only commands are read-only by default. Commands that write data apply changes when run without `--dry-run`. Use `--dry-run` to preview what would change. `app:audit:purge-import-assessments` is an exception: it previews by default and requires `--execute` to delete rows.
+**Dry-run rule:** Analysis-only commands are read-only by default. Commands that write data apply changes when run without `--dry-run`. Use `--dry-run` to preview what would change. Exceptions that preview by default: `app:audit:purge-import-assessments` (`--execute` to delete) and `app:user:backfill-created-at` (`--apply` to write).
 
 ### Output
 
@@ -86,6 +86,12 @@ Commands are invokable classes with `#[AsCommand]` and autoconfiguration via `co
 | Command | Purpose |
 |---|---|
 | `app:content:analyze-page-images` | Analyze CMS page images; optional dimension backfill and layout migration. Runs on deploy via Deployer. |
+
+### User
+
+| Command | Purpose |
+|---|---|
+| `app:user:backfill-created-at` | One-time legacy tool: reconstruct `User.createdAt` from the earliest successful own import, otherwise the earliest successful import of an **owned** hospital. Access-grant users are not backfilled from hospital imports. Default: dry-run preview. Writes only with `--apply`. Removable after the production run. |
 
 ### Audit
 

--- a/src/Import/Infrastructure/Adapter/DoctrineUserCreatedAtBackfillImportSource.php
+++ b/src/Import/Infrastructure/Adapter/DoctrineUserCreatedAtBackfillImportSource.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Adapter;
+
+use App\Import\Domain\Entity\Import;
+use App\Import\Domain\Enum\ImportStatus;
+use App\User\Application\Contract\UserCreatedAtBackfillImportSourceInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for UserCreatedAtBackfillImportSourceInterface. */
+#[AsAlias(UserCreatedAtBackfillImportSourceInterface::class)]
+final readonly class DoctrineUserCreatedAtBackfillImportSource implements UserCreatedAtBackfillImportSourceInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    #[\Override]
+    public function firstSuccessfulCreatedAtByUser(): array
+    {
+        /** @var list<array{userId: int|string, firstAt: \DateTimeImmutable|string|null}> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('IDENTITY(i.createdBy) AS userId', 'MIN(i.createdAt) AS firstAt')
+            ->from(Import::class, 'i')
+            ->andWhere('i.status IN (:statuses)')
+            ->setParameter('statuses', [ImportStatus::COMPLETED, ImportStatus::PARTIAL])
+            ->groupBy('i.createdBy')
+            ->getQuery()
+            ->getArrayResult();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $firstAt = $this->parseDateTime($row['firstAt']);
+            if (!$firstAt instanceof \DateTimeImmutable) {
+                continue;
+            }
+
+            $result[(int) $row['userId']] = $firstAt;
+        }
+
+        return $result;
+    }
+
+    #[\Override]
+    public function firstSuccessfulCreatedAtByHospital(): array
+    {
+        /** @var list<array{hospitalId: int|string, firstAt: \DateTimeImmutable|string|null}> $rows */
+        $rows = $this->entityManager->createQueryBuilder()
+            ->select('IDENTITY(i.hospital) AS hospitalId', 'MIN(i.createdAt) AS firstAt')
+            ->from(Import::class, 'i')
+            ->andWhere('i.status IN (:statuses)')
+            ->setParameter('statuses', [ImportStatus::COMPLETED, ImportStatus::PARTIAL])
+            ->groupBy('i.hospital')
+            ->getQuery()
+            ->getArrayResult();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $firstAt = $this->parseDateTime($row['firstAt']);
+            if (!$firstAt instanceof \DateTimeImmutable) {
+                continue;
+            }
+
+            $result[(int) $row['hospitalId']] = $firstAt;
+        }
+
+        return $result;
+    }
+
+    private function parseDateTime(mixed $value): ?\DateTimeImmutable
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value);
+        }
+
+        if (\is_string($value) && '' !== $value) {
+            return new \DateTimeImmutable($value);
+        }
+
+        return null;
+    }
+}

--- a/src/User/Application/Contract/UserCreatedAtBackfillImportSourceInterface.php
+++ b/src/User/Application/Contract/UserCreatedAtBackfillImportSourceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Contract;
+
+interface UserCreatedAtBackfillImportSourceInterface
+{
+    /**
+     * @return array<int, \DateTimeImmutable> userId => earliest successful import createdAt
+     */
+    public function firstSuccessfulCreatedAtByUser(): array;
+
+    /**
+     * @return array<int, \DateTimeImmutable> hospitalId => earliest successful import createdAt
+     */
+    public function firstSuccessfulCreatedAtByHospital(): array;
+}

--- a/src/User/Infrastructure/Query/UserCreatedAtBackfillHospitalQuery.php
+++ b/src/User/Infrastructure/Query/UserCreatedAtBackfillHospitalQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Query;
+
+use App\Allocation\Domain\Entity\Hospital;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class UserCreatedAtBackfillHospitalQuery
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * Owned hospitals only. Access-grant associations are ignored because those
+     * users may have been created later than the hospital's first import.
+     *
+     * @return array<int, list<array{id: int, name: string}>>
+     */
+    public function ownedHospitalsByUserId(): array
+    {
+        /** @var list<array{userId: int|string, id: int|string, name: string}> $owned */
+        $owned = $this->entityManager->createQueryBuilder()
+            ->select('IDENTITY(h.owner) AS userId', 'h.id AS id', 'h.name AS name')
+            ->from(Hospital::class, 'h')
+            ->andWhere('IDENTITY(h.owner) IS NOT NULL')
+            ->getQuery()
+            ->getArrayResult();
+
+        $byUser = [];
+        foreach ($owned as $row) {
+            $userId = (int) $row['userId'];
+            $byUser[$userId][] = [
+                'id' => (int) $row['id'],
+                'name' => $row['name'],
+            ];
+        }
+
+        return $byUser;
+    }
+}

--- a/src/User/UI/Console/Command/BackfillUserCreatedAtCommand.php
+++ b/src/User/UI/Console/Command/BackfillUserCreatedAtCommand.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Console\Command;
+
+use App\User\Application\Contract\UserCreatedAtBackfillImportSourceInterface;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Query\UserCreatedAtBackfillHospitalQuery;
+use App\User\Infrastructure\Repository\UserRepository;
+use App\User\UI\Console\Input\BackfillUserCreatedAtInput;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:user:backfill-created-at',
+    description: 'Reconstruct User.createdAt from the earliest successful own import, otherwise an owned hospital import (default: dry-run preview).',
+)]
+final readonly class BackfillUserCreatedAtCommand
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private UserCreatedAtBackfillImportSourceInterface $importSource,
+        private UserCreatedAtBackfillHospitalQuery $hospitalQuery,
+        private Connection $connection,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[MapInput] BackfillUserCreatedAtInput $input,
+    ): int {
+        $this->entityManager->clear();
+
+        $apply = $input->apply;
+        if ($apply && $input->dryRun) {
+            $io->warning('Both --apply and --dry-run were passed; --apply takes precedence.');
+        }
+        $dryRun = !$apply;
+
+        $io->title('Backfill user createdAt from historical imports');
+
+        if ($dryRun) {
+            $io->note('Dry run: no rows will be written. Re-run with --apply to persist changes.');
+        } else {
+            $io->warning('Apply mode: user.created_at will be updated where an earlier historical date is found.');
+        }
+
+        $users = $this->userRepository->findBy([], ['id' => 'ASC']);
+        $firstOwnByUser = $this->importSource->firstSuccessfulCreatedAtByUser();
+        $firstImportByHospital = $this->importSource->firstSuccessfulCreatedAtByHospital();
+        $hospitalsByUser = $this->hospitalQuery->ownedHospitalsByUserId();
+
+        $inspected = 0;
+        $earlierFromOwnImport = 0;
+        $earlierFromHospitalImport = 0;
+        $noHistoricalInformation = 0;
+        $currentAlreadyEarlier = 0;
+        /** @var array<int, \DateTimeImmutable> $updates */
+        $updates = [];
+
+        foreach ($users as $user) {
+            $userId = $user->getId();
+            if (null === $userId) {
+                continue;
+            }
+
+            ++$inspected;
+            $currentCreatedAt = $user->getCreatedAt();
+            $decision = $this->decide(
+                $userId,
+                $currentCreatedAt,
+                $firstOwnByUser,
+                $firstImportByHospital,
+                $hospitalsByUser[$userId] ?? [],
+            );
+
+            $this->writeUserReport($io, $user, $userId, $currentCreatedAt, $decision, $dryRun);
+
+            if (
+                'own' === $decision['source']
+                && $decision['shouldUpdate']
+                && $decision['candidate'] instanceof \DateTimeImmutable
+            ) {
+                ++$earlierFromOwnImport;
+                $updates[$userId] = $decision['candidate'];
+            } elseif (
+                'hospital' === $decision['source']
+                && $decision['shouldUpdate']
+                && $decision['candidate'] instanceof \DateTimeImmutable
+            ) {
+                ++$earlierFromHospitalImport;
+                $updates[$userId] = $decision['candidate'];
+            } elseif (null === $decision['candidate']) {
+                ++$noHistoricalInformation;
+            } else {
+                ++$currentAlreadyEarlier;
+            }
+        }
+
+        $changed = \count($updates);
+
+        if (!$dryRun && [] !== $updates) {
+            $this->applyUpdates($updates);
+        }
+
+        $io->section('Summary');
+        $io->table(
+            ['Metric', 'Count'],
+            [
+                ['Users inspected', (string) $inspected],
+                ['Earlier date from own import', (string) $earlierFromOwnImport],
+                ['Earlier date from hospital import', (string) $earlierFromHospitalImport],
+                ['No historical information found', (string) $noHistoricalInformation],
+                ['Current createdAt already earlier', (string) $currentAlreadyEarlier],
+                [$dryRun ? 'Users would be changed' : 'Users changed', (string) $changed],
+            ],
+        );
+
+        if ($dryRun) {
+            $io->success('Dry run finished. Re-run with --apply to persist changes.');
+        } else {
+            $io->success(sprintf('Updated %d user(s).', $changed));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<int, \DateTimeImmutable>     $firstOwnByUser
+     * @param array<int, \DateTimeImmutable>     $firstImportByHospital
+     * @param list<array{id: int, name: string}> $hospitals
+     *
+     * @return array{
+     *     source: 'own'|'hospital'|null,
+     *     candidate: \DateTimeImmutable|null,
+     *     hospitalName: string|null,
+     *     shouldUpdate: bool
+     * }
+     */
+    private function decide(
+        int $userId,
+        \DateTimeImmutable $currentCreatedAt,
+        array $firstOwnByUser,
+        array $firstImportByHospital,
+        array $hospitals,
+    ): array {
+        $ownFirst = $firstOwnByUser[$userId] ?? null;
+        if ($ownFirst instanceof \DateTimeImmutable) {
+            return [
+                'source' => 'own',
+                'candidate' => $ownFirst,
+                'hospitalName' => null,
+                'shouldUpdate' => $ownFirst < $currentCreatedAt,
+            ];
+        }
+
+        $hospitalCandidate = $this->earliestHospitalImport($hospitals, $firstImportByHospital);
+        if (null !== $hospitalCandidate) {
+            return [
+                'source' => 'hospital',
+                'candidate' => $hospitalCandidate['createdAt'],
+                'hospitalName' => $hospitalCandidate['name'],
+                'shouldUpdate' => $hospitalCandidate['createdAt'] < $currentCreatedAt,
+            ];
+        }
+
+        return [
+            'source' => null,
+            'candidate' => null,
+            'hospitalName' => null,
+            'shouldUpdate' => false,
+        ];
+    }
+
+    /**
+     * @param list<array{id: int, name: string}> $hospitals
+     * @param array<int, \DateTimeImmutable>     $firstImportByHospital
+     *
+     * @return array{createdAt: \DateTimeImmutable, name: string}|null
+     */
+    private function earliestHospitalImport(array $hospitals, array $firstImportByHospital): ?array
+    {
+        $bestAt = null;
+        $bestName = null;
+        $bestHospitalId = null;
+
+        foreach ($hospitals as $hospital) {
+            $createdAt = $firstImportByHospital[$hospital['id']] ?? null;
+            if (!$createdAt instanceof \DateTimeImmutable) {
+                continue;
+            }
+
+            if (
+                !$bestAt instanceof \DateTimeImmutable
+                || $createdAt < $bestAt
+                || ($createdAt == $bestAt && $hospital['id'] < (int) $bestHospitalId)
+            ) {
+                $bestAt = $createdAt;
+                $bestName = $hospital['name'];
+                $bestHospitalId = $hospital['id'];
+            }
+        }
+
+        if (!$bestAt instanceof \DateTimeImmutable || null === $bestName) {
+            return null;
+        }
+
+        return [
+            'createdAt' => $bestAt,
+            'name' => $bestName,
+        ];
+    }
+
+    /**
+     * @param array{
+     *     source: 'own'|'hospital'|null,
+     *     candidate: \DateTimeImmutable|null,
+     *     hospitalName: string|null,
+     *     shouldUpdate: bool
+     * } $decision
+     */
+    private function writeUserReport(
+        SymfonyStyle $io,
+        User $user,
+        int $userId,
+        \DateTimeImmutable $currentCreatedAt,
+        array $decision,
+        bool $dryRun,
+    ): void {
+        $io->writeln(sprintf('User #%d – %s', $userId, $user->getUsername() ?? ''));
+        $io->writeln('Current createdAt:');
+        $io->writeln($currentCreatedAt->format('Y-m-d H:i'));
+
+        if (null === $decision['candidate']) {
+            $io->writeln('Own import:');
+            $io->writeln('none');
+            $io->writeln('Hospital import:');
+            $io->writeln('none');
+            $io->writeln('Action:');
+            $io->writeln('no change');
+            $io->newLine();
+
+            return;
+        }
+
+        $io->writeln('Source:');
+        $io->writeln('own' === $decision['source'] ? 'own import' : 'hospital import');
+        if ('hospital' === $decision['source'] && null !== $decision['hospitalName']) {
+            $io->writeln('Hospital:');
+            $io->writeln($decision['hospitalName']);
+        }
+        $io->writeln('Reconstructed createdAt:');
+        $io->writeln($decision['candidate']->format('Y-m-d H:i'));
+        $io->writeln('Action:');
+        if ($decision['shouldUpdate']) {
+            $io->writeln($dryRun ? 'would update' : 'updated');
+        } else {
+            $io->writeln('no change – current value is already earlier');
+        }
+        $io->newLine();
+    }
+
+    /**
+     * @param array<int, \DateTimeImmutable> $updates
+     */
+    private function applyUpdates(array $updates): void
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            foreach ($updates as $userId => $createdAt) {
+                $this->connection->executeStatement(
+                    'UPDATE "user" SET created_at = :createdAt WHERE id = :id',
+                    [
+                        'createdAt' => $createdAt,
+                        'id' => $userId,
+                    ],
+                    [
+                        'createdAt' => Types::DATETIME_IMMUTABLE,
+                        'id' => Types::INTEGER,
+                    ],
+                );
+            }
+
+            $this->connection->commit();
+        } catch (\Throwable $exception) {
+            $this->connection->rollBack();
+
+            throw $exception;
+        }
+    }
+}

--- a/src/User/UI/Console/Input/BackfillUserCreatedAtInput.php
+++ b/src/User/UI/Console/Input/BackfillUserCreatedAtInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\UI\Console\Input;
+
+use Symfony\Component\Console\Attribute\Option;
+
+final class BackfillUserCreatedAtInput
+{
+    #[Option(description: 'Preview reconstructed dates without writing (default)', name: 'dry-run')]
+    public bool $dryRun = false;
+
+    #[Option(description: 'Persist earlier reconstructed createdAt values', name: 'apply')]
+    public bool $apply = false;
+}

--- a/tests/User/Functional/Command/BackfillUserCreatedAtCommandTest.php
+++ b/tests/User/Functional/Command/BackfillUserCreatedAtCommandTest.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Functional\Command;
+
+use App\Allocation\Infrastructure\Factory\HospitalAccessGrantFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Import\Domain\Enum\ImportStatus;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Factory\UserFactory;
+use App\User\UI\Console\Command\BackfillUserCreatedAtCommand;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class BackfillUserCreatedAtCommandTest extends KernelTestCase
+{
+    use Factories;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    public function testOwnImportUpdatesCreatedAtAndIsIdempotent(): void
+    {
+        $user = $this->createUser('max-mustermann', '2026-08-13 14:20:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Own Import Klinik',
+            'owner' => $user,
+            'createdBy' => $user,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2022-05-10 09:42:00'),
+        ]);
+
+        $userId = $this->userId($user);
+        $updatedAtBefore = $this->fetchUpdatedAt($userId);
+
+        $tester = $this->createCommandTester();
+        $dryRun = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $dryRun);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('User #'.$userId.' – max-mustermann', $display);
+        self::assertStringContainsString('2026-08-13 14:20', $display);
+        self::assertStringContainsString('own import', $display);
+        self::assertStringContainsString('2022-05-10 09:42', $display);
+        self::assertStringContainsString('would update', $display);
+        self::assertStringContainsString('Dry run: no rows will be written.', $display);
+        self::assertSame('2026-08-13 14:20:00', $this->fetchCreatedAt($userId)->format('Y-m-d H:i:s'));
+
+        $apply = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $apply);
+        self::assertStringContainsString('updated', $tester->getDisplay());
+        self::assertSame('2022-05-10 09:42:00', $this->fetchCreatedAt($userId)->format('Y-m-d H:i:s'));
+        self::assertSame($updatedAtBefore, $this->fetchUpdatedAt($userId));
+
+        $second = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $second);
+        self::assertStringContainsString('no change – current value is already earlier', $tester->getDisplay());
+        self::assertSame('2022-05-10 09:42:00', $this->fetchCreatedAt($userId)->format('Y-m-d H:i:s'));
+        self::assertSame($updatedAtBefore, $this->fetchUpdatedAt($userId));
+    }
+
+    public function testHospitalOwnerImportUsedWhenNoOwnImport(): void
+    {
+        $user = $this->createUser('max-mustermann', '2026-08-13 14:20:00');
+        $importer = $this->createUser('legacy-importer', '2020-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Klinikum Musterstadt',
+            'owner' => $user,
+            'createdBy' => $importer,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $importer,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2021-04-03 08:15:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('hospital import', $display);
+        self::assertStringContainsString('Klinikum Musterstadt', $display);
+        self::assertStringContainsString('2021-04-03 08:15', $display);
+        self::assertSame('2021-04-03 08:15:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testAccessGrantHospitalImportIsIgnored(): void
+    {
+        $user = $this->createUser('erika-beispiel', '2026-08-13 14:20:00');
+        $owner = $this->createUser('hospital-owner', '2020-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Grant Klinik',
+            'owner' => $owner,
+            'createdBy' => $owner,
+        ]);
+        HospitalAccessGrantFactory::createOne([
+            'user' => $user,
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2021-09-03 11:14:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $block = $this->userBlock($tester->getDisplay(), 'erika-beispiel');
+        self::assertStringContainsString('Own import:', $block);
+        self::assertStringContainsString('none', $block);
+        self::assertStringContainsString('Hospital import:', $block);
+        self::assertStringContainsString('no change', $block);
+        self::assertSame('2026-08-13 14:20:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testAccessGrantUserStillUsesOwnImport(): void
+    {
+        $user = $this->createUser('grant-with-own-import', '2026-08-13 14:20:00');
+        $owner = $this->createUser('grant-hospital-owner', '2020-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Grant Own Import Klinik',
+            'owner' => $owner,
+            'createdBy' => $owner,
+        ]);
+        HospitalAccessGrantFactory::createOne([
+            'user' => $user,
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $owner,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2020-01-01 00:00:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2022-05-10 09:42:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $block = $this->userBlock($tester->getDisplay(), 'grant-with-own-import');
+        self::assertStringContainsString('own import', $block);
+        self::assertStringNotContainsString('hospital import', $block);
+        self::assertSame('2022-05-10 09:42:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testGrantHospitalIsIgnoredWhenUserAlsoOwnsAnotherHospital(): void
+    {
+        $user = $this->createUser('owner-and-grantee', '2026-08-13 14:20:00');
+        $otherOwner = $this->createUser('other-hospital-owner', '2019-01-01 00:00:00');
+        $ownedHospital = HospitalFactory::createOne([
+            'name' => 'Owned Klinik',
+            'owner' => $user,
+            'createdBy' => $user,
+        ]);
+        $grantedHospital = HospitalFactory::createOne([
+            'name' => 'Older Grant Klinik',
+            'owner' => $otherOwner,
+            'createdBy' => $otherOwner,
+        ]);
+        HospitalAccessGrantFactory::createOne([
+            'user' => $user,
+            'hospital' => $grantedHospital,
+            'createdBy' => $otherOwner,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $ownedHospital,
+            'createdBy' => $otherOwner,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2023-01-01 10:00:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $grantedHospital,
+            'createdBy' => $otherOwner,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2020-08-15 07:30:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $block = $this->userBlock($tester->getDisplay(), 'owner-and-grantee');
+        self::assertStringContainsString('hospital import', $block);
+        self::assertStringContainsString('Owned Klinik', $block);
+        self::assertStringNotContainsString('Older Grant Klinik', $block);
+        self::assertSame('2023-01-01 10:00:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testEarliestHospitalImportWinsAcrossMultipleHospitals(): void
+    {
+        $user = $this->createUser('multi-hospital', '2026-08-13 14:20:00');
+        $importer = $this->createUser('multi-importer', '2019-01-01 00:00:00');
+        $hospitalA = HospitalFactory::createOne([
+            'name' => 'Hospital A',
+            'owner' => $user,
+            'createdBy' => $importer,
+        ]);
+        $hospitalB = HospitalFactory::createOne([
+            'name' => 'Hospital B',
+            'owner' => $user,
+            'createdBy' => $importer,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospitalA,
+            'createdBy' => $importer,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2023-01-01 10:00:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospitalB,
+            'createdBy' => $importer,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2020-08-15 07:30:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Hospital B', $tester->getDisplay());
+        self::assertSame('2020-08-15 07:30:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testOwnImportTakesPrecedenceOverOlderHospitalImport(): void
+    {
+        $user = $this->createUser('priority-user', '2026-08-13 14:20:00');
+        $importer = $this->createUser('priority-importer', '2019-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Priority Klinik',
+            'owner' => $user,
+            'createdBy' => $importer,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2022-05-10 09:42:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $importer,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2020-01-01 00:00:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('own import', $display);
+        self::assertStringNotContainsString('hospital import', $this->userBlock($display, 'priority-user'));
+        self::assertSame('2022-05-10 09:42:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testNoHistoricalDataLeavesCreatedAtUnchanged(): void
+    {
+        $user = $this->createUser('no-history', '2026-08-13 14:20:00');
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('Own import:', $display);
+        self::assertStringContainsString('none', $display);
+        self::assertStringContainsString('Hospital import:', $display);
+        self::assertStringContainsString('no change', $this->userBlock($display, 'no-history'));
+        self::assertSame('2026-08-13 14:20:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testCurrentCreatedAtAlreadyEarlierIsNotReplaced(): void
+    {
+        $user = $this->createUser('already-earlier', '2021-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Later Import Klinik',
+            'owner' => $user,
+            'createdBy' => $user,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2022-05-10 09:42:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('no change – current value is already earlier', $tester->getDisplay());
+        self::assertSame('2021-01-01 00:00:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testFailedAndPendingImportsAreIgnoredAndPartialCounts(): void
+    {
+        $user = $this->createUser('status-user', '2026-08-13 14:20:00');
+        $importer = $this->createUser('status-importer', '2018-01-01 00:00:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Status Klinik',
+            'owner' => $user,
+            'createdBy' => $importer,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::FAILED,
+            'createdAt' => new \DateTimeImmutable('2020-01-01 00:00:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::PENDING,
+            'createdAt' => new \DateTimeImmutable('2020-06-01 00:00:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::PARTIAL,
+            'createdAt' => new \DateTimeImmutable('2022-05-10 09:42:00'),
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $importer,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2019-01-01 00:00:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $block = $this->userBlock($tester->getDisplay(), 'status-user');
+        self::assertStringContainsString('own import', $block);
+        self::assertStringContainsString('2022-05-10 09:42', $block);
+        self::assertSame('2022-05-10 09:42:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    public function testExplicitDryRunFlagDoesNotWrite(): void
+    {
+        $user = $this->createUser('dry-run-flag', '2026-08-13 14:20:00');
+        $hospital = HospitalFactory::createOne([
+            'name' => 'Dry Run Klinik',
+            'owner' => $user,
+            'createdBy' => $user,
+        ]);
+        ImportFactory::createOne([
+            'hospital' => $hospital,
+            'createdBy' => $user,
+            'status' => ImportStatus::COMPLETED,
+            'createdAt' => new \DateTimeImmutable('2022-04-17 09:42:00'),
+        ]);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('would update', $tester->getDisplay());
+        self::assertSame('2026-08-13 14:20:00', $this->fetchCreatedAt($this->userId($user))->format('Y-m-d H:i:s'));
+    }
+
+    private function createUser(string $username, string $createdAt): User
+    {
+        return UserFactory::createOne([
+            'username' => $username,
+            'email' => $username.'@example.test',
+            'createdAt' => new \DateTimeImmutable($createdAt),
+        ]);
+    }
+
+    private function userId(User $user): int
+    {
+        $id = $user->getId();
+        self::assertNotNull($id);
+
+        return $id;
+    }
+
+    private function fetchCreatedAt(int $userId): \DateTimeImmutable
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+        $value = $connection->fetchOne('SELECT created_at FROM "user" WHERE id = :id', ['id' => $userId]);
+        self::assertNotFalse($value);
+        self::assertNotNull($value);
+
+        if ($value instanceof \DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value);
+        }
+
+        return new \DateTimeImmutable((string) $value);
+    }
+
+    private function fetchUpdatedAt(int $userId): mixed
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        return $connection->fetchOne('SELECT updated_at FROM "user" WHERE id = :id', ['id' => $userId]);
+    }
+
+    private function userBlock(string $display, string $username): string
+    {
+        if (1 !== preg_match('/User #\d+ – '.preg_quote($username, '/').'\n.*?(?=User #\d+ – |\nSummary\n|\n \[OK\])/s', $display, $matches)) {
+            self::fail('Could not find report block for user '.$username);
+        }
+
+        return $matches[0];
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        /** @var BackfillUserCreatedAtCommand $command */
+        $command = self::getContainer()->get(BackfillUserCreatedAtCommand::class);
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a one-time console command `app:user:backfill-created-at` that reconstructs `User.createdAt` from existing historical import data.
- The current value is never treated as a legacy marker. It is only replaced when a reconstructed candidate is **earlier** than the stored date.
- Own successful imports take precedence. If none exist, the earliest successful import of an **owned** hospital is used. Access-grant associations are ignored, because those users may have been created later.
- Default is a dry-run. Writes require `--apply`. Updates touch only `created_at` (no `updatedAt` bump, no audit side effects). The command is idempotent and fully removable after the production run.

## Reconstruction rule

```text
candidate =
    first successful own import
    OR, if none exists,
    first successful import of an owned hospital
if candidate exists AND candidate < current createdAt:
    createdAt = candidate
else:
    do nothing