### PR TITLE
feat(statistics): Add a new report for transport time profiles

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -531,3 +531,109 @@
 .input-group [data-testid^="password-toggle-"] .icon {
     margin: 0;
 }
+
+.stats-ttp-table-scroll {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.stats-ttp-table {
+    width: 100%;
+    table-layout: fixed;
+    margin-bottom: 0;
+}
+
+.stats-ttp-table > :not(caption) > * > * {
+    padding: 0.4rem 0.45rem;
+    vertical-align: top;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
+}
+
+.stats-ttp-table .stats-ttp-metric-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    width: 9.5rem;
+    background: var(--tblr-bg-surface, #fff);
+    box-shadow: 1px 0 0 var(--tblr-border-color, #e6e7e9);
+}
+
+.stats-ttp-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--tblr-bg-surface, #fff);
+    font-size: 0.75rem;
+    line-height: 1.2;
+}
+
+.stats-ttp-table thead th.stats-ttp-metric-col {
+    z-index: 4;
+}
+
+.stats-ttp-section-row th {
+    background: var(--tblr-bg-surface-secondary, #f6f8fb);
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--tblr-secondary);
+}
+
+.stats-ttp-ranked-td {
+    font-size: 0.8125rem;
+    line-height: 1.25;
+}
+
+.stats-ttp-ranked-cell {
+    min-width: 0;
+}
+
+.stats-ttp-ranked-label {
+    display: block;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
+}
+
+.stats-ttp-ranked-meta {
+    margin-top: 0.15rem;
+}
+
+.stats-ttp-small-n {
+    opacity: 0.7;
+}
+
+.stats-ttp-heat-low-1 {
+    background-color: rgba(32, 107, 196, 0.08);
+}
+
+.stats-ttp-heat-low-2 {
+    background-color: rgba(32, 107, 196, 0.16);
+}
+
+.stats-ttp-heat-low-3 {
+    background-color: rgba(32, 107, 196, 0.28);
+}
+
+.stats-ttp-heat-high-1 {
+    background-color: rgba(250, 176, 5, 0.12);
+}
+
+.stats-ttp-heat-high-2 {
+    background-color: rgba(250, 176, 5, 0.22);
+}
+
+.stats-ttp-heat-high-3 {
+    background-color: rgba(250, 176, 5, 0.34);
+}
+
+.stats-ttp-insight {
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+}

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -382,6 +382,8 @@ deptrac:
       - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByCohortQuery
       - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByDispatchAreaQuery
       - App\Statistics\Infrastructure\Query\Overview\GetDistinctHospitalIdsByStateQuery
+    App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileBuilder:
+      - App\Statistics\UI\Http\Navigation\StatisticsQueryKeys
     App\Statistics\Application\TopDiagnosesQuery:
       - App\Statistics\Infrastructure\Query\ProjectionDiagnosisQuery
       - App\Statistics\Infrastructure\Query\ProjectionTimeSeriesQuery

--- a/docs/02-architecture/extension-points.md
+++ b/docs/02-architecture/extension-points.md
@@ -42,7 +42,7 @@ To add a new CSV row type, extend `AllocationRowType` and implement `AllocationR
 
 **Registry:** `ReportTypeRegistry`
 
-**Implementations:** `MonthlyReportType` (previous completed calendar month summary).
+**Implementations:** `MonthlyReportType` (previous completed calendar month summary), `TransportTimeProfileReportType` (allocation composition across transport-time buckets).
 
 Catalog: `GET /statistics/reports`. Detail: `GET /statistics/reports/{type}`.
 

--- a/docs/04-features/statistics/README.md
+++ b/docs/04-features/statistics/README.md
@@ -8,7 +8,7 @@
 |-----------|--------------|-------------|
 | Projection & MVs | (background) | Denormalized `allocation_stats_projection` and materialized views |
 | Top Lists | `/statistics/top-lists` | Ranked Top-N tables (diagnoses, departments, …) |
-| Reports | `/statistics/reports` | Report catalog; detail routes under `/statistics/reports/{type}` (Monthly Report first) |
+| Reports | `/statistics/reports` | Report catalog; detail routes under `/statistics/reports/{type}` (Monthly Report, Transport Time Profile) |
 | AnalysisExplorer | `/statistics/explorer` | Interactive saved-view analytics |
 | Benchmarking | `/statistics/benchmarking` | Hospital comparison |
 | DataQuality | Dashboard badges | Traffic-light data quality indicator |

--- a/src/Statistics/Application/Mapping/StatisticsTransportTimeBucketSql.php
+++ b/src/Statistics/Application/Mapping/StatisticsTransportTimeBucketSql.php
@@ -32,4 +32,31 @@ CASE
     ELSE 'over_60'
 END
 SQL;
+
+    /**
+     * PHP mirror of {@see CASE_EXPRESSION} for rounded transport_time_minutes.
+     *
+     * Boundaries are half-open [N, N+10): 10 minutes is 10_20, not under_10.
+     */
+    public static function bucketKeyForMinutes(?int $minutes): string
+    {
+        if (null === $minutes || $minutes < 0) {
+            return 'unknown';
+        }
+
+        return match (true) {
+            $minutes < 10 => 'under_10',
+            $minutes < 20 => '10_20',
+            $minutes < 30 => '20_30',
+            $minutes < 40 => '30_40',
+            $minutes < 50 => '40_50',
+            $minutes < 60 => '50_60',
+            default => 'over_60',
+        };
+    }
+
+    public static function translationKey(string $bucketKey): string
+    {
+        return 'statistics.distribution.transport_time_bucket.'.$bucketKey;
+    }
 }

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileCell.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileCell.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileCell
+{
+    public function __construct(
+        public int $bucketN,
+        public bool $smallSample,
+        public ?int $count = null,
+        public ?float $percent = null,
+        public ?float $deltaPp = null,
+        public string $heatClass = '',
+        public ?int $rank = null,
+        public ?int $rankDelta = null,
+        public bool $enteredTop = false,
+        public ?string $entityLabel = null,
+        public ?string $linkUrl = null,
+        public ?int $entityId = null,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return null === $this->count
+            && null === $this->percent
+            && null === $this->entityLabel;
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileInsight.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileInsight.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileInsight
+{
+    public function __construct(
+        public string $id,
+        public string $title,
+        public string $body,
+    ) {
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileMatrixRow.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileMatrixRow.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileMatrixRow
+{
+    /**
+     * @param array<string, TransportTimeProfileCell> $cells
+     */
+    public function __construct(
+        public string $key,
+        public string $label,
+        public string $kind,
+        public array $cells,
+        public ?float $overallPercent = null,
+    ) {
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileMatrixSection.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileMatrixSection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileMatrixSection
+{
+    /**
+     * @param list<TransportTimeProfileMatrixRow> $rows
+     */
+    public function __construct(
+        public string $key,
+        public string $titleKey,
+        public array $rows,
+    ) {
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileSliceData.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileSliceData.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileSliceData
+{
+    /**
+     * @param array<string, int>                              $volumeByBucket
+     * @param array<string, array<int|string, int>>           $genderByBucket
+     * @param array<string, array<int|string, int>>           $urgencyByBucket
+     * @param array<string, array<int|string, int>>           $physicianByBucket
+     * @param array<string, array<int|string, int>>           $resusByBucket
+     * @param array<string, array<int|string, int>>           $cathlabByBucket
+     * @param array<string, array<int|string, int>>           $transportTypeByBucket
+     * @param array<string, list<array{id: int, count: int}>> $departmentsByBucket
+     * @param array<string, list<array{id: int, count: int}>> $specialitiesByBucket
+     * @param array<string, list<array{id: int, count: int}>> $indicationsByBucket
+     */
+    public function __construct(
+        public int $unknownCount,
+        public array $volumeByBucket,
+        public array $genderByBucket,
+        public array $urgencyByBucket,
+        public array $physicianByBucket,
+        public array $resusByBucket,
+        public array $cathlabByBucket,
+        public array $transportTypeByBucket,
+        public array $departmentsByBucket,
+        public array $specialitiesByBucket,
+        public array $indicationsByBucket,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(0, [], [], [], [], [], [], [], [], [], []);
+    }
+
+    public function knownTotal(): int
+    {
+        return array_sum($this->volumeByBucket);
+    }
+
+    public function allocationTotal(): int
+    {
+        return $this->knownTotal() + $this->unknownCount;
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileView.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileView.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
+
+final readonly class TransportTimeProfileView
+{
+    /**
+     * @param array<string, string>                   $bucketLabels
+     * @param array<string, array<string, mixed>>     $chartSpecs
+     * @param list<TransportTimeProfileInsight>       $insights
+     * @param list<TransportTimeProfileMatrixSection> $matrixSections
+     * @param list<TransportTimeProfileMatrixSection> $rankedSections
+     */
+    public function __construct(
+        public bool $hasData,
+        public int $allocationCount,
+        public int $knownTransportCount,
+        public int $unknownTransportCount,
+        public string $contextLine,
+        public string $scopeLabel,
+        public string $periodLabel,
+        public string $importCreateUrl,
+        public string $dashboardUrl,
+        public string $explorerTransportTimeUrl,
+        public array $bucketLabels,
+        public array $chartSpecs,
+        public array $insights,
+        public array $matrixSections,
+        public array $rankedSections,
+        public bool $drawerFilterActive,
+    ) {
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileAssembler.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileAssembler.php
@@ -1,0 +1,675 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Statistics\Application\Mapping\AllocationStatsGenderProjectionCode;
+use App\Statistics\Application\Mapping\AllocationStatsTransportTypeProjectionCode;
+use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileCell;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixRow;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileSliceData;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class TransportTimeProfileAssembler
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $departmentNames
+     * @param array<int, string> $specialityNames
+     * @param array<int, string> $indicationNames
+     * @param array<int, string> $indicationUrls
+     *
+     * @return list<TransportTimeProfileMatrixSection>
+     */
+    public function matrix(
+        TransportTimeProfileSliceData $slice,
+        string $locale,
+        array $departmentNames,
+        array $specialityNames,
+        array $indicationNames,
+        array $indicationUrls,
+        string $departmentsUrl,
+        string $specialitiesUrl,
+    ): array {
+        $buckets = StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS;
+        $volume = $this->volumeByBucket($slice);
+        $knownTotal = array_sum($volume);
+
+        return [
+            $this->volumeSection($volume, $knownTotal, $buckets, $locale),
+            $this->compositionSection(
+                'gender',
+                'stats.reports.transport_time_profile.section.gender',
+                $this->genderRows($slice, $volume, $knownTotal, $buckets, $locale),
+            ),
+            $this->compositionSection(
+                'urgency',
+                'stats.reports.transport_time_profile.section.urgency',
+                $this->urgencyRows($slice, $volume, $knownTotal, $buckets, $locale),
+            ),
+            $this->rankedSection(
+                'departments',
+                'stats.reports.transport_time_profile.section.departments',
+                $slice->departmentsByBucket,
+                $departmentNames,
+                $volume,
+                $buckets,
+                $departmentsUrl,
+                [],
+            ),
+            $this->rankedSection(
+                'specialities',
+                'stats.reports.transport_time_profile.section.specialities',
+                $slice->specialitiesByBucket,
+                $specialityNames,
+                $volume,
+                $buckets,
+                $specialitiesUrl,
+                [],
+            ),
+            $this->rankedSection(
+                'indications',
+                'stats.reports.transport_time_profile.section.indications',
+                $slice->indicationsByBucket,
+                $indicationNames,
+                $volume,
+                $buckets,
+                null,
+                $indicationUrls,
+            ),
+            $this->compositionSection(
+                'physician',
+                'stats.reports.transport_time_profile.section.physician',
+                [$this->rateRow(
+                    'with_physician',
+                    $this->translator->trans('stats.reports.transport_time_profile.metric.with_physician', [], 'statistics', $locale),
+                    $this->trueCounts($slice->physicianByBucket),
+                    $volume,
+                    $knownTotal,
+                    $buckets,
+                )],
+            ),
+            $this->compositionSection(
+                'resources',
+                'stats.reports.transport_time_profile.section.resources',
+                [
+                    $this->rateRow(
+                        'requires_resus',
+                        $this->translator->trans('stats.reports.transport_time_profile.metric.requires_resus', [], 'statistics', $locale),
+                        $this->trueCounts($slice->resusByBucket),
+                        $volume,
+                        $knownTotal,
+                        $buckets,
+                    ),
+                    $this->rateRow(
+                        'requires_cathlab',
+                        $this->translator->trans('stats.reports.transport_time_profile.metric.requires_cathlab', [], 'statistics', $locale),
+                        $this->trueCounts($slice->cathlabByBucket),
+                        $volume,
+                        $knownTotal,
+                        $buckets,
+                    ),
+                ],
+            ),
+            $this->compositionSection(
+                'transport_mode',
+                'stats.reports.transport_time_profile.section.transport_mode',
+                $this->transportRows($slice, $volume, $knownTotal, $buckets, $locale),
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $bucketLabels
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function chartSpecs(
+        TransportTimeProfileSliceData $slice,
+        array $bucketLabels,
+        string $locale,
+    ): array {
+        $buckets = StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS;
+        $labels = [];
+        $counts = [];
+        $volume = $this->volumeByBucket($slice);
+        foreach ($buckets as $bucket) {
+            $labels[] = $bucketLabels[$bucket] ?? $bucket;
+            $counts[] = $volume[$bucket];
+        }
+
+        $casesLabel = $this->translator->trans(
+            'stats.reports.transport_time_profile.chart.cases',
+            [],
+            'statistics',
+            $locale,
+        );
+        $axisLabel = $this->translator->trans(
+            'stats.reports.transport_time_profile.chart.axis',
+            [],
+            'statistics',
+            $locale,
+        );
+
+        return [
+            'cases' => [
+                'chartType' => 'bar',
+                'labels' => $labels,
+                'counts' => $counts,
+                'valueLabel' => $casesLabel,
+                'xAxisLabel' => $axisLabel,
+                'yAxisLabel' => $casesLabel,
+            ],
+            'gender' => $this->percentStackedSpec(
+                $labels,
+                $this->genderSeries($slice, $volume, $buckets, $locale),
+                $axisLabel,
+            ),
+            'urgency' => $this->percentStackedSpec(
+                $labels,
+                $this->urgencySeries($slice, $volume, $buckets, $locale),
+                $axisLabel,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function volumeByBucket(TransportTimeProfileSliceData $slice): array
+    {
+        $volume = [];
+        foreach (StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS as $bucket) {
+            $volume[$bucket] = $slice->volumeByBucket[$bucket] ?? 0;
+        }
+
+        return $volume;
+    }
+
+    /**
+     * @param list<TransportTimeProfileMatrixSection> $sections
+     *
+     * @return array<string, float>
+     */
+    public function rateSeriesByRow(array $sections, string $sectionKey, string $rowKey): array
+    {
+        foreach ($sections as $section) {
+            if ($section->key !== $sectionKey) {
+                continue;
+            }
+            foreach ($section->rows as $row) {
+                if ($row->key !== $rowKey) {
+                    continue;
+                }
+                $percents = [];
+                foreach ($row->cells as $bucket => $cell) {
+                    $percents[$bucket] = $cell->percent ?? 0.0;
+                }
+
+                return $percents;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param list<TransportTimeProfileMatrixSection> $sections
+     *
+     * @return array<string, list<array{id: string, label: string, percent: float, rank: int}>>
+     */
+    public function rankedByBucket(array $sections, string $sectionKey): array
+    {
+        $byBucket = [];
+        foreach ($sections as $section) {
+            if ($section->key !== $sectionKey) {
+                continue;
+            }
+            foreach ($section->rows as $row) {
+                foreach ($row->cells as $bucket => $cell) {
+                    $item = $this->rankedItemFromCell($cell);
+                    if (null === $item) {
+                        continue;
+                    }
+                    $byBucket[$bucket][] = $item;
+                }
+            }
+        }
+
+        return $byBucket;
+    }
+
+    /**
+     * @return array{id: string, label: string, percent: float, rank: int}|null
+     */
+    private function rankedItemFromCell(TransportTimeProfileCell $cell): ?array
+    {
+        $label = $cell->entityLabel;
+        $rank = $cell->rank;
+        $percent = $cell->percent;
+        if (!\is_string($label) || !\is_int($rank) || !\is_float($percent)) {
+            return null;
+        }
+
+        return [
+            'id' => (string) ($cell->entityId ?? $label),
+            'label' => $label,
+            'percent' => $percent,
+            'rank' => $rank,
+        ];
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     */
+    private function volumeSection(array $volume, int $knownTotal, array $buckets, string $locale): TransportTimeProfileMatrixSection
+    {
+        $countCells = [];
+        $shareCells = [];
+        foreach ($buckets as $bucket) {
+            $n = $volume[$bucket];
+            $small = TransportTimeProfileMath::isSmallSample($n);
+            $countCells[$bucket] = new TransportTimeProfileCell($n, $small, count: $n);
+            $shareCells[$bucket] = new TransportTimeProfileCell(
+                $n,
+                $small,
+                count: $n,
+                percent: TransportTimeProfileMath::percent($n, $knownTotal),
+            );
+        }
+
+        return new TransportTimeProfileMatrixSection(
+            'volume',
+            'stats.reports.transport_time_profile.section.volume',
+            [
+                new TransportTimeProfileMatrixRow(
+                    'cases',
+                    $this->translator->trans('stats.reports.transport_time_profile.metric.cases', [], 'statistics', $locale),
+                    'count',
+                    $countCells,
+                ),
+                new TransportTimeProfileMatrixRow(
+                    'share',
+                    $this->translator->trans('stats.reports.transport_time_profile.metric.share', [], 'statistics', $locale),
+                    'share',
+                    $shareCells,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @param list<TransportTimeProfileMatrixRow> $rows
+     */
+    private function compositionSection(string $key, string $titleKey, array $rows): TransportTimeProfileMatrixSection
+    {
+        return new TransportTimeProfileMatrixSection($key, $titleKey, $rows);
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<TransportTimeProfileMatrixRow>
+     */
+    private function genderRows(
+        TransportTimeProfileSliceData $slice,
+        array $volume,
+        int $knownTotal,
+        array $buckets,
+        string $locale,
+    ): array {
+        $rows = [];
+        foreach (AllocationStatsGenderProjectionCode::cases() as $code) {
+            $label = $this->translator->trans($code->labelTranslationKey(), [], 'messages', $locale);
+            $counts = $this->dimensionCounts($slice->genderByBucket, (string) $code->value);
+            $rows[] = $this->rateRow((string) $code->value, $label, $counts, $volume, $knownTotal, $buckets);
+        }
+
+        $unknownCounts = $this->dimensionCounts($slice->genderByBucket, 'unknown');
+        if (array_sum($unknownCounts) > 0) {
+            $rows[] = $this->rateRow(
+                'unknown',
+                $this->translator->trans('stats.indication.gender.unknown', [], 'statistics', $locale),
+                $unknownCounts,
+                $volume,
+                $knownTotal,
+                $buckets,
+            );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<TransportTimeProfileMatrixRow>
+     */
+    private function urgencyRows(
+        TransportTimeProfileSliceData $slice,
+        array $volume,
+        int $knownTotal,
+        array $buckets,
+        string $locale,
+    ): array {
+        $rows = [];
+        foreach (AllocationUrgency::cases() as $urgency) {
+            $label = $this->translator->trans($urgency->label(), [], 'messages', $locale);
+            $counts = $this->dimensionCounts($slice->urgencyByBucket, (string) $urgency->value);
+            $rows[] = $this->rateRow((string) $urgency->value, $label, $counts, $volume, $knownTotal, $buckets);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<TransportTimeProfileMatrixRow>
+     */
+    private function transportRows(
+        TransportTimeProfileSliceData $slice,
+        array $volume,
+        int $knownTotal,
+        array $buckets,
+        string $locale,
+    ): array {
+        $rows = [];
+        foreach (AllocationStatsTransportTypeProjectionCode::displayOrder() as $code) {
+            $label = $this->translator->trans($code->labelTranslationKey(), [], 'messages', $locale);
+            $counts = $this->dimensionCounts($slice->transportTypeByBucket, (string) $code->value);
+            $rows[] = $this->rateRow((string) $code->value, $label, $counts, $volume, $knownTotal, $buckets);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, int> $countsByBucket
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     */
+    private function rateRow(
+        string $key,
+        string $label,
+        array $countsByBucket,
+        array $volume,
+        int $knownTotal,
+        array $buckets,
+    ): TransportTimeProfileMatrixRow {
+        $overallCount = array_sum($countsByBucket);
+        $overallPercent = TransportTimeProfileMath::percent($overallCount, $knownTotal);
+        $cells = [];
+        foreach ($buckets as $bucket) {
+            $n = $volume[$bucket];
+            $count = $countsByBucket[$bucket] ?? 0;
+            $percent = TransportTimeProfileMath::percent($count, $n);
+            $delta = TransportTimeProfileMath::deltaPp($percent, $overallPercent);
+            $small = TransportTimeProfileMath::isSmallSample($n);
+            $cells[$bucket] = new TransportTimeProfileCell(
+                $n,
+                $small,
+                count: $count,
+                percent: $percent,
+                deltaPp: $delta,
+                heatClass: TransportTimeProfileMath::heatClass($delta, $small),
+            );
+        }
+
+        return new TransportTimeProfileMatrixRow($key, $label, 'percent', $cells, $overallPercent);
+    }
+
+    /**
+     * @param array<string, list<array{id: int, count: int}>> $ranked
+     * @param array<int, string>                              $names
+     * @param array<string, int>                              $volume
+     * @param list<string>                                    $buckets
+     * @param array<int, string>                              $entityUrls
+     */
+    private function rankedSection(
+        string $key,
+        string $titleKey,
+        array $ranked,
+        array $names,
+        array $volume,
+        array $buckets,
+        ?string $sharedUrl,
+        array $entityUrls,
+    ): TransportTimeProfileMatrixSection {
+        $rows = [];
+        for ($rank = 1; $rank <= 5; ++$rank) {
+            $cells = [];
+            foreach ($buckets as $bucket) {
+                $n = $volume[$bucket];
+                $small = TransportTimeProfileMath::isSmallSample($n);
+                $item = $ranked[$bucket][$rank - 1] ?? null;
+                if (null === $item) {
+                    $cells[$bucket] = new TransportTimeProfileCell($n, $small);
+                    continue;
+                }
+
+                $id = $item['id'];
+                $percent = TransportTimeProfileMath::percent($item['count'], $n);
+                $cells[$bucket] = new TransportTimeProfileCell(
+                    $n,
+                    $small,
+                    count: $item['count'],
+                    percent: $percent,
+                    rank: $rank,
+                    entityLabel: $names[$id] ?? (string) $id,
+                    linkUrl: $entityUrls[$id] ?? $sharedUrl,
+                    entityId: $id,
+                );
+            }
+            $rows[] = new TransportTimeProfileMatrixRow(
+                'rank_'.$rank,
+                '#'.$rank,
+                'ranked',
+                $cells,
+            );
+        }
+
+        return $this->withColumnRelativeRanks(
+            new TransportTimeProfileMatrixSection($key, $titleKey, $rows),
+            $ranked,
+            $buckets,
+        );
+    }
+
+    /**
+     * Rebuild rank deltas relative to the preceding bucket column.
+     *
+     * @param array<string, list<array{id: int, count: int}>> $ranked
+     * @param list<string>                                    $buckets
+     */
+    private function withColumnRelativeRanks(
+        TransportTimeProfileMatrixSection $section,
+        array $ranked,
+        array $buckets,
+    ): TransportTimeProfileMatrixSection {
+        $rankByBucketAndId = [];
+        foreach ($buckets as $bucket) {
+            foreach ($ranked[$bucket] ?? [] as $index => $item) {
+                $rankByBucketAndId[$bucket][$item['id']] = $index + 1;
+            }
+        }
+
+        $previousRankedBucketByBucket = [];
+        $previousRankedBucket = null;
+        foreach ($buckets as $bucket) {
+            $previousRankedBucketByBucket[$bucket] = $previousRankedBucket;
+            if ([] !== ($ranked[$bucket] ?? [])) {
+                $previousRankedBucket = $bucket;
+            }
+        }
+
+        $rows = [];
+        foreach ($section->rows as $row) {
+            $cells = [];
+            foreach ($buckets as $bucket) {
+                $cell = $row->cells[$bucket];
+                if (null === $cell->entityId) {
+                    $cells[$bucket] = $cell;
+                    continue;
+                }
+
+                $previousBucket = $previousRankedBucketByBucket[$bucket];
+                $previousRank = null;
+                $enteredTop = false;
+                if (null !== $previousBucket) {
+                    $previousRank = $rankByBucketAndId[$previousBucket][$cell->entityId] ?? null;
+                    $enteredTop = null === $previousRank;
+                }
+
+                $cells[$bucket] = new TransportTimeProfileCell(
+                    $cell->bucketN,
+                    $cell->smallSample,
+                    count: $cell->count,
+                    percent: $cell->percent,
+                    deltaPp: $cell->deltaPp,
+                    heatClass: $cell->heatClass,
+                    rank: $cell->rank,
+                    rankDelta: null !== $previousRank && null !== $cell->rank ? $previousRank - $cell->rank : null,
+                    enteredTop: $enteredTop,
+                    entityLabel: $cell->entityLabel,
+                    linkUrl: $cell->linkUrl,
+                    entityId: $cell->entityId,
+                );
+            }
+            $rows[] = new TransportTimeProfileMatrixRow($row->key, $row->label, $row->kind, $cells, $row->overallPercent);
+        }
+
+        return new TransportTimeProfileMatrixSection($section->key, $section->titleKey, $rows);
+    }
+
+    /**
+     * @param array<string, array<int|string, int>> $byBucket
+     *
+     * @return array<string, int>
+     */
+    private function dimensionCounts(array $byBucket, string $code): array
+    {
+        $counts = [];
+        foreach (StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS as $bucket) {
+            $counts[$bucket] = $byBucket[$bucket][$code] ?? 0;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array<string, array<int|string, int>> $byBucket
+     *
+     * @return array<string, int>
+     */
+    private function trueCounts(array $byBucket): array
+    {
+        return $this->dimensionCounts($byBucket, '1');
+    }
+
+    /**
+     * @param list<string>                                 $labels
+     * @param list<array{name: string, data: list<float>}> $series
+     *
+     * @return array<string, mixed>
+     */
+    private function percentStackedSpec(array $labels, array $series, string $axisLabel): array
+    {
+        return [
+            'chartType' => 'bar',
+            'stacked' => true,
+            'percentScale' => true,
+            'labels' => $labels,
+            'series' => $series,
+            'xAxisLabel' => $axisLabel,
+            'yAxisLabel' => '%',
+        ];
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<array{name: string, data: list<float>}>
+     */
+    private function genderSeries(
+        TransportTimeProfileSliceData $slice,
+        array $volume,
+        array $buckets,
+        string $locale,
+    ): array {
+        $series = [];
+        foreach (AllocationStatsGenderProjectionCode::cases() as $code) {
+            $series[] = [
+                'name' => $this->translator->trans($code->labelTranslationKey(), [], 'messages', $locale),
+                'data' => $this->percentSeries($this->dimensionCounts($slice->genderByBucket, (string) $code->value), $volume, $buckets),
+            ];
+        }
+
+        $unknown = $this->dimensionCounts($slice->genderByBucket, 'unknown');
+        if (array_sum($unknown) > 0) {
+            $series[] = [
+                'name' => $this->translator->trans('stats.indication.gender.unknown', [], 'statistics', $locale),
+                'data' => $this->percentSeries($unknown, $volume, $buckets),
+            ];
+        }
+
+        return $series;
+    }
+
+    /**
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<array{name: string, data: list<float>}>
+     */
+    private function urgencySeries(
+        TransportTimeProfileSliceData $slice,
+        array $volume,
+        array $buckets,
+        string $locale,
+    ): array {
+        $series = [];
+        foreach (AllocationUrgency::cases() as $urgency) {
+            $series[] = [
+                'name' => $this->translator->trans($urgency->label(), [], 'messages', $locale),
+                'data' => $this->percentSeries(
+                    $this->dimensionCounts($slice->urgencyByBucket, (string) $urgency->value),
+                    $volume,
+                    $buckets,
+                ),
+            ];
+        }
+
+        return $series;
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @param array<string, int> $volume
+     * @param list<string>       $buckets
+     *
+     * @return list<float>
+     */
+    private function percentSeries(array $counts, array $volume, array $buckets): array
+    {
+        $data = [];
+        foreach ($buckets as $bucket) {
+            $data[] = TransportTimeProfileMath::percent($counts[$bucket] ?? 0, $volume[$bucket]);
+        }
+
+        return $data;
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileBuilder.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileBuilder.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+use App\Statistics\AnalysisExplorer\Application\ExplorerAnalysisSummaryLabelResolverInterface;
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Application\StatisticsScopeResolver;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileView;
+use App\Statistics\GenericAnalysis\Application\Contract\GenericAnalysisEntityLabelResolverInterface;
+use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class TransportTimeProfileBuilder
+{
+    public function __construct(
+        private StatisticsScopeResolver $scopeResolver,
+        private TransportTimeProfileSliceQueryInterface $sliceQuery,
+        private TransportTimeProfileAssembler $assembler,
+        private TransportTimeProfileInsightGenerator $insightGenerator,
+        private GenericAnalysisEntityLabelResolverInterface $entityLabelResolver,
+        private ExplorerAnalysisSummaryLabelResolverInterface $summaryLabelResolver,
+        private TranslatorInterface $translator,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function build(StatisticsContext $context, string $locale): TransportTimeProfileView
+    {
+        $scopeCriteria = $this->scopeResolver->resolveCriteria($context);
+        $periodBounds = StatisticsPeriodResolver::resolve($context->filter);
+        $slice = $this->sliceQuery->fetch($scopeCriteria, $periodBounds);
+
+        $bucketLabels = $this->bucketLabels($locale);
+        $scopeLabel = $this->summaryLabelResolver->scopeLabel($context->filter, $context->user, $locale);
+        $periodLabel = $this->summaryLabelResolver->periodLabel($context->filter, $locale);
+        $allocationCount = $slice->allocationTotal();
+        $knownTotal = $slice->knownTotal();
+        $hasData = $allocationCount > 0;
+
+        $contextLine = $this->translator->trans(
+            'stats.reports.transport_time_profile.context',
+            [
+                'scope' => $scopeLabel,
+                'period' => $periodLabel,
+                'count' => $allocationCount,
+            ],
+            'statistics',
+            $locale,
+        );
+
+        $filterParams = $this->filterQueryParams($context->filter);
+        $departmentIds = $this->collectIds($slice->departmentsByBucket);
+        $specialityIds = $this->collectIds($slice->specialitiesByBucket);
+        $indicationIds = $this->collectIds($slice->indicationsByBucket);
+
+        $departmentNames = $this->entityLabelResolver->resolve('department', $departmentIds);
+        $specialityNames = $this->entityLabelResolver->resolve('speciality', $specialityIds);
+        $indicationNames = $this->entityLabelResolver->resolve('indication', $indicationIds);
+
+        $indicationUrls = [];
+        foreach ($indicationIds as $id) {
+            $indicationUrls[$id] = $this->urlGenerator->generate(
+                'app_stats_indication_dashboard',
+                ['indicationId' => $id] + $filterParams,
+            );
+        }
+
+        $departmentsUrl = $this->urlGenerator->generate(
+            'app_stats_top_lists',
+            [StatisticsQueryKeys::REPORT => 'top_departments'] + $filterParams,
+        );
+        $specialitiesUrl = $this->urlGenerator->generate(
+            'app_stats_top_lists',
+            [StatisticsQueryKeys::REPORT => 'top_specialities'] + $filterParams,
+        );
+        $explorerUrl = $this->urlGenerator->generate(
+            'app_stats_analysis_explorer_view',
+            ['view' => 'transport-time-bucket-distribution'] + $filterParams,
+        );
+
+        $matrix = $hasData && $knownTotal > 0
+            ? $this->assembler->matrix(
+                $slice,
+                $locale,
+                $departmentNames,
+                $specialityNames,
+                $indicationNames,
+                $indicationUrls,
+                $departmentsUrl,
+                $specialitiesUrl,
+            )
+            : [];
+        $chartSpecs = $hasData && $knownTotal > 0
+            ? $this->assembler->chartSpecs($slice, $bucketLabels, $locale)
+            : [];
+        $volume = $this->assembler->volumeByBucket($slice);
+        $insights = $hasData && $knownTotal > 0
+            ? $this->insightGenerator->generate($volume, $matrix, $bucketLabels, $knownTotal, $locale)
+            : [];
+        [$matrixSections, $rankedSections] = $this->partitionMatrix($matrix);
+
+        return new TransportTimeProfileView(
+            hasData: $hasData,
+            allocationCount: $allocationCount,
+            knownTransportCount: $knownTotal,
+            unknownTransportCount: $slice->unknownCount,
+            contextLine: $contextLine,
+            scopeLabel: $scopeLabel,
+            periodLabel: $periodLabel,
+            importCreateUrl: $this->urlGenerator->generate('app_import_new'),
+            dashboardUrl: $this->urlGenerator->generate('app_stats_dashboard', $filterParams),
+            explorerTransportTimeUrl: $explorerUrl,
+            bucketLabels: $bucketLabels,
+            chartSpecs: $chartSpecs,
+            insights: $insights,
+            matrixSections: $matrixSections,
+            rankedSections: $rankedSections,
+            drawerFilterActive: false,
+        );
+    }
+
+    /**
+     * @param list<TransportTimeProfileMatrixSection> $sections
+     *
+     * @return array{0: list<TransportTimeProfileMatrixSection>, 1: list<TransportTimeProfileMatrixSection>}
+     */
+    private function partitionMatrix(array $sections): array
+    {
+        $composition = [];
+        $ranked = [];
+        foreach ($sections as $section) {
+            if (\in_array($section->key, ['departments', 'specialities', 'indications'], true)) {
+                $ranked[] = $section;
+            } else {
+                $composition[] = $section;
+            }
+        }
+
+        return [$composition, $ranked];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function bucketLabels(string $locale): array
+    {
+        $labels = [];
+        foreach (StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS as $key) {
+            $labels[$key] = $this->translator->trans(
+                StatisticsTransportTimeBucketSql::translationKey($key),
+                [],
+                'statistics',
+                $locale,
+            );
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @param array<string, list<array{id: int, count: int}>> $ranked
+     *
+     * @return list<int>
+     */
+    private function collectIds(array $ranked): array
+    {
+        $ids = [];
+        foreach ($ranked as $items) {
+            foreach ($items as $item) {
+                $ids[] = $item['id'];
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    private function filterQueryParams(StatisticsFilter $filter): array
+    {
+        return array_filter(
+            [
+                StatisticsQueryKeys::SCOPE => $filter->scope->value,
+                StatisticsQueryKeys::HOSPITAL => $filter->hospitalId,
+                StatisticsQueryKeys::STATE => $filter->stateId,
+                StatisticsQueryKeys::DISPATCH_AREA => $filter->dispatchAreaId,
+                StatisticsQueryKeys::COHORT => $filter->cohortType?->value(),
+                StatisticsQueryKeys::PERIOD => $filter->period->value,
+                StatisticsQueryKeys::YEAR => $filter->referenceYear,
+                StatisticsQueryKeys::MONTH => $filter->referenceMonth,
+                StatisticsQueryKeys::QUARTER => $filter->referenceQuarter,
+            ],
+            static fn (mixed $value): bool => null !== $value && '' !== $value,
+        );
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileInsightGenerator.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileInsightGenerator.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class TransportTimeProfileInsightGenerator
+{
+    private const int MAX_INSIGHTS = 4;
+
+    public function __construct(
+        private TranslatorInterface $translator,
+        private TransportTimeProfileAssembler $assembler,
+    ) {
+    }
+
+    /**
+     * @param array<string, int>                      $volume
+     * @param list<TransportTimeProfileMatrixSection> $sections
+     * @param array<string, string>                   $bucketLabels
+     *
+     * @return list<TransportTimeProfileInsight>
+     */
+    public function generate(
+        array $volume,
+        array $sections,
+        array $bucketLabels,
+        int $populationN,
+        string $locale,
+    ): array {
+        if ($populationN < TransportTimeProfileMath::INSIGHT_MIN_POPULATION_N) {
+            return [];
+        }
+
+        $short = $this->firstEligibleBucket($volume);
+        $long = $this->lastEligibleBucket($volume);
+        if (null === $short || null === $long || $short === $long) {
+            return [];
+        }
+
+        $candidates = [];
+
+        $this->addRateSpan(
+            $candidates,
+            'urgency_emergency',
+            $this->assembler->rateSeriesByRow($sections, 'urgency', '1'),
+            $volume,
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRateSpan(
+            $candidates,
+            'physician',
+            $this->assembler->rateSeriesByRow($sections, 'physician', 'with_physician'),
+            $volume,
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRateSpan(
+            $candidates,
+            'resus',
+            $this->assembler->rateSeriesByRow($sections, 'resources', 'requires_resus'),
+            $volume,
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRateSpan(
+            $candidates,
+            'cathlab',
+            $this->assembler->rateSeriesByRow($sections, 'resources', 'requires_cathlab'),
+            $volume,
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRateSpan(
+            $candidates,
+            'air',
+            $this->assembler->rateSeriesByRow($sections, 'transport_mode', '2'),
+            $volume,
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+
+        $this->addRankChange(
+            $candidates,
+            'departments',
+            $this->assembler->rankedByBucket($sections, 'departments'),
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRankChange(
+            $candidates,
+            'specialities',
+            $this->assembler->rankedByBucket($sections, 'specialities'),
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+        $this->addRankChange(
+            $candidates,
+            'indications',
+            $this->assembler->rankedByBucket($sections, 'indications'),
+            $short,
+            $long,
+            $bucketLabels,
+            $locale,
+        );
+
+        $this->addOverallDeviation(
+            $candidates,
+            $this->assembler->rateSeriesByRow($sections, 'transport_mode', '2'),
+            $volume,
+            $long,
+            $locale,
+        );
+
+        return \array_slice($candidates, 0, self::MAX_INSIGHTS);
+    }
+
+    /**
+     * @param array<string, int> $volume
+     */
+    public function firstEligibleBucket(array $volume): ?string
+    {
+        foreach (StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS as $bucket) {
+            if (($volume[$bucket] ?? 0) >= TransportTimeProfileMath::INSIGHT_MIN_BUCKET_N) {
+                return $bucket;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, int> $volume
+     */
+    public function lastEligibleBucket(array $volume): ?string
+    {
+        foreach (array_reverse(StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS) as $bucket) {
+            if (($volume[$bucket] ?? 0) >= TransportTimeProfileMath::INSIGHT_MIN_BUCKET_N) {
+                return $bucket;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<TransportTimeProfileInsight> $candidates
+     * @param array<string, float>              $percents
+     * @param array<string, int>                $volume
+     * @param array<string, string>             $bucketLabels
+     */
+    private function addRateSpan(
+        array &$candidates,
+        string $id,
+        array $percents,
+        array $volume,
+        string $short,
+        string $long,
+        array $bucketLabels,
+        string $locale,
+    ): void {
+        if (($volume[$short] ?? 0) < TransportTimeProfileMath::INSIGHT_MIN_BUCKET_N
+            || ($volume[$long] ?? 0) < TransportTimeProfileMath::INSIGHT_MIN_BUCKET_N) {
+            return;
+        }
+
+        $from = $percents[$short] ?? 0.0;
+        $to = $percents[$long] ?? 0.0;
+        $delta = round($to - $from, 1);
+        if (abs($delta) < TransportTimeProfileMath::INSIGHT_MIN_PP) {
+            return;
+        }
+
+        $direction = $delta > 0 ? 'increase' : 'decrease';
+        $candidates[] = new TransportTimeProfileInsight(
+            $id,
+            $this->translator->trans(
+                'stats.reports.transport_time_profile.insight.'.$id.'.title',
+                [],
+                'statistics',
+                $locale,
+            ),
+            $this->translator->trans(
+                'stats.reports.transport_time_profile.insight.rate_'.$direction,
+                [
+                    'metric' => $this->translator->trans(
+                        'stats.reports.transport_time_profile.insight.metric.'.$id,
+                        [],
+                        'statistics',
+                        $locale,
+                    ),
+                    'from_percent' => $from,
+                    'to_percent' => $to,
+                    'from_bucket' => $bucketLabels[$short] ?? $short,
+                    'to_bucket' => $bucketLabels[$long] ?? $long,
+                ],
+                'statistics',
+                $locale,
+            ),
+        );
+    }
+
+    /**
+     * @param list<TransportTimeProfileInsight>                                                $candidates
+     * @param array<string, list<array{id: string, label: string, percent: float, rank: int}>> $byBucket
+     * @param array<string, string>                                                            $bucketLabels
+     */
+    private function addRankChange(
+        array &$candidates,
+        string $id,
+        array $byBucket,
+        string $short,
+        string $long,
+        array $bucketLabels,
+        string $locale,
+    ): void {
+        $shortItems = $byBucket[$short] ?? [];
+        $longItems = $byBucket[$long] ?? [];
+        if ([] === $shortItems || [] === $longItems) {
+            return;
+        }
+
+        $shortById = [];
+        foreach ($shortItems as $item) {
+            $shortById[$item['id']] = $item;
+        }
+
+        foreach ($longItems as $longItem) {
+            $shortItem = $shortById[$longItem['id']] ?? null;
+            if (null === $shortItem) {
+                continue;
+            }
+            $rankChange = $shortItem['rank'] - $longItem['rank'];
+            $percentDelta = abs($longItem['percent'] - $shortItem['percent']);
+            if (abs($rankChange) < TransportTimeProfileMath::INSIGHT_MIN_RANK_CHANGE
+                || $percentDelta < TransportTimeProfileMath::INSIGHT_MIN_PP) {
+                continue;
+            }
+
+            $candidates[] = new TransportTimeProfileInsight(
+                $id.'_'.$longItem['id'],
+                $this->translator->trans(
+                    'stats.reports.transport_time_profile.insight.rank.title',
+                    ['label' => $longItem['label']],
+                    'statistics',
+                    $locale,
+                ),
+                $this->translator->trans(
+                    'stats.reports.transport_time_profile.insight.rank.body',
+                    [
+                        'label' => $longItem['label'],
+                        'from_rank' => $shortItem['rank'],
+                        'to_rank' => $longItem['rank'],
+                        'from_bucket' => $bucketLabels[$short] ?? $short,
+                        'to_bucket' => $bucketLabels[$long] ?? $long,
+                    ],
+                    'statistics',
+                    $locale,
+                ),
+            );
+
+            return;
+        }
+    }
+
+    /**
+     * @param list<TransportTimeProfileInsight> $candidates
+     * @param array<string, float>              $percents
+     * @param array<string, int>                $volume
+     */
+    private function addOverallDeviation(
+        array &$candidates,
+        array $percents,
+        array $volume,
+        string $long,
+        string $locale,
+    ): void {
+        if (($volume[$long] ?? 0) < TransportTimeProfileMath::INSIGHT_MIN_DEVIATION_N) {
+            return;
+        }
+
+        $knownTotal = array_sum($volume);
+        if ($knownTotal <= 0) {
+            return;
+        }
+
+        $weighted = 0.0;
+        foreach ($percents as $bucket => $percent) {
+            $weighted += $percent * (float) ($volume[$bucket] ?? 0);
+        }
+        $overall = round($weighted / (float) $knownTotal, 1);
+        $bucketPercent = $percents[$long] ?? 0.0;
+        $delta = round($bucketPercent - $overall, 1);
+        if ($delta < TransportTimeProfileMath::INSIGHT_MIN_OVERALL_PP) {
+            return;
+        }
+
+        $candidates[] = new TransportTimeProfileInsight(
+            'air_overrepresented',
+            $this->translator->trans(
+                'stats.reports.transport_time_profile.insight.air_overrepresented.title',
+                [],
+                'statistics',
+                $locale,
+            ),
+            $this->translator->trans(
+                'stats.reports.transport_time_profile.insight.air_overrepresented.body',
+                [
+                    'bucket_percent' => $bucketPercent,
+                    'overall_percent' => $overall,
+                ],
+                'statistics',
+                $locale,
+            ),
+        );
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileMath.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileMath.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+final class TransportTimeProfileMath
+{
+    public const int SMALL_SAMPLE_THRESHOLD = 10;
+
+    public const int INSIGHT_MIN_BUCKET_N = 20;
+
+    public const int INSIGHT_MIN_POPULATION_N = 50;
+
+    public const int INSIGHT_MIN_DEVIATION_N = 30;
+
+    public const float INSIGHT_MIN_PP = 5.0;
+
+    public const float INSIGHT_MIN_OVERALL_PP = 8.0;
+
+    public const int INSIGHT_MIN_RANK_CHANGE = 2;
+
+    public static function percent(int $numerator, int $denominator): float
+    {
+        if ($denominator <= 0) {
+            return 0.0;
+        }
+
+        return round(100 * $numerator / $denominator, 1);
+    }
+
+    public static function deltaPp(float $bucketPercent, float $overallPercent): float
+    {
+        return round($bucketPercent - $overallPercent, 1);
+    }
+
+    public static function isSmallSample(int $n): bool
+    {
+        return $n > 0 && $n < self::SMALL_SAMPLE_THRESHOLD;
+    }
+
+    public static function heatClass(float $deltaPp, bool $smallSample): string
+    {
+        if (0.0 === $deltaPp) {
+            return '';
+        }
+
+        $scale = $smallSample ? 0.35 : 1.0;
+        $heat = max(-1.0, min(1.0, ($deltaPp / 20.0) * $scale));
+        $abs = abs($heat);
+        if ($abs < 0.08) {
+            return '';
+        }
+
+        $level = $abs >= 0.6 ? '3' : ($abs >= 0.3 ? '2' : '1');
+        $direction = $heat < 0 ? 'low' : 'high';
+
+        return 'stats-ttp-heat-'.$direction.'-'.$level;
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileReportType.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileReportType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\SummarizedReport\ReportBuildResult;
+use App\Statistics\Application\SummarizedReport\ReportTypeInterface;
+
+final readonly class TransportTimeProfileReportType implements ReportTypeInterface
+{
+    public function __construct(
+        private TransportTimeProfileBuilder $builder,
+    ) {
+    }
+
+    #[\Override]
+    public function key(): string
+    {
+        return 'transport_time_profile';
+    }
+
+    #[\Override]
+    public function labelTranslationKey(): string
+    {
+        return 'stats.reports.types.transport_time_profile.label';
+    }
+
+    #[\Override]
+    public function descriptionTranslationKey(): string
+    {
+        return 'stats.reports.types.transport_time_profile.description';
+    }
+
+    #[\Override]
+    public function supports(StatisticsFilter $filter): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function build(StatisticsContext $context, string $locale, array $options = []): ReportBuildResult
+    {
+        unset($options);
+
+        return new ReportBuildResult(
+            '@Statistics/reports/types/transport_time_profile.html.twig',
+            $this->builder->build($context, $locale),
+        );
+    }
+}

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileSliceQueryInterface.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileSliceQueryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
+
+use App\Statistics\Application\DTO\StatisticsDrawerFilter;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileSliceData;
+
+interface TransportTimeProfileSliceQueryInterface
+{
+    public function fetch(
+        StatisticsScopeCriteria $scope,
+        StatisticsPeriodBounds $period,
+        ?StatisticsDrawerFilter $drawerFilter = null,
+    ): TransportTimeProfileSliceData;
+}

--- a/src/Statistics/Infrastructure/Query/ProjectionDrawerFilterSql.php
+++ b/src/Statistics/Infrastructure/Query/ProjectionDrawerFilterSql.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query;
+
+use App\Statistics\Application\DTO\StatisticsDrawerFilter;
+use App\Statistics\Application\Mapping\StatisticsAgeGroupFilter;
+
+/**
+ * DBAL WHERE fragments for {@see StatisticsDrawerFilter} on allocation_stats_projection.
+ */
+final class ProjectionDrawerFilterSql
+{
+    /**
+     * @return array{0: list<string>, 1: array<string, mixed>}
+     */
+    public function apply(StatisticsDrawerFilter $filter, string $columnPrefix = ''): array
+    {
+        $prefix = '' === $columnPrefix ? '' : rtrim($columnPrefix, '.').'.';
+        $conditions = [];
+        $params = [];
+
+        if (null !== $filter->gender) {
+            $conditions[] = sprintf('%sgender_code = :drawer_gender', $prefix);
+            $params['drawer_gender'] = $filter->gender;
+        }
+
+        if (null !== $filter->urgency) {
+            $conditions[] = sprintf('%surgency_code = :drawer_urgency', $prefix);
+            $params['drawer_urgency'] = $filter->urgency;
+        }
+
+        if (null !== $filter->ageGroup) {
+            $ageCondition = StatisticsAgeGroupFilter::sqlCondition($prefix.'age', $filter->ageGroup);
+            if (null !== $ageCondition) {
+                $conditions[] = $ageCondition;
+            }
+        }
+
+        if (null !== $filter->department) {
+            $conditions[] = sprintf('%sdepartment_id = :drawer_department_id', $prefix);
+            $params['drawer_department_id'] = $filter->department;
+        }
+
+        if (null !== $filter->speciality) {
+            $conditions[] = sprintf('%sspeciality_id = :drawer_speciality_id', $prefix);
+            $params['drawer_speciality_id'] = $filter->speciality;
+        }
+
+        if (null !== $filter->requiresResus) {
+            $conditions[] = sprintf('%srequires_resus = :drawer_requires_resus', $prefix);
+            $params['drawer_requires_resus'] = $filter->requiresResus;
+        }
+
+        if (null !== $filter->requiresCathlab) {
+            $conditions[] = sprintf('%srequires_cathlab = :drawer_requires_cathlab', $prefix);
+            $params['drawer_requires_cathlab'] = $filter->requiresCathlab;
+        }
+
+        if (null !== $filter->isVentilated) {
+            $conditions[] = sprintf('%sis_ventilated = :drawer_is_ventilated', $prefix);
+            $params['drawer_is_ventilated'] = $filter->isVentilated;
+        }
+
+        if (null !== $filter->isShock) {
+            $conditions[] = sprintf('%sis_shock = :drawer_is_shock', $prefix);
+            $params['drawer_is_shock'] = $filter->isShock;
+        }
+
+        if (null !== $filter->isCpr) {
+            $conditions[] = sprintf('%sis_cpr = :drawer_is_cpr', $prefix);
+            $params['drawer_is_cpr'] = $filter->isCpr;
+        }
+
+        if (null !== $filter->isPregnant) {
+            $conditions[] = sprintf('%sis_pregnant = :drawer_is_pregnant', $prefix);
+            $params['drawer_is_pregnant'] = $filter->isPregnant;
+        }
+
+        if (null !== $filter->isWorkAccident) {
+            $conditions[] = sprintf('%sis_work_accident = :drawer_is_work_accident', $prefix);
+            $params['drawer_is_work_accident'] = $filter->isWorkAccident;
+        }
+
+        if (null !== $filter->isInfectious) {
+            $conditions[] = $filter->isInfectious
+                ? sprintf('%sinfection_id IS NOT NULL', $prefix)
+                : sprintf('%sinfection_id IS NULL', $prefix);
+        }
+
+        if (null !== $filter->infection) {
+            $conditions[] = sprintf('%sinfection_id = :drawer_infection_id', $prefix);
+            $params['drawer_infection_id'] = $filter->infection;
+        }
+
+        return [$conditions, $params];
+    }
+}

--- a/src/Statistics/Infrastructure/Query/SummarizedReport/TransportTimeProfileSliceQuery.php
+++ b/src/Statistics/Infrastructure/Query/SummarizedReport/TransportTimeProfileSliceQuery.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query\SummarizedReport;
+
+use App\Statistics\Application\DTO\StatisticsDrawerFilter;
+use App\Statistics\Application\DTO\StatisticsPeriodBounds;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileSliceData;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileSliceQueryInterface;
+use App\Statistics\GenericAnalysis\Infrastructure\Query\GenericAnalysisScopeSqlFilter;
+use App\Statistics\Infrastructure\Query\ProjectionDrawerFilterSql;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+/** @psalm-suppress UnusedClass Wired via #[AsAlias] for TransportTimeProfileSliceQueryInterface. */
+#[AsAlias(TransportTimeProfileSliceQueryInterface::class)]
+final readonly class TransportTimeProfileSliceQuery implements TransportTimeProfileSliceQueryInterface
+{
+    private const int TOP_LIMIT = 5;
+
+    public function __construct(
+        private Connection $connection,
+        private GenericAnalysisScopeSqlFilter $scopeSqlFilter,
+        private ProjectionDrawerFilterSql $drawerFilterSql,
+    ) {
+    }
+
+    #[\Override]
+    public function fetch(
+        StatisticsScopeCriteria $scope,
+        StatisticsPeriodBounds $period,
+        ?StatisticsDrawerFilter $drawerFilter = null,
+    ): TransportTimeProfileSliceData {
+        if (\is_array($scope->hospitalIds) && [] === $scope->hospitalIds) {
+            return TransportTimeProfileSliceData::empty();
+        }
+
+        [$scopeConditions, $params] = $this->scopeSqlFilter->applyScopeAndPeriod($scope, $period);
+        $types = $this->scopeSqlFilter->parameterTypes($params);
+
+        if ($drawerFilter instanceof StatisticsDrawerFilter && $drawerFilter->isActive()) {
+            [$drawerConditions, $drawerParams] = $this->drawerFilterSql->apply($drawerFilter);
+            $scopeConditions = [...$scopeConditions, ...$drawerConditions];
+            $params = [...$params, ...$drawerParams];
+        }
+
+        $where = implode(' AND ', $scopeConditions);
+        $bucketCase = StatisticsTransportTimeBucketSql::CASE_EXPRESSION;
+        $topLimit = self::TOP_LIMIT;
+
+        $sql = <<<SQL
+WITH slice AS (
+    SELECT
+        {$bucketCase} AS transport_bucket,
+        gender_code,
+        urgency_code,
+        department_id,
+        speciality_id,
+        indication_normalized_id,
+        is_with_physician,
+        requires_resus,
+        requires_cathlab,
+        transport_type_code
+    FROM allocation_stats_projection
+    WHERE {$where}
+)
+SELECT 'unknown_volume' AS slice_kind, 'unknown' AS dim1, NULL AS dim2, COUNT(*)::int AS count
+FROM slice
+WHERE transport_bucket = 'unknown'
+UNION ALL
+SELECT 'volume', transport_bucket, NULL, COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket
+UNION ALL
+SELECT 'gender', transport_bucket, COALESCE(gender_code::text, 'unknown'), COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, gender_code
+UNION ALL
+SELECT 'urgency', transport_bucket, urgency_code::text, COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, urgency_code
+UNION ALL
+SELECT 'physician', transport_bucket, CASE WHEN is_with_physician IS TRUE THEN '1' ELSE '0' END, COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, CASE WHEN is_with_physician IS TRUE THEN '1' ELSE '0' END
+UNION ALL
+SELECT 'resus', transport_bucket, CASE WHEN requires_resus IS TRUE THEN '1' ELSE '0' END, COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, CASE WHEN requires_resus IS TRUE THEN '1' ELSE '0' END
+UNION ALL
+SELECT 'cathlab', transport_bucket, CASE WHEN requires_cathlab IS TRUE THEN '1' ELSE '0' END, COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, CASE WHEN requires_cathlab IS TRUE THEN '1' ELSE '0' END
+UNION ALL
+SELECT 'transport_type', transport_bucket, COALESCE(transport_type_code::text, 'unknown'), COUNT(*)::int
+FROM slice
+WHERE transport_bucket <> 'unknown'
+GROUP BY transport_bucket, transport_type_code
+UNION ALL
+SELECT 'department', transport_bucket, department_id::text, cnt
+FROM (
+    SELECT
+        transport_bucket,
+        department_id,
+        COUNT(*)::int AS cnt,
+        ROW_NUMBER() OVER (PARTITION BY transport_bucket ORDER BY COUNT(*) DESC, department_id ASC) AS rn
+    FROM slice
+    WHERE transport_bucket <> 'unknown' AND department_id IS NOT NULL
+    GROUP BY transport_bucket, department_id
+) ranked_department
+WHERE rn <= {$topLimit}
+UNION ALL
+SELECT 'speciality', transport_bucket, speciality_id::text, cnt
+FROM (
+    SELECT
+        transport_bucket,
+        speciality_id,
+        COUNT(*)::int AS cnt,
+        ROW_NUMBER() OVER (PARTITION BY transport_bucket ORDER BY COUNT(*) DESC, speciality_id ASC) AS rn
+    FROM slice
+    WHERE transport_bucket <> 'unknown' AND speciality_id IS NOT NULL
+    GROUP BY transport_bucket, speciality_id
+) ranked_speciality
+WHERE rn <= {$topLimit}
+UNION ALL
+SELECT 'indication', transport_bucket, indication_normalized_id::text, cnt
+FROM (
+    SELECT
+        transport_bucket,
+        indication_normalized_id,
+        COUNT(*)::int AS cnt,
+        ROW_NUMBER() OVER (PARTITION BY transport_bucket ORDER BY COUNT(*) DESC, indication_normalized_id ASC) AS rn
+    FROM slice
+    WHERE transport_bucket <> 'unknown' AND indication_normalized_id IS NOT NULL
+    GROUP BY transport_bucket, indication_normalized_id
+) ranked_indication
+WHERE rn <= {$topLimit}
+SQL;
+
+        /** @var list<array{slice_kind: string, dim1: ?string, dim2: ?string, count: int|string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params, $types);
+
+        return $this->parseRows($rows);
+    }
+
+    /**
+     * @param list<array{slice_kind: string, dim1: ?string, dim2: ?string, count: int|string}> $rows
+     */
+    private function parseRows(array $rows): TransportTimeProfileSliceData
+    {
+        $unknownCount = 0;
+        $volumeByBucket = [];
+        $genderByBucket = [];
+        $urgencyByBucket = [];
+        $physicianByBucket = [];
+        $resusByBucket = [];
+        $cathlabByBucket = [];
+        $transportTypeByBucket = [];
+        $departmentsByBucket = [];
+        $specialitiesByBucket = [];
+        $indicationsByBucket = [];
+
+        foreach ($rows as $row) {
+            $count = (int) $row['count'];
+            $kind = $row['slice_kind'];
+            $dim1 = $row['dim1'] ?? '';
+            $dim2 = $row['dim2'];
+
+            match ($kind) {
+                'unknown_volume' => $unknownCount = $count,
+                'volume' => $volumeByBucket[$dim1] = $count,
+                'gender' => $this->addNested($genderByBucket, $dim1, (string) $dim2, $count),
+                'urgency' => $this->addNested($urgencyByBucket, $dim1, (string) $dim2, $count),
+                'physician' => $this->addNested($physicianByBucket, $dim1, (string) $dim2, $count),
+                'resus' => $this->addNested($resusByBucket, $dim1, (string) $dim2, $count),
+                'cathlab' => $this->addNested($cathlabByBucket, $dim1, (string) $dim2, $count),
+                'transport_type' => $this->addNested($transportTypeByBucket, $dim1, (string) $dim2, $count),
+                'department' => $this->addTop($departmentsByBucket, $dim1, (int) $dim2, $count),
+                'speciality' => $this->addTop($specialitiesByBucket, $dim1, (int) $dim2, $count),
+                'indication' => $this->addTop($indicationsByBucket, $dim1, (int) $dim2, $count),
+                default => null,
+            };
+        }
+
+        $this->sortTopLists($departmentsByBucket);
+        $this->sortTopLists($specialitiesByBucket);
+        $this->sortTopLists($indicationsByBucket);
+
+        return new TransportTimeProfileSliceData(
+            $unknownCount,
+            $volumeByBucket,
+            $genderByBucket,
+            $urgencyByBucket,
+            $physicianByBucket,
+            $resusByBucket,
+            $cathlabByBucket,
+            $transportTypeByBucket,
+            $departmentsByBucket,
+            $specialitiesByBucket,
+            $indicationsByBucket,
+        );
+    }
+
+    /**
+     * @param array<string, array<int|string, int>> $target
+     */
+    private function addNested(array &$target, string $bucket, string $code, int $count): void
+    {
+        $target[$bucket][$code] = ($target[$bucket][$code] ?? 0) + $count;
+    }
+
+    /**
+     * @param array<string, list<array{id: int, count: int}>> $target
+     */
+    private function addTop(array &$target, string $bucket, int $id, int $count): void
+    {
+        $target[$bucket][] = ['id' => $id, 'count' => $count];
+    }
+
+    /**
+     * @param array<string, list<array{id: int, count: int}>> $grouped
+     */
+    private function sortTopLists(array &$grouped): void
+    {
+        foreach ($grouped as &$items) {
+            usort(
+                $items,
+                static fn (array $a, array $b): int => $b['count'] <=> $a['count'] ?: $a['id'] <=> $b['id'],
+            );
+        }
+    }
+}

--- a/src/Statistics/UI/Http/Controller/ReportsController.php
+++ b/src/Statistics/UI/Http/Controller/ReportsController.php
@@ -8,6 +8,8 @@ use App\Statistics\Application\DTO\StatisticsFilter;
 use App\Statistics\Application\StatisticsContextFactory;
 use App\Statistics\Application\StatisticsDrawerFilterFactory;
 use App\Statistics\Application\SummarizedReport\Exception\UnknownReportTypeException;
+use App\Statistics\Application\SummarizedReport\Monthly\Dto\MonthlyReportView;
+use App\Statistics\Application\SummarizedReport\ReportTypeInterface;
 use App\Statistics\Application\SummarizedReport\ReportTypeRegistry;
 use App\Statistics\UI\Http\Navigation\StatisticsNavigationUrlBuilder;
 use App\Statistics\UI\Http\Navigation\StatisticsQueryKeys;
@@ -34,6 +36,7 @@ final class ReportsController extends AbstractController
         private readonly StatisticsDrawerFilterFactory $statisticsDrawerFilterFactory,
         private readonly StatisticsNavigationUrlBuilder $statisticsNavigationUrlBuilder,
         private readonly StatisticsDataQualityReportFactory $dataQualityReportFactory,
+        private readonly OverviewPeriodViewModelFactory $overviewPeriodViewModelFactory,
     ) {
     }
 
@@ -112,11 +115,14 @@ final class ReportsController extends AbstractController
         }
 
         $reportType = $this->reportTypeRegistry->get($type);
-        if (!$reportType instanceof \App\Statistics\Application\SummarizedReport\ReportTypeInterface) {
+        if (!$reportType instanceof ReportTypeInterface) {
             throw new NotFoundHttpException(sprintf('Unknown report type "%s".', $type));
         }
 
-        $drawerFilter = $this->statisticsDrawerFilterFactory->fromRequest($request);
+        $showFilterDrawer = 'transport_time_profile' !== $reportType->key();
+        $drawerFilter = $showFilterDrawer
+            ? $this->statisticsDrawerFilterFactory->fromRequest($request)
+            : null;
         $context = $this->statisticsContextFactory->create($user, $filter, drawerFilter: $drawerFilter);
         $pageViewModel = $this->statisticsPageViewModelFactory->create(
             $request,
@@ -139,8 +145,23 @@ final class ReportsController extends AbstractController
         }
 
         $reportsPage = $this->reportsPagePresenter->present($request, $reportType, $buildResult);
-        $statsFilterDrawer = $this->statisticsFilterDrawerViewModelFactory->create($request);
-        $overviewPeriodViewModel = $reportsPage->periodNavigation ?? $this->fixedPeriodViewModel($reportsPage->periodLabel);
+        $statsFilterDrawer = $showFilterDrawer
+            ? $this->statisticsFilterDrawerViewModelFactory->create($request)
+            : null;
+        $isMonthly = $buildResult->viewModel instanceof MonthlyReportView;
+        if ($isMonthly) {
+            $overviewPeriodViewModel = $reportsPage->periodNavigation ?? $this->fixedPeriodViewModel($reportsPage->periodLabel);
+            $headingPeriod = $reportsPage->periodLabel;
+        } else {
+            $overviewPeriodViewModel = $this->overviewPeriodViewModelFactory->create(
+                $request,
+                'app_stats_reports_show',
+                $filter,
+            );
+            $headingPeriod = 'transport_time_profile' === $reportType->key()
+                ? ''
+                : $overviewPeriodViewModel->headingLabel;
+        }
         $dataQualityReport = $this->dataQualityReportFactory->create(
             $filter,
             $user,
@@ -156,8 +177,8 @@ final class ReportsController extends AbstractController
             'app_stats_reports_show',
             [
                 'reportsPage' => $reportsPage,
-                'statisticsHeadingPeriod' => $reportsPage->periodLabel,
-                'statsShowFilterDrawer' => true,
+                'statisticsHeadingPeriod' => $headingPeriod,
+                'statsShowFilterDrawer' => $showFilterDrawer,
                 'statsFilterDrawer' => $statsFilterDrawer,
                 'statsUseOverviewPeriodControls' => true,
                 'statsHidePeriodControls' => false,

--- a/src/Statistics/UI/Twig/templates/_header_controls.html.twig
+++ b/src/Statistics/UI/Twig/templates/_header_controls.html.twig
@@ -28,6 +28,14 @@
             </button>
         {% endif %}
 
+        {% if statsTtpExplorerUrl|default(null) %}
+            <a class="btn"
+               href="{{ statsTtpExplorerUrl }}"
+               data-testid="stats-ttp-explorer-link">
+                {{ 'stats.reports.transport_time_profile.explorer_link'|trans({}, 'statistics') }}
+            </a>
+        {% endif %}
+
         {{ include('@Statistics/_scope_controls.html.twig', {
             pageViewModel: {
                 showScopeSecondaryPicker: statsShowScopeSecondaryPicker|default(false),

--- a/src/Statistics/UI/Twig/templates/reports/show.html.twig
+++ b/src/Statistics/UI/Twig/templates/reports/show.html.twig
@@ -32,14 +32,17 @@
                     </div>
                     <h2 class="page-title" data-testid="stats-heading-title">
                         {{ reportsPage.headerTitleKey|trans({}, 'statistics') }}
-                        {% if reportsPage.periodLabel %}
-                            <span class="text-secondary fs-3">· {{ reportsPage.periodLabel }}</span>
+                        {% if statisticsHeadingPeriod %}
+                            <span class="text-secondary fs-3 ps-2">· {{ statisticsHeadingPeriod }}</span>
                         {% endif %}
                     </h2>
                 </div>
                 {{ include('@Statistics/_header_controls.html.twig', {
-                    statsShowFilterDrawer: true,
+                    statsShowFilterDrawer: statsShowFilterDrawer|default(false),
                     statsUseOverviewPeriodControls: true,
+                    statsTtpExplorerUrl: reportsPage.currentTypeKey == 'transport_time_profile'
+                        ? reportsPage.buildResult.viewModel.explorerTransportTimeUrl
+                        : null,
                 }) }}
             </div>
         </div>
@@ -48,9 +51,10 @@
 
 {% block page_content %}
     {{ include('@Statistics/_data_quality_drawer.html.twig') }}
-    {{ include('@Statistics/_filter_drawer.html.twig') }}
-
-    {{ include('@Statistics/_filter_active_badges.html.twig') }}
+    {% if statsShowFilterDrawer|default(false) %}
+        {{ include('@Statistics/_filter_drawer.html.twig') }}
+        {{ include('@Statistics/_filter_active_badges.html.twig') }}
+    {% endif %}
 
     <div data-testid="stats-reports-content">
         {{ include(reportsPage.buildResult.template, {report: reportsPage.buildResult.viewModel}) }}

--- a/src/Statistics/UI/Twig/templates/reports/types/_transport_time_profile_table.html.twig
+++ b/src/Statistics/UI/Twig/templates/reports/types/_transport_time_profile_table.html.twig
@@ -1,0 +1,75 @@
+<div class="stats-ttp-table-scroll">
+    <table class="table card-table mb-0 stats-ttp-table">
+        <thead>
+            <tr>
+                <th scope="col" class="stats-ttp-metric-col">{{ 'stats.reports.transport_time_profile.matrix.metric'|trans({}, 'statistics') }}</th>
+                {% for key, label in report.bucketLabels %}
+                    <th scope="col" class="text-end stats-ttp-bucket-col">{{ label }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for section in sections %}
+                <tr class="stats-ttp-section-row">
+                    <th scope="rowgroup" colspan="{{ 1 + report.bucketLabels|length }}">
+                        {{ section.titleKey|trans({}, 'statistics') }}
+                    </th>
+                </tr>
+                {% for row in section.rows %}
+                    <tr class="stats-ttp-{{ row.kind }}-row" data-testid="stats-ttp-row-{{ section.key }}-{{ row.key }}">
+                        <th scope="row" class="stats-ttp-metric-col">
+                            {{ row.label }}
+                            {% if row.overallPercent is not null %}
+                                <span class="d-block small text-secondary fw-normal">
+                                    {{ 'stats.reports.transport_time_profile.overall'|trans({percent: row.overallPercent}, 'statistics') }}
+                                </span>
+                            {% endif %}
+                        </th>
+                        {% for bucket, cell in row.cells %}
+                            <td class="{{ row.kind == 'ranked' ? 'stats-ttp-ranked-td' : 'text-end' }} {{ cell.heatClass }}{% if cell.smallSample %} stats-ttp-small-n{% endif %}">
+                                {% if cell.isEmpty %}
+                                    <span class="text-secondary">—</span>
+                                {% elseif row.kind == 'count' %}
+                                    {{ cell.count|number_format(0, ',', '.') }}
+                                {% elseif row.kind == 'ranked' %}
+                                    <div class="stats-ttp-ranked-cell">
+                                        {% if cell.linkUrl %}
+                                            <a href="{{ cell.linkUrl }}" class="stats-ttp-ranked-label">{{ cell.entityLabel }}</a>
+                                        {% else %}
+                                            <span class="stats-ttp-ranked-label">{{ cell.entityLabel }}</span>
+                                        {% endif %}
+                                        <div class="small text-secondary stats-ttp-ranked-meta">
+                                            {{ cell.percent|number_format(1, ',', '.') }}%
+                                            · #{{ cell.rank }}
+                                            {% if cell.enteredTop %}
+                                                · {{ 'stats.reports.transport_time_profile.rank.new'|trans({}, 'statistics') }}
+                                            {% elseif cell.rankDelta is not null and cell.rankDelta != 0 %}
+                                                · {{ cell.rankDelta > 0 ? '↑' : '↓' }}{{ cell.rankDelta|abs }}
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                {% else %}
+                                    <span title="n={{ cell.count }}">
+                                        {{ cell.percent|number_format(1, ',', '.') }}%
+                                        {% if cell.deltaPp is not null %}
+                                            <span class="d-block small text-secondary">
+                                                {{ cell.deltaPp > 0 ? '+' : '' }}{{ cell.deltaPp|number_format(1, ',', '.') }}
+                                                {{ 'stats.reports.transport_time_profile.pp'|trans({}, 'statistics') }}
+                                            </span>
+                                        {% endif %}
+                                    </span>
+                                {% endif %}
+                                {% if cell.smallSample %}
+                                    <span class="d-block small text-secondary" title="{{ 'stats.reports.transport_time_profile.small_n.hint'|trans({}, 'statistics') }}">
+                                        <twig:ux:icon name="tabler:alert-triangle" class="icon icon-sm" />
+                                        {{ 'stats.reports.transport_time_profile.small_n.label'|trans({}, 'statistics') }}
+                                    </span>
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/src/Statistics/UI/Twig/templates/reports/types/transport_time_profile.html.twig
+++ b/src/Statistics/UI/Twig/templates/reports/types/transport_time_profile.html.twig
@@ -1,0 +1,122 @@
+<div class="stats-ttp-report" data-testid="stats-ttp-report">
+    {% if not report.hasData %}
+        <div class="empty" data-testid="stats-ttp-empty">
+            <div class="empty-icon">
+                <twig:ux:icon name="tabler:clock-bolt" class="icon icon-lg text-secondary" />
+            </div>
+            <p class="empty-title">{{ 'stats.reports.transport_time_profile.empty.title'|trans({}, 'statistics') }}</p>
+            <p class="empty-subtitle text-secondary" data-testid="stats-ttp-context">
+                {{ 'stats.reports.transport_time_profile.empty.body'|trans({context: report.contextLine}, 'statistics') }}
+            </p>
+            <div class="empty-action">
+                <a href="{{ report.importCreateUrl }}" class="btn btn-primary">
+                    {{ 'stats.reports.monthly.empty.cta_import'|trans({}, 'statistics') }}
+                </a>
+                <a href="{{ report.dashboardUrl }}" class="btn btn-outline-secondary">
+                    {{ 'stats.reports.monthly.empty.cta_dashboard'|trans({}, 'statistics') }}
+                </a>
+            </div>
+        </div>
+    {% else %}
+        {% if report.unknownTransportCount > 0 %}
+            <p class="text-secondary small mb-3" data-testid="stats-ttp-unknown-note">
+                {{ 'stats.reports.transport_time_profile.unknown_transport'|trans({count: report.unknownTransportCount}, 'statistics') }}
+            </p>
+        {% endif %}
+
+        <div class="row g-3 mb-3 align-items-stretch">
+            <div class="{% if report.insights is not empty %}col-lg-8{% else %}col-12{% endif %}">
+                <div class="card h-100" data-testid="stats-ttp-chart-card"
+                     {% if report.chartSpecs %}
+                     data-controller="generic-analysis-chart"
+                     data-generic-analysis-chart-specs-value="{{ report.chartSpecs|json_encode|e('html_attr') }}"
+                     data-generic-analysis-chart-default-type-value="cases"
+                     {% endif %}>
+                    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
+                        <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.chart.title'|trans({}, 'statistics') }}</h3>
+                        {% if report.chartSpecs %}
+                            <div class="btn-group btn-group-sm"
+                                 role="group"
+                                 aria-label="{{ 'stats.reports.transport_time_profile.chart.modes'|trans({}, 'statistics') }}"
+                                 data-testid="stats-ttp-chart-modes">
+                                <button type="button"
+                                        class="btn btn-outline-secondary active"
+                                        data-action="generic-analysis-chart#selectType"
+                                        data-generic-analysis-chart-target="typeButton"
+                                        data-chart-type="cases"
+                                        data-testid="stats-ttp-chart-mode-cases"
+                                        aria-pressed="true">
+                                    {{ 'stats.reports.transport_time_profile.chart.cases'|trans({}, 'statistics') }}
+                                </button>
+                                <button type="button"
+                                        class="btn btn-outline-secondary"
+                                        data-action="generic-analysis-chart#selectType"
+                                        data-generic-analysis-chart-target="typeButton"
+                                        data-chart-type="gender"
+                                        data-testid="stats-ttp-chart-mode-gender"
+                                        aria-pressed="false">
+                                    {{ 'stats.reports.transport_time_profile.chart.gender'|trans({}, 'statistics') }}
+                                </button>
+                                <button type="button"
+                                        class="btn btn-outline-secondary"
+                                        data-action="generic-analysis-chart#selectType"
+                                        data-generic-analysis-chart-target="typeButton"
+                                        data-chart-type="urgency"
+                                        data-testid="stats-ttp-chart-mode-urgency"
+                                        aria-pressed="false">
+                                    {{ 'stats.reports.transport_time_profile.chart.urgency'|trans({}, 'statistics') }}
+                                </button>
+                            </div>
+                        {% endif %}
+                    </div>
+                    <div class="card-body">
+                        {% if report.chartSpecs %}
+                            <div class="chart-lg" data-generic-analysis-chart-target="chart" data-testid="stats-ttp-chart"></div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            {% if report.insights is not empty %}
+                <div class="col-lg-4">
+                    <div class="card h-100 stats-ttp-insights" data-testid="stats-ttp-insights">
+                        <div class="card-header py-2">
+                            <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.insights.title'|trans({}, 'statistics') }}</h3>
+                        </div>
+                        <div class="list-group list-group-flush">
+                            {% for insight in report.insights %}
+                                <div class="list-group-item stats-ttp-insight" data-testid="stats-ttp-insight">
+                                    <div class="fw-bold">{{ insight.title }}</div>
+                                    <div class="text-muted small">{{ insight.body }}</div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="card" data-testid="stats-ttp-matrix-card">
+            <div class="card-header">
+                <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.matrix.title'|trans({}, 'statistics') }}</h3>
+            </div>
+            <div class="card-body p-0">
+                {{ include('@Statistics/reports/types/_transport_time_profile_table.html.twig', {sections: report.matrixSections}) }}
+            </div>
+        </div>
+
+        {% if report.rankedSections is not empty %}
+            <div class="card mt-3" data-testid="stats-ttp-ranked-card">
+                <div class="card-header">
+                    <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.ranked.title'|trans({}, 'statistics') }}</h3>
+                </div>
+                <div class="card-body p-0">
+                    {{ include('@Statistics/reports/types/_transport_time_profile_table.html.twig', {sections: report.rankedSections}) }}
+                </div>
+            </div>
+        {% endif %}
+
+        <p class="text-secondary small mt-3 stats-ttp-disclaimer" data-testid="stats-ttp-disclaimer">
+            {{ 'stats.reports.transport_time_profile.disclaimer'|trans({}, 'statistics') }}
+        </p>
+    {% endif %}
+</div>

--- a/tests/Statistics/Functional/Controller/ReportsControllerTest.php
+++ b/tests/Statistics/Functional/Controller/ReportsControllerTest.php
@@ -4,7 +4,24 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Functional\Controller;
 
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
 use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Zenstruck\Foundry\Attribute\ResetDatabase;
@@ -24,16 +41,19 @@ final class ReportsControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSelectorExists('[data-testid="stats-reports-index"]');
         $this->assertSelectorExists('[data-testid="stats-reports-card-monthly"]');
+        $this->assertSelectorExists('[data-testid="stats-reports-card-transport_time_profile"]');
         $this->assertSelectorExists('a[href*="/statistics/top-lists"]');
         $this->assertStringContainsString('Reports', $crawler->filter('[data-testid="stats-heading-title"]')->text());
         $this->assertStringContainsString('Monthly report', $crawler->filter('[data-testid="stats-reports-card-title-monthly"]')->text());
+        $this->assertStringContainsString('Concise summary of a completed calendar month', $crawler->filter('[data-testid="stats-reports-card-monthly"]')->text());
+        $this->assertStringContainsString('Transport Time Profile', $crawler->filter('[data-testid="stats-reports-card-title-transport_time_profile"]')->text());
         $this->assertSelectorNotExists('[data-testid="stats-reports-content"]');
     }
 
     public function testMonthlyReportDetailRendersEmptyState(): void
     {
         $client = $this->createClientAsRoleUser();
-        $client->request(
+        $crawler = $client->request(
             Request::METHOD_GET,
             '/statistics/reports/monthly?scope=public',
         );
@@ -42,6 +62,9 @@ final class ReportsControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-reports-content"]');
         $this->assertSelectorExists('[data-testid="stats-monthly-report-empty"]');
         $this->assertSelectorExists('[data-testid="stats-heading-title"]');
+        $this->assertSelectorExists('[data-testid="stats-heading-title"] .ps-2');
+        $this->assertSelectorNotExists('[data-testid="stats-reports-print"]');
+        $this->assertStringContainsString('Monthly report', $crawler->filter('[data-testid="stats-heading-title"]')->text());
     }
 
     public function testLegacyTypeQueryRedirectsToDetailRoute(): void
@@ -110,6 +133,43 @@ final class ReportsControllerTest extends WebTestCase
         $this->assertStringContainsString('/statistics/reports/monthly', (string) $monthHref);
     }
 
+    public function testTransportTimeProfileUsesDashboardPeriodControls(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/statistics/reports/transport_time_profile?scope=public&period=all',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('[data-testid="stats-reports-content"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-report"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-empty"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-context"]');
+        $this->assertSelectorExists('[data-testid="stats-period-primary"]');
+        $this->assertSelectorExists('.dropdown-menu a.dropdown-item[href*="period=all"]');
+        $this->assertSelectorExists('.dropdown-menu a.dropdown-item[href*="period=year"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-explorer-link"]');
+        $this->assertSelectorExists('.page-header [data-testid="stats-ttp-explorer-link"].btn');
+        $this->assertSelectorNotExists('[data-testid="stats-reports-print"]');
+        $this->assertSelectorNotExists('[data-testid="statistics-filters-drawer-trigger"]');
+        $title = $crawler->filter('[data-testid="stats-heading-title"]')->text();
+        $this->assertStringContainsString('Transport Time Profile', $title);
+        $this->assertStringNotContainsString('Last 12 months', $title);
+        $this->assertStringNotContainsString('All time', $title);
+        $context = $crawler->filter('[data-testid="stats-ttp-context"]')->text();
+        $this->assertStringContainsString('all hospitals', $context);
+        $this->assertStringContainsString('Last 12 months', $context);
+    }
+
+    public function testTransportTimeProfileRequiresLogin(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/statistics/reports/transport_time_profile?scope=public');
+
+        $this->assertResponseRedirects('/login');
+    }
+
     public function testReportsIndexHidesPeriodControls(): void
     {
         $client = $this->createClientAsRoleUser();
@@ -118,5 +178,88 @@ final class ReportsControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSelectorNotExists('[data-testid="stats-period-primary"]');
         $this->assertSelectorNotExists('.dropdown-menu a.dropdown-item[href*="period=all"]');
+    }
+
+    public function testTransportTimeProfileRendersMatrixForSeededAllocations(): void
+    {
+        $client = self::createClient();
+
+        $user = UserFactory::createOne(['username' => 'ttp-ctrl-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'TtpCtrlState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'TtpCtrlDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'TtpCtrlHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $department = DepartmentFactory::createOne(['name' => 'TtpCtrlDept']);
+        SpecialityFactory::createOne(['name' => 'TtpCtrlSpec']);
+        AssignmentFactory::createOne(['name' => 'TtpCtrlAssign']);
+        IndicationRawFactory::createOne(['name' => 'TtpCtrlRaw', 'code' => 912_361]);
+        IndicationNormalizedFactory::createOne(['name' => 'TtpCtrlNorm']);
+        $import = ImportFactory::createOne(['name' => 'TtpCtrlImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'department' => $department,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:05:00'),
+        ]);
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'department' => $department,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 11:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 12:10:00'),
+        ]);
+        $unknown = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 13:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 13:20:00'),
+        ]);
+
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)
+            ->rebuildForImport($import->getId());
+        self::getContainer()->get(Connection::class)->update(
+            'allocation_stats_projection',
+            ['transport_time_minutes' => -1],
+            ['id' => $unknown->getId()],
+        );
+
+        $this->loginAsRoleUser($client);
+        $crawler = $client->request(
+            Request::METHOD_GET,
+            '/statistics/reports/transport_time_profile?scope=public&period=month&year=2025&month=6',
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorNotExists('[data-testid="stats-ttp-empty"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-chart-card"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-chart-modes"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-matrix-card"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-ranked-card"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-disclaimer"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-unknown-note"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-row-volume-cases"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-row-resources-requires_cathlab"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-explorer-link"]');
+        $this->assertStringContainsString(
+            'generic-analysis-chart',
+            (string) $crawler->filter('[data-testid="stats-ttp-chart-card"]')->attr('data-controller'),
+        );
     }
 }

--- a/tests/Statistics/Integration/Query/SummarizedReport/TransportTimeProfileSliceQueryTest.php
+++ b/tests/Statistics/Integration/Query/SummarizedReport/TransportTimeProfileSliceQueryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\Query\SummarizedReport;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsDrawerFilter;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\DTO\StatisticsScopeCriteria;
+use App\Statistics\Application\StatisticsPeriodResolver;
+use App\Statistics\Infrastructure\Query\SummarizedReport\TransportTimeProfileSliceQuery;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class TransportTimeProfileSliceQueryTest extends KernelTestCase
+{
+    use Factories;
+
+    public function testAggregatesBucketsAndTopNInOneQuery(): void
+    {
+        self::bootKernel();
+
+        [$hospitalA, $hospitalB, $importA, $importB, $deptShort, $deptLong, $state, $dispatchArea] = $this->seed();
+
+        AllocationFactory::createOne([
+            'import' => $importA,
+            'hospital' => $hospitalA,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::GROUND,
+            'department' => $deptShort,
+            'isWithPhysician' => false,
+            'requiresResus' => false,
+            'requiresCathlab' => false,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:05:00'),
+        ]);
+        AllocationFactory::createOne([
+            'import' => $importA,
+            'hospital' => $hospitalA,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::AIR,
+            'department' => $deptLong,
+            'isWithPhysician' => true,
+            'requiresResus' => true,
+            'requiresCathlab' => true,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 11:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 12:10:00'),
+        ]);
+        AllocationFactory::createOne([
+            'import' => $importB,
+            'hospital' => $hospitalB,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::GROUND,
+            'department' => $deptShort,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:08:00'),
+        ]);
+
+        $unknown = AllocationFactory::createOne([
+            'import' => $importA,
+            'hospital' => $hospitalA,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 13:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 13:20:00'),
+        ]);
+
+        $rebuilder = self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class);
+        $rebuilder->rebuildForImport($importA->getId());
+        $rebuilder->rebuildForImport($importB->getId());
+        self::getContainer()->get(Connection::class)->update(
+            'allocation_stats_projection',
+            ['transport_time_minutes' => -1],
+            ['id' => $unknown->getId()],
+        );
+
+        $filter = new StatisticsFilter(
+            StatisticsFilterScope::Hospital,
+            $hospitalA->getId(),
+            null,
+            StatisticsFilterPeriod::Month,
+            2025,
+            6,
+        );
+        $slice = self::getContainer()->get(TransportTimeProfileSliceQuery::class)->fetch(
+            new StatisticsScopeCriteria([$hospitalA->getId()]),
+            StatisticsPeriodResolver::resolve($filter),
+        );
+
+        self::assertSame(1, $slice->unknownCount);
+        self::assertSame(1, $slice->volumeByBucket['under_10'] ?? 0);
+        self::assertSame(1, $slice->volumeByBucket['over_60'] ?? 0);
+        self::assertSame(2, $slice->knownTotal());
+        self::assertSame(3, $slice->allocationTotal());
+        self::assertSame(1, $slice->genderByBucket['under_10']['2'] ?? 0);
+        self::assertSame(1, $slice->urgencyByBucket['over_60']['1'] ?? 0);
+        self::assertSame(1, $slice->physicianByBucket['over_60']['1'] ?? 0);
+        self::assertSame(1, $slice->resusByBucket['over_60']['1'] ?? 0);
+        self::assertSame(1, $slice->cathlabByBucket['over_60']['1'] ?? 0);
+        self::assertSame(1, $slice->transportTypeByBucket['over_60']['2'] ?? 0);
+        self::assertSame($deptShort->getId(), $slice->departmentsByBucket['under_10'][0]['id']);
+        self::assertSame($deptLong->getId(), $slice->departmentsByBucket['over_60'][0]['id']);
+
+        $otherHospital = self::getContainer()->get(TransportTimeProfileSliceQuery::class)->fetch(
+            new StatisticsScopeCriteria([$hospitalB->getId()]),
+            StatisticsPeriodResolver::resolve($filter),
+        );
+        self::assertSame(1, $otherHospital->knownTotal());
+        self::assertSame(0, $otherHospital->volumeByBucket['over_60'] ?? 0);
+
+        $emptyScope = self::getContainer()->get(TransportTimeProfileSliceQuery::class)->fetch(
+            new StatisticsScopeCriteria([]),
+            StatisticsPeriodResolver::resolve($filter),
+        );
+        self::assertSame(0, $emptyScope->allocationTotal());
+
+        $outsidePeriod = self::getContainer()->get(TransportTimeProfileSliceQuery::class)->fetch(
+            new StatisticsScopeCriteria([$hospitalA->getId()]),
+            StatisticsPeriodResolver::resolve(new StatisticsFilter(
+                StatisticsFilterScope::Hospital,
+                $hospitalA->getId(),
+                null,
+                StatisticsFilterPeriod::Month,
+                2025,
+                5,
+            )),
+        );
+        self::assertSame(0, $outsidePeriod->knownTotal());
+
+        $femaleOnly = self::getContainer()->get(TransportTimeProfileSliceQuery::class)->fetch(
+            new StatisticsScopeCriteria([$hospitalA->getId()]),
+            StatisticsPeriodResolver::resolve($filter),
+            new StatisticsDrawerFilter(gender: 2),
+        );
+        self::assertSame(1, $femaleOnly->knownTotal());
+        self::assertSame(1, $femaleOnly->volumeByBucket['under_10'] ?? 0);
+        self::assertSame(0, $femaleOnly->volumeByBucket['over_60'] ?? 0);
+    }
+
+    /**
+     * @return array{0: object, 1: object, 2: object, 3: object, 4: object, 5: object, 6: object, 7: object}
+     */
+    private function seed(): array
+    {
+        $user = UserFactory::createOne(['username' => 'ttp-slice-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'TtpSliceState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'TtpSliceDispatch', 'state' => $state]);
+        $hospitalA = HospitalFactory::createOne([
+            'name' => 'TtpSliceHospitalA',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $hospitalB = HospitalFactory::createOne([
+            'name' => 'TtpSliceHospitalB',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $deptShort = DepartmentFactory::createOne(['name' => 'TtpShortDept']);
+        $deptLong = DepartmentFactory::createOne(['name' => 'TtpLongDept']);
+        SpecialityFactory::createOne(['name' => 'TtpSliceSpec']);
+        AssignmentFactory::createOne(['name' => 'TtpSliceAssign']);
+        IndicationRawFactory::createOne(['name' => 'TtpSliceRaw', 'code' => 912_352]);
+        IndicationNormalizedFactory::createOne(['name' => 'TtpSliceNorm']);
+        $importA = ImportFactory::createOne(['name' => 'TtpSliceImportA', 'hospital' => $hospitalA, 'createdBy' => $user]);
+        $importB = ImportFactory::createOne(['name' => 'TtpSliceImportB', 'hospital' => $hospitalB, 'createdBy' => $user]);
+
+        return [$hospitalA, $hospitalB, $importA, $importB, $deptShort, $deptLong, $state, $dispatchArea];
+    }
+}

--- a/tests/Statistics/Integration/SummarizedReport/TransportTimeProfileBuilderTest.php
+++ b/tests/Statistics/Integration/SummarizedReport/TransportTimeProfileBuilderTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Integration\SummarizedReport;
+
+use App\Allocation\Domain\Enum\AllocationGender;
+use App\Allocation\Domain\Enum\AllocationTransportType;
+use App\Allocation\Domain\Enum\AllocationUrgency;
+use App\Allocation\Domain\Enum\HospitalLocation;
+use App\Allocation\Domain\Enum\HospitalTier;
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Statistics\Application\Contract\AllocationStatsProjectionRebuildInterface;
+use App\Statistics\Application\DTO\StatisticsContext;
+use App\Statistics\Application\DTO\StatisticsFilter;
+use App\Statistics\Application\DTO\StatisticsFilterPeriod;
+use App\Statistics\Application\DTO\StatisticsFilterScope;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileView;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileBuilder;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileReportType;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+
+final class TransportTimeProfileBuilderTest extends DatabaseKernelTestCase
+{
+    public function testEmptySliceProducesEmptyView(): void
+    {
+        $view = $this->builder()->build($this->publicJuneContext(), 'en');
+
+        self::assertFalse($view->hasData);
+        self::assertSame(0, $view->allocationCount);
+        self::assertSame([], $view->matrixSections);
+        self::assertSame([], $view->rankedSections);
+        self::assertSame([], $view->chartSpecs);
+        self::assertSame([], $view->insights);
+        self::assertStringContainsString('transport-time-bucket-distribution', $view->explorerTransportTimeUrl);
+    }
+
+    public function testBuildPartitionsCompositionAndRankedSections(): void
+    {
+        $this->seedJuneAllocations();
+
+        $type = self::getContainer()->get(TransportTimeProfileReportType::class);
+        $result = $type->build($this->publicJuneContext(), 'en');
+        $view = $result->viewModel;
+
+        self::assertSame('transport_time_profile', $type->key());
+        self::assertSame('stats.reports.types.transport_time_profile.label', $type->labelTranslationKey());
+        self::assertTrue($type->supports($this->publicJuneContext()->filter));
+        self::assertSame('@Statistics/reports/types/transport_time_profile.html.twig', $result->template);
+        self::assertInstanceOf(TransportTimeProfileView::class, $view);
+        self::assertTrue($view->hasData);
+        self::assertGreaterThan(0, $view->knownTransportCount);
+        self::assertSame(1, $view->unknownTransportCount);
+        self::assertNotEmpty($view->chartSpecs['cases']['counts']);
+        self::assertContains('volume', array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection $section): string => $section->key, $view->matrixSections));
+        self::assertContains('resources', array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection $section): string => $section->key, $view->matrixSections));
+        self::assertSame(['departments', 'specialities', 'indications'], array_map(
+            static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection $section): string => $section->key,
+            $view->rankedSections,
+        ));
+        self::assertStringContainsString('transport-time-bucket-distribution', $view->explorerTransportTimeUrl);
+        self::assertStringContainsString('year=2025', $view->explorerTransportTimeUrl);
+        self::assertStringContainsString('month=6', $view->dashboardUrl);
+    }
+
+    private function builder(): TransportTimeProfileBuilder
+    {
+        return self::getContainer()->get(TransportTimeProfileBuilder::class);
+    }
+
+    private function publicJuneContext(): StatisticsContext
+    {
+        return new StatisticsContext(
+            null,
+            new StatisticsFilter(
+                StatisticsFilterScope::Public,
+                null,
+                null,
+                StatisticsFilterPeriod::Month,
+                2025,
+                6,
+            ),
+        );
+    }
+
+    private function seedJuneAllocations(): void
+    {
+        $user = UserFactory::createOne(['username' => 'ttp-builder-'.bin2hex(random_bytes(4))]);
+        $state = StateFactory::createOne(['name' => 'TtpBuilderState']);
+        $dispatchArea = DispatchAreaFactory::createOne(['name' => 'TtpBuilderDispatch', 'state' => $state]);
+        $hospital = HospitalFactory::createOne([
+            'name' => 'TtpBuilderHospital',
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'tier' => HospitalTier::FULL,
+            'location' => HospitalLocation::URBAN,
+        ]);
+        $department = DepartmentFactory::createOne(['name' => 'TtpBuilderDept']);
+        SpecialityFactory::createOne(['name' => 'TtpBuilderSpec']);
+        AssignmentFactory::createOne(['name' => 'TtpBuilderAssign']);
+        IndicationRawFactory::createOne(['name' => 'TtpBuilderRaw', 'code' => 912_360]);
+        IndicationNormalizedFactory::createOne(['name' => 'TtpBuilderNorm']);
+        $import = ImportFactory::createOne(['name' => 'TtpBuilderImport', 'hospital' => $hospital, 'createdBy' => $user]);
+
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::FEMALE,
+            'urgency' => AllocationUrgency::INPATIENT,
+            'transportType' => AllocationTransportType::GROUND,
+            'department' => $department,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 10:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 10:05:00'),
+        ]);
+        AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'urgency' => AllocationUrgency::EMERGENCY,
+            'transportType' => AllocationTransportType::AIR,
+            'department' => $department,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 11:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 12:10:00'),
+        ]);
+        $unknown = AllocationFactory::createOne([
+            'import' => $import,
+            'hospital' => $hospital,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'gender' => AllocationGender::MALE,
+            'createdAt' => new \DateTimeImmutable('2025-06-15 13:00:00'),
+            'arrivalAt' => new \DateTimeImmutable('2025-06-15 13:20:00'),
+        ]);
+
+        self::getContainer()->get(AllocationStatsProjectionRebuildInterface::class)
+            ->rebuildForImport($import->getId());
+        self::getContainer()->get(Connection::class)->update(
+            'allocation_stats_projection',
+            ['transport_time_minutes' => -1],
+            ['id' => $unknown->getId()],
+        );
+    }
+}

--- a/tests/Statistics/Unit/Application/Mapping/StatisticsTransportTimeBucketSqlTest.php
+++ b/tests/Statistics/Unit/Application/Mapping/StatisticsTransportTimeBucketSqlTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Application\Mapping;
+
+use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StatisticsTransportTimeBucketSqlTest extends TestCase
+{
+    #[DataProvider('boundaryMinutes')]
+    public function testBucketKeyForMinutesUsesHalfOpenBoundaries(?int $minutes, string $expected): void
+    {
+        self::assertSame($expected, StatisticsTransportTimeBucketSql::bucketKeyForMinutes($minutes));
+    }
+
+    /**
+     * @return iterable<string, array{0: ?int, 1: string}>
+     */
+    public static function boundaryMinutes(): iterable
+    {
+        yield 'null' => [null, 'unknown'];
+        yield 'negative' => [-1, 'unknown'];
+        yield 'zero' => [0, 'under_10'];
+        yield 'nine' => [9, 'under_10'];
+        yield 'ten' => [10, '10_20'];
+        yield 'nineteen' => [19, '10_20'];
+        yield 'twenty' => [20, '20_30'];
+        yield 'fifty_nine' => [59, '50_60'];
+        yield 'sixty' => [60, 'over_60'];
+        yield 'ninety' => [90, 'over_60'];
+    }
+
+    public function testDisplayBucketsExcludeUnknown(): void
+    {
+        self::assertNotContains('unknown', StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS);
+        self::assertSame(
+            ['under_10', '10_20', '20_30', '30_40', '40_50', '50_60', 'over_60'],
+            StatisticsTransportTimeBucketSql::DISPLAY_BUCKET_KEYS,
+        );
+    }
+
+    public function testTranslationKeyUsesDistributionDomain(): void
+    {
+        self::assertSame(
+            'statistics.distribution.transport_time_bucket.under_10',
+            StatisticsTransportTimeBucketSql::translationKey('under_10'),
+        );
+    }
+}

--- a/tests/Statistics/Unit/Controller/SummarizedReportsPagePresenterTest.php
+++ b/tests/Statistics/Unit/Controller/SummarizedReportsPagePresenterTest.php
@@ -69,6 +69,37 @@ final class SummarizedReportsPagePresenterTest extends TestCase
         }
     }
 
+    public function testPresentOmitsMonthOnlyNavigationForOtherReports(): void
+    {
+        $router = $this->createStub(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturn('/statistics/reports');
+        $earliestDateProvider = $this->createStub(ProjectionEarliestDateProviderInterface::class);
+        $presenter = new SummarizedReportsPagePresenter(
+            new StatisticsNavigationUrlBuilder($router),
+            $earliestDateProvider,
+        );
+
+        $reportType = $this->createStub(ReportTypeInterface::class);
+        $reportType->method('key')->willReturn('transport_time_profile');
+        $reportType->method('labelTranslationKey')->willReturn('stats.reports.types.transport_time_profile.label');
+        $reportType->method('descriptionTranslationKey')->willReturn('stats.reports.types.transport_time_profile.description');
+
+        $request = new Request(
+            query: ['scope' => 'public', 'period' => 'all'],
+            attributes: ['_route' => 'app_stats_reports_show', 'type' => 'transport_time_profile'],
+        );
+        $request->setLocale('en');
+
+        $model = $presenter->present(
+            $request,
+            $reportType,
+            new ReportBuildResult('@Statistics/reports/types/transport_time_profile.html.twig', new \stdClass()),
+        );
+
+        self::assertNull($model->periodNavigation);
+        self::assertSame('', $model->periodLabel);
+    }
+
     private function monthlyReportView(int $year, int $month): MonthlyReportView
     {
         return new MonthlyReportView(

--- a/tests/Statistics/Unit/Infrastructure/Query/ProjectionDrawerFilterSqlTest.php
+++ b/tests/Statistics/Unit/Infrastructure/Query/ProjectionDrawerFilterSqlTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\Infrastructure\Query;
+
+use App\Statistics\Application\DTO\StatisticsDrawerFilter;
+use App\Statistics\Infrastructure\Query\ProjectionDrawerFilterSql;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectionDrawerFilterSqlTest extends TestCase
+{
+    public function testInactiveFilterAddsNoConditions(): void
+    {
+        [$conditions, $params] = new ProjectionDrawerFilterSql()->apply(new StatisticsDrawerFilter());
+
+        self::assertSame([], $conditions);
+        self::assertSame([], $params);
+    }
+
+    public function testAppliesGenderAndUrgencyAsSqlFragments(): void
+    {
+        [$conditions, $params] = new ProjectionDrawerFilterSql()->apply(
+            new StatisticsDrawerFilter(gender: 2, urgency: 1),
+        );
+
+        self::assertContains('gender_code = :drawer_gender', $conditions);
+        self::assertContains('urgency_code = :drawer_urgency', $conditions);
+        self::assertSame(2, $params['drawer_gender']);
+        self::assertSame(1, $params['drawer_urgency']);
+    }
+
+    public function testAppliesRemainingFiltersWithColumnPrefix(): void
+    {
+        [$conditions, $params] = new ProjectionDrawerFilterSql()->apply(
+            new StatisticsDrawerFilter(
+                ageGroup: 'under_18',
+                department: 4,
+                speciality: 8,
+                requiresResus: true,
+                requiresCathlab: false,
+                isVentilated: true,
+                isShock: false,
+                isCpr: true,
+                isPregnant: false,
+                isWorkAccident: true,
+                infection: 12,
+            ),
+            'p',
+        );
+
+        self::assertContains('p.age IS NOT NULL AND p.age < 18', $conditions);
+        self::assertContains('p.department_id = :drawer_department_id', $conditions);
+        self::assertContains('p.speciality_id = :drawer_speciality_id', $conditions);
+        self::assertContains('p.requires_resus = :drawer_requires_resus', $conditions);
+        self::assertContains('p.requires_cathlab = :drawer_requires_cathlab', $conditions);
+        self::assertContains('p.is_ventilated = :drawer_is_ventilated', $conditions);
+        self::assertContains('p.is_shock = :drawer_is_shock', $conditions);
+        self::assertContains('p.is_cpr = :drawer_is_cpr', $conditions);
+        self::assertContains('p.is_pregnant = :drawer_is_pregnant', $conditions);
+        self::assertContains('p.is_work_accident = :drawer_is_work_accident', $conditions);
+        self::assertContains('p.infection_id = :drawer_infection_id', $conditions);
+        self::assertSame(4, $params['drawer_department_id']);
+        self::assertSame(8, $params['drawer_speciality_id']);
+        self::assertTrue($params['drawer_requires_resus']);
+        self::assertFalse($params['drawer_requires_cathlab']);
+        self::assertSame(12, $params['drawer_infection_id']);
+    }
+
+    public function testInfectiousFlagUsesNullCheckAndUnknownAgeGroupIsIgnored(): void
+    {
+        [$infectious, $infectiousParams] = new ProjectionDrawerFilterSql()->apply(
+            new StatisticsDrawerFilter(isInfectious: true),
+        );
+        [$notInfectious] = new ProjectionDrawerFilterSql()->apply(
+            new StatisticsDrawerFilter(isInfectious: false),
+        );
+        [$unknownAge] = new ProjectionDrawerFilterSql()->apply(
+            new StatisticsDrawerFilter(ageGroup: 'not-a-bucket'),
+        );
+
+        self::assertSame(['infection_id IS NOT NULL'], $infectious);
+        self::assertSame([], $infectiousParams);
+        self::assertSame(['infection_id IS NULL'], $notInfectious);
+        self::assertSame([], $unknownAge);
+    }
+}

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileAssemblerTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileAssemblerTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\SummarizedReport;
+
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileSliceData;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileAssembler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TransportTimeProfileAssemblerTest extends TestCase
+{
+    public function testWithinBucketPercentUsesBucketNAsDenominator(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = $this->sliceWithUrgency([
+            'under_10' => ['1' => 10, '2' => 90],
+            'over_60' => ['1' => 40, '2' => 60],
+        ], [
+            'under_10' => 100,
+            'over_60' => 100,
+        ]);
+
+        $matrix = $assembler->matrix($slice, 'en', [], [], [], [], '', '');
+        $emergency = $this->row($matrix, 'urgency', '1');
+
+        self::assertSame(10.0, $emergency->cells['under_10']->percent);
+        self::assertSame(40.0, $emergency->cells['over_60']->percent);
+        self::assertSame(25.0, $emergency->overallPercent);
+        self::assertSame(-15.0, $emergency->cells['under_10']->deltaPp);
+        self::assertSame(15.0, $emergency->cells['over_60']->deltaPp);
+    }
+
+    public function testTopFiveIsRankedIndependentlyPerBucket(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = new TransportTimeProfileSliceData(
+            0,
+            ['under_10' => 100, 'over_60' => 50],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [
+                'under_10' => [
+                    ['id' => 1, 'count' => 40],
+                    ['id' => 2, 'count' => 30],
+                    ['id' => 3, 'count' => 10],
+                ],
+                'over_60' => [
+                    ['id' => 3, 'count' => 25],
+                    ['id' => 1, 'count' => 10],
+                    ['id' => 4, 'count' => 8],
+                ],
+            ],
+            [],
+            [],
+        );
+
+        $matrix = $assembler->matrix(
+            $slice,
+            'en',
+            [1 => 'Internal', 2 => 'Surgery', 3 => 'Neurology', 4 => 'Trauma'],
+            [],
+            [],
+            [],
+            '/departments',
+            '',
+        );
+        $rank1 = $this->row($matrix, 'departments', 'rank_1');
+        $rank3 = $this->row($matrix, 'departments', 'rank_3');
+
+        self::assertSame('Internal', $rank1->cells['under_10']->entityLabel);
+        self::assertSame('Neurology', $rank1->cells['over_60']->entityLabel);
+        self::assertSame(2, $rank1->cells['over_60']->rankDelta);
+        self::assertSame('Neurology', $rank3->cells['under_10']->entityLabel);
+        self::assertTrue($rank3->cells['over_60']->enteredTop);
+        self::assertSame('Trauma', $rank3->cells['over_60']->entityLabel);
+        self::assertSame(40.0, $rank1->cells['under_10']->percent);
+        self::assertSame(50.0, $rank1->cells['over_60']->percent);
+    }
+
+    public function testSmallSampleIsFlaggedBelowTen(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = $this->sliceWithUrgency([
+            'under_10' => ['1' => 4],
+            'over_60' => ['1' => 20],
+        ], [
+            'under_10' => 9,
+            'over_60' => 40,
+        ]);
+
+        $matrix = $assembler->matrix($slice, 'en', [], [], [], [], '', '');
+        $emergency = $this->row($matrix, 'urgency', '1');
+
+        self::assertTrue($emergency->cells['under_10']->smallSample);
+        self::assertFalse($emergency->cells['over_60']->smallSample);
+        self::assertSame(4, $emergency->cells['under_10']->count);
+    }
+
+    public function testResourcesSectionContainsResusAndCathlabRows(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = new TransportTimeProfileSliceData(
+            0,
+            ['under_10' => 100, 'over_60' => 50],
+            [],
+            [],
+            [],
+            ['under_10' => ['1' => 20], 'over_60' => ['1' => 5]],
+            ['under_10' => ['1' => 10], 'over_60' => ['1' => 25]],
+            [],
+            [],
+            [],
+            [],
+        );
+
+        $matrix = $assembler->matrix($slice, 'en', [], [], [], [], '', '');
+        $resus = $this->row($matrix, 'resources', 'requires_resus');
+        $cathlab = $this->row($matrix, 'resources', 'requires_cathlab');
+
+        self::assertSame(20.0, $resus->cells['under_10']->percent);
+        self::assertSame(10.0, $resus->cells['over_60']->percent);
+        self::assertSame(10.0, $cathlab->cells['under_10']->percent);
+        self::assertSame(50.0, $cathlab->cells['over_60']->percent);
+    }
+
+    public function testChartSpecsIncludeCasesGenderAndUrgencyModes(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = $this->sliceWithUrgency([
+            'under_10' => ['1' => 10],
+            'over_60' => ['1' => 40],
+        ], [
+            'under_10' => 100,
+            'over_60' => 100,
+        ]);
+
+        $specs = $assembler->chartSpecs($slice, $this->bucketLabels(), 'en');
+
+        self::assertSame('bar', $specs['cases']['chartType']);
+        self::assertSame([100, 0, 0, 0, 0, 0, 100], $specs['cases']['counts']);
+        self::assertSame('Under 10 min', $specs['cases']['labels'][0]);
+        self::assertArrayHasKey('series', $specs['gender']);
+        self::assertArrayHasKey('series', $specs['urgency']);
+        self::assertSame($specs['cases']['labels'], $specs['gender']['labels']);
+    }
+
+    public function testMissingRankedBucketIsEmptyAndIndicationUsesEntityUrl(): void
+    {
+        $assembler = new TransportTimeProfileAssembler($this->translator());
+        $slice = new TransportTimeProfileSliceData(
+            0,
+            ['under_10' => 40],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [
+                'under_10' => [
+                    ['id' => 9, 'count' => 12],
+                ],
+            ],
+        );
+
+        $matrix = $assembler->matrix(
+            $slice,
+            'en',
+            [],
+            [],
+            [9 => 'STEMI'],
+            [9 => '/indications/9'],
+            '/departments',
+            '/specialities',
+        );
+        $rank1 = $this->row($matrix, 'indications', 'rank_1');
+
+        self::assertSame('STEMI', $rank1->cells['under_10']->entityLabel);
+        self::assertSame('/indications/9', $rank1->cells['under_10']->linkUrl);
+        self::assertTrue($rank1->cells['over_60']->isEmpty());
+        self::assertSame([], $assembler->rateSeriesByRow($matrix, 'missing', 'row'));
+        self::assertSame(
+            ['under_10' => 40, '10_20' => 0, '20_30' => 0, '30_40' => 0, '40_50' => 0, '50_60' => 0, 'over_60' => 0],
+            $assembler->volumeByBucket($slice),
+        );
+    }
+
+    /**
+     * @param array<string, array<int|string, int>> $urgency
+     * @param array<string, int>                    $volume
+     */
+    private function sliceWithUrgency(array $urgency, array $volume): TransportTimeProfileSliceData
+    {
+        return new TransportTimeProfileSliceData(
+            0,
+            $volume,
+            [],
+            $urgency,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function bucketLabels(): array
+    {
+        return [
+            'under_10' => 'Under 10 min',
+            '10_20' => '10–20 min',
+            '20_30' => '20–30 min',
+            '30_40' => '30–40 min',
+            '40_50' => '40–50 min',
+            '50_60' => '50–60 min',
+            'over_60' => 'Over 60 min',
+        ];
+    }
+
+    /**
+     * @param list<\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection> $sections
+     */
+    private function row(array $sections, string $sectionKey, string $rowKey): \App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixRow
+    {
+        foreach ($sections as $section) {
+            if ($section->key !== $sectionKey) {
+                continue;
+            }
+            foreach ($section->rows as $row) {
+                if ($row->key === $rowKey) {
+                    return $row;
+                }
+            }
+        }
+
+        self::fail(sprintf('Row %s/%s not found.', $sectionKey, $rowKey));
+    }
+
+    private function translator(): TranslatorInterface
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id, array $parameters = []): string => $parameters['percent'] ?? $id,
+        );
+
+        return $translator;
+    }
+}

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileInsightGeneratorTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileInsightGeneratorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\SummarizedReport;
+
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileCell;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixRow;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileAssembler;
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileInsightGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class TransportTimeProfileInsightGeneratorTest extends TestCase
+{
+    public function testStrongUrgencyPatternProducesDescriptiveInsight(): void
+    {
+        $insights = $this->generator()->generate(
+            $this->volume(100),
+            [$this->percentSection('urgency', '1', ['under_10' => 10.0, 'over_60' => 32.0])],
+            $this->bucketLabels(),
+            700,
+            'en',
+        );
+
+        self::assertNotEmpty($insights);
+        self::assertSame('urgency_emergency', $insights[0]->id);
+        self::assertStringContainsString('rate_increase', $insights[0]->body);
+        self::assertStringNotContainsString('require', strtolower($insights[0]->body));
+        self::assertStringNotContainsString('cause', strtolower($insights[0]->body));
+    }
+
+    public function testTrivialChangeDoesNotProduceInsight(): void
+    {
+        $insights = $this->generator()->generate(
+            $this->volume(100),
+            [$this->percentSection('urgency', '1', ['under_10' => 14.0, 'over_60' => 16.0])],
+            $this->bucketLabels(),
+            700,
+            'en',
+        );
+
+        self::assertSame([], $insights);
+    }
+
+    public function testInsufficientSampleSuppressesInsights(): void
+    {
+        $insights = $this->generator()->generate(
+            ['under_10' => 8, 'over_60' => 8],
+            [$this->percentSection('urgency', '1', ['under_10' => 10.0, 'over_60' => 40.0])],
+            $this->bucketLabels(),
+            16,
+            'en',
+        );
+
+        self::assertSame([], $insights);
+    }
+
+    public function testRankChangeRequiresBothRankAndShareMovement(): void
+    {
+        $section = new TransportTimeProfileMatrixSection('departments', 'departments', [
+            new TransportTimeProfileMatrixRow('rank_1', '#1', 'ranked', [
+                'under_10' => $this->rankedCell(1, 'Neurology', 20.0, 1),
+                'over_60' => $this->rankedCell(3, 'Neurology', 32.0, 1),
+            ]),
+            new TransportTimeProfileMatrixRow('rank_3', '#3', 'ranked', [
+                'under_10' => $this->rankedCell(3, 'Internal', 18.0, 2),
+                'over_60' => $this->rankedCell(1, 'Internal', 19.0, 2),
+            ]),
+        ]);
+
+        $insights = $this->generator()->generate(
+            $this->volume(100),
+            [$section],
+            $this->bucketLabels(),
+            700,
+            'en',
+        );
+
+        $ids = array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): string => $insight->id, $insights);
+        self::assertContains('departments_1', $ids);
+        self::assertNotContains('departments_2', $ids);
+    }
+
+    public function testCathlabRateSpanUsesResourcesSection(): void
+    {
+        $insights = $this->generator()->generate(
+            $this->volume(100),
+            [$this->percentSection('resources', 'requires_cathlab', ['under_10' => 4.0, 'over_60' => 22.0])],
+            $this->bucketLabels(),
+            700,
+            'en',
+        );
+
+        self::assertNotEmpty($insights);
+        self::assertSame('cathlab', $insights[0]->id);
+    }
+
+    public function testRateDecreaseAndAirOverrepresentationProduceInsights(): void
+    {
+        $insights = $this->generator()->generate(
+            $this->volume(100),
+            [
+                $this->percentSection('urgency', '1', ['under_10' => 32.0, 'over_60' => 10.0]),
+                $this->percentSection('transport_mode', '2', [
+                    'under_10' => 5.0,
+                    '10_20' => 5.0,
+                    '20_30' => 5.0,
+                    '30_40' => 5.0,
+                    '40_50' => 5.0,
+                    '50_60' => 5.0,
+                    'over_60' => 20.0,
+                ]),
+            ],
+            $this->bucketLabels(),
+            700,
+            'en',
+        );
+
+        $ids = array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): string => $insight->id, $insights);
+        self::assertContains('urgency_emergency', $ids);
+        self::assertStringContainsString('rate_decrease', $insights[0]->body);
+        self::assertContains('air_overrepresented', $ids);
+        self::assertLessThanOrEqual(4, \count($insights));
+    }
+
+    private function generator(): TransportTimeProfileInsightGenerator
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => $id,
+        );
+
+        return new TransportTimeProfileInsightGenerator(
+            $translator,
+            new TransportTimeProfileAssembler($translator),
+        );
+    }
+
+    /**
+     * @param array<string, float> $percents
+     */
+    private function percentSection(string $sectionKey, string $rowKey, array $percents): TransportTimeProfileMatrixSection
+    {
+        $cells = [];
+        foreach (['under_10', '10_20', '20_30', '30_40', '40_50', '50_60', 'over_60'] as $bucket) {
+            $percent = $percents[$bucket] ?? 12.0;
+            $cells[$bucket] = new TransportTimeProfileCell(100, false, count: 12, percent: $percent);
+        }
+
+        return new TransportTimeProfileMatrixSection($sectionKey, $sectionKey, [
+            new TransportTimeProfileMatrixRow($rowKey, $rowKey, 'percent', $cells, 12.0),
+        ]);
+    }
+
+    private function rankedCell(int $rank, string $label, float $percent, int $id): TransportTimeProfileCell
+    {
+        return new TransportTimeProfileCell(
+            100,
+            false,
+            count: (int) round($percent),
+            percent: $percent,
+            rank: $rank,
+            entityLabel: $label,
+            entityId: $id,
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function volume(int $n): array
+    {
+        return [
+            'under_10' => $n,
+            '10_20' => $n,
+            '20_30' => $n,
+            '30_40' => $n,
+            '40_50' => $n,
+            '50_60' => $n,
+            'over_60' => $n,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function bucketLabels(): array
+    {
+        return [
+            'under_10' => 'Under 10 min',
+            'over_60' => 'Over 60 min',
+        ];
+    }
+}

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileMathTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileMathTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Statistics\Unit\SummarizedReport;
+
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileMath;
+use PHPUnit\Framework\TestCase;
+
+final class TransportTimeProfileMathTest extends TestCase
+{
+    public function testPercentUsesBucketDenominator(): void
+    {
+        self::assertSame(40.0, TransportTimeProfileMath::percent(4, 10));
+        self::assertSame(0.0, TransportTimeProfileMath::percent(4, 0));
+        self::assertSame(24.1, TransportTimeProfileMath::percent(241, 1000));
+    }
+
+    public function testDeltaPpIsPercentagePointsNotRelativeChange(): void
+    {
+        self::assertSame(16.3, TransportTimeProfileMath::deltaPp(27.8, 11.5));
+        self::assertSame(-3.3, TransportTimeProfileMath::deltaPp(8.2, 11.5));
+    }
+
+    public function testSmallSampleThreshold(): void
+    {
+        self::assertTrue(TransportTimeProfileMath::isSmallSample(9));
+        self::assertFalse(TransportTimeProfileMath::isSmallSample(10));
+        self::assertFalse(TransportTimeProfileMath::isSmallSample(0));
+    }
+
+    public function testHeatClassLevelsAndSmallSampleDamping(): void
+    {
+        self::assertSame('', TransportTimeProfileMath::heatClass(1.0, false));
+        self::assertSame('stats-ttp-heat-high-1', TransportTimeProfileMath::heatClass(4.0, false));
+        self::assertSame('stats-ttp-heat-high-2', TransportTimeProfileMath::heatClass(8.0, false));
+        self::assertSame('stats-ttp-heat-high-3', TransportTimeProfileMath::heatClass(16.3, false));
+        self::assertSame('stats-ttp-heat-low-1', TransportTimeProfileMath::heatClass(-4.0, false));
+        self::assertSame('', TransportTimeProfileMath::heatClass(4.0, true));
+        self::assertSame('stats-ttp-heat-high-2', TransportTimeProfileMath::heatClass(20.0, true));
+    }
+
+    public function testHeatClassIsDivergingNotNormative(): void
+    {
+        self::assertSame('', TransportTimeProfileMath::heatClass(0.0, false));
+        self::assertStringContainsString('high', TransportTimeProfileMath::heatClass(16.3, false));
+        self::assertStringContainsString('low', TransportTimeProfileMath::heatClass(-16.3, false));
+        self::assertStringNotContainsString('success', TransportTimeProfileMath::heatClass(16.3, false));
+        self::assertStringNotContainsString('danger', TransportTimeProfileMath::heatClass(-16.3, false));
+    }
+}

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -4583,7 +4583,7 @@
       </trans-unit>
       <trans-unit id="A5bf632f9b" resname="stats.reports.types.monthly.description">
         <source>stats.reports.types.monthly.description</source>
-        <target>Kompakte Zusammenfassung des letzten abgeschlossenen Kalendermonats</target>
+        <target>Kompakte Zusammenfassung eines abgeschlossenen Kalendermonats</target>
       </trans-unit>
       <trans-unit id="A5ddf44334" resname="stats.reports.monthly.empty.title">
         <source>stats.reports.monthly.empty.title</source>
@@ -5212,6 +5212,226 @@
       <trans-unit id="statsAexSum24" resname="stats.analysis_explorer.summary.more_filters">
         <source>stats.analysis_explorer.summary.more_filters</source>
         <target>{count, plural, one {mit # weiterem Filter} other {mit # weiteren Filtern}}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp01" resname="stats.reports.types.transport_time_profile.label">
+        <source>stats.reports.types.transport_time_profile.label</source>
+        <target>Transportzeitprofil</target>
+      </trans-unit>
+      <trans-unit id="statsTtp02" resname="stats.reports.types.transport_time_profile.description">
+        <source>stats.reports.types.transport_time_profile.description</source>
+        <target>Änderung der Fallzusammensetzung abhängig von der Transportzeit</target>
+      </trans-unit>
+      <trans-unit id="statsTtp03" resname="stats.reports.transport_time_profile.empty.title">
+        <source>stats.reports.transport_time_profile.empty.title</source>
+        <target>Keine Zuweisungen in diesem Bereich</target>
+      </trans-unit>
+      <trans-unit id="statsTtp04" resname="stats.reports.transport_time_profile.empty.body">
+        <source>stats.reports.transport_time_profile.empty.body</source>
+        <target>Für {context} liegen noch keine Zuweisungsdaten vor.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp05" resname="stats.reports.transport_time_profile.context">
+        <source>stats.reports.transport_time_profile.context</source>
+        <target>{scope} · {period} · {count, number} Zuweisungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp06" resname="stats.reports.transport_time_profile.context_filtered">
+        <source>stats.reports.transport_time_profile.context_filtered</source>
+        <target>{context} · zusätzliche Filter aktiv</target>
+      </trans-unit>
+      <trans-unit id="statsTtp07" resname="stats.reports.transport_time_profile.unknown_transport">
+        <source>stats.reports.transport_time_profile.unknown_transport</source>
+        <target>{count, plural, one {# Zuweisung ohne nutzbare Transportzeit ist in den Profilspalten nicht enthalten.} other {# Zuweisungen ohne nutzbare Transportzeit sind in den Profilspalten nicht enthalten.}}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp08" resname="stats.reports.transport_time_profile.chart.title">
+        <source>stats.reports.transport_time_profile.chart.title</source>
+        <target>Transportzeitgruppen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp09" resname="stats.reports.transport_time_profile.chart.modes">
+        <source>stats.reports.transport_time_profile.chart.modes</source>
+        <target>Chartdarstellung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp10" resname="stats.reports.transport_time_profile.chart.cases">
+        <source>stats.reports.transport_time_profile.chart.cases</source>
+        <target>Fälle</target>
+      </trans-unit>
+      <trans-unit id="statsTtp11" resname="stats.reports.transport_time_profile.chart.gender">
+        <source>stats.reports.transport_time_profile.chart.gender</source>
+        <target>Geschlecht</target>
+      </trans-unit>
+      <trans-unit id="statsTtp12" resname="stats.reports.transport_time_profile.chart.urgency">
+        <source>stats.reports.transport_time_profile.chart.urgency</source>
+        <target>Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="statsTtp13" resname="stats.reports.transport_time_profile.chart.axis">
+        <source>stats.reports.transport_time_profile.chart.axis</source>
+        <target>Transportzeit</target>
+      </trans-unit>
+      <trans-unit id="statsTtp14" resname="stats.reports.transport_time_profile.print">
+        <source>stats.reports.transport_time_profile.print</source>
+        <target>Drucken</target>
+      </trans-unit>
+      <trans-unit id="statsTtp15" resname="stats.reports.transport_time_profile.explorer_link">
+        <source>stats.reports.transport_time_profile.explorer_link</source>
+        <target>Im Explorer öffnen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp16" resname="stats.reports.transport_time_profile.insights.title">
+        <source>stats.reports.transport_time_profile.insights.title</source>
+        <target>Auffällige Muster</target>
+      </trans-unit>
+      <trans-unit id="statsTtp17" resname="stats.reports.transport_time_profile.matrix.title">
+        <source>stats.reports.transport_time_profile.matrix.title</source>
+        <target>Transportzeitprofil</target>
+      </trans-unit>
+      <trans-unit id="statsTtp18" resname="stats.reports.transport_time_profile.matrix.metric">
+        <source>stats.reports.transport_time_profile.matrix.metric</source>
+        <target>Merkmal</target>
+      </trans-unit>
+      <trans-unit id="statsTtp19" resname="stats.reports.transport_time_profile.section.volume">
+        <source>stats.reports.transport_time_profile.section.volume</source>
+        <target>Volumen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp20" resname="stats.reports.transport_time_profile.section.gender">
+        <source>stats.reports.transport_time_profile.section.gender</source>
+        <target>Demografie</target>
+      </trans-unit>
+      <trans-unit id="statsTtp21" resname="stats.reports.transport_time_profile.section.urgency">
+        <source>stats.reports.transport_time_profile.section.urgency</source>
+        <target>Dringlichkeit</target>
+      </trans-unit>
+      <trans-unit id="statsTtp22" resname="stats.reports.transport_time_profile.section.departments">
+        <source>stats.reports.transport_time_profile.section.departments</source>
+        <target>Häufigste Abteilungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp23" resname="stats.reports.transport_time_profile.section.specialities">
+        <source>stats.reports.transport_time_profile.section.specialities</source>
+        <target>Häufigste Fachgebiete</target>
+      </trans-unit>
+      <trans-unit id="statsTtp24" resname="stats.reports.transport_time_profile.section.indications">
+        <source>stats.reports.transport_time_profile.section.indications</source>
+        <target>Häufigste Indikationen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp25" resname="stats.reports.transport_time_profile.section.physician">
+        <source>stats.reports.transport_time_profile.section.physician</source>
+        <target>Arztbegleitung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp26" resname="stats.reports.transport_time_profile.section.resources">
+        <source>stats.reports.transport_time_profile.section.resources</source>
+        <target>Ressourcenanforderungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp27" resname="stats.reports.transport_time_profile.section.transport_mode">
+        <source>stats.reports.transport_time_profile.section.transport_mode</source>
+        <target>Transportmittel</target>
+      </trans-unit>
+      <trans-unit id="statsTtp28" resname="stats.reports.transport_time_profile.metric.cases">
+        <source>stats.reports.transport_time_profile.metric.cases</source>
+        <target>Fälle</target>
+      </trans-unit>
+      <trans-unit id="statsTtp29" resname="stats.reports.transport_time_profile.metric.share">
+        <source>stats.reports.transport_time_profile.metric.share</source>
+        <target>Anteil insgesamt</target>
+      </trans-unit>
+      <trans-unit id="statsTtp30" resname="stats.reports.transport_time_profile.metric.with_physician">
+        <source>stats.reports.transport_time_profile.metric.with_physician</source>
+        <target>Mit Arzt</target>
+      </trans-unit>
+      <trans-unit id="statsTtp31" resname="stats.reports.transport_time_profile.metric.requires_resus">
+        <source>stats.reports.transport_time_profile.metric.requires_resus</source>
+        <target>Schockraum angefordert</target>
+      </trans-unit>
+      <trans-unit id="statsTtp53" resname="stats.reports.transport_time_profile.metric.requires_cathlab">
+        <source>stats.reports.transport_time_profile.metric.requires_cathlab</source>
+        <target>Herzkatheter angefordert</target>
+      </trans-unit>
+      <trans-unit id="statsTtp32" resname="stats.reports.transport_time_profile.overall">
+        <source>stats.reports.transport_time_profile.overall</source>
+        <target>{percent, number, ::.0} % insgesamt</target>
+      </trans-unit>
+      <trans-unit id="statsTtp33" resname="stats.reports.transport_time_profile.pp">
+        <source>stats.reports.transport_time_profile.pp</source>
+        <target>pp</target>
+      </trans-unit>
+      <trans-unit id="statsTtp34" resname="stats.reports.transport_time_profile.rank.new">
+        <source>stats.reports.transport_time_profile.rank.new</source>
+        <target>neu</target>
+      </trans-unit>
+      <trans-unit id="statsTtp35" resname="stats.reports.transport_time_profile.small_n.label">
+        <source>stats.reports.transport_time_profile.small_n.label</source>
+        <target>Kleine n</target>
+      </trans-unit>
+      <trans-unit id="statsTtp36" resname="stats.reports.transport_time_profile.small_n.hint">
+        <source>stats.reports.transport_time_profile.small_n.hint</source>
+        <target>Kleine Fallzahl – vorsichtig interpretieren</target>
+      </trans-unit>
+      <trans-unit id="statsTtp37" resname="stats.reports.transport_time_profile.disclaimer">
+        <source>stats.reports.transport_time_profile.disclaimer</source>
+        <target>Deskriptive Analyse der ausgewählten IVENA-Zuweisungspopulation. Beobachtete Unterschiede implizieren keine Kausalität.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp38" resname="stats.reports.transport_time_profile.insight.urgency_emergency.title">
+        <source>stats.reports.transport_time_profile.insight.urgency_emergency.title</source>
+        <target>Dringlichkeitszusammensetzung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp39" resname="stats.reports.transport_time_profile.insight.physician.title">
+        <source>stats.reports.transport_time_profile.insight.physician.title</source>
+        <target>Arztbegleitung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp40" resname="stats.reports.transport_time_profile.insight.resus.title">
+        <source>stats.reports.transport_time_profile.insight.resus.title</source>
+        <target>Schockraumanforderungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp41" resname="stats.reports.transport_time_profile.insight.air.title">
+        <source>stats.reports.transport_time_profile.insight.air.title</source>
+        <target>Luftrettung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp42" resname="stats.reports.transport_time_profile.insight.metric.urgency_emergency">
+        <source>stats.reports.transport_time_profile.insight.metric.urgency_emergency</source>
+        <target>Hochdringliche Zuweisungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp43" resname="stats.reports.transport_time_profile.insight.metric.physician">
+        <source>stats.reports.transport_time_profile.insight.metric.physician</source>
+        <target>Arztbegleitung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp44" resname="stats.reports.transport_time_profile.insight.metric.resus">
+        <source>stats.reports.transport_time_profile.insight.metric.resus</source>
+        <target>Schockraumanforderungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp45" resname="stats.reports.transport_time_profile.insight.metric.air">
+        <source>stats.reports.transport_time_profile.insight.metric.air</source>
+        <target>Luftrettung</target>
+      </trans-unit>
+      <trans-unit id="statsTtp46" resname="stats.reports.transport_time_profile.insight.rate_increase">
+        <source>stats.reports.transport_time_profile.insight.rate_increase</source>
+        <target>{metric} ist in der Gruppe {to_bucket} ({to_percent} %) häufiger als in der Gruppe {from_bucket} ({from_percent} %).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp47" resname="stats.reports.transport_time_profile.insight.rate_decrease">
+        <source>stats.reports.transport_time_profile.insight.rate_decrease</source>
+        <target>{metric} ist in der Gruppe {to_bucket} ({to_percent} %) seltener als in der Gruppe {from_bucket} ({from_percent} %).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp48" resname="stats.reports.transport_time_profile.insight.rank.title">
+        <source>stats.reports.transport_time_profile.insight.rank.title</source>
+        <target>Rangänderung: {label}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp49" resname="stats.reports.transport_time_profile.insight.rank.body">
+        <source>stats.reports.transport_time_profile.insight.rank.body</source>
+        <target>{label} verschiebt sich von Rang {from_rank} in der Gruppe {from_bucket} auf Rang {to_rank} in der Gruppe {to_bucket}.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp50" resname="stats.reports.transport_time_profile.insight.air_overrepresented.title">
+        <source>stats.reports.transport_time_profile.insight.air_overrepresented.title</source>
+        <target>Luftrettung bei langen Transporten</target>
+      </trans-unit>
+      <trans-unit id="statsTtp51" resname="stats.reports.transport_time_profile.insight.air_overrepresented.body">
+        <source>stats.reports.transport_time_profile.insight.air_overrepresented.body</source>
+        <target>Luftrettung ist in der längsten Transportzeitgruppe ({bucket_percent} %) häufiger als in der ausgewählten Population insgesamt ({overall_percent} %).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp52" resname="stats.reports.transport_time_profile.ranked.title">
+        <source>stats.reports.transport_time_profile.ranked.title</source>
+        <target>Häufigste Abteilungen, Fachgebiete und Indikationen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp54" resname="stats.reports.transport_time_profile.insight.cathlab.title">
+        <source>stats.reports.transport_time_profile.insight.cathlab.title</source>
+        <target>Herzkatheteranforderungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp55" resname="stats.reports.transport_time_profile.insight.metric.cathlab">
+        <source>stats.reports.transport_time_profile.insight.metric.cathlab</source>
+        <target>Herzkatheteranforderungen</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -1139,7 +1139,7 @@
       </trans-unit>
       <trans-unit id="A689964a80" resname="stats.reports.types.monthly.description">
         <source>stats.reports.types.monthly.description</source>
-        <target>Concise summary of the previous completed calendar month</target>
+        <target>Concise summary of a completed calendar month</target>
       </trans-unit>
       <trans-unit id="Ae491dbf70" resname="stats.reports.monthly.empty.title">
         <source>stats.reports.monthly.empty.title</source>
@@ -5212,6 +5212,226 @@
       <trans-unit id="statsAexSum24" resname="stats.analysis_explorer.summary.more_filters">
         <source>stats.analysis_explorer.summary.more_filters</source>
         <target>{count, plural, one {with # more filter} other {with # more filters}}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp01" resname="stats.reports.types.transport_time_profile.label">
+        <source>stats.reports.types.transport_time_profile.label</source>
+        <target>Transport Time Profile</target>
+      </trans-unit>
+      <trans-unit id="statsTtp02" resname="stats.reports.types.transport_time_profile.description">
+        <source>stats.reports.types.transport_time_profile.description</source>
+        <target>Change in case mix depending on transport time</target>
+      </trans-unit>
+      <trans-unit id="statsTtp03" resname="stats.reports.transport_time_profile.empty.title">
+        <source>stats.reports.transport_time_profile.empty.title</source>
+        <target>No allocations in this scope</target>
+      </trans-unit>
+      <trans-unit id="statsTtp04" resname="stats.reports.transport_time_profile.empty.body">
+        <source>stats.reports.transport_time_profile.empty.body</source>
+        <target>There is no allocation data for {context} yet.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp05" resname="stats.reports.transport_time_profile.context">
+        <source>stats.reports.transport_time_profile.context</source>
+        <target>{scope} · {period} · {count, number} allocations</target>
+      </trans-unit>
+      <trans-unit id="statsTtp06" resname="stats.reports.transport_time_profile.context_filtered">
+        <source>stats.reports.transport_time_profile.context_filtered</source>
+        <target>{context} · additional filters applied</target>
+      </trans-unit>
+      <trans-unit id="statsTtp07" resname="stats.reports.transport_time_profile.unknown_transport">
+        <source>stats.reports.transport_time_profile.unknown_transport</source>
+        <target>{count, plural, one {# allocation without a usable transport time is excluded from the profile columns.} other {# allocations without a usable transport time are excluded from the profile columns.}}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp08" resname="stats.reports.transport_time_profile.chart.title">
+        <source>stats.reports.transport_time_profile.chart.title</source>
+        <target>Transport-time groups</target>
+      </trans-unit>
+      <trans-unit id="statsTtp09" resname="stats.reports.transport_time_profile.chart.modes">
+        <source>stats.reports.transport_time_profile.chart.modes</source>
+        <target>Chart perspective</target>
+      </trans-unit>
+      <trans-unit id="statsTtp10" resname="stats.reports.transport_time_profile.chart.cases">
+        <source>stats.reports.transport_time_profile.chart.cases</source>
+        <target>Cases</target>
+      </trans-unit>
+      <trans-unit id="statsTtp11" resname="stats.reports.transport_time_profile.chart.gender">
+        <source>stats.reports.transport_time_profile.chart.gender</source>
+        <target>Gender</target>
+      </trans-unit>
+      <trans-unit id="statsTtp12" resname="stats.reports.transport_time_profile.chart.urgency">
+        <source>stats.reports.transport_time_profile.chart.urgency</source>
+        <target>Urgency</target>
+      </trans-unit>
+      <trans-unit id="statsTtp13" resname="stats.reports.transport_time_profile.chart.axis">
+        <source>stats.reports.transport_time_profile.chart.axis</source>
+        <target>Transport time</target>
+      </trans-unit>
+      <trans-unit id="statsTtp14" resname="stats.reports.transport_time_profile.print">
+        <source>stats.reports.transport_time_profile.print</source>
+        <target>Print</target>
+      </trans-unit>
+      <trans-unit id="statsTtp15" resname="stats.reports.transport_time_profile.explorer_link">
+        <source>stats.reports.transport_time_profile.explorer_link</source>
+        <target>Open in Explorer</target>
+      </trans-unit>
+      <trans-unit id="statsTtp16" resname="stats.reports.transport_time_profile.insights.title">
+        <source>stats.reports.transport_time_profile.insights.title</source>
+        <target>Key patterns</target>
+      </trans-unit>
+      <trans-unit id="statsTtp17" resname="stats.reports.transport_time_profile.matrix.title">
+        <source>stats.reports.transport_time_profile.matrix.title</source>
+        <target>Transport time profile</target>
+      </trans-unit>
+      <trans-unit id="statsTtp18" resname="stats.reports.transport_time_profile.matrix.metric">
+        <source>stats.reports.transport_time_profile.matrix.metric</source>
+        <target>Metric</target>
+      </trans-unit>
+      <trans-unit id="statsTtp19" resname="stats.reports.transport_time_profile.section.volume">
+        <source>stats.reports.transport_time_profile.section.volume</source>
+        <target>Volume</target>
+      </trans-unit>
+      <trans-unit id="statsTtp20" resname="stats.reports.transport_time_profile.section.gender">
+        <source>stats.reports.transport_time_profile.section.gender</source>
+        <target>Demographics</target>
+      </trans-unit>
+      <trans-unit id="statsTtp21" resname="stats.reports.transport_time_profile.section.urgency">
+        <source>stats.reports.transport_time_profile.section.urgency</source>
+        <target>Urgency</target>
+      </trans-unit>
+      <trans-unit id="statsTtp22" resname="stats.reports.transport_time_profile.section.departments">
+        <source>stats.reports.transport_time_profile.section.departments</source>
+        <target>Top departments</target>
+      </trans-unit>
+      <trans-unit id="statsTtp23" resname="stats.reports.transport_time_profile.section.specialities">
+        <source>stats.reports.transport_time_profile.section.specialities</source>
+        <target>Top specialties</target>
+      </trans-unit>
+      <trans-unit id="statsTtp24" resname="stats.reports.transport_time_profile.section.indications">
+        <source>stats.reports.transport_time_profile.section.indications</source>
+        <target>Top indications</target>
+      </trans-unit>
+      <trans-unit id="statsTtp25" resname="stats.reports.transport_time_profile.section.physician">
+        <source>stats.reports.transport_time_profile.section.physician</source>
+        <target>Physician involvement</target>
+      </trans-unit>
+      <trans-unit id="statsTtp26" resname="stats.reports.transport_time_profile.section.resources">
+        <source>stats.reports.transport_time_profile.section.resources</source>
+        <target>Resource requirements</target>
+      </trans-unit>
+      <trans-unit id="statsTtp27" resname="stats.reports.transport_time_profile.section.transport_mode">
+        <source>stats.reports.transport_time_profile.section.transport_mode</source>
+        <target>Transport mode</target>
+      </trans-unit>
+      <trans-unit id="statsTtp28" resname="stats.reports.transport_time_profile.metric.cases">
+        <source>stats.reports.transport_time_profile.metric.cases</source>
+        <target>Cases</target>
+      </trans-unit>
+      <trans-unit id="statsTtp29" resname="stats.reports.transport_time_profile.metric.share">
+        <source>stats.reports.transport_time_profile.metric.share</source>
+        <target>Share of total</target>
+      </trans-unit>
+      <trans-unit id="statsTtp30" resname="stats.reports.transport_time_profile.metric.with_physician">
+        <source>stats.reports.transport_time_profile.metric.with_physician</source>
+        <target>With physician</target>
+      </trans-unit>
+      <trans-unit id="statsTtp31" resname="stats.reports.transport_time_profile.metric.requires_resus">
+        <source>stats.reports.transport_time_profile.metric.requires_resus</source>
+        <target>Shock room requested</target>
+      </trans-unit>
+      <trans-unit id="statsTtp53" resname="stats.reports.transport_time_profile.metric.requires_cathlab">
+        <source>stats.reports.transport_time_profile.metric.requires_cathlab</source>
+        <target>Cath lab requested</target>
+      </trans-unit>
+      <trans-unit id="statsTtp32" resname="stats.reports.transport_time_profile.overall">
+        <source>stats.reports.transport_time_profile.overall</source>
+        <target>{percent, number, ::.0}% overall</target>
+      </trans-unit>
+      <trans-unit id="statsTtp33" resname="stats.reports.transport_time_profile.pp">
+        <source>stats.reports.transport_time_profile.pp</source>
+        <target>pp</target>
+      </trans-unit>
+      <trans-unit id="statsTtp34" resname="stats.reports.transport_time_profile.rank.new">
+        <source>stats.reports.transport_time_profile.rank.new</source>
+        <target>new</target>
+      </trans-unit>
+      <trans-unit id="statsTtp35" resname="stats.reports.transport_time_profile.small_n.label">
+        <source>stats.reports.transport_time_profile.small_n.label</source>
+        <target>Small n</target>
+      </trans-unit>
+      <trans-unit id="statsTtp36" resname="stats.reports.transport_time_profile.small_n.hint">
+        <source>stats.reports.transport_time_profile.small_n.hint</source>
+        <target>Small number of cases – interpret with caution</target>
+      </trans-unit>
+      <trans-unit id="statsTtp37" resname="stats.reports.transport_time_profile.disclaimer">
+        <source>stats.reports.transport_time_profile.disclaimer</source>
+        <target>Descriptive analysis of the selected IVENA allocation population. Observed differences do not imply causality.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp38" resname="stats.reports.transport_time_profile.insight.urgency_emergency.title">
+        <source>stats.reports.transport_time_profile.insight.urgency_emergency.title</source>
+        <target>Urgency composition</target>
+      </trans-unit>
+      <trans-unit id="statsTtp39" resname="stats.reports.transport_time_profile.insight.physician.title">
+        <source>stats.reports.transport_time_profile.insight.physician.title</source>
+        <target>Physician accompaniment</target>
+      </trans-unit>
+      <trans-unit id="statsTtp40" resname="stats.reports.transport_time_profile.insight.resus.title">
+        <source>stats.reports.transport_time_profile.insight.resus.title</source>
+        <target>Shock-room requests</target>
+      </trans-unit>
+      <trans-unit id="statsTtp41" resname="stats.reports.transport_time_profile.insight.air.title">
+        <source>stats.reports.transport_time_profile.insight.air.title</source>
+        <target>Air transport</target>
+      </trans-unit>
+      <trans-unit id="statsTtp42" resname="stats.reports.transport_time_profile.insight.metric.urgency_emergency">
+        <source>stats.reports.transport_time_profile.insight.metric.urgency_emergency</source>
+        <target>High-urgency allocations</target>
+      </trans-unit>
+      <trans-unit id="statsTtp43" resname="stats.reports.transport_time_profile.insight.metric.physician">
+        <source>stats.reports.transport_time_profile.insight.metric.physician</source>
+        <target>Physician accompaniment</target>
+      </trans-unit>
+      <trans-unit id="statsTtp44" resname="stats.reports.transport_time_profile.insight.metric.resus">
+        <source>stats.reports.transport_time_profile.insight.metric.resus</source>
+        <target>Shock-room requests</target>
+      </trans-unit>
+      <trans-unit id="statsTtp45" resname="stats.reports.transport_time_profile.insight.metric.air">
+        <source>stats.reports.transport_time_profile.insight.metric.air</source>
+        <target>Air transport</target>
+      </trans-unit>
+      <trans-unit id="statsTtp46" resname="stats.reports.transport_time_profile.insight.rate_increase">
+        <source>stats.reports.transport_time_profile.insight.rate_increase</source>
+        <target>{metric} is more common in the {to_bucket} group ({to_percent}%) than in the {from_bucket} group ({from_percent}%).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp47" resname="stats.reports.transport_time_profile.insight.rate_decrease">
+        <source>stats.reports.transport_time_profile.insight.rate_decrease</source>
+        <target>{metric} is less common in the {to_bucket} group ({to_percent}%) than in the {from_bucket} group ({from_percent}%).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp48" resname="stats.reports.transport_time_profile.insight.rank.title">
+        <source>stats.reports.transport_time_profile.insight.rank.title</source>
+        <target>Ranking change: {label}</target>
+      </trans-unit>
+      <trans-unit id="statsTtp49" resname="stats.reports.transport_time_profile.insight.rank.body">
+        <source>stats.reports.transport_time_profile.insight.rank.body</source>
+        <target>{label} moves from rank {from_rank} in the {from_bucket} group to rank {to_rank} in the {to_bucket} group.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp50" resname="stats.reports.transport_time_profile.insight.air_overrepresented.title">
+        <source>stats.reports.transport_time_profile.insight.air_overrepresented.title</source>
+        <target>Air transport in long transports</target>
+      </trans-unit>
+      <trans-unit id="statsTtp51" resname="stats.reports.transport_time_profile.insight.air_overrepresented.body">
+        <source>stats.reports.transport_time_profile.insight.air_overrepresented.body</source>
+        <target>Air transport is more common in the longest transport-time group ({bucket_percent}%) than in the selected population overall ({overall_percent}%).</target>
+      </trans-unit>
+      <trans-unit id="statsTtp52" resname="stats.reports.transport_time_profile.ranked.title">
+        <source>stats.reports.transport_time_profile.ranked.title</source>
+        <target>Top departments, specialties, and indications</target>
+      </trans-unit>
+      <trans-unit id="statsTtp54" resname="stats.reports.transport_time_profile.insight.cathlab.title">
+        <source>stats.reports.transport_time_profile.insight.cathlab.title</source>
+        <target>Cath-lab requests</target>
+      </trans-unit>
+      <trans-unit id="statsTtp55" resname="stats.reports.transport_time_profile.insight.metric.cathlab">
+        <source>stats.reports.transport_time_profile.insight.metric.cathlab</source>
+        <target>Cath-lab requests</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary

Adds a **Transport Time Profile** report under `/statistics/reports/transport_time_profile`. It shows how case mix changes across transport-time buckets (under 10 minutes through over 60), so users can see which diagnoses, departments, and clinical flags become more or less common as transport time increases.

The report sits next to the monthly report in the catalog. It uses the same scope and period controls as the dashboard (not month-only). A link opens the matching Analysis Explorer view. The statistics filter drawer is hidden here, because the matrix is already a full cross-section.

### What you see
- A bar chart of case counts, with switches for gender and urgency mix
- Up to four conservative, descriptive insights (no causal language)
- A heatmap matrix of volume, gender, urgency, physician, resource requests (shock room and cath lab), and transport mode
- Ranked top-5 departments, specialities, and indications per bucket, with rank movement between columns
- Small-n flags when a bucket has fewer than 10 cases
- A note when some allocations have no usable transport time

Rates are **within-bucket shares** (denominator = cases in that bucket), compared with the overall mix in percentage points. Heatmap colors are diverging (higher/lower than overall), not traffic-light good/bad.

Print/PDF is intentionally not included. Safari could not produce a reliable A4 layout for this wide matrix.

### Implementation
- New `ReportType` wired through the existing report registry
- One projection `UNION ALL` query for volume, composition, and top-N per bucket
- Shared transport-time bucket mapping aligned with the rest of statistics
- German and English copy for the report; monthly catalog blurb shortened to “concise summary of a completed calendar month”

## Test plan

- [x] Open **Reports** and confirm both Monthly report and Transport Time Profile appear in the catalog
- [x] Open Transport Time Profile with no data and confirm the empty state plus Explorer link
- [x] With allocations that have arrival times, confirm chart, matrix, ranked tables, and disclaimer render
- [x] Switch chart modes (cases / gender / urgency)
- [x] Change scope and period (all / year / month) and confirm the page updates; heading should not duplicate the period (period stays in the controls)
- [x] Confirm the filter drawer is **not** shown on this report, but still works on the monthly report
- [x] Confirm small-n and unknown-transport notes appear when those cases exist
- [ ] Follow the Explorer link and a ranked indication/department cell into the existing analytics pages