### PR TITLE
feat: Turn the home dashboard into a project overview

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -61,6 +61,7 @@ security:
         - { path: ^/explore/indication/raw/assign, roles: ROLE_PARTICIPANT }
         - { path: ^/explore, roles: ROLE_PARTICIPANT }
         - { path: ^/statistics, roles: ROLE_USER }
+        - { path: ^/dashboard, roles: ROLE_USER }
         - { path: ^/_components, roles: ROLE_USER }
         - { path: ^/login/confirm, roles: IS_AUTHENTICATED_REMEMBERED }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -202,11 +202,7 @@ deptrac:
       - App\Content\Infrastructure\Repository\PostRepository
       - App\Content\Infrastructure\Repository\PostTagRepository
     App\Content\UI\Http\Controller\DefaultController:
-      - App\Allocation\Infrastructure\Repository\AllocationRepository
-      - App\Allocation\Infrastructure\Repository\HospitalRepository
       - App\Content\Infrastructure\Repository\PostRepository
-      - App\Import\Infrastructure\Repository\ImportRepository
-      - App\Onboarding\Application\OnboardingProgressService
     App\Content\UI\Http\Controller\PageController:
       - App\Content\Infrastructure\Repository\PageRepository
     App\Engagement\Application\MonthlyReminderSender:

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -505,11 +505,14 @@ deptrac:
             - User_Infrastructure
             - User_UI
         Content_Application:
+            - Allocation_Infrastructure
             - Content_Domain
+            - Import_Infrastructure
             - Shared_Application
             - Shared_Domain
             - Shared_Infrastructure
             - Shared_UI
+            - Statistics_Infrastructure
             - User_Application
             - User_Domain
             - User_Infrastructure
@@ -537,6 +540,7 @@ deptrac:
         Content_UI:
             - Content_Application
             - Content_Domain
+            - Onboarding_Application
             - Shared_Application
             - Shared_Domain
             - Shared_Infrastructure

--- a/docs/02-architecture/bounded-contexts.md
+++ b/docs/02-architecture/bounded-contexts.md
@@ -14,7 +14,7 @@ Each bounded context under `src/` follows the layered structure described in [ov
 | `Analytics` | Server-side usage analytics (request tracking, consent-gated visitor keys) |
 | `Install` | `app:install`, `app:env:check` |
 | `Shared` | Cross-cutting concerns (audit, monitoring, mail, infrastructure) |
-| `Content` | Content pages and blog |
+| `Content` | Content pages, blog, and the authenticated home dashboard (composition of project metrics and activity) |
 | `Onboarding` | Participant dashboard onboarding steps and progress |
 | `Engagement` | Monthly submission reminders and related mail content |
 | `DataFixtures` | Reference YAML, pattern-based demo data, dev/test fixture groups |

--- a/docs/04-features/README.md
+++ b/docs/04-features/README.md
@@ -12,6 +12,7 @@
 | [statistics/](statistics/) | Projection, explorer, data quality, dashboards |
 | [allocation/](allocation/) | Allocation exploration, indication normalization |
 | [onboarding/](onboarding/) | Participant onboarding checklist |
+| [content/](content/) | Pages, translations, home dashboard overview |
 | [kpi/](kpi/) | Daily KPI aggregation |
 | [analytics/](analytics/) | Server-side usage analytics |
 

--- a/docs/04-features/content/README.md
+++ b/docs/04-features/content/README.md
@@ -1,0 +1,8 @@
+# Content
+
+**Audience:** Developers working on pages, blog, and the home dashboard.
+
+| Document | Description |
+|----------|-------------|
+| [page-translations.md](page-translations.md) | Multilingual CMS pages |
+| [dashboard-overview.md](dashboard-overview.md) | Authenticated home dashboard KPIs and activity feed |

--- a/docs/04-features/content/dashboard-overview.md
+++ b/docs/04-features/content/dashboard-overview.md
@@ -1,0 +1,69 @@
+# Dashboard overview
+
+**Audience:** Developers changing the authenticated home page (`/`) or public homepage metrics.
+
+The Content home dashboard is a **project overview**, not a second statistics explorer. After login it should answer:
+
+- How large is the project?
+- What was added in the last 30 days?
+- What happened recently in the community?
+- Where do I go next?
+
+## Layout
+
+Authenticated `GET /` (`DefaultController`) renders `@Content/dashboard/dashboard.html.twig`:
+
+1. Full-width KPI cards (allocations, participating hospitals, users, imports), above the two-column layout
+2. Main column: action tiles, then the project activity feed (lazy Turbo Frame)
+3. Sidebar: participant notice, onboarding, latest blog posts, pages
+
+Guests still see `@Content/public/home.html.twig`. Totals come from the same `DashboardMetricsService`.
+
+## KPIs
+
+`DashboardMetricsService` returns a list of `DashboardMetric` DTOs (key, value, 30-day delta, icon, translation key) so further compact stats can be appended later.
+
+| Key | Total | 30-day delta |
+|---|---|---|
+| `allocations` | `COUNT(*)` on `allocation_stats_projection` | `created_at >= now() - 30 days` on the projection |
+| `hospitals` | `Hospital.isParticipating = true` | participating hospitals with `created_at` in the last 30 days |
+| `users` | `COUNT` on `user` | `created_at` in the last 30 days |
+| `imports` | `COUNT` on `import` | `created_at` in the last 30 days |
+
+User, hospital, and import counts run **live** on each dashboard request (small tables).
+
+Allocation counts are the expensive path. They are stored in `cache.app` under `dashboard.allocation_counts` with a **1 hour TTL**. A cache miss runs the two projection counts once; later requests in that hour do not touch `allocation_stats_projection`. There is no scheduler job and no dedicated cache pool.
+
+A growth of `0` is shown neutrally (no down-trend styling).
+
+## Activity feed
+
+The feed reads the existing `user_activity` table (`ProjectActivityQuery`). It is not an audit log.
+
+Included types: `joined`, `first_import`, `import_milestone`, `post_published`, `comment_created`, `hospital_associated`, `hospital_owner_granted`.
+
+Excluded: `hospital_disassociated`, `hospital_owner_revoked`. Disabled users are omitted.
+
+The initial dashboard HTML only embeds a lazy Turbo Frame (`/dashboard/activity`). The first page (10 items) and further pages load separately with keyset pagination (`occurred_at DESC, id DESC`, cursor `occurredAt` + `id`).
+
+Index: `idx_user_activity_project_feed` on `(occurred_at DESC, id DESC)`.
+
+Privacy: all `ROLE_USER` viewers see the feed. Profile and hospital links render only for `ROLE_PARTICIPANT`. Failures in the activity endpoint are logged and replaced with a compact error state; the rest of the dashboard remains usable.
+
+## Performance
+
+Typical **initial** dashboard request (warm allocation cache):
+
+- Live counts for users, participating hospitals, imports (and their 30-day deltas)
+- Cache get for allocation totals
+- Existing onboarding, posts, and page-tree queries
+- **No** `user_activity` query and **no** scan of `allocation` / `allocation_stats_projection`
+
+Activity SQL runs only on `GET /dashboard/activity` (and subsequent cursor requests).
+
+## Intentionally deferred
+
+- Extra KPIs (current month, regions, data freshness, last import)
+- Event for “hospital started participating”
+- Cache invalidation after each import / scheduler warm-up
+- Redis or a persisted snapshot table

--- a/migrations/Version20260821194242.php
+++ b/migrations/Version20260821194242.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260821194242 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add project activity feed index on user_activity (occurred_at, id).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_user_activity_project_feed ON user_activity (occurred_at DESC, id DESC)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_user_activity_project_feed');
+    }
+}

--- a/src/Allocation/Infrastructure/Repository/HospitalRepository.php
+++ b/src/Allocation/Infrastructure/Repository/HospitalRepository.php
@@ -18,6 +18,7 @@ use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -77,6 +78,17 @@ final class HospitalRepository extends ServiceEntityRepository implements Hospit
         return (int) $this->createQueryBuilder('h')
             ->select('COUNT(h.id)')
             ->andWhere('h.isParticipating = true')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countParticipatingCreatedSince(\DateTimeInterface $from): int
+    {
+        return (int) $this->createQueryBuilder('h')
+            ->select('COUNT(h.id)')
+            ->andWhere('h.isParticipating = true')
+            ->andWhere('h.createdAt >= :from')
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/src/Content/Application/Dashboard/DTO/DashboardMetric.php
+++ b/src/Content/Application/Dashboard/DTO/DashboardMetric.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Dashboard\DTO;
+
+/** @psalm-suppress PossiblyUnusedProperty Consumed by Twig dashboard templates. */
+final readonly class DashboardMetric
+{
+    public function __construct(
+        public string $key,
+        public int $value,
+        public int $deltaLast30Days,
+        public string $icon,
+        public string $labelTranslationKey,
+    ) {
+    }
+}

--- a/src/Content/Application/Dashboard/DTO/DashboardMetrics.php
+++ b/src/Content/Application/Dashboard/DTO/DashboardMetrics.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Dashboard\DTO;
+
+final readonly class DashboardMetrics
+{
+    /**
+     * @param list<DashboardMetric> $items
+     */
+    public function __construct(
+        public array $items,
+    ) {
+    }
+
+    public function value(string $key): int
+    {
+        foreach ($this->items as $item) {
+            if ($item->key === $key) {
+                return $item->value;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown dashboard metric "%s".', $key));
+    }
+}

--- a/src/Content/Application/Dashboard/DashboardMetricsService.php
+++ b/src/Content/Application/Dashboard/DashboardMetricsService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\Application\Dashboard;
+
+use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Content\Application\Dashboard\DTO\DashboardMetric;
+use App\Content\Application\Dashboard\DTO\DashboardMetrics;
+use App\Import\Infrastructure\Repository\ImportRepository;
+use App\Statistics\Infrastructure\Query\GetPlatformAllocationCountsQuery;
+use App\Statistics\Infrastructure\Query\PlatformAllocationCounts;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final readonly class DashboardMetricsService
+{
+    private const string TIMEZONE = 'Europe/Berlin';
+
+    private const string CACHE_KEY = 'dashboard.allocation_counts';
+
+    private const int CACHE_TTL_SECONDS = 3600;
+
+    /** @psalm-suppress PossiblyUnusedMethod Symfony autowires this service */
+    public function __construct(
+        private CacheInterface $cache,
+        private GetPlatformAllocationCountsQuery $allocationCountsQuery,
+        private HospitalRepository $hospitalRepository,
+        private UserRepository $userRepository,
+        private ImportRepository $importRepository,
+    ) {
+    }
+
+    public function get(): DashboardMetrics
+    {
+        $since = $this->since30Days();
+        $allocationCounts = $this->allocationCounts($since);
+
+        return new DashboardMetrics([
+            new DashboardMetric(
+                key: 'allocations',
+                value: $allocationCounts->total,
+                deltaLast30Days: $allocationCounts->last30Days,
+                icon: 'tabler:ambulance',
+                labelTranslationKey: 'dashboard.metrics.allocations',
+            ),
+            new DashboardMetric(
+                key: 'hospitals',
+                value: $this->hospitalRepository->countParticipating(),
+                deltaLast30Days: $this->hospitalRepository->countParticipatingCreatedSince($since),
+                icon: 'tabler:building-hospital',
+                labelTranslationKey: 'dashboard.metrics.hospitals',
+            ),
+            new DashboardMetric(
+                key: 'users',
+                value: $this->userRepository->count(),
+                deltaLast30Days: $this->userRepository->countCreatedSince($since),
+                icon: 'tabler:users',
+                labelTranslationKey: 'dashboard.metrics.users',
+            ),
+            new DashboardMetric(
+                key: 'imports',
+                value: $this->importRepository->count(),
+                deltaLast30Days: $this->importRepository->countCreatedSince($since),
+                icon: 'tabler:database-import',
+                labelTranslationKey: 'dashboard.metrics.imports',
+            ),
+        ]);
+    }
+
+    private function allocationCounts(\DateTimeImmutable $since): PlatformAllocationCounts
+    {
+        $cached = $this->cache->get(self::CACHE_KEY, function (ItemInterface $item) use ($since): PlatformAllocationCounts {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return ($this->allocationCountsQuery)($since);
+        });
+
+        if (!$cached instanceof PlatformAllocationCounts) {
+            throw new \LogicException('Cached dashboard allocation counts have an unexpected type.');
+        }
+
+        return $cached;
+    }
+
+    private function since30Days(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('-30 days', new \DateTimeZone(self::TIMEZONE));
+    }
+}

--- a/src/Content/Application/Page/PageSidebarDataProvider.php
+++ b/src/Content/Application/Page/PageSidebarDataProvider.php
@@ -30,6 +30,19 @@ final readonly class PageSidebarDataProvider
      */
     public function getData(): array
     {
+        return [
+            'pageTree' => $this->getPageTree(),
+            'latest_posts' => $this->postRepository->findPublishedForIndex(5),
+        ];
+    }
+
+    /**
+     * @return array<int, array{page: Page, title: string, path: string, children: array<int, mixed>}>
+     *
+     * @psalm-suppress PossiblyUnusedMethod Called from the authenticated dashboard controller.
+     */
+    public function getPageTree(): array
+    {
         $locale = $this->requestStack->getCurrentRequest()?->getLocale()
             ?? $this->pageTranslationResolver->getContentDefaultLocale();
 
@@ -59,9 +72,6 @@ final readonly class PageSidebarDataProvider
             ];
         }
 
-        return [
-            'pageTree' => $this->pageNavigationTreeBuilder->build($pages, $displayByPageId),
-            'latest_posts' => $this->postRepository->findPublishedForIndex(5),
-        ];
+        return $this->pageNavigationTreeBuilder->build($pages, $displayByPageId);
     }
 }

--- a/src/Content/UI/Http/Controller/DashboardActivityController.php
+++ b/src/Content/UI/Http/Controller/DashboardActivityController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Content\UI\Http\Controller;
+
+use App\User\Application\Explore\ProjectActivityCursor;
+use App\User\Application\Explore\ProjectActivityQueryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/** @psalm-suppress UnusedClass */
+#[IsGranted('ROLE_USER')]
+final class DashboardActivityController extends AbstractController
+{
+    public function __construct(
+        private readonly ProjectActivityQueryInterface $activityQuery,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/dashboard/activity', name: 'app_dashboard_activity', methods: ['GET'])]
+    public function __invoke(Request $request): Response
+    {
+        $rawCursor = $request->query->get('cursor');
+        $cursor = \is_string($rawCursor) && '' !== $rawCursor ? $rawCursor : null;
+        $frameId = null !== $cursor
+            ? ProjectActivityCursor::frameId($cursor)
+            : 'dashboard-activity';
+
+        try {
+            $page = $this->activityQuery->getPage($cursor);
+        } catch (\Throwable $exception) {
+            $this->logger->error('Dashboard activity feed failed.', [
+                'exception' => $exception,
+            ]);
+
+            return $this->render('@Content/dashboard/_activity_error.html.twig', [
+                'frameId' => $frameId,
+            ]);
+        }
+
+        return $this->render('@Content/dashboard/_activity_page.html.twig', [
+            'page' => $page,
+            'frameId' => $frameId,
+        ]);
+    }
+}

--- a/src/Content/UI/Http/Controller/DefaultController.php
+++ b/src/Content/UI/Http/Controller/DefaultController.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace App\Content\UI\Http\Controller;
 
-use App\Allocation\Infrastructure\Repository\AllocationRepository;
-use App\Allocation\Infrastructure\Repository\HospitalRepository;
+use App\Content\Application\Dashboard\DashboardMetricsService;
 use App\Content\Application\Page\PageSidebarDataProvider;
 use App\Content\Infrastructure\Repository\PostRepository;
-use App\Import\Infrastructure\Repository\ImportRepository;
 use App\Onboarding\Application\OnboardingProgressService;
 use App\User\Domain\Entity\User;
-use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -19,10 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 final class DefaultController extends AbstractController
 {
     public function __construct(
-        private readonly UserRepository $userRepository,
-        private readonly HospitalRepository $hospitalRepository,
-        private readonly ImportRepository $importRepository,
-        private readonly AllocationRepository $allocationRepository,
+        private readonly DashboardMetricsService $dashboardMetricsService,
         private readonly PostRepository $postRepository,
         private readonly PageSidebarDataProvider $pageSidebarDataProvider,
         private readonly OnboardingProgressService $onboardingProgressService,
@@ -32,6 +26,8 @@ final class DefaultController extends AbstractController
     #[Route('/', name: 'app_default')]
     public function index(): Response
     {
+        $metrics = $this->dashboardMetricsService->get();
+
         if ($this->isGranted('ROLE_USER')) {
             $user = $this->getUser();
             $onboardingCard = $user instanceof User
@@ -39,17 +35,18 @@ final class DefaultController extends AbstractController
                 : null;
 
             return $this->render('@Content/dashboard/dashboard.html.twig', [
+                'metrics' => $metrics,
                 'recentPosts' => $this->postRepository->findPublishedForIndex(5),
                 'onboardingCard' => $onboardingCard,
-                ...$this->pageSidebarDataProvider->getData(),
+                'pageTree' => $this->pageSidebarDataProvider->getPageTree(),
             ]);
         }
 
         return $this->render('@Content/public/home.html.twig', [
-            'userCount' => $this->userRepository->count(),
-            'hospitalCount' => $this->hospitalRepository->countParticipating(),
-            'importCount' => $this->importRepository->count(),
-            'allocationCount' => $this->allocationRepository->count(),
+            'userCount' => $metrics->value('users'),
+            'hospitalCount' => $metrics->value('hospitals'),
+            'importCount' => $metrics->value('imports'),
+            'allocationCount' => $metrics->value('allocations'),
         ]);
     }
 }

--- a/src/Content/UI/Twig/templates/dashboard/_activity_error.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/_activity_error.html.twig
@@ -1,0 +1,5 @@
+<turbo-frame id="{{ frameId }}">
+    <div class="card-body py-3 text-secondary" data-testid="dashboard-activity-error">
+        {{ 'dashboard.activity.error'|trans({}, 'content') }}
+    </div>
+</turbo-frame>

--- a/src/Content/UI/Twig/templates/dashboard/_activity_items.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/_activity_items.html.twig
@@ -1,0 +1,88 @@
+{% set activityIcons = {
+    joined: 'tabler:user-plus',
+    first_import: 'tabler:database-import',
+    import_milestone: 'tabler:award',
+    post_published: 'tabler:file-text',
+    comment_created: 'tabler:message-circle',
+    hospital_associated: 'tabler:link',
+    hospital_owner_granted: 'tabler:key',
+} %}
+
+{% for activity in activities %}
+    <div
+        class="list-group-item"
+        data-testid="dashboard-activity-item"
+        data-activity-type="{{ activity.type.value }}"
+        data-activity-stable-id="{{ activity.stableId }}"
+    >
+        <div class="row align-items-start">
+            <div class="col-auto">
+                <span class="avatar avatar-sm rounded">
+                    <twig:ux:icon name="{{ activityIcons[activity.type.value] }}" width="1.25em" height="1.25em" />
+                </span>
+            </div>
+            <div class="col min-w-0">
+                <div class="text-secondary small" data-testid="dashboard-activity-date">
+                    {{ activity.occurredAt|date('d.m.Y') }}
+                </div>
+                <div class="fw-medium">
+                    {% if is_granted('ROLE_PARTICIPANT') and activity.actorPublicId %}
+                        <a href="{{ path('app_explore_user_show', {publicId: activity.actorPublicId}) }}" target="_top">{{ activity.actorUsername }}</a>
+                    {% else %}
+                        {{ activity.actorUsername }}
+                    {% endif %}
+                </div>
+                <div>
+                    {% if activity.type.value == 'joined' %}
+                        {{ 'label.user.activity.joined'|trans({}, 'user') }}
+                    {% elseif activity.type.value == 'first_import' %}
+                        {{ 'label.user.activity.first_import'|trans({}, 'user') }}
+                    {% elseif activity.type.value == 'import_milestone' %}
+                        {{ 'label.user.activity.import_milestone'|trans(({count: activity.milestone}), 'user') }}
+                    {% elseif activity.type.value == 'post_published' %}
+                        {{ 'label.user.activity.post_published'|trans({}, 'user') }}
+                    {% elseif activity.type.value == 'comment_created' %}
+                        {{ 'label.user.activity.comment_created'|trans({}, 'user') }}
+                    {% elseif activity.type.value == 'hospital_associated' %}
+                        {{ 'label.user.activity.hospital_associated'|trans({}, 'user') }}
+                    {% elseif activity.type.value == 'hospital_owner_granted' %}
+                        {{ 'label.user.activity.hospital_owner_granted'|trans({}, 'user') }}
+                    {% endif %}
+                </div>
+                {% if activity.type.value == 'post_published' and activity.postTitle %}
+                    <div>
+                        {% if activity.postSlug %}
+                            <a href="{{ path('app_blog_show', {slug: activity.postSlug}) }}" target="_top">„{{ activity.postTitle }}“</a>
+                        {% else %}
+                            <span class="text-secondary">„{{ activity.postTitle }}“</span>
+                        {% endif %}
+                    </div>
+                {% elseif activity.type.value == 'comment_created' %}
+                    {% if activity.postTitle %}
+                        <div>
+                            {{ 'label.user.activity.comment_on'|trans({}, 'user') }}
+                            {% if activity.postSlug %}
+                                <a href="{{ path('app_blog_show', {slug: activity.postSlug}) }}" target="_top">„{{ activity.postTitle }}“</a>
+                            {% else %}
+                                <span class="text-secondary">„{{ activity.postTitle }}“</span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                    {% if activity.excerpt %}
+                        <div class="text-secondary small text-truncate">{{ activity.excerpt }}</div>
+                    {% endif %}
+                {% elseif activity.hospitalName %}
+                    <div class="text-secondary">
+                        {% if is_granted('ROLE_PARTICIPANT') and activity.hospitalPublicId %}
+                            <a href="{{ path('app_explore_hospital_show', {publicId: activity.hospitalPublicId}) }}" target="_top">
+                                {{ activity.hospitalName }}
+                            </a>
+                        {% else %}
+                            {{ activity.hospitalName }}
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endfor %}

--- a/src/Content/UI/Twig/templates/dashboard/_activity_next_frame.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/_activity_next_frame.html.twig
@@ -1,0 +1,16 @@
+<turbo-frame
+    id="{{ frameId }}"
+    src="{{ path('app_dashboard_activity', {cursor: nextCursor}) }}"
+    loading="lazy"
+    data-testid="dashboard-activity-next"
+>
+    <div class="list-group-item text-center text-secondary py-3" aria-busy="true" aria-live="polite">
+        <div class="spinner-border spinner-border-sm text-secondary" role="status" aria-hidden="true"></div>
+        <span class="visually-hidden">{{ 'dashboard.activity.loading'|trans({}, 'content') }}</span>
+        <div class="mt-2">
+            <a href="{{ path('app_dashboard_activity', {cursor: nextCursor}) }}">
+                {{ 'dashboard.activity.load_more'|trans({}, 'content') }}
+            </a>
+        </div>
+    </div>
+</turbo-frame>

--- a/src/Content/UI/Twig/templates/dashboard/_activity_page.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/_activity_page.html.twig
@@ -1,0 +1,17 @@
+<turbo-frame id="{{ frameId }}">
+    {% if page.items is empty %}
+        <div class="card-body py-3 text-secondary" data-testid="dashboard-activity-empty">
+            {{ 'dashboard.activity.empty'|trans({}, 'content') }}
+        </div>
+    {% else %}
+        <div class="list-group list-group-flush">
+            {{ include('@Content/dashboard/_activity_items.html.twig', {activities: page.items}) }}
+            {% if page.hasMore and page.nextCursor and page.nextFrameId %}
+                {{ include('@Content/dashboard/_activity_next_frame.html.twig', {
+                    nextCursor: page.nextCursor,
+                    frameId: page.nextFrameId,
+                }) }}
+            {% endif %}
+        </div>
+    {% endif %}
+</turbo-frame>

--- a/src/Content/UI/Twig/templates/dashboard/_metric_cards.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/_metric_cards.html.twig
@@ -1,0 +1,25 @@
+<div class="row row-cards" data-testid="dashboard-metrics">
+    {% for metric in metrics.items %}
+        <div class="col-6 col-lg-3">
+            <div class="card" data-testid="dashboard-metric-{{ metric.key }}">
+                <div class="card-body">
+                    <div class="d-flex align-items-start gap-2">
+                        <span class="avatar avatar-sm bg-primary-lt text-primary flex-shrink-0">
+                            {{ ux_icon(metric.icon, {style: 'height: 1.25em;'}) }}
+                        </span>
+                        <div class="min-w-0">
+                            <div class="subheader">{{ metric.labelTranslationKey|trans({}, 'content') }}</div>
+                            <div class="h1 mb-1">{{ metric.value|number_format(0, ',', '.') }}</div>
+                            <div class="text-secondary small d-flex align-items-center gap-1">
+                                {% if metric.deltaLast30Days > 0 %}
+                                    <twig:ux:icon name="tabler:plus" class="flex-shrink-0" style="height: 1em;" />
+                                {% endif %}
+                                <span>{{ metric.deltaLast30Days|number_format(0, ',', '.') }} {{ 'dashboard.metrics.last_30_days'|trans({}, 'content') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>

--- a/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
+++ b/src/Content/UI/Twig/templates/dashboard/dashboard.html.twig
@@ -1,7 +1,5 @@
 {% extends '@Shared/_layout_vertical.html.twig' %}
 
-{% import '@Shared/_macros/users.html.twig' as users %}
-
 {% block title %}{{ 'title.dashboard'|trans({}, 'messages') }} - {{ parent() }}{% endblock %}
 
 {% block page_header %}
@@ -60,84 +58,88 @@
         url: canViewOwnedHospitals ? path('app_import_new') : path('app_blog_index'),
     }]) %}
 
-    <div class="row g-3 align-items-start">
-        <div class="col-12 col-lg-8 d-flex flex-column gap-3">
-            <div class="row row-cards">
-                {% for step in nextSteps %}
-                    <div class="col-12 col-md-6">
-                        <a href="{{ step.url }}" class="card card-link h-100 text-reset text-decoration-none">
-                            <div class="card-body d-flex gap-3">
-                                <span class="avatar avatar-lg bg-primary-lt text-primary flex-shrink-0">
-                                    {{ ux_icon(step.icon, {style: 'height: 1.75em;'}) }}
-                                </span>
-                                <div>
-                                    <h3 class="h4 mb-1">{{ step.title|trans({}, 'content') }}</h3>
-                                    <p class="text-secondary mb-0">{{ step.description|trans({}, 'content') }}</p>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                {% endfor %}
-            </div>
+    <div class="d-flex flex-column gap-3">
+        {{ include('@Content/dashboard/_metric_cards.html.twig', {metrics: metrics}) }}
 
-            <div class="card">
-                <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
-                    <h3 class="card-title mb-0">{{ 'dashboard.blog.recent_title'|trans({}, 'content') }}</h3>
-                    <a href="{{ path('app_blog_index') }}" class="btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2">
-                        <twig:ux:icon name="tabler:notes" style="height: 1.25em;" />
-                        {{ 'dashboard.blog.visit'|trans({}, 'content') }}
-                    </a>
-                </div>
-                <div class="list-group list-group-flush">
-                    {% for post in recentPosts %}
-                        <div class="list-group-item">
-                            <div class="d-flex flex-column gap-2">
-                                <a href="{{ path('app_blog_show', {slug: post.slug}) }}" class="fw-medium">{{ post.title }}</a>
-                                <div class="text-secondary small d-flex flex-wrap align-items-center gap-2 pt-1">
-                                    <twig:ux:icon name="tabler:clock" class="w-3 h-3 flex-shrink-0" />
-                                    {{ post.publishedAt|date('d.m.Y H:i') }}
-                                    <span class="text-secondary">|</span>
-                                    <twig:ux:icon name="tabler:folder" class="w-3 h-3 flex-shrink-0" />
-                                    <a class="badge bg-blue-lt text-blue-emphasis" href="{{ path('app_blog_category', {slug: post.category.slug}) }}">{{ post.category.name }}</a>
-                                    <span class="text-secondary">|</span>
-                                    <twig:ux:icon name="tabler:user" class="w-3 h-3 flex-shrink-0" />
-                                    {{ users.link(post.createdBy, {
-                                        requireParticipant: true,
-                                        empty: 'blog.meta.unknown_author'|trans({}, 'content'),
-                                    }) }}
-                                    <span class="text-secondary">|</span>
-                                    {{ 'blog.comments.count'|trans(({count: post.comments|length}), 'content') }}
+        <div class="row g-3 align-items-start">
+            <div class="col-12 col-lg-8 d-flex flex-column gap-3">
+                <div class="row row-cards">
+                    {% for step in nextSteps %}
+                        <div class="col-12 col-md-6">
+                            <a href="{{ step.url }}" class="card card-link h-100 text-reset text-decoration-none">
+                                <div class="card-body d-flex gap-3">
+                                    <span class="avatar avatar-lg bg-primary-lt text-primary flex-shrink-0">
+                                        {{ ux_icon(step.icon, {style: 'height: 1.75em;'}) }}
+                                    </span>
+                                    <div>
+                                        <h3 class="h4 mb-1">{{ step.title|trans({}, 'content') }}</h3>
+                                        <p class="text-secondary mb-0">{{ step.description|trans({}, 'content') }}</p>
+                                    </div>
                                 </div>
-                            </div>
-                        </div>
-                    {% else %}
-                        <div class="list-group-item text-secondary">
-                            {{ 'dashboard.blog.recent_empty'|trans({}, 'content') }}
+                            </a>
                         </div>
                     {% endfor %}
                 </div>
-            </div>
-        </div>
 
-        <div class="col-12 col-lg-4 d-flex flex-column gap-3">
-            {% if showParticipantAccessNotice %}
-                {{ include('@Content/dashboard/_participant_access_notice.html.twig') }}
-            {% endif %}
-            {% if onboardingCard is defined and onboardingCard is not null %}
-                {{ include('@Content/dashboard/_onboarding_card.html.twig') }}
-            {% endif %}
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title mb-0">{{ 'dashboard.pages.card_title'|trans({}, 'content') }}</h3>
+                <div class="card" data-testid="dashboard-activity-feed">
+                    <div class="card-header">
+                        <h3 class="card-title mb-0">{{ 'dashboard.activity.title'|trans({}, 'content') }}</h3>
+                    </div>
+                    <turbo-frame
+                        id="dashboard-activity"
+                        src="{{ path('app_dashboard_activity') }}"
+                        loading="lazy"
+                        data-testid="dashboard-activity-frame"
+                    >
+                        <div class="card-body text-secondary py-3" aria-busy="true" aria-live="polite">
+                            <div class="spinner-border spinner-border-sm text-secondary" role="status" aria-hidden="true"></div>
+                            <span class="visually-hidden">{{ 'dashboard.activity.loading'|trans({}, 'content') }}</span>
+                        </div>
+                    </turbo-frame>
                 </div>
-                <div class="card-body">
-                    {% if pageTree is empty %}
-                        <p class="text-secondary mb-0">{{ 'dashboard.pages.empty'|trans({}, 'content') }}</p>
-                    {% else %}
-                        <ul class="list-unstyled mb-0">
-                            {{ include('@Content/page/_page_tree_nodes.html.twig', {nodes: pageTree}, false) }}
-                        </ul>
-                    {% endif %}
+            </div>
+
+            <div class="col-12 col-lg-4 d-flex flex-column gap-3">
+                {% if showParticipantAccessNotice %}
+                    {{ include('@Content/dashboard/_participant_access_notice.html.twig') }}
+                {% endif %}
+                {% if onboardingCard is defined and onboardingCard is not null %}
+                    {{ include('@Content/dashboard/_onboarding_card.html.twig') }}
+                {% endif %}
+                <div class="card">
+                    <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
+                        <h3 class="card-title mb-0">{{ 'dashboard.blog.recent_title'|trans({}, 'content') }}</h3>
+                        <a href="{{ path('app_blog_index') }}" class="btn btn-outline-primary btn-sm d-inline-flex align-items-center gap-2">
+                            <twig:ux:icon name="tabler:notes" style="height: 1.25em;" />
+                            {{ 'dashboard.blog.visit'|trans({}, 'content') }}
+                        </a>
+                    </div>
+                    <div class="list-group list-group-flush">
+                        {% for post in recentPosts %}
+                            <a href="{{ path('app_blog_show', {slug: post.slug}) }}" class="list-group-item list-group-item-action">
+                                <div class="fw-medium">{{ post.title }}</div>
+                                <div class="text-secondary small">{{ post.publishedAt|date('d.m.Y') }}</div>
+                            </a>
+                        {% else %}
+                            <div class="list-group-item text-secondary">
+                                {{ 'dashboard.blog.recent_empty'|trans({}, 'content') }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title mb-0">{{ 'dashboard.pages.card_title'|trans({}, 'content') }}</h3>
+                    </div>
+                    <div class="card-body">
+                        {% if pageTree is empty %}
+                            <p class="text-secondary mb-0">{{ 'dashboard.pages.empty'|trans({}, 'content') }}</p>
+                        {% else %}
+                            <ul class="list-unstyled mb-0">
+                                {{ include('@Content/page/_page_tree_nodes.html.twig', {nodes: pageTree}, false) }}
+                            </ul>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/Import/Infrastructure/Repository/ImportRepository.php
+++ b/src/Import/Infrastructure/Repository/ImportRepository.php
@@ -337,4 +337,14 @@ SQL;
 
         return $count > 0;
     }
+
+    public function countCreatedSince(\DateTimeInterface $from): int
+    {
+        return (int) $this->createQueryBuilder('i')
+            ->select('COUNT(i.id)')
+            ->andWhere('i.createdAt >= :from')
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/src/Statistics/Infrastructure/Query/GetPlatformAllocationCountsQuery.php
+++ b/src/Statistics/Infrastructure/Query/GetPlatformAllocationCountsQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+
+final readonly class GetPlatformAllocationCountsQuery
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function __invoke(\DateTimeImmutable $since): PlatformAllocationCounts
+    {
+        $total = (int) $this->connection->fetchOne('SELECT COUNT(*)::int FROM allocation_stats_projection');
+        $last30Days = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*)::int FROM allocation_stats_projection WHERE created_at >= :since',
+            ['since' => $since],
+            ['since' => Types::DATETIME_IMMUTABLE],
+        );
+
+        return new PlatformAllocationCounts($total, $last30Days);
+    }
+}

--- a/src/Statistics/Infrastructure/Query/PlatformAllocationCounts.php
+++ b/src/Statistics/Infrastructure/Query/PlatformAllocationCounts.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Statistics\Infrastructure\Query;
+
+final readonly class PlatformAllocationCounts
+{
+    public function __construct(
+        public int $total,
+        public int $last30Days,
+    ) {
+    }
+}

--- a/src/User/Application/Explore/ProjectActivity.php
+++ b/src/User/Application/Explore/ProjectActivity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Explore;
+
+/** @psalm-suppress PossiblyUnusedProperty Consumed by Twig dashboard templates. */
+final readonly class ProjectActivity
+{
+    public function __construct(
+        public \DateTimeImmutable $occurredAt,
+        public ProfileActivityType $type,
+        public string $stableId,
+        public string $actorUsername,
+        public ?string $actorPublicId = null,
+        public ?string $hospitalName = null,
+        public ?string $hospitalPublicId = null,
+        public ?int $milestone = null,
+        public ?string $postTitle = null,
+        public ?string $postSlug = null,
+        public ?string $excerpt = null,
+    ) {
+    }
+}

--- a/src/User/Application/Explore/ProjectActivityCursor.php
+++ b/src/User/Application/Explore/ProjectActivityCursor.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Explore;
+
+final readonly class ProjectActivityCursor
+{
+    private const int VERSION = 1;
+
+    public function __construct(
+        public \DateTimeImmutable $occurredAt,
+        public int $id,
+    ) {
+    }
+
+    public static function fromActivity(ProjectActivity $activity): self
+    {
+        return new self($activity->occurredAt, (int) $activity->stableId);
+    }
+
+    public static function padId(int $id): string
+    {
+        return sprintf('%020d', $id);
+    }
+
+    public function encode(): string
+    {
+        $payload = [
+            'v' => self::VERSION,
+            'occurredAt' => $this->occurredAt->format(\DateTimeInterface::ATOM),
+            'id' => $this->id,
+        ];
+
+        return base64_encode(json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    public static function decode(string $cursor): self
+    {
+        $decoded = base64_decode($cursor, true);
+        if (false === $decoded) {
+            throw new \InvalidArgumentException('Cursor is not valid base64.');
+        }
+
+        try {
+            $payload = json_decode($decoded, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new \InvalidArgumentException('Cursor payload is not valid JSON.', 0, $exception);
+        }
+
+        if (!\is_array($payload)) {
+            throw new \InvalidArgumentException('Cursor payload must be an object.');
+        }
+
+        foreach (['v', 'occurredAt', 'id'] as $key) {
+            if (!\array_key_exists($key, $payload)) {
+                throw new \InvalidArgumentException(sprintf('Cursor payload misses key "%s".', $key));
+            }
+        }
+
+        if (self::VERSION !== $payload['v']) {
+            throw new \InvalidArgumentException('Unsupported cursor version.');
+        }
+
+        if (!\is_string($payload['occurredAt']) || !\is_int($payload['id'])) {
+            throw new \InvalidArgumentException('Cursor payload has invalid field types.');
+        }
+
+        if ($payload['id'] < 1) {
+            throw new \InvalidArgumentException('Cursor payload has invalid id.');
+        }
+
+        try {
+            $occurredAt = new \DateTimeImmutable($payload['occurredAt']);
+        } catch (\Exception $exception) {
+            throw new \InvalidArgumentException('Cursor payload has invalid occurredAt.', 0, $exception);
+        }
+
+        return new self($occurredAt, $payload['id']);
+    }
+
+    public static function tryDecode(?string $cursor): ?self
+    {
+        if (null === $cursor || '' === $cursor) {
+            return null;
+        }
+
+        try {
+            return self::decode($cursor);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    public static function frameId(string $encodedCursor): string
+    {
+        return 'dashboard-activity-after-'.rtrim(strtr($encodedCursor, '+/', '-_'), '=');
+    }
+}

--- a/src/User/Application/Explore/ProjectActivityPage.php
+++ b/src/User/Application/Explore/ProjectActivityPage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Explore;
+
+use App\User\Domain\Enum\UserActivityType;
+
+/** @psalm-suppress PossiblyUnusedProperty Consumed by Twig dashboard templates. */
+final readonly class ProjectActivityPage
+{
+    public const int PAGE_SIZE = 10;
+
+    /**
+     * @return list<UserActivityType>
+     */
+    public static function feedTypes(): array
+    {
+        return [
+            UserActivityType::JOINED,
+            UserActivityType::FIRST_IMPORT,
+            UserActivityType::IMPORT_MILESTONE,
+            UserActivityType::POST_PUBLISHED,
+            UserActivityType::COMMENT_CREATED,
+            UserActivityType::HOSPITAL_ASSOCIATED,
+            UserActivityType::HOSPITAL_OWNER_GRANTED,
+        ];
+    }
+
+    /**
+     * @param list<ProjectActivity> $items
+     */
+    public function __construct(
+        public array $items,
+        public ?string $nextCursor,
+        public int $pageSize = self::PAGE_SIZE,
+    ) {
+    }
+
+    /** @psalm-suppress PossiblyUnusedMethod Consumed by Twig dashboard templates. */
+    public function hasMore(): bool
+    {
+        return null !== $this->nextCursor;
+    }
+
+    /** @psalm-suppress PossiblyUnusedMethod Consumed by Twig dashboard templates. */
+    public function nextFrameId(): ?string
+    {
+        if (null === $this->nextCursor) {
+            return null;
+        }
+
+        return ProjectActivityCursor::frameId($this->nextCursor);
+    }
+}

--- a/src/User/Application/Explore/ProjectActivityQueryInterface.php
+++ b/src/User/Application/Explore/ProjectActivityQueryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Explore;
+
+interface ProjectActivityQueryInterface
+{
+    public function getPage(?string $cursor, int $limit = ProjectActivityPage::PAGE_SIZE): ProjectActivityPage;
+}

--- a/src/User/Domain/Entity/UserActivity.php
+++ b/src/User/Domain/Entity/UserActivity.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Table(name: 'user_activity')]
 #[ORM\UniqueConstraint(name: 'uniq_user_activity_deduplication_key', columns: ['deduplication_key'])]
 #[ORM\Index(name: 'idx_user_activity_feed', columns: ['user_id', 'occurred_at', 'id'])]
+#[ORM\Index(name: 'idx_user_activity_project_feed', columns: ['occurred_at', 'id'])]
 class UserActivity
 {
     #[ORM\Id]

--- a/src/User/Infrastructure/Query/ProjectActivityQuery.php
+++ b/src/User/Infrastructure/Query/ProjectActivityQuery.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Query;
+
+use App\User\Application\Explore\ProfileActivityType;
+use App\User\Application\Explore\ProjectActivity;
+use App\User\Application\Explore\ProjectActivityCursor;
+use App\User\Application\Explore\ProjectActivityPage;
+use App\User\Application\Explore\ProjectActivityQueryInterface;
+use App\User\Domain\Entity\UserActivity;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class ProjectActivityQuery implements ProjectActivityQueryInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    #[\Override]
+    public function getPage(?string $cursor, int $limit = ProjectActivityPage::PAGE_SIZE): ProjectActivityPage
+    {
+        if ($limit < 1) {
+            return new ProjectActivityPage([], null, max(1, $limit));
+        }
+
+        $decodedCursor = ProjectActivityCursor::tryDecode($cursor);
+        $rows = $this->fetchPage($decodedCursor, $limit + 1);
+
+        $hasMore = \count($rows) > $limit;
+        $visible = array_slice($rows, 0, $limit);
+        $items = array_map($this->toActivity(...), $visible);
+
+        $nextCursor = null;
+        if ($hasMore && [] !== $items) {
+            $nextCursor = ProjectActivityCursor::fromActivity($items[array_key_last($items)])->encode();
+        }
+
+        return new ProjectActivityPage($items, $nextCursor, $limit);
+    }
+
+    /**
+     * @return list<UserActivity>
+     */
+    private function fetchPage(?ProjectActivityCursor $cursor, int $limit): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('a', 'u')
+            ->from(UserActivity::class, 'a')
+            ->innerJoin('a.user', 'u')
+            ->andWhere('u.isEnabled = true')
+            ->andWhere('a.type IN (:types)')
+            ->setParameter('types', ProjectActivityPage::feedTypes())
+            ->orderBy('a.occurredAt', 'DESC')
+            ->addOrderBy('a.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($cursor instanceof ProjectActivityCursor) {
+            $qb->andWhere(
+                $qb->expr()->orX(
+                    $qb->expr()->lt('a.occurredAt', ':cursorAt'),
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('a.occurredAt', ':cursorAt'),
+                        $qb->expr()->lt('a.id', ':cursorId'),
+                    ),
+                ),
+            )
+                ->setParameter('cursorAt', $cursor->occurredAt, Types::DATETIME_IMMUTABLE)
+                ->setParameter('cursorId', $cursor->id);
+        }
+
+        /** @var list<UserActivity> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    private function toActivity(UserActivity $activity): ProjectActivity
+    {
+        $id = $activity->getId();
+        if (null === $id) {
+            throw new \LogicException('UserActivity must be persisted.');
+        }
+
+        $user = $activity->getUser();
+        $metadata = $activity->getMetadata();
+        $type = ProfileActivityType::from($activity->getType()->value);
+        $milestone = $metadata['milestone'] ?? null;
+        $publicId = $user->getPublicId();
+
+        return new ProjectActivity(
+            occurredAt: $activity->getOccurredAt(),
+            type: $type,
+            stableId: ProjectActivityCursor::padId($id),
+            actorUsername: $user->getUsername() ?? '',
+            actorPublicId: $publicId instanceof Uuid ? $publicId->toRfc4122() : null,
+            hospitalName: $this->stringMetadata($metadata, 'hospitalName'),
+            hospitalPublicId: $this->stringMetadata($metadata, 'hospitalPublicId'),
+            milestone: \is_int($milestone) ? $milestone : (is_numeric($milestone) ? (int) $milestone : null),
+            postTitle: $this->stringMetadata($metadata, 'title') ?? $this->stringMetadata($metadata, 'postTitle'),
+            postSlug: $this->stringMetadata($metadata, 'slug') ?? $this->stringMetadata($metadata, 'postSlug'),
+            excerpt: $this->stringMetadata($metadata, 'excerpt'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function stringMetadata(array $metadata, string $key): ?string
+    {
+        $value = $metadata[$key] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/src/User/Infrastructure/Repository/UserRepository.php
+++ b/src/User/Infrastructure/Repository/UserRepository.php
@@ -10,6 +10,7 @@ use App\Shared\Infrastructure\Repository\PublicIdRepositoryTrait;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Security\UserRole;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -103,6 +104,16 @@ final class UserRepository extends ServiceEntityRepository implements PasswordUp
         );
 
         return $choices;
+    }
+
+    public function countCreatedSince(\DateTimeInterface $from): int
+    {
+        return (int) $this->createQueryBuilder('u')
+            ->select('COUNT(u.id)')
+            ->andWhere('u.createdAt >= :from')
+            ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     #[\Override]

--- a/tests/Content/Functional/Controller/DashboardActivityControllerTest.php
+++ b/tests/Content/Functional/Controller/DashboardActivityControllerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Functional\Controller;
+
+use App\User\Application\Activity\UserActivityDeduplicationKey;
+use App\User\Application\Explore\ProjectActivityPage;
+use App\User\Application\Explore\ProjectActivityQueryInterface;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserActivity;
+use App\User\Domain\Enum\UserActivityType;
+use App\User\Domain\Factory\UserFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DashboardActivityControllerTest extends WebTestCase
+{
+    use Factories;
+
+    public function testEmptyStateForAuthenticatedUser(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['username' => 'activity-empty-user']);
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-activity-empty"]');
+        self::assertSelectorTextContains('body', 'No recent activity yet.');
+    }
+
+    public function testGuestIsDenied(): void
+    {
+        $client = self::createClient();
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseRedirects();
+    }
+
+    public function testShowsCommunityTypesAndHidesLinksForRoleUser(): void
+    {
+        $client = self::createClient();
+        $viewer = UserFactory::createOne(['username' => 'activity-viewer']);
+        $actor = UserFactory::createOne(['username' => 'activity-actor']);
+        $actorId = $actor->getId();
+        self::assertNotNull($actorId);
+
+        $this->record(
+            $actor,
+            UserActivityType::POST_PUBLISHED,
+            new \DateTimeImmutable('2026-05-01 12:00:00'),
+            UserActivityDeduplicationKey::postPublished($actorId, 1),
+            ['title' => 'Hello Post', 'slug' => 'hello-post'],
+        );
+        $this->record(
+            $actor,
+            UserActivityType::HOSPITAL_ASSOCIATED,
+            new \DateTimeImmutable('2026-05-03 12:00:00'),
+            UserActivityDeduplicationKey::hospitalAssociated($actorId, 1, 1),
+            [
+                'hospitalName' => 'Plain Clinic',
+                'hospitalPublicId' => 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+            ],
+        );
+        $this->record(
+            $actor,
+            UserActivityType::HOSPITAL_DISASSOCIATED,
+            new \DateTimeImmutable('2026-05-02 12:00:00'),
+            UserActivityDeduplicationKey::hospitalDisassociated($actorId, 1, 1),
+            ['hospitalName' => 'Hidden Clinic'],
+        );
+
+        $client->loginUser($viewer);
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="post_published"]');
+        self::assertSelectorTextContains('body', 'activity-actor');
+        self::assertSelectorTextContains('body', 'Hello Post');
+        self::assertSelectorTextContains('body', 'Plain Clinic');
+        self::assertSelectorNotExists('a[href^="/explore/user/"]');
+        self::assertSelectorNotExists('a[href^="/explore/hospital/"]');
+        self::assertSelectorTextNotContains('body', 'Hidden Clinic');
+    }
+
+    public function testParticipantSeesProfileLinksAndCanPaginate(): void
+    {
+        $client = self::createClient();
+        $participant = UserFactory::createOne([
+            'username' => 'activity-participant',
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $actor = UserFactory::createOne(['username' => 'activity-pager']);
+        $actorId = $actor->getId();
+        self::assertNotNull($actorId);
+
+        for ($i = 1; $i <= 11; ++$i) {
+            $this->record(
+                $actor,
+                UserActivityType::POST_PUBLISHED,
+                new \DateTimeImmutable(sprintf('2026-06-%02d 12:00:00', $i)),
+                UserActivityDeduplicationKey::postPublished($actorId, $i),
+                ['title' => 'Paged '.$i, 'slug' => 'paged-'.$i],
+            );
+        }
+
+        $client->loginUser($participant);
+        $crawler = $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href^="/explore/user/"]');
+        self::assertCount(10, $crawler->filter('[data-testid="dashboard-activity-item"]'));
+        self::assertSelectorExists('[data-testid="dashboard-activity-next"]');
+
+        $nextSrc = $crawler->filter('[data-testid="dashboard-activity-next"]')->attr('src');
+        self::assertNotNull($nextSrc);
+        $crawler = $client->request(Request::METHOD_GET, $nextSrc);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('[data-testid="dashboard-activity-item"]'));
+        self::assertSelectorNotExists('[data-testid="dashboard-activity-next"]');
+    }
+
+    public function testInvalidCursorFallsBackToFirstPage(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['username' => 'activity-cursor-fallback']);
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+        $this->record(
+            $user,
+            UserActivityType::JOINED,
+            new \DateTimeImmutable('2026-01-01 10:00:00'),
+            UserActivityDeduplicationKey::joined($userId),
+        );
+
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/dashboard/activity?cursor=not-a-cursor');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="joined"]');
+    }
+
+    public function testParticipantSeesHospitalNameAsLink(): void
+    {
+        $client = self::createClient();
+        $participant = UserFactory::createOne([
+            'username' => 'activity-hospital-viewer',
+            'roles' => ['ROLE_USER', 'ROLE_PARTICIPANT'],
+        ]);
+        $actor = UserFactory::createOne(['username' => 'activity-hospital-actor']);
+        $actorId = $actor->getId();
+        self::assertNotNull($actorId);
+        $this->record(
+            $actor,
+            UserActivityType::HOSPITAL_ASSOCIATED,
+            new \DateTimeImmutable('2026-07-01 09:00:00'),
+            UserActivityDeduplicationKey::hospitalAssociated($actorId, 3, 7),
+            [
+                'hospitalName' => 'Linked Clinic',
+                'hospitalPublicId' => 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            ],
+        );
+
+        $client->loginUser($participant);
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href="/explore/hospital/cccccccc-cccc-4ccc-8ccc-cccccccccccc"]');
+        self::assertSelectorTextContains('body', 'Linked Clinic');
+    }
+
+    public function testFeedFailureRendersErrorInsideTheFrame(): void
+    {
+        $client = self::createClient();
+        $client->disableReboot();
+        $user = UserFactory::createOne(['username' => 'activity-error-user']);
+        $client->loginUser($user);
+
+        self::getContainer()->set(ProjectActivityQueryInterface::class, new class implements ProjectActivityQueryInterface {
+            public function getPage(?string $cursor, int $limit = ProjectActivityPage::PAGE_SIZE): ProjectActivityPage
+            {
+                throw new \RuntimeException('activity query failed');
+            }
+        });
+
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-activity-error"]');
+        self::assertSelectorTextContains('body', 'Activity could not be loaded.');
+    }
+
+    /**
+     * @param array<string, scalar|null> $metadata
+     */
+    private function record(
+        User $user,
+        UserActivityType $type,
+        \DateTimeImmutable $occurredAt,
+        string $deduplicationKey,
+        array $metadata = [],
+    ): void {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist(new UserActivity(
+            user: $user,
+            type: $type,
+            occurredAt: $occurredAt,
+            deduplicationKey: $deduplicationKey,
+            metadata: $metadata,
+        ));
+        $entityManager->flush();
+    }
+}

--- a/tests/Content/Functional/Controller/DashboardActivityControllerTest.php
+++ b/tests/Content/Functional/Controller/DashboardActivityControllerTest.php
@@ -174,6 +174,62 @@ final class DashboardActivityControllerTest extends WebTestCase
         self::assertSelectorTextContains('body', 'Linked Clinic');
     }
 
+    public function testRendersRemainingCommunityTypesWithoutOptionalLinks(): void
+    {
+        $client = self::createClient();
+        $viewer = UserFactory::createOne(['username' => 'activity-types-viewer']);
+        $actor = UserFactory::createOne(['username' => 'activity-types-actor']);
+        $actorId = $actor->getId();
+        self::assertNotNull($actorId);
+
+        $this->record(
+            $actor,
+            UserActivityType::FIRST_IMPORT,
+            new \DateTimeImmutable('2026-08-01 09:00:00'),
+            UserActivityDeduplicationKey::importMilestone($actorId, 1),
+            ['milestone' => 1, 'hospitalName' => 'First Clinic'],
+        );
+        $this->record(
+            $actor,
+            UserActivityType::IMPORT_MILESTONE,
+            new \DateTimeImmutable('2026-08-02 09:00:00'),
+            UserActivityDeduplicationKey::importMilestone($actorId, 5),
+            ['milestone' => 5, 'hospitalName' => 'First Clinic'],
+        );
+        $this->record(
+            $actor,
+            UserActivityType::COMMENT_CREATED,
+            new \DateTimeImmutable('2026-08-03 09:00:00'),
+            UserActivityDeduplicationKey::commentCreated($actorId, 11),
+            ['postTitle' => 'Untitled Comment Post', 'excerpt' => 'Nice work'],
+        );
+        $this->record(
+            $actor,
+            UserActivityType::POST_PUBLISHED,
+            new \DateTimeImmutable('2026-08-04 09:00:00'),
+            UserActivityDeduplicationKey::postPublished($actorId, 12),
+            ['title' => 'Draft Headline'],
+        );
+
+        $client->loginUser($viewer);
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="first_import"]');
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="import_milestone"]');
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="comment_created"]');
+        self::assertSelectorExists('[data-testid="dashboard-activity-item"][data-activity-type="post_published"]');
+        self::assertSelectorTextContains('body', 'Imported first dataset');
+        self::assertSelectorTextContains('body', 'Reached 5 data imports');
+        self::assertSelectorTextContains('body', 'Wrote a comment');
+        self::assertSelectorTextContains('body', 'On');
+        self::assertSelectorTextContains('body', 'Untitled Comment Post');
+        self::assertSelectorTextContains('body', 'Nice work');
+        self::assertSelectorTextContains('body', 'Draft Headline');
+        self::assertSelectorNotExists('a[href^="/blog/"]');
+        self::assertSelectorNotExists('a[href^="/explore/hospital/"]');
+    }
+
     public function testFeedFailureRendersErrorInsideTheFrame(): void
     {
         $client = self::createClient();

--- a/tests/Content/Functional/Controller/DashboardQueryCountTest.php
+++ b/tests/Content/Functional/Controller/DashboardQueryCountTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Functional\Controller;
+
+use App\Tests\Support\Security\InteractsWithAuthenticatedUser;
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Attribute\ResetDatabase;
+use Zenstruck\Foundry\Test\Factories;
+
+#[ResetDatabase]
+final class DashboardQueryCountTest extends WebTestCase
+{
+    use Factories;
+    use InteractsWithAuthenticatedUser;
+
+    public function testInitialDashboardDoesNotScanAllocationTablesWhenCacheIsWarm(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $client->request(Request::METHOD_GET, '/');
+        self::assertResponseIsSuccessful();
+
+        $client->enableProfiler();
+        $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+
+        $profile = $client->getProfile();
+        self::assertNotNull($profile);
+        $collector = $profile->getCollector('db');
+        self::assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        $sqlParts = [];
+        foreach ($collector->getQueries() as $connectionQueries) {
+            foreach ($connectionQueries as $query) {
+                $sqlParts[] = (string) ($query['sql'] ?? '');
+            }
+        }
+        $sqlBlob = strtolower(implode("\n", $sqlParts));
+
+        self::assertStringNotContainsString('allocation_stats_projection', $sqlBlob);
+        self::assertDoesNotMatchRegularExpression('/\\bfrom\\s+allocation\\b/', $sqlBlob);
+        self::assertDoesNotMatchRegularExpression('/\\bfrom\\s+"allocation"\\b/', $sqlBlob);
+        self::assertStringNotContainsString('user_activity', $sqlBlob);
+    }
+
+    public function testActivityEndpointQueriesUserActivity(): void
+    {
+        $client = $this->createClientAsRoleUser();
+        $client->enableProfiler();
+        $client->request(Request::METHOD_GET, '/dashboard/activity');
+
+        self::assertResponseIsSuccessful();
+
+        $profile = $client->getProfile();
+        self::assertNotNull($profile);
+        $collector = $profile->getCollector('db');
+        self::assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        $sqlParts = [];
+        foreach ($collector->getQueries() as $connectionQueries) {
+            foreach ($connectionQueries as $query) {
+                $sqlParts[] = (string) ($query['sql'] ?? '');
+            }
+        }
+        $sqlBlob = strtolower(implode("\n", $sqlParts));
+        self::assertStringContainsString('user_activity', $sqlBlob);
+        self::assertStringNotContainsString('allocation_stats_projection', $sqlBlob);
+    }
+}

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -16,6 +16,11 @@ use App\Allocation\Infrastructure\Factory\OccasionFactory;
 use App\Allocation\Infrastructure\Factory\SecondaryTransportFactory;
 use App\Allocation\Infrastructure\Factory\SpecialityFactory;
 use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Content\Domain\Entity\Page;
+use App\Content\Domain\Entity\PageTranslation;
+use App\Content\Domain\Enum\PostStatus;
+use App\Content\Infrastructure\Factory\PageFactory;
+use App\Content\Infrastructure\Factory\PostFactory;
 use App\Import\Infrastructure\Factory\ImportFactory;
 use App\Onboarding\Domain\Enum\OnboardingStepKey;
 use App\Onboarding\Infrastructure\Factory\UserOnboardingStepFactory;
@@ -279,6 +284,36 @@ final class DefaultControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertSelectorNotExists('[data-testid="dashboard-onboarding-card"]');
+    }
+
+    public function testDashboardSidebarShowsPublishedPostsAndPages(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['username' => 'dashboard-sidebar-user']);
+        PostFactory::createOne([
+            'title' => 'Dashboard Sidebar Post',
+            'slug' => 'dashboard-sidebar-post',
+            'status' => PostStatus::PUBLISHED,
+            'publishedAt' => new \DateTimeImmutable('-2 hours'),
+            'createdBy' => $user,
+        ]);
+        PageFactory::createOne([
+            'title' => 'Dashboard Guide',
+            'slug' => 'dashboard-guide',
+            'status' => PageTranslation::STATUS_PUBLISHED,
+            'visibility' => Page::VISIBILITY_AUTHENTICATED,
+            'content' => [['type' => 'richtext', 'data' => ['html' => '<p>Guide</p>']]],
+        ]);
+
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('a[href="/blog/dashboard-sidebar-post"]');
+        self::assertSelectorTextContains('body', 'Dashboard Sidebar Post');
+        self::assertSelectorTextNotContains('body', 'No published posts yet.');
+        self::assertSelectorTextContains('body', 'Dashboard Guide');
+        self::assertSelectorTextNotContains('body', 'No pages available.');
     }
 
     public function testDashboardStaysUsableWhenActivityFrameIsSeparate(): void

--- a/tests/Content/Functional/Controller/DefaultControllerTest.php
+++ b/tests/Content/Functional/Controller/DefaultControllerTest.php
@@ -66,6 +66,10 @@ final class DefaultControllerTest extends WebTestCase
         self::assertSelectorExists('.home-screenshot-carousel .carousel-caption-background');
         self::assertSelectorExists('.home-screenshot-carousel .carousel-caption[data-testid="home-screenshot-caption"]');
         self::assertSelectorTextContains('body', 'Shared overview of allocations, trends and clinical distributions across the network.');
+        self::assertSelectorTextContains('body', 'Users');
+        self::assertSelectorTextContains('body', 'Hospitals');
+        self::assertSelectorTextContains('body', 'Allocations');
+        self::assertSelectorTextContains('body', 'Imports');
     }
 
     public function testAuthenticatedUsersSeeDashboardOnHomepage(): void
@@ -86,6 +90,13 @@ final class DefaultControllerTest extends WebTestCase
         self::assertSelectorTextContains('body', 'Pages');
         self::assertSelectorTextContains('body', 'No published posts yet.');
         self::assertSelectorTextContains('body', 'No pages available.');
+        self::assertSelectorExists('[data-testid="dashboard-metrics"]');
+        self::assertSelectorExists('[data-testid="dashboard-metric-allocations"]');
+        self::assertSelectorExists('[data-testid="dashboard-metric-hospitals"]');
+        self::assertSelectorExists('[data-testid="dashboard-metric-users"]');
+        self::assertSelectorExists('[data-testid="dashboard-metric-imports"]');
+        self::assertSelectorTextContains('[data-testid="dashboard-metric-users"]', 'last 30 days');
+        self::assertSelectorExists('turbo-frame#dashboard-activity[src="/dashboard/activity"]');
         self::assertSelectorExists('[data-testid="dashboard-participant-access-notice"]');
         self::assertSelectorTextContains('body', 'Your current access');
         self::assertSelectorTextContains('body', 'Browse and explore allocation data');
@@ -268,5 +279,19 @@ final class DefaultControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertSelectorNotExists('[data-testid="dashboard-onboarding-card"]');
+    }
+
+    public function testDashboardStaysUsableWhenActivityFrameIsSeparate(): void
+    {
+        $client = self::createClient();
+        $user = UserFactory::createOne(['username' => 'dashboard-activity-isolated']);
+        $client->loginUser($user);
+        $client->request(Request::METHOD_GET, '/');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('[data-testid="dashboard-metrics"]');
+        self::assertSelectorExists('a[href="/statistics/"]');
+        self::assertSelectorExists('turbo-frame#dashboard-activity[loading="lazy"]');
+        self::assertSelectorNotExists('[data-testid="dashboard-activity-item"]');
     }
 }

--- a/tests/Content/Integration/Application/Dashboard/DashboardMetricsServiceTest.php
+++ b/tests/Content/Integration/Application/Dashboard/DashboardMetricsServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Integration\Application\Dashboard;
+
+use App\Allocation\Infrastructure\Factory\AllocationFactory;
+use App\Allocation\Infrastructure\Factory\AssignmentFactory;
+use App\Allocation\Infrastructure\Factory\DepartmentFactory;
+use App\Allocation\Infrastructure\Factory\DispatchAreaFactory;
+use App\Allocation\Infrastructure\Factory\HospitalFactory;
+use App\Allocation\Infrastructure\Factory\IndicationNormalizedFactory;
+use App\Allocation\Infrastructure\Factory\IndicationRawFactory;
+use App\Allocation\Infrastructure\Factory\OccasionFactory;
+use App\Allocation\Infrastructure\Factory\SpecialityFactory;
+use App\Allocation\Infrastructure\Factory\StateFactory;
+use App\Content\Application\Dashboard\DashboardMetricsService;
+use App\Import\Infrastructure\Factory\ImportFactory;
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\Tests\Support\Statistics\RefreshesStatisticsFunctionalDataTrait;
+use App\User\Domain\Factory\UserFactory;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class DashboardMetricsServiceTest extends DatabaseKernelTestCase
+{
+    use RefreshesStatisticsFunctionalDataTrait;
+
+    public function testComputesTotalsAndLast30DaysDeltas(): void
+    {
+        $old = new \DateTimeImmutable('-40 days');
+        $recent = new \DateTimeImmutable('-2 days');
+        $userOld = UserFactory::createOne([
+            'username' => 'metrics-old',
+            'createdAt' => $old,
+        ]);
+        UserFactory::createOne([
+            'username' => 'metrics-new',
+            'createdAt' => $recent,
+        ]);
+
+        $state = StateFactory::createOne(['name' => 'Metrics State', 'createdBy' => $userOld]);
+        $dispatchArea = DispatchAreaFactory::createOne([
+            'name' => 'Metrics Dispatch',
+            'createdBy' => $userOld,
+            'state' => $state,
+        ]);
+        $hospitalOld = HospitalFactory::createOne([
+            'name' => 'Metrics Hospital Old',
+            'createdBy' => $userOld,
+            'owner' => $userOld,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+            'createdAt' => $old,
+        ]);
+        $hospitalNew = HospitalFactory::createOne([
+            'name' => 'Metrics Hospital New',
+            'createdBy' => $userOld,
+            'owner' => $userOld,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => true,
+            'createdAt' => $recent,
+        ]);
+        HospitalFactory::createOne([
+            'name' => 'Metrics Hospital Inactive',
+            'createdBy' => $userOld,
+            'owner' => $userOld,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+            'isParticipating' => false,
+            'createdAt' => $recent,
+        ]);
+
+        SpecialityFactory::createOne(['name' => 'Metrics Spec', 'createdBy' => $userOld]);
+        DepartmentFactory::createOne(['name' => 'Metrics Dept', 'createdBy' => $userOld]);
+        AssignmentFactory::createOne(['name' => 'Metrics Assign', 'createdBy' => $userOld]);
+        OccasionFactory::createOne(['name' => 'Metrics Occ', 'createdBy' => $userOld]);
+        IndicationRawFactory::createOne(['name' => 'Metrics Raw', 'createdBy' => $userOld]);
+        IndicationNormalizedFactory::createOne(['name' => 'Metrics Norm', 'createdBy' => $userOld]);
+
+        $importOld = ImportFactory::createOne([
+            'name' => 'Metrics Import Old',
+            'createdBy' => $userOld,
+            'hospital' => $hospitalOld,
+            'createdAt' => $old,
+        ]);
+        $importNew = ImportFactory::createOne([
+            'name' => 'Metrics Import New',
+            'createdBy' => $userOld,
+            'hospital' => $hospitalNew,
+            'createdAt' => $recent,
+        ]);
+
+        AllocationFactory::createMany(3, [
+            'createdAt' => $old,
+            'import' => $importOld,
+            'hospital' => $hospitalOld,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+        AllocationFactory::createMany(2, [
+            'createdAt' => $recent,
+            'import' => $importNew,
+            'hospital' => $hospitalNew,
+            'state' => $state,
+            'dispatchArea' => $dispatchArea,
+        ]);
+
+        $this->rebuildProjectionForImports([(int) $importOld->getId(), (int) $importNew->getId()]);
+        self::getContainer()->get(CacheInterface::class)->delete('dashboard.allocation_counts');
+
+        $metrics = self::getContainer()->get(DashboardMetricsService::class)->get();
+        $byKey = [];
+        foreach ($metrics->items as $item) {
+            $byKey[$item->key] = $item;
+        }
+
+        self::assertSame(5, $byKey['allocations']->value);
+        self::assertSame(2, $byKey['allocations']->deltaLast30Days);
+        self::assertSame(2, $byKey['hospitals']->value);
+        self::assertSame(1, $byKey['hospitals']->deltaLast30Days);
+        self::assertSame(2, $byKey['users']->value);
+        self::assertSame(1, $byKey['users']->deltaLast30Days);
+        self::assertSame(2, $byKey['imports']->value);
+        self::assertSame(1, $byKey['imports']->deltaLast30Days);
+
+        $cached = self::getContainer()->get(DashboardMetricsService::class)->get();
+        self::assertSame(5, $cached->value('allocations'));
+        self::assertSame(2, $cached->value('imports'));
+    }
+
+    public function testRejectsUnexpectedCachedAllocationPayload(): void
+    {
+        $cache = self::getContainer()->get(CacheInterface::class);
+        $cache->delete('dashboard.allocation_counts');
+        $cache->get('dashboard.allocation_counts', static function (ItemInterface $item): string {
+            $item->expiresAfter(3600);
+
+            return 'invalid';
+        });
+
+        try {
+            self::getContainer()->get(DashboardMetricsService::class)->get();
+            self::fail('Expected a LogicException for an unexpected cache payload.');
+        } catch (\LogicException $exception) {
+            self::assertStringContainsString('unexpected type', $exception->getMessage());
+        } finally {
+            $cache->delete('dashboard.allocation_counts');
+        }
+    }
+}

--- a/tests/Content/Unit/Application/Dashboard/DashboardMetricsTest.php
+++ b/tests/Content/Unit/Application/Dashboard/DashboardMetricsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Content\Unit\Application\Dashboard;
+
+use App\Content\Application\Dashboard\DTO\DashboardMetric;
+use App\Content\Application\Dashboard\DTO\DashboardMetrics;
+use PHPUnit\Framework\TestCase;
+
+final class DashboardMetricsTest extends TestCase
+{
+    public function testValueReturnsMatchingMetric(): void
+    {
+        $metrics = new DashboardMetrics([
+            new DashboardMetric('users', 12, 3, 'tabler:users', 'dashboard.metrics.users'),
+            new DashboardMetric('imports', 4, 0, 'tabler:database-import', 'dashboard.metrics.imports'),
+        ]);
+
+        self::assertSame(12, $metrics->value('users'));
+        self::assertSame(4, $metrics->value('imports'));
+    }
+
+    public function testValueThrowsForUnknownKey(): void
+    {
+        $metrics = new DashboardMetrics([
+            new DashboardMetric('users', 1, 0, 'tabler:users', 'dashboard.metrics.users'),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown dashboard metric "allocations".');
+        $metrics->value('allocations');
+    }
+}

--- a/tests/User/Integration/Infrastructure/Query/ProjectActivityQueryTest.php
+++ b/tests/User/Integration/Infrastructure/Query/ProjectActivityQueryTest.php
@@ -148,6 +148,47 @@ final class ProjectActivityQueryTest extends DatabaseKernelTestCase
         self::assertSame(ProfileActivityType::HOSPITAL_ASSOCIATED, $page->items[2]->type);
     }
 
+    public function testMapsFirstImportNumericMilestoneAndIgnoresEmptyMetadata(): void
+    {
+        $user = UserFactory::createOne(['username' => 'project-feed-first-import']);
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $this->record(
+            $user,
+            UserActivityType::FIRST_IMPORT,
+            new \DateTimeImmutable('2026-06-01 08:00:00'),
+            UserActivityDeduplicationKey::importMilestone($userId, 1),
+            [
+                'milestone' => '1',
+                'hospitalName' => '',
+                'hospitalPublicId' => '',
+                'title' => '',
+                'postTitle' => 'Fallback Title',
+                'slug' => '',
+                'postSlug' => 'fallback-slug',
+            ],
+        );
+        $this->record(
+            $user,
+            UserActivityType::IMPORT_MILESTONE,
+            new \DateTimeImmutable('2026-06-02 08:00:00'),
+            UserActivityDeduplicationKey::importMilestone($userId, 5),
+            ['milestone' => 'not-a-number'],
+        );
+
+        $page = self::getContainer()->get(ProjectActivityQuery::class)->getPage(null);
+        self::assertCount(2, $page->items);
+        self::assertSame(ProfileActivityType::IMPORT_MILESTONE, $page->items[0]->type);
+        self::assertNull($page->items[0]->milestone);
+        self::assertSame(ProfileActivityType::FIRST_IMPORT, $page->items[1]->type);
+        self::assertSame(1, $page->items[1]->milestone);
+        self::assertNull($page->items[1]->hospitalName);
+        self::assertNull($page->items[1]->hospitalPublicId);
+        self::assertSame('Fallback Title', $page->items[1]->postTitle);
+        self::assertSame('fallback-slug', $page->items[1]->postSlug);
+    }
+
     /**
      * @param array<string, scalar|null> $metadata
      */

--- a/tests/User/Integration/Infrastructure/Query/ProjectActivityQueryTest.php
+++ b/tests/User/Integration/Infrastructure/Query/ProjectActivityQueryTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Integration\Infrastructure\Query;
+
+use App\Tests\Support\Foundry\DatabaseKernelTestCase;
+use App\User\Application\Activity\UserActivityDeduplicationKey;
+use App\User\Application\Explore\ProfileActivityType;
+use App\User\Application\Explore\ProjectActivityPage;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserActivity;
+use App\User\Domain\Enum\UserActivityType;
+use App\User\Domain\Factory\UserFactory;
+use App\User\Infrastructure\Query\ProjectActivityQuery;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ProjectActivityQueryTest extends DatabaseKernelTestCase
+{
+    public function testOrdersByOccurredAtAndPaginatesWithoutDuplicates(): void
+    {
+        $alice = UserFactory::createOne(['username' => 'project-feed-alice', 'isEnabled' => true]);
+        $bob = UserFactory::createOne(['username' => 'project-feed-bob', 'isEnabled' => true]);
+        $aliceId = $alice->getId();
+        $bobId = $bob->getId();
+        self::assertNotNull($aliceId);
+        self::assertNotNull($bobId);
+
+        $this->record($alice, UserActivityType::JOINED, new \DateTimeImmutable('2026-01-01 10:00:00'), UserActivityDeduplicationKey::joined($aliceId));
+        $this->record($bob, UserActivityType::HOSPITAL_DISASSOCIATED, new \DateTimeImmutable('2026-03-01 10:00:00'), UserActivityDeduplicationKey::hospitalDisassociated($bobId, 1, 1));
+        $this->record($bob, UserActivityType::HOSPITAL_OWNER_REVOKED, new \DateTimeImmutable('2026-03-02 10:00:00'), UserActivityDeduplicationKey::hospitalOwnerRevoked($bobId, 1));
+
+        for ($i = 1; $i <= 12; ++$i) {
+            $this->record(
+                $alice,
+                UserActivityType::POST_PUBLISHED,
+                new \DateTimeImmutable(sprintf('2026-02-%02d 12:00:00', $i)),
+                UserActivityDeduplicationKey::postPublished($aliceId, $i),
+                ['title' => 'Post '.$i, 'slug' => 'post-'.$i, 'postId' => $i],
+            );
+        }
+
+        $query = self::getContainer()->get(ProjectActivityQuery::class);
+        $first = $query->getPage(null, ProjectActivityPage::PAGE_SIZE);
+        self::assertCount(10, $first->items);
+        self::assertTrue($first->hasMore());
+        self::assertNotNull($first->nextCursor);
+        self::assertSame(ProfileActivityType::POST_PUBLISHED, $first->items[0]->type);
+        self::assertSame('project-feed-alice', $first->items[0]->actorUsername);
+        self::assertSame('Post 12', $first->items[0]->postTitle);
+
+        $types = array_map(static fn ($item) => $item->type, $first->items);
+        self::assertNotContains(ProfileActivityType::HOSPITAL_DISASSOCIATED, $types);
+        self::assertNotContains(ProfileActivityType::HOSPITAL_OWNER_REVOKED, $types);
+
+        $second = $query->getPage($first->nextCursor, ProjectActivityPage::PAGE_SIZE);
+        $allKeys = [
+            ...array_map(static fn ($activity): string => $activity->type->value.':'.$activity->stableId, $first->items),
+            ...array_map(static fn ($activity): string => $activity->type->value.':'.$activity->stableId, $second->items),
+        ];
+
+        self::assertCount(3, $second->items);
+        self::assertCount(13, $allKeys);
+        self::assertCount(13, array_values(array_unique($allKeys)));
+        self::assertFalse($second->hasMore());
+        self::assertSame(ProfileActivityType::JOINED, $second->items[array_key_last($second->items)]->type);
+    }
+
+    public function testSkipsDisabledUsersAndExcludedTypes(): void
+    {
+        $enabled = UserFactory::createOne(['username' => 'project-feed-enabled']);
+        $disabled = UserFactory::createOne(['username' => 'project-feed-disabled', 'isEnabled' => false]);
+        $enabledId = $enabled->getId();
+        $disabledId = $disabled->getId();
+        self::assertNotNull($enabledId);
+        self::assertNotNull($disabledId);
+
+        $this->record(
+            $enabled,
+            UserActivityType::COMMENT_CREATED,
+            new \DateTimeImmutable('2026-04-01 09:00:00'),
+            UserActivityDeduplicationKey::commentCreated($enabledId, 3),
+            ['postTitle' => 'Artikel', 'postSlug' => 'artikel', 'excerpt' => 'Hi'],
+        );
+        $this->record(
+            $disabled,
+            UserActivityType::POST_PUBLISHED,
+            new \DateTimeImmutable('2026-04-02 09:00:00'),
+            UserActivityDeduplicationKey::postPublished($disabledId, 99),
+            ['title' => 'Hidden', 'slug' => 'hidden'],
+        );
+        $this->record(
+            $enabled,
+            UserActivityType::HOSPITAL_DISASSOCIATED,
+            new \DateTimeImmutable('2026-04-03 09:00:00'),
+            UserActivityDeduplicationKey::hospitalDisassociated($enabledId, 4, 8),
+            ['hospitalName' => 'Secret'],
+        );
+
+        $page = self::getContainer()->get(ProjectActivityQuery::class)->getPage(null);
+        self::assertCount(1, $page->items);
+        self::assertSame(ProfileActivityType::COMMENT_CREATED, $page->items[0]->type);
+        self::assertSame('project-feed-enabled', $page->items[0]->actorUsername);
+        self::assertSame('Hi', $page->items[0]->excerpt);
+    }
+
+    public function testMapsHospitalAndMilestoneMetadataAndIgnoresEmptyLimit(): void
+    {
+        $user = UserFactory::createOne(['username' => 'project-feed-meta']);
+        $userId = $user->getId();
+        self::assertNotNull($userId);
+
+        $this->record(
+            $user,
+            UserActivityType::HOSPITAL_ASSOCIATED,
+            new \DateTimeImmutable('2026-05-01 08:00:00'),
+            UserActivityDeduplicationKey::hospitalAssociated($userId, 12, 41),
+            ['hospitalName' => 'Grant Klinik', 'hospitalPublicId' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'],
+        );
+        $this->record(
+            $user,
+            UserActivityType::HOSPITAL_OWNER_GRANTED,
+            new \DateTimeImmutable('2026-05-02 08:00:00'),
+            UserActivityDeduplicationKey::hospitalOwnerGranted($userId, 12),
+            ['hospitalName' => 'Grant Klinik', 'hospitalPublicId' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'],
+        );
+        $this->record(
+            $user,
+            UserActivityType::IMPORT_MILESTONE,
+            new \DateTimeImmutable('2026-05-03 08:00:00'),
+            UserActivityDeduplicationKey::importMilestone($userId, 5),
+            ['milestone' => 5, 'hospitalName' => 'Grant Klinik', 'hospitalPublicId' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'],
+        );
+
+        $query = self::getContainer()->get(ProjectActivityQuery::class);
+        $empty = $query->getPage(null, 0);
+        self::assertSame([], $empty->items);
+        self::assertNull($empty->nextCursor);
+
+        $page = $query->getPage(null);
+        self::assertCount(3, $page->items);
+        self::assertSame(ProfileActivityType::IMPORT_MILESTONE, $page->items[0]->type);
+        self::assertSame(5, $page->items[0]->milestone);
+        self::assertSame(ProfileActivityType::HOSPITAL_OWNER_GRANTED, $page->items[1]->type);
+        self::assertSame('Grant Klinik', $page->items[1]->hospitalName);
+        self::assertSame('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', $page->items[1]->hospitalPublicId);
+        self::assertNotNull($page->items[1]->actorPublicId);
+        self::assertSame(ProfileActivityType::HOSPITAL_ASSOCIATED, $page->items[2]->type);
+    }
+
+    /**
+     * @param array<string, scalar|null> $metadata
+     */
+    private function record(
+        User $user,
+        UserActivityType $type,
+        \DateTimeImmutable $occurredAt,
+        string $deduplicationKey,
+        array $metadata = [],
+    ): void {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist(new UserActivity(
+            user: $user,
+            type: $type,
+            occurredAt: $occurredAt,
+            deduplicationKey: $deduplicationKey,
+            metadata: $metadata,
+        ));
+        $entityManager->flush();
+    }
+}

--- a/tests/User/Unit/Application/Explore/ProjectActivityCursorTest.php
+++ b/tests/User/Unit/Application/Explore/ProjectActivityCursorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Unit\Application\Explore;
+
+use App\User\Application\Explore\ProfileActivityType;
+use App\User\Application\Explore\ProjectActivity;
+use App\User\Application\Explore\ProjectActivityCursor;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectActivityCursorTest extends TestCase
+{
+    public function testEncodeDecodeRoundtrip(): void
+    {
+        $occurredAt = new \DateTimeImmutable('2024-06-03T12:00:00+00:00');
+        $cursor = new ProjectActivityCursor($occurredAt, 50);
+
+        $decoded = ProjectActivityCursor::decode($cursor->encode());
+
+        self::assertEquals($occurredAt, $decoded->occurredAt);
+        self::assertSame(50, $decoded->id);
+    }
+
+    public function testTryDecodeReturnsNullForInvalidCursors(): void
+    {
+        self::assertNull(ProjectActivityCursor::tryDecode(null));
+        self::assertNull(ProjectActivityCursor::tryDecode(''));
+        self::assertNull(ProjectActivityCursor::tryDecode('%%%'));
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode('not-json')));
+
+        $legacy = base64_encode(json_encode([
+            'v' => 2,
+            'occurredAt' => '2024-06-03T12:00:00+00:00',
+            'id' => 8,
+            'joined' => false,
+        ], JSON_THROW_ON_ERROR));
+        self::assertNull(ProjectActivityCursor::tryDecode($legacy));
+
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode(json_encode('scalar', JSON_THROW_ON_ERROR))));
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode(json_encode([
+            'v' => 1,
+            'occurredAt' => '2024-06-03T12:00:00+00:00',
+        ], JSON_THROW_ON_ERROR))));
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode(json_encode([
+            'v' => 1,
+            'occurredAt' => '2024-06-03T12:00:00+00:00',
+            'id' => '9',
+        ], JSON_THROW_ON_ERROR))));
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode(json_encode([
+            'v' => 1,
+            'occurredAt' => '2024-06-03T12:00:00+00:00',
+            'id' => 0,
+        ], JSON_THROW_ON_ERROR))));
+        self::assertNull(ProjectActivityCursor::tryDecode(base64_encode(json_encode([
+            'v' => 1,
+            'occurredAt' => 'not-a-date',
+            'id' => 3,
+        ], JSON_THROW_ON_ERROR))));
+    }
+
+    public function testFromActivityUsesStableId(): void
+    {
+        $occurredAt = new \DateTimeImmutable('2024-01-01T00:00:00+00:00');
+        $cursor = ProjectActivityCursor::fromActivity(new ProjectActivity(
+            occurredAt: $occurredAt,
+            type: ProfileActivityType::POST_PUBLISHED,
+            stableId: ProjectActivityCursor::padId(9),
+            actorUsername: 'alice',
+        ));
+
+        self::assertSame(9, $cursor->id);
+        self::assertEquals($occurredAt, $cursor->occurredAt);
+    }
+
+    public function testFrameIdIsHtmlSafe(): void
+    {
+        $cursor = new ProjectActivityCursor(
+            new \DateTimeImmutable('2024-01-01T00:00:00+00:00'),
+            1,
+        );
+        $frameId = ProjectActivityCursor::frameId($cursor->encode());
+
+        self::assertStringStartsWith('dashboard-activity-after-', $frameId);
+        self::assertStringNotContainsString('+', $frameId);
+        self::assertStringNotContainsString('/', $frameId);
+        self::assertStringNotContainsString('=', $frameId);
+    }
+}

--- a/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
+++ b/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
@@ -34,7 +34,7 @@ final class ProjectActivityPageTest extends TestCase
         self::assertTrue($page->hasMore());
         self::assertSame(ProjectActivityCursor::frameId($cursor), $page->nextFrameId());
         self::assertContains(ProfileActivityType::FIRST_IMPORT->value, array_map(
-            static fn ($type) => $type->value,
+            static fn (\App\User\Domain\Enum\UserActivityType $type) => $type->value,
             ProjectActivityPage::feedTypes(),
         ));
     }

--- a/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
+++ b/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\User\Unit\Application\Explore;
 
+use App\User\Application\Explore\ProfileActivityType;
+use App\User\Application\Explore\ProjectActivity;
+use App\User\Application\Explore\ProjectActivityCursor;
 use App\User\Application\Explore\ProjectActivityPage;
 use PHPUnit\Framework\TestCase;
 
@@ -15,5 +18,24 @@ final class ProjectActivityPageTest extends TestCase
 
         self::assertFalse($page->hasMore());
         self::assertNull($page->nextFrameId());
+    }
+
+    public function testNextFrameIdUsesEncodedCursor(): void
+    {
+        $activity = new ProjectActivity(
+            occurredAt: new \DateTimeImmutable('2026-04-01T12:00:00+00:00'),
+            type: ProfileActivityType::JOINED,
+            stableId: ProjectActivityCursor::padId(7),
+            actorUsername: 'alice',
+        );
+        $cursor = ProjectActivityCursor::fromActivity($activity)->encode();
+        $page = new ProjectActivityPage([$activity], $cursor);
+
+        self::assertTrue($page->hasMore());
+        self::assertSame(ProjectActivityCursor::frameId($cursor), $page->nextFrameId());
+        self::assertContains(ProfileActivityType::FIRST_IMPORT->value, array_map(
+            static fn ($type) => $type->value,
+            ProjectActivityPage::feedTypes(),
+        ));
     }
 }

--- a/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
+++ b/tests/User/Unit/Application/Explore/ProjectActivityPageTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\User\Unit\Application\Explore;
+
+use App\User\Application\Explore\ProjectActivityPage;
+use PHPUnit\Framework\TestCase;
+
+final class ProjectActivityPageTest extends TestCase
+{
+    public function testNextFrameIdIsNullWhenThereIsNoCursor(): void
+    {
+        $page = new ProjectActivityPage([], null);
+
+        self::assertFalse($page->hasMore());
+        self::assertNull($page->nextFrameId());
+    }
+}

--- a/translations/content+intl-icu.de.xlf
+++ b/translations/content+intl-icu.de.xlf
@@ -157,6 +157,26 @@
         <source>blog.sidebar.tags</source>
         <target>Schlagwörter</target>
       </trans-unit>
+      <trans-unit id="dshActEmptyDe" resname="dashboard.activity.empty">
+        <source>dashboard.activity.empty</source>
+        <target>Noch keine aktuellen Aktivitäten vorhanden.</target>
+      </trans-unit>
+      <trans-unit id="dshActErrorDe" resname="dashboard.activity.error">
+        <source>dashboard.activity.error</source>
+        <target>Aktivitäten konnten nicht geladen werden.</target>
+      </trans-unit>
+      <trans-unit id="dshActLoadDe" resname="dashboard.activity.load_more">
+        <source>dashboard.activity.load_more</source>
+        <target>Weitere Aktivitäten laden</target>
+      </trans-unit>
+      <trans-unit id="dshActLoadgDe" resname="dashboard.activity.loading">
+        <source>dashboard.activity.loading</source>
+        <target>Aktivitäten werden geladen …</target>
+      </trans-unit>
+      <trans-unit id="dshActTitleDe" resname="dashboard.activity.title">
+        <source>dashboard.activity.title</source>
+        <target>Was zuletzt passiert ist</target>
+      </trans-unit>
       <trans-unit id="De2a3648d3" resname="dashboard.blog.recent_empty">
         <source>dashboard.blog.recent_empty</source>
         <target>Noch keine veröffentlichten Beiträge.</target>
@@ -168,6 +188,26 @@
       <trans-unit id="De68bfad58" resname="dashboard.blog.visit">
         <source>dashboard.blog.visit</source>
         <target>Blog besuchen</target>
+      </trans-unit>
+      <trans-unit id="dshMtrAllocDe" resname="dashboard.metrics.allocations">
+        <source>dashboard.metrics.allocations</source>
+        <target>Einsätze</target>
+      </trans-unit>
+      <trans-unit id="dshMtrHospDe" resname="dashboard.metrics.hospitals">
+        <source>dashboard.metrics.hospitals</source>
+        <target>Kliniken</target>
+      </trans-unit>
+      <trans-unit id="dshMtrImpDe" resname="dashboard.metrics.imports">
+        <source>dashboard.metrics.imports</source>
+        <target>Importe</target>
+      </trans-unit>
+      <trans-unit id="dshMtr30De" resname="dashboard.metrics.last_30_days">
+        <source>dashboard.metrics.last_30_days</source>
+        <target>letzte 30 Tage</target>
+      </trans-unit>
+      <trans-unit id="dshMtrUsrDe" resname="dashboard.metrics.users">
+        <source>dashboard.metrics.users</source>
+        <target>Benutzer</target>
       </trans-unit>
       <trans-unit id="De04d93e0b" resname="dashboard.next_steps.analysis.description">
         <source>dashboard.next_steps.analysis.description</source>

--- a/translations/content+intl-icu.en.xlf
+++ b/translations/content+intl-icu.en.xlf
@@ -121,6 +121,46 @@
         <source>dashboard.blog.visit</source>
         <target>Visit Blog</target>
       </trans-unit>
+      <trans-unit id="dshActEmptyEn" resname="dashboard.activity.empty">
+        <source>dashboard.activity.empty</source>
+        <target>No recent activity yet.</target>
+      </trans-unit>
+      <trans-unit id="dshActErrorEn" resname="dashboard.activity.error">
+        <source>dashboard.activity.error</source>
+        <target>Activity could not be loaded.</target>
+      </trans-unit>
+      <trans-unit id="dshActLoadEn" resname="dashboard.activity.load_more">
+        <source>dashboard.activity.load_more</source>
+        <target>Show more activity</target>
+      </trans-unit>
+      <trans-unit id="dshActLoadgEn" resname="dashboard.activity.loading">
+        <source>dashboard.activity.loading</source>
+        <target>Loading activity…</target>
+      </trans-unit>
+      <trans-unit id="dshActTitleEn" resname="dashboard.activity.title">
+        <source>dashboard.activity.title</source>
+        <target>What happened recently</target>
+      </trans-unit>
+      <trans-unit id="dshMtrAllocEn" resname="dashboard.metrics.allocations">
+        <source>dashboard.metrics.allocations</source>
+        <target>Allocations</target>
+      </trans-unit>
+      <trans-unit id="dshMtrHospEn" resname="dashboard.metrics.hospitals">
+        <source>dashboard.metrics.hospitals</source>
+        <target>Hospitals</target>
+      </trans-unit>
+      <trans-unit id="dshMtrImpEn" resname="dashboard.metrics.imports">
+        <source>dashboard.metrics.imports</source>
+        <target>Imports</target>
+      </trans-unit>
+      <trans-unit id="dshMtr30En" resname="dashboard.metrics.last_30_days">
+        <source>dashboard.metrics.last_30_days</source>
+        <target>last 30 days</target>
+      </trans-unit>
+      <trans-unit id="dshMtrUsrEn" resname="dashboard.metrics.users">
+        <source>dashboard.metrics.users</source>
+        <target>Users</target>
+      </trans-unit>
       <trans-unit id="ZKHDIRf" resname="public.cta.learn_more">
         <source>public.cta.learn_more</source>
         <target>Learn more</target>


### PR DESCRIPTION
## Summary

- Replace the authenticated home (`GET /`) with a compact project overview: live KPIs for users, participating hospitals, and imports, plus last-30-day growth.
- Cache only the expensive allocation projection counts (`cache.app`, 1 hour TTL) and reuse the same metrics service on the public homepage.
- Add a community activity feed from existing `user_activity` (cursor pagination, Turbo lazy frame, privacy-aware links for `ROLE_PARTICIPANT`).

## Test plan
- [x] Log in as `ROLE_USER` and confirm KPI cards render above the two-column layout, with the activity frame loading lazily.
- [x] Confirm guests still see public homepage stats from the same metrics service.
- [x] As `ROLE_USER`, activity items show names but no profile/hospital explore links; as `ROLE_PARTICIPANT`, those links appear.
- [x] Load more activity pages via the Turbo frame and confirm excluded types (`hospital_disassociated`, `hospital_owner_revoked`) stay hidden.
- [x] Confirm the sidebar shows recent blog posts and pages when they exist, and empty states otherwise.