### PR TITLE
feat(statistics): Enhance visual highlighting in the transport time profile report

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -605,32 +605,87 @@
     margin-top: 0.15rem;
 }
 
+.stats-ttp-marker {
+    display: flex;
+    align-items: center;
+    gap: 0.15rem;
+    width: fit-content;
+    margin-top: 0.15rem;
+    margin-left: auto;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 500;
+    white-space: nowrap;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+}
+
+.stats-ttp-marker .icon {
+    width: 0.85rem;
+    height: 0.85rem;
+}
+
+.stats-ttp-ranked-td .stats-ttp-marker {
+    margin-left: 0;
+}
+
 .stats-ttp-small-n {
     opacity: 0.7;
 }
 
+.stats-ttp-heat-low-1,
+.stats-ttp-heat-low-2,
+.stats-ttp-heat-low-3,
+.stats-ttp-heat-high-1,
+.stats-ttp-heat-high-2,
+.stats-ttp-heat-high-3,
+.stats-ttp-rank-shift-up,
+.stats-ttp-rank-shift-down,
+.stats-ttp-rank-shift-new {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+}
+
 .stats-ttp-heat-low-1 {
-    background-color: rgba(32, 107, 196, 0.08);
+    background-color: rgba(214, 57, 57, 0.08);
+    border-left: 2px solid rgba(214, 57, 57, 0.38);
 }
 
 .stats-ttp-heat-low-2 {
-    background-color: rgba(32, 107, 196, 0.16);
+    background-color: rgba(214, 57, 57, 0.16);
+    border-left: 3px solid rgba(214, 57, 57, 0.55);
 }
 
 .stats-ttp-heat-low-3 {
-    background-color: rgba(32, 107, 196, 0.28);
+    background-color: rgba(214, 57, 57, 0.28);
+    border-left: 4px solid rgba(214, 57, 57, 0.78);
 }
 
 .stats-ttp-heat-high-1 {
-    background-color: rgba(250, 176, 5, 0.12);
+    background-color: rgba(47, 179, 68, 0.10);
+    border-left: 2px solid rgba(47, 179, 68, 0.40);
 }
 
 .stats-ttp-heat-high-2 {
-    background-color: rgba(250, 176, 5, 0.22);
+    background-color: rgba(47, 179, 68, 0.18);
+    border-left: 3px solid rgba(47, 179, 68, 0.58);
 }
 
 .stats-ttp-heat-high-3 {
-    background-color: rgba(250, 176, 5, 0.34);
+    background-color: rgba(47, 179, 68, 0.30);
+    border-left: 4px solid rgba(47, 179, 68, 0.82);
+}
+
+.stats-ttp-rank-shift-up {
+    border-left: 3px solid rgba(47, 179, 68, 0.85);
+}
+
+.stats-ttp-rank-shift-down {
+    border-left: 3px solid rgba(214, 57, 57, 0.85);
+}
+
+.stats-ttp-rank-shift-new {
+    border-left: 3px solid rgba(32, 107, 196, 0.75);
 }
 
 .stats-ttp-insight {

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileCell.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileCell.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
 
+use App\Statistics\Application\SummarizedReport\TransportTimeProfile\TransportTimeProfileMath;
+
 final readonly class TransportTimeProfileCell
 {
     public function __construct(
@@ -27,5 +29,20 @@ final readonly class TransportTimeProfileCell
         return null === $this->count
             && null === $this->percent
             && null === $this->entityLabel;
+    }
+
+    public function deltaBadgeClass(): string
+    {
+        return TransportTimeProfileMath::deltaBadgeClass($this->heatClass);
+    }
+
+    public function rankBadgeClass(): string
+    {
+        return TransportTimeProfileMath::rankBadgeClass($this->rankDelta, $this->enteredTop);
+    }
+
+    public function rankShiftClass(): string
+    {
+        return TransportTimeProfileMath::rankShiftClass($this->rankDelta, $this->enteredTop);
     }
 }

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileInsight.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/Dto/TransportTimeProfileInsight.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto;
 
+use App\Statistics\Application\Insights\HospitalInsightTrend;
+
 final readonly class TransportTimeProfileInsight
 {
     public function __construct(
         public string $id,
         public string $title,
         public string $body,
+        public HospitalInsightTrend $trend,
     ) {
     }
 }

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileInsightGenerator.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileInsightGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Statistics\Application\SummarizedReport\TransportTimeProfile;
 
+use App\Statistics\Application\Insights\HospitalInsightTrend;
 use App\Statistics\Application\Mapping\StatisticsTransportTimeBucketSql;
 use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight;
 use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
@@ -217,6 +218,7 @@ final readonly class TransportTimeProfileInsightGenerator
                 'statistics',
                 $locale,
             ),
+            $delta > 0 ? HospitalInsightTrend::Up : HospitalInsightTrend::Down,
         );
     }
 
@@ -277,6 +279,7 @@ final readonly class TransportTimeProfileInsightGenerator
                     'statistics',
                     $locale,
                 ),
+                $rankChange > 0 ? HospitalInsightTrend::Up : HospitalInsightTrend::Down,
             );
 
             return;
@@ -332,6 +335,7 @@ final readonly class TransportTimeProfileInsightGenerator
                 'statistics',
                 $locale,
             ),
+            HospitalInsightTrend::Up,
         );
     }
 }

--- a/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileMath.php
+++ b/src/Statistics/Application/SummarizedReport/TransportTimeProfile/TransportTimeProfileMath.php
@@ -57,4 +57,43 @@ final class TransportTimeProfileMath
 
         return 'stats-ttp-heat-'.$direction.'-'.$level;
     }
+
+    public static function deltaBadgeClass(string $heatClass): string
+    {
+        if (str_contains($heatClass, 'high')) {
+            return 'bg-green-lt';
+        }
+
+        if (str_contains($heatClass, 'low')) {
+            return 'bg-red-lt';
+        }
+
+        return '';
+    }
+
+    public static function rankBadgeClass(?int $rankDelta, bool $enteredTop): string
+    {
+        if ($enteredTop) {
+            return 'bg-blue-lt';
+        }
+
+        if (null === $rankDelta || 0 === $rankDelta) {
+            return '';
+        }
+
+        return $rankDelta > 0 ? 'bg-green-lt' : 'bg-red-lt';
+    }
+
+    public static function rankShiftClass(?int $rankDelta, bool $enteredTop): string
+    {
+        if ($enteredTop) {
+            return 'stats-ttp-rank-shift-new';
+        }
+
+        if (null === $rankDelta || abs($rankDelta) < self::INSIGHT_MIN_RANK_CHANGE) {
+            return '';
+        }
+
+        return $rankDelta > 0 ? 'stats-ttp-rank-shift-up' : 'stats-ttp-rank-shift-down';
+    }
 }

--- a/src/Statistics/UI/Twig/templates/reports/types/_transport_time_profile_table.html.twig
+++ b/src/Statistics/UI/Twig/templates/reports/types/_transport_time_profile_table.html.twig
@@ -26,7 +26,7 @@
                             {% endif %}
                         </th>
                         {% for bucket, cell in row.cells %}
-                            <td class="{{ row.kind == 'ranked' ? 'stats-ttp-ranked-td' : 'text-end' }} {{ cell.heatClass }}{% if cell.smallSample %} stats-ttp-small-n{% endif %}">
+                            <td class="{{ row.kind == 'ranked' ? 'stats-ttp-ranked-td' : 'text-end' }} {{ cell.heatClass }} {{ cell.rankShiftClass }}{% if cell.smallSample %} stats-ttp-small-n{% endif %}">
                                 {% if cell.isEmpty %}
                                     <span class="text-secondary">—</span>
                                 {% elseif row.kind == 'count' %}
@@ -41,23 +41,50 @@
                                         <div class="small text-secondary stats-ttp-ranked-meta">
                                             {{ cell.percent|number_format(1, ',', '.') }}%
                                             · #{{ cell.rank }}
-                                            {% if cell.enteredTop %}
-                                                · {{ 'stats.reports.transport_time_profile.rank.new'|trans({}, 'statistics') }}
-                                            {% elseif cell.rankDelta is not null and cell.rankDelta != 0 %}
-                                                · {{ cell.rankDelta > 0 ? '↑' : '↓' }}{{ cell.rankDelta|abs }}
-                                            {% endif %}
                                         </div>
-                                    </div>
-                                {% else %}
-                                    <span title="n={{ cell.count }}">
-                                        {{ cell.percent|number_format(1, ',', '.') }}%
-                                        {% if cell.deltaPp is not null %}
-                                            <span class="d-block small text-secondary">
-                                                {{ cell.deltaPp > 0 ? '+' : '' }}{{ cell.deltaPp|number_format(1, ',', '.') }}
-                                                {{ 'stats.reports.transport_time_profile.pp'|trans({}, 'statistics') }}
+                                        {% if cell.enteredTop %}
+                                            <span class="badge {{ cell.rankBadgeClass }} stats-ttp-marker"
+                                                  data-testid="stats-ttp-rank-badge"
+                                                  aria-label="{{ 'stats.reports.transport_time_profile.rank.aria.new'|trans({}, 'statistics') }}">
+                                                <span class="text-blue" aria-hidden="true">
+                                                    <twig:ux:icon name="tabler:circle-filled" class="icon icon-xs" />
+                                                </span>
+                                                {{ 'stats.reports.transport_time_profile.rank.new'|trans({}, 'statistics') }}
+                                            </span>
+                                        {% elseif cell.rankDelta is not null and cell.rankDelta != 0 %}
+                                            <span class="badge {{ cell.rankBadgeClass }} stats-ttp-marker"
+                                                  data-testid="stats-ttp-rank-badge"
+                                                  aria-label="{{ (cell.rankDelta > 0 ? 'stats.reports.transport_time_profile.rank.aria.up' : 'stats.reports.transport_time_profile.rank.aria.down')|trans({delta: cell.rankDelta|abs}, 'statistics') }}">
+                                                <span class="{{ cell.rankDelta > 0 ? 'text-success' : 'text-danger' }}" aria-hidden="true">
+                                                    {% if cell.rankDelta > 0 %}
+                                                        <twig:ux:icon name="tabler:arrow-up" class="icon icon-sm" />
+                                                    {% else %}
+                                                        <twig:ux:icon name="tabler:arrow-down" class="icon icon-sm" />
+                                                    {% endif %}
+                                                </span>
+                                                {{ cell.rankDelta|abs }}
                                             </span>
                                         {% endif %}
-                                    </span>
+                                    </div>
+                                {% else %}
+                                    <div class="d-flex flex-column align-items-end gap-1 w-100" title="n={{ cell.count }}">
+                                        <div>{{ cell.percent|number_format(1, ',', '.') }}%</div>
+                                        {% if cell.deltaBadgeClass %}
+                                            {% set deltaLabel = (cell.deltaPp > 0 ? '+' : '') ~ cell.deltaPp|number_format(1, ',', '.') ~ '%' %}
+                                            <span class="badge {{ cell.deltaBadgeClass }} stats-ttp-marker"
+                                                  data-testid="stats-ttp-delta-badge"
+                                                  aria-label="{{ 'stats.reports.transport_time_profile.delta.aria'|trans({delta: deltaLabel}, 'statistics') }}">
+                                                <span class="{{ cell.deltaPp > 0 ? 'text-success' : 'text-danger' }}" aria-hidden="true">
+                                                    {% if cell.deltaPp > 0 %}
+                                                        <twig:ux:icon name="tabler:arrow-up" class="icon icon-sm" />
+                                                    {% else %}
+                                                        <twig:ux:icon name="tabler:arrow-down" class="icon icon-sm" />
+                                                    {% endif %}
+                                                </span>
+                                                {{ deltaLabel }}
+                                            </span>
+                                        {% endif %}
+                                    </div>
                                 {% endif %}
                                 {% if cell.smallSample %}
                                     <span class="d-block small text-secondary" title="{{ 'stats.reports.transport_time_profile.small_n.hint'|trans({}, 'statistics') }}">

--- a/src/Statistics/UI/Twig/templates/reports/types/transport_time_profile.html.twig
+++ b/src/Statistics/UI/Twig/templates/reports/types/transport_time_profile.html.twig
@@ -84,9 +84,22 @@
                         </div>
                         <div class="list-group list-group-flush">
                             {% for insight in report.insights %}
-                                <div class="list-group-item stats-ttp-insight" data-testid="stats-ttp-insight">
-                                    <div class="fw-bold">{{ insight.title }}</div>
-                                    <div class="text-muted small">{{ insight.body }}</div>
+                                <div class="list-group-item stats-ttp-insight d-flex align-items-start gap-2" data-testid="stats-ttp-insight">
+                                    <span class="mt-1 flex-shrink-0 {% if insight.trend.value == 'up' %}text-success{% elseif insight.trend.value == 'down' %}text-danger{% else %}text-secondary{% endif %}"
+                                          data-testid="stats-ttp-insight-trend"
+                                          aria-hidden="true">
+                                        {% if insight.trend.value == 'up' %}
+                                            <twig:ux:icon name="tabler:arrow-up" class="icon icon-sm" />
+                                        {% elseif insight.trend.value == 'down' %}
+                                            <twig:ux:icon name="tabler:arrow-down" class="icon icon-sm" />
+                                        {% else %}
+                                            <twig:ux:icon name="tabler:circle-filled" class="icon icon-xs" />
+                                        {% endif %}
+                                    </span>
+                                    <div class="min-w-0">
+                                        <div class="fw-bold">{{ insight.title }}</div>
+                                        <div class="text-muted small">{{ insight.body }}</div>
+                                    </div>
                                 </div>
                             {% endfor %}
                         </div>
@@ -96,8 +109,11 @@
         </div>
 
         <div class="card" data-testid="stats-ttp-matrix-card">
-            <div class="card-header">
+            <div class="card-header d-flex flex-column align-items-stretch gap-2">
                 <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.matrix.title'|trans({}, 'statistics') }}</h3>
+                <p class="text-secondary small mb-0" data-testid="stats-ttp-matrix-legend">
+                    {{ 'stats.reports.transport_time_profile.matrix.legend'|trans({}, 'statistics') }}
+                </p>
             </div>
             <div class="card-body p-0">
                 {{ include('@Statistics/reports/types/_transport_time_profile_table.html.twig', {sections: report.matrixSections}) }}
@@ -106,17 +122,16 @@
 
         {% if report.rankedSections is not empty %}
             <div class="card mt-3" data-testid="stats-ttp-ranked-card">
-                <div class="card-header">
+                <div class="card-header d-flex flex-column align-items-stretch gap-2">
                     <h3 class="card-title mb-0">{{ 'stats.reports.transport_time_profile.ranked.title'|trans({}, 'statistics') }}</h3>
+                    <p class="text-secondary small mb-0" data-testid="stats-ttp-ranked-legend">
+                        {{ 'stats.reports.transport_time_profile.ranked.legend'|trans({}, 'statistics') }}
+                    </p>
                 </div>
                 <div class="card-body p-0">
                     {{ include('@Statistics/reports/types/_transport_time_profile_table.html.twig', {sections: report.rankedSections}) }}
                 </div>
             </div>
         {% endif %}
-
-        <p class="text-secondary small mt-3 stats-ttp-disclaimer" data-testid="stats-ttp-disclaimer">
-            {{ 'stats.reports.transport_time_profile.disclaimer'|trans({}, 'statistics') }}
-        </p>
     {% endif %}
 </div>

--- a/tests/Statistics/Functional/Controller/ReportsControllerTest.php
+++ b/tests/Statistics/Functional/Controller/ReportsControllerTest.php
@@ -195,6 +195,7 @@ final class ReportsControllerTest extends WebTestCase
             'location' => HospitalLocation::URBAN,
         ]);
         $department = DepartmentFactory::createOne(['name' => 'TtpCtrlDept']);
+        $longHaulDepartment = DepartmentFactory::createOne(['name' => 'TtpCtrlLongDept']);
         SpecialityFactory::createOne(['name' => 'TtpCtrlSpec']);
         AssignmentFactory::createOne(['name' => 'TtpCtrlAssign']);
         IndicationRawFactory::createOne(['name' => 'TtpCtrlRaw', 'code' => 912_361]);
@@ -219,7 +220,7 @@ final class ReportsControllerTest extends WebTestCase
             'dispatchArea' => $dispatchArea,
             'gender' => AllocationGender::MALE,
             'urgency' => AllocationUrgency::EMERGENCY,
-            'department' => $department,
+            'department' => $longHaulDepartment,
             'createdAt' => new \DateTimeImmutable('2025-06-15 11:00:00'),
             'arrivalAt' => new \DateTimeImmutable('2025-06-15 12:10:00'),
         ]);
@@ -252,10 +253,14 @@ final class ReportsControllerTest extends WebTestCase
         $this->assertSelectorExists('[data-testid="stats-ttp-chart-modes"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-matrix-card"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-ranked-card"]');
-        $this->assertSelectorExists('[data-testid="stats-ttp-disclaimer"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-unknown-note"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-row-volume-cases"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-row-resources-requires_cathlab"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-matrix-legend"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-ranked-legend"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-delta-badge"]');
+        $this->assertSelectorExists('[data-testid="stats-ttp-delta-badge"] .text-success, [data-testid="stats-ttp-delta-badge"] .text-danger');
+        $this->assertSelectorExists('[data-testid="stats-ttp-rank-badge"]');
         $this->assertSelectorExists('[data-testid="stats-ttp-explorer-link"]');
         $this->assertStringContainsString(
             'generic-analysis-chart',

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileAssemblerTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileAssemblerTest.php
@@ -30,6 +30,10 @@ final class TransportTimeProfileAssemblerTest extends TestCase
         self::assertSame(25.0, $emergency->overallPercent);
         self::assertSame(-15.0, $emergency->cells['under_10']->deltaPp);
         self::assertSame(15.0, $emergency->cells['over_60']->deltaPp);
+        self::assertSame('stats-ttp-heat-low-3', $emergency->cells['under_10']->heatClass);
+        self::assertSame('stats-ttp-heat-high-3', $emergency->cells['over_60']->heatClass);
+        self::assertSame('bg-red-lt', $emergency->cells['under_10']->deltaBadgeClass());
+        self::assertSame('bg-green-lt', $emergency->cells['over_60']->deltaBadgeClass());
     }
 
     public function testTopFiveIsRankedIndependentlyPerBucket(): void
@@ -76,8 +80,12 @@ final class TransportTimeProfileAssemblerTest extends TestCase
         self::assertSame('Internal', $rank1->cells['under_10']->entityLabel);
         self::assertSame('Neurology', $rank1->cells['over_60']->entityLabel);
         self::assertSame(2, $rank1->cells['over_60']->rankDelta);
+        self::assertSame('stats-ttp-rank-shift-up', $rank1->cells['over_60']->rankShiftClass());
+        self::assertSame('bg-green-lt', $rank1->cells['over_60']->rankBadgeClass());
         self::assertSame('Neurology', $rank3->cells['under_10']->entityLabel);
         self::assertTrue($rank3->cells['over_60']->enteredTop);
+        self::assertSame('stats-ttp-rank-shift-new', $rank3->cells['over_60']->rankShiftClass());
+        self::assertSame('bg-blue-lt', $rank3->cells['over_60']->rankBadgeClass());
         self::assertSame('Trauma', $rank3->cells['over_60']->entityLabel);
         self::assertSame(40.0, $rank1->cells['under_10']->percent);
         self::assertSame(50.0, $rank1->cells['over_60']->percent);

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileInsightGeneratorTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileInsightGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Statistics\Unit\SummarizedReport;
 
+use App\Statistics\Application\Insights\HospitalInsightTrend;
 use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileCell;
 use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixRow;
 use App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileMatrixSection;
@@ -26,6 +27,7 @@ final class TransportTimeProfileInsightGeneratorTest extends TestCase
 
         self::assertNotEmpty($insights);
         self::assertSame('urgency_emergency', $insights[0]->id);
+        self::assertSame(HospitalInsightTrend::Up, $insights[0]->trend);
         self::assertStringContainsString('rate_increase', $insights[0]->body);
         self::assertStringNotContainsString('require', strtolower($insights[0]->body));
         self::assertStringNotContainsString('cause', strtolower($insights[0]->body));
@@ -81,6 +83,11 @@ final class TransportTimeProfileInsightGeneratorTest extends TestCase
         $ids = array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): string => $insight->id, $insights);
         self::assertContains('departments_1', $ids);
         self::assertNotContains('departments_2', $ids);
+        $rankInsight = array_values(array_filter(
+            $insights,
+            static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): bool => 'departments_1' === $insight->id,
+        ))[0];
+        self::assertSame(HospitalInsightTrend::Down, $rankInsight->trend);
     }
 
     public function testCathlabRateSpanUsesResourcesSection(): void
@@ -120,8 +127,13 @@ final class TransportTimeProfileInsightGeneratorTest extends TestCase
 
         $ids = array_map(static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): string => $insight->id, $insights);
         self::assertContains('urgency_emergency', $ids);
+        self::assertSame(HospitalInsightTrend::Down, $insights[0]->trend);
         self::assertStringContainsString('rate_decrease', $insights[0]->body);
-        self::assertContains('air_overrepresented', $ids);
+        $airInsight = array_values(array_filter(
+            $insights,
+            static fn (\App\Statistics\Application\SummarizedReport\TransportTimeProfile\Dto\TransportTimeProfileInsight $insight): bool => 'air_overrepresented' === $insight->id,
+        ))[0];
+        self::assertSame(HospitalInsightTrend::Up, $airInsight->trend);
         self::assertLessThanOrEqual(4, \count($insights));
     }
 

--- a/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileMathTest.php
+++ b/tests/Statistics/Unit/SummarizedReport/TransportTimeProfileMathTest.php
@@ -40,12 +40,39 @@ final class TransportTimeProfileMathTest extends TestCase
         self::assertSame('stats-ttp-heat-high-2', TransportTimeProfileMath::heatClass(20.0, true));
     }
 
-    public function testHeatClassIsDivergingNotNormative(): void
+    public function testHeatClassUsesHighLowDirection(): void
     {
         self::assertSame('', TransportTimeProfileMath::heatClass(0.0, false));
         self::assertStringContainsString('high', TransportTimeProfileMath::heatClass(16.3, false));
         self::assertStringContainsString('low', TransportTimeProfileMath::heatClass(-16.3, false));
-        self::assertStringNotContainsString('success', TransportTimeProfileMath::heatClass(16.3, false));
-        self::assertStringNotContainsString('danger', TransportTimeProfileMath::heatClass(-16.3, false));
+    }
+
+    public function testDeltaBadgeClassMapsHeatToSuccessAndDanger(): void
+    {
+        self::assertSame('bg-green-lt', TransportTimeProfileMath::deltaBadgeClass('stats-ttp-heat-high-2'));
+        self::assertSame('bg-red-lt', TransportTimeProfileMath::deltaBadgeClass('stats-ttp-heat-low-1'));
+        self::assertSame('', TransportTimeProfileMath::deltaBadgeClass(''));
+    }
+
+    public function testRankBadgeClassUsesSuccessDangerAndNeutralBlue(): void
+    {
+        self::assertSame('', TransportTimeProfileMath::rankBadgeClass(null, false));
+        self::assertSame('', TransportTimeProfileMath::rankBadgeClass(0, false));
+        self::assertSame('bg-green-lt', TransportTimeProfileMath::rankBadgeClass(1, false));
+        self::assertSame('bg-red-lt', TransportTimeProfileMath::rankBadgeClass(-1, false));
+        self::assertSame('bg-blue-lt', TransportTimeProfileMath::rankBadgeClass(null, true));
+        self::assertSame('bg-blue-lt', TransportTimeProfileMath::rankBadgeClass(3, true));
+    }
+
+    public function testRankShiftClassUsesInsightThreshold(): void
+    {
+        self::assertSame('', TransportTimeProfileMath::rankShiftClass(null, false));
+        self::assertSame('', TransportTimeProfileMath::rankShiftClass(0, false));
+        self::assertSame('', TransportTimeProfileMath::rankShiftClass(1, false));
+        self::assertSame('', TransportTimeProfileMath::rankShiftClass(-1, false));
+        self::assertSame('stats-ttp-rank-shift-up', TransportTimeProfileMath::rankShiftClass(2, false));
+        self::assertSame('stats-ttp-rank-shift-down', TransportTimeProfileMath::rankShiftClass(-2, false));
+        self::assertSame('stats-ttp-rank-shift-new', TransportTimeProfileMath::rankShiftClass(null, true));
+        self::assertSame('stats-ttp-rank-shift-new', TransportTimeProfileMath::rankShiftClass(3, true));
     }
 }

--- a/translations/statistics+intl-icu.de.xlf
+++ b/translations/statistics+intl-icu.de.xlf
@@ -5345,10 +5345,6 @@
         <source>stats.reports.transport_time_profile.overall</source>
         <target>{percent, number, ::.0} % insgesamt</target>
       </trans-unit>
-      <trans-unit id="statsTtp33" resname="stats.reports.transport_time_profile.pp">
-        <source>stats.reports.transport_time_profile.pp</source>
-        <target>pp</target>
-      </trans-unit>
       <trans-unit id="statsTtp34" resname="stats.reports.transport_time_profile.rank.new">
         <source>stats.reports.transport_time_profile.rank.new</source>
         <target>neu</target>
@@ -5360,10 +5356,6 @@
       <trans-unit id="statsTtp36" resname="stats.reports.transport_time_profile.small_n.hint">
         <source>stats.reports.transport_time_profile.small_n.hint</source>
         <target>Kleine Fallzahl – vorsichtig interpretieren</target>
-      </trans-unit>
-      <trans-unit id="statsTtp37" resname="stats.reports.transport_time_profile.disclaimer">
-        <source>stats.reports.transport_time_profile.disclaimer</source>
-        <target>Deskriptive Analyse der ausgewählten IVENA-Zuweisungspopulation. Beobachtete Unterschiede implizieren keine Kausalität.</target>
       </trans-unit>
       <trans-unit id="statsTtp38" resname="stats.reports.transport_time_profile.insight.urgency_emergency.title">
         <source>stats.reports.transport_time_profile.insight.urgency_emergency.title</source>
@@ -5432,6 +5424,30 @@
       <trans-unit id="statsTtp55" resname="stats.reports.transport_time_profile.insight.metric.cathlab">
         <source>stats.reports.transport_time_profile.insight.metric.cathlab</source>
         <target>Herzkatheteranforderungen</target>
+      </trans-unit>
+      <trans-unit id="statsTtp56" resname="stats.reports.transport_time_profile.matrix.legend">
+        <source>stats.reports.transport_time_profile.matrix.legend</source>
+        <target>Badges zeigen Abweichungen gegenüber der Gesamtpopulation. Grün = höher, Rot = niedriger.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp57" resname="stats.reports.transport_time_profile.ranked.legend">
+        <source>stats.reports.transport_time_profile.ranked.legend</source>
+        <target>Grüne Pfeile: Anstieg, rote Pfeile: Rückgang gegenüber der vorherigen Transportzeit-Gruppe.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp58" resname="stats.reports.transport_time_profile.delta.aria">
+        <source>stats.reports.transport_time_profile.delta.aria</source>
+        <target>{delta} gegenüber der Gesamtpopulation</target>
+      </trans-unit>
+      <trans-unit id="statsTtp59" resname="stats.reports.transport_time_profile.rank.aria.up">
+        <source>stats.reports.transport_time_profile.rank.aria.up</source>
+        <target>Rang +{delta} gegenüber der vorherigen Zeitgruppe</target>
+      </trans-unit>
+      <trans-unit id="statsTtp60" resname="stats.reports.transport_time_profile.rank.aria.down">
+        <source>stats.reports.transport_time_profile.rank.aria.down</source>
+        <target>Rang −{delta} gegenüber der vorherigen Zeitgruppe</target>
+      </trans-unit>
+      <trans-unit id="statsTtp61" resname="stats.reports.transport_time_profile.rank.aria.new">
+        <source>stats.reports.transport_time_profile.rank.aria.new</source>
+        <target>Neu in den Top 5 gegenüber der vorherigen Zeitgruppe</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/statistics+intl-icu.en.xlf
+++ b/translations/statistics+intl-icu.en.xlf
@@ -5345,10 +5345,6 @@
         <source>stats.reports.transport_time_profile.overall</source>
         <target>{percent, number, ::.0}% overall</target>
       </trans-unit>
-      <trans-unit id="statsTtp33" resname="stats.reports.transport_time_profile.pp">
-        <source>stats.reports.transport_time_profile.pp</source>
-        <target>pp</target>
-      </trans-unit>
       <trans-unit id="statsTtp34" resname="stats.reports.transport_time_profile.rank.new">
         <source>stats.reports.transport_time_profile.rank.new</source>
         <target>new</target>
@@ -5360,10 +5356,6 @@
       <trans-unit id="statsTtp36" resname="stats.reports.transport_time_profile.small_n.hint">
         <source>stats.reports.transport_time_profile.small_n.hint</source>
         <target>Small number of cases – interpret with caution</target>
-      </trans-unit>
-      <trans-unit id="statsTtp37" resname="stats.reports.transport_time_profile.disclaimer">
-        <source>stats.reports.transport_time_profile.disclaimer</source>
-        <target>Descriptive analysis of the selected IVENA allocation population. Observed differences do not imply causality.</target>
       </trans-unit>
       <trans-unit id="statsTtp38" resname="stats.reports.transport_time_profile.insight.urgency_emergency.title">
         <source>stats.reports.transport_time_profile.insight.urgency_emergency.title</source>
@@ -5432,6 +5424,30 @@
       <trans-unit id="statsTtp55" resname="stats.reports.transport_time_profile.insight.metric.cathlab">
         <source>stats.reports.transport_time_profile.insight.metric.cathlab</source>
         <target>Cath-lab requests</target>
+      </trans-unit>
+      <trans-unit id="statsTtp56" resname="stats.reports.transport_time_profile.matrix.legend">
+        <source>stats.reports.transport_time_profile.matrix.legend</source>
+        <target>Badges highlight deviations from the overall population. Green is higher, red is lower.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp57" resname="stats.reports.transport_time_profile.ranked.legend">
+        <source>stats.reports.transport_time_profile.ranked.legend</source>
+        <target>Green arrows show an increase, red arrows a decrease versus the previous transport-time group.</target>
+      </trans-unit>
+      <trans-unit id="statsTtp58" resname="stats.reports.transport_time_profile.delta.aria">
+        <source>stats.reports.transport_time_profile.delta.aria</source>
+        <target>{delta} versus the overall population</target>
+      </trans-unit>
+      <trans-unit id="statsTtp59" resname="stats.reports.transport_time_profile.rank.aria.up">
+        <source>stats.reports.transport_time_profile.rank.aria.up</source>
+        <target>Rank +{delta} versus the previous transport-time group</target>
+      </trans-unit>
+      <trans-unit id="statsTtp60" resname="stats.reports.transport_time_profile.rank.aria.down">
+        <source>stats.reports.transport_time_profile.rank.aria.down</source>
+        <target>Rank −{delta} versus the previous transport-time group</target>
+      </trans-unit>
+      <trans-unit id="statsTtp61" resname="stats.reports.transport_time_profile.rank.aria.new">
+        <source>stats.reports.transport_time_profile.rank.aria.new</source>
+        <target>New in the top 5 versus the previous transport-time group</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary
- Make composition shifts in the Transport Time Profile scannable with compact badges, direction arrows, and green/red highlighting for notable deviations from the overall population (blue for entities newly entering the Top 5).
- Place share-change badges on their own line under the percentage, and mark notable patterns with the same up/down arrows used on the overview.
- Add short table legends for that meaning, and remove the unused causality disclaimer.

## Test plan
- [x] Open the Transport Time Profile with enough data to see composition rows and Top-5 sections
- [x] Confirm notable cells show `+x,x%` / `-x,x%` badges below the share, with green up / red down arrows
- [x] Confirm Top-5 rank changes use the same colors, and “new” entries are blue
- [x] Confirm notable patterns in the sidebar have matching trend arrows
- [x] Check the table header legend sits below the title with spacing, and the old disclaimer is gone
- [x] Spot-check grayscale/print: signed percentages and arrows remain readable without color